### PR TITLE
Add dynamic completion of hook ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67e4efcbb5da11a92e8a609233aa1e8a7d91e38de0be865f016d14700d45a7fd"
 dependencies = [
  "clap",
+ "clap_lex",
+ "is_executable",
+ "shlex",
 ]
 
 [[package]]
@@ -1249,6 +1252,15 @@ name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
+name = "is_executable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a1b5bad6f9072935961dfbf1cced2f3d129963d091b6f69f007fe04e758ae2"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "is_terminal_polyfill"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ async_zip = { git = "https://github.com/astral-sh/rs-async-zip", rev = "c909fda6
 axoupdater = { version = "0.9.0", default-features = false, features = [ "github_releases"] }
 bstr = { version = "1.11.0" }
 clap = { version = "4.5.16", features = ["derive", "env", "string", "wrap_help"] }
-clap_complete = { version = "4.5.37" }
+clap_complete = { version = "4.5.37", features = ["unstable-dynamic"]}
 ctrlc = { version = "3.4.5" }
 dunce = { version = "1.0.5" }
 etcetera = { version = "0.10.0" }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -64,12 +64,7 @@ fn hook_id_completer(current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
     };
 
     hook_ids
-        .filter(|h| {
-            h.get_value()
-                .to_str()
-                .unwrap_or_default()
-                .starts_with(current)
-        })
+        .filter(|h| h.get_value().to_str().unwrap_or_default().contains(current))
         .collect()
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 use anstream::{ColorChoice, eprintln};
 use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser};
+use clap_complete::CompleteEnv;
 use owo_colors::OwoColorize;
 use tracing::{debug, error};
 use tracing_subscriber::EnvFilter;
@@ -288,6 +289,8 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
 }
 
 fn main() -> ExitCode {
+    CompleteEnv::with_factory(Cli::command).complete();
+
     ctrlc::set_handler(move || {
         cleanup();
 


### PR DESCRIPTION
Fixes #370

Just playing around with clap's unstable dynamic completions to see what's possible: https://github.com/clap-rs/clap/issues/3166. IIUC, it seems like the dynamic completion engine requires generating completions via [`CompleteEnv`](https://docs.rs/clap_complete/latest/clap_complete/env/struct.CompleteEnv.html) but maybe there's a way to keep the current `generate-shell-completion` command

Demo using fish:

```console
$ complete --erase prefligit; COMPLETE=fish cargo run | source
$ time complete -C './target/debug/prefligit run c'
cargo-fmt
cargo-clippy

________________________________________________________
Executed in   25.92 millis    fish           external
   usr time   17.36 millis   13.97 millis    3.38 millis
   sys time    8.14 millis    0.67 millis    7.47 millis
```
