### PR TITLE
Disable building for s390x temporarily

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -246,50 +246,51 @@ jobs:
             *.tar.gz
             *.sha256
 
-  linux-s390x:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        platform:
-          - target: s390x-unknown-linux-gnu
-            arch: s390x
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-      - name: "Build wheels"
-        uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
-        with:
-          target: ${{ matrix.platform.target }}
-          manylinux: auto
-          args: --release --locked --out dist --features self-update
-          # Until the llvm updates hit stable
-          # https://github.com/rust-lang/rust/issues/141287
-          rust-toolchain: nightly-2025-08-18
-      - name: "Upload wheels"
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: wheels-linux-${{ matrix.platform.target }}
-          path: dist
-      - name: "Archive binary"
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          TARGET=${{ matrix.platform.target }}
-          ARCHIVE_NAME=prek-$TARGET
-          ARCHIVE_FILE=$ARCHIVE_NAME.tar.gz
-
-          mkdir -p $ARCHIVE_NAME
-          cp target/$TARGET/release/prek $ARCHIVE_NAME/prek
-          tar czvf $ARCHIVE_FILE $ARCHIVE_NAME
-          shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
-      - name: "Upload binary"
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: artifacts-${{ matrix.platform.target }}
-          path: |
-            *.tar.gz
-            *.sha256
+# `psm` cannot compile on s390x, disable for now.
+#  linux-s390x:
+#    runs-on: ubuntu-latest
+#    timeout-minutes: 30
+#    strategy:
+#      matrix:
+#        platform:
+#          - target: s390x-unknown-linux-gnu
+#            arch: s390x
+#    steps:
+#      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+#      - name: "Build wheels"
+#        uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
+#        with:
+#          target: ${{ matrix.platform.target }}
+#          manylinux: auto
+#          args: --release --locked --out dist --features self-update
+#          # Until the llvm updates hit stable
+#          # https://github.com/rust-lang/rust/issues/141287
+#          rust-toolchain: nightly-2025-08-18
+#      - name: "Upload wheels"
+#        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+#        with:
+#          name: wheels-linux-${{ matrix.platform.target }}
+#          path: dist
+#      - name: "Archive binary"
+#        shell: bash
+#        run: |
+#          set -euo pipefail
+#
+#          TARGET=${{ matrix.platform.target }}
+#          ARCHIVE_NAME=prek-$TARGET
+#          ARCHIVE_FILE=$ARCHIVE_NAME.tar.gz
+#
+#          mkdir -p $ARCHIVE_NAME
+#          cp target/$TARGET/release/prek $ARCHIVE_NAME/prek
+#          tar czvf $ARCHIVE_FILE $ARCHIVE_NAME
+#          shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
+#      - name: "Upload binary"
+#        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+#        with:
+#          name: artifacts-${{ matrix.platform.target }}
+#          path: |
+#            *.tar.gz
+#            *.sha256
 
   linux-powerpc:
     runs-on: ubuntu-latest

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -32,7 +32,8 @@ targets = [
     "powerpc64-unknown-linux-gnu",
     "powerpc64le-unknown-linux-gnu",
     "riscv64gc-unknown-linux-gnu",
-    "s390x-unknown-linux-gnu",
+    # `psm` cannot compile on s390x, disable for now.
+    # "s390x-unknown-linux-gnu",
     "x86_64-unknown-linux-gnu",
     "x86_64-unknown-linux-musl",
     "x86_64-pc-windows-msvc",


### PR DESCRIPTION
```
warning: psm@0.1.26: src/arch/zseries_linux.s: Assembler messages:
warning: psm@0.1.26: src/arch/zseries_linux.s:49: Error: Unrecognized opcode: `lay'
warning: psm@0.1.26: src/arch/zseries_linux.s:63: Error: operand out of range (0xfffffffffffffff0 is not between 0x0000000000000000 and 0x0000000000000fff)
warning: psm@0.1.26: src/arch/zseries_linux.s:64: Error: Unrecognized opcode: `lay'
error: failed to run custom build command for `psm v0.1.26`
Caused by:
  process didn't exit successfully: `/home/runner/work/prek/prek/target/release/build/psm-31777c8ee3a8b240/build-script-build` (exit status: 1)
  --- stdout
  cargo:rustc-check-cfg=cfg(switchable_stack,asm,link_asm)
  OPT_LEVEL = Some(3)
  OUT_DIR = Some(/home/runner/work/prek/prek/target/s390x-unknown-linux-gnu/release/build/psm-03bb3d9d74a0ab74/out)
  TARGET = Some(s390x-unknown-linux-gnu)
  HOST = Some(x86_64-unknown-linux-gnu)
  cargo:rerun-if-env-changed=CC_s390x-unknown-linux-gnu
  CC_s390x-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=CC_s390x_unknown_linux_gnu
  CC_s390x_unknown_linux_gnu = Some(s390x-ibm-linux-gnu-gcc)
  cargo:rerun-if-env-changed=CC_KNOWN_WRAPPER_CUSTOM
  CC_KNOWN_WRAPPER_CUSTOM = None
  RUSTC_WRAPPER = None
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some(false)
  CARGO_CFG_TARGET_FEATURE = None
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  cargo:rerun-if-env-changed=TARGET_CFLAGS
  TARGET_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS_s390x_unknown_linux_gnu
  CFLAGS_s390x_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=CFLAGS_s390x-unknown-linux-gnu
  CFLAGS_s390x-unknown-linux-gnu = None
  CARGO_ENCODED_RUSTFLAGS = Some()
  cargo:rustc-cfg=asm
  cargo:rustc-cfg=link_asm
  cargo:rustc-cfg=switchable_stack
  cargo:warning=src/arch/zseries_linux.s: Assembler messages:
  cargo:warning=src/arch/zseries_linux.s:49: Error: Unrecognized opcode: `lay'
  cargo:warning=src/arch/zseries_linux.s:63: Error: operand out of range (0xfffffffffffffff0 is not between 0x0000000000000000 and 0x0000000000000fff)
  cargo:warning=src/arch/zseries_linux.s:64: Error: Unrecognized opcode: `lay'
  --- stderr
  error occurred in cc-rs: command did not execute successfully (status code exit status: 1): LC_ALL="C" "s390x-ibm-linux-gnu-gcc" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "-Wall" "-Wextra" "-xassembler-with-cpp" "-DCFG_TARGET_OS_linux" "-DCFG_TARGET_ARCH_s390x" "-DCFG_TARGET_ENV_gnu" "-o" "/home/runner/work/prek/prek/target/s390x-unknown-linux-gnu/release/build/psm-03bb3d9d74a0ab74/out/4f9a91766097c4c5-zseries_linux.o" "-c" "src/arch/zseries_linux.s"
```