### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.1.0
+## 0.1.1
 
 ### Breaking changes
 
@@ -16,6 +16,7 @@
 
 - Fix recursion limit when checking deeply nested json ([#507](https://github.com/j178/prek/pull/507))
 - Fix rename tempfile across device ([#508](https://github.com/j178/prek/pull/508))
+- Fix build on s390x ([#518](https://github.com/j178/prek/pull/518))
 
 ### Other changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "prek"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anstream",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ tracing = { version = "0.1.40" }
 
 [package]
 name = "prek"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["j178 <hi@j178.dev>"]
 description = "Better `pre-commit`, re-engineered in Rust"
 repository = "https://github.com/j178/prek"

--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ prek provides a standalone installer script to download and install the tool:
 
 ```console
 # On Linux and macOS
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/j178/prek/releases/download/v0.1.0/prek-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/j178/prek/releases/download/v0.1.1/prek-installer.sh | sh
 
 # On Windows
-powershell -ExecutionPolicy ByPass -c "irm https://github.com/j178/prek/releases/download/v0.1.0/prek-installer.ps1 | iex"
+powershell -ExecutionPolicy ByPass -c "irm https://github.com/j178/prek/releases/download/v0.1.1/prek-installer.ps1 | iex"
 ```
 </details>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prek"
-version = "0.1.0"
+version = "0.1.1"
 description = "Better `pre-commit`, re-engineered in Rust"
 authors = [{ name = "j178", email = "hi@j178.dev" }]
 requires-python = ">=3.8"


### PR DESCRIPTION
Previous `0.1.0` release failed, this is a re-release of the `0.1.0` version.