### PR TITLE
Remove color from trace log

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: end-of-file-fixer
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.35.7
+    rev: v1.35.6
     hooks:
       - id: typos
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -468,7 +468,7 @@ impl Display for Cmd {
         let program = self.get_program();
         let mut args = self.get_args().peekable();
 
-        write!(f, "{}", program.to_string_lossy().cyan())?;
+        write!(f, "{}", program.to_string_lossy())?;
         if args.peek().is_some_and(|arg| *arg == program) {
             args.next(); // Skip the program if it's repeated
         }
@@ -482,10 +482,10 @@ impl Display for Cmd {
                 }
                 continue;
             }
-            write!(f, " {}", arg.to_string_lossy().dimmed())?;
+            write!(f, " {}", arg.to_string_lossy())?;
             len += arg.len() + 1;
             if len > 100 {
-                write!(f, " {}", "[...]".dimmed())?;
+                write!(f, " [...]",)?;
                 break;
             }
         }


### PR DESCRIPTION
Since `tracing-subscriber 0.3.20`, ANSI codes will be escaped so that color can not be shown in log. https://github.com/tokio-rs/tracing/commit/4c52ca5266a3920fc5dfeebda2accf15ee7fb278
