### PR TITLE
docs(manifest): Correctly specify metadata for all packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = ["lib/*"]
 
 [workspace.package]
 edition = "2024"
+repository = "https://github.com/j178/prek"
 
 [workspace.dependencies]
 constants = { path = "lib/constants" }
@@ -13,7 +14,7 @@ name = "prek"
 version = "0.2.0-alpha.3"
 authors = ["j178 <hi@j178.dev>"]
 description = "Better `pre-commit`, re-engineered in Rust"
-repository = "https://github.com/j178/prek"
+repository = { workspace = true }
 homepage = "https://github.com/j178/prek"
 edition = { workspace = true }
 license-file = "LICENSE"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ description = "Better `pre-commit`, re-engineered in Rust"
 repository = { workspace = true }
 homepage = "https://github.com/j178/prek"
 edition = { workspace = true }
-license-file = "LICENSE"
+license = "MIT"
 
 [features]
 default = ["docker"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = ["lib/*"]
 [workspace.package]
 edition = "2024"
 repository = "https://github.com/j178/prek"
+license = "MIT"
 
 [workspace.dependencies]
 constants = { path = "lib/constants" }
@@ -17,7 +18,7 @@ description = "Better `pre-commit`, re-engineered in Rust"
 repository = { workspace = true }
 homepage = "https://github.com/j178/prek"
 edition = { workspace = true }
-license = "MIT"
+license = { workspace = true }
 
 [features]
 default = ["docker"]

--- a/lib/constants/Cargo.toml
+++ b/lib/constants/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "constants"
 version = "0.0.1"
+repository = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]

--- a/lib/constants/Cargo.toml
+++ b/lib/constants/Cargo.toml
@@ -3,6 +3,7 @@ name = "constants"
 version = "0.0.1"
 repository = { workspace = true }
 edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 tracing = { workspace = true }

--- a/lib/pty/Cargo.toml
+++ b/lib/pty/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "pty"
 version = "0.0.1"
+repository = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]

--- a/lib/pty/Cargo.toml
+++ b/lib/pty/Cargo.toml
@@ -3,6 +3,7 @@ name = "pty"
 version = "0.0.1"
 repository = { workspace = true }
 edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 rustix = { version = "1.0.8", features = ["pty", "process", "fs", "termios"] }


### PR DESCRIPTION
- Having `repository` on every package will be helpful for provenance checking, see also https://lawngno.me/blog/2024/06/10/divine-provenance.html
- All packages should have a license
- `package.license` is the correct field to use for standard licenses