### PR TITLE
Note that Rust 1.89 is required to build prek

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ mise use prek
 <details>
 <summary>Cargo</summary>
 
-Build from source using Cargo:
+Build from source using Cargo (Rust 1.89+ is required):
 
 ```bash
 cargo install --locked --git https://github.com/j178/prek


### PR DESCRIPTION
Closes https://github.com/j178/prek/issues/709
