### PR TITLE
Fix installation on fish and with missing tags

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -69,7 +69,7 @@ fn commit_info(workspace_root: &Path) {
         .arg("--date=short")
         .arg("--abbrev=9")
         // describe:tags => Instead of only considering annotated tags, consider lightweight tags as well.
-        .arg("--format=%H %h %cd %(describe:tags)")
+        .arg("--format='%H %h %cd %(describe:tags)'")
         .output()
     {
         Ok(output) if output.status.success() => output,
@@ -86,16 +86,16 @@ fn commit_info(workspace_root: &Path) {
     // https://git-scm.com/docs/pretty-formats#Documentation/pretty-formats.txt-emdescribeoptionsem
     if let Some(describe) = parts.next() {
         // e.g. 'v0.2.0-alpha.5-1-g4e9faf2'
+        println!("cargo:rustc-env=PREK_TAG_DESCRIBE={describe}");
         let mut describe_parts = describe.rsplitn(3, '-');
         describe_parts.next();
         println!(
             "cargo:rustc-env=PREK_LAST_TAG_DISTANCE={}",
             describe_parts.next().unwrap_or("0")
         );
-        println!(
-            "cargo:rustc-env=PREK_LAST_TAG={}",
-            describe_parts.next().unwrap()
-        );
+        if let Some(last_tag) = describe_parts.next(){
+            println!("cargo:rustc-env=PREK_LAST_TAG={last_tag}");
+        }
     }
 }
 

--- a/build.rs
+++ b/build.rs
@@ -92,7 +92,7 @@ fn commit_info(workspace_root: &Path) {
             "cargo:rustc-env=PREK_LAST_TAG_DISTANCE={}",
             describe_parts.next().unwrap_or("0")
         );
-        if let Some(last_tag) = describe_parts.next(){
+        if let Some(last_tag) = describe_parts.next() {
             println!("cargo:rustc-env=PREK_LAST_TAG={last_tag}");
         }
     }

--- a/build.rs
+++ b/build.rs
@@ -86,7 +86,6 @@ fn commit_info(workspace_root: &Path) {
     // https://git-scm.com/docs/pretty-formats#Documentation/pretty-formats.txt-emdescribeoptionsem
     if let Some(describe) = parts.next() {
         // e.g. 'v0.2.0-alpha.5-1-g4e9faf2'
-        println!("cargo:rustc-env=PREK_TAG_DESCRIBE={describe}");
         let mut describe_parts = describe.rsplitn(3, '-');
         describe_parts.next();
         println!(


### PR DESCRIPTION
I use `fish`. I see this error when trying to use cargo install on the git repository because the `()` are command substitutions.

```
Caused by:
  process didn't exit successfully: `/tmp/cargo-installWK97dR/release/build/prek-241b93c8fdd9f249/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-changed=/home/kudai/.cargo/git/checkouts/prek-5d0019c4f3435dba/83d1700/.git/HEAD
  cargo:rerun-if-changed=/home/kudai/.cargo/git/checkouts/prek-5d0019c4f3435dba/83d1700/.git/refs/heads/master
  cargo:rustc-env=PREK_COMMIT_HASH=83d170020a940e9d7db3b82a6f23326f0d9f6d6a
  cargo:rustc-env=PREK_COMMIT_SHORT_HASH=83d170020
  cargo:rustc-env=PREK_COMMIT_DATE=2025-09-12
  cargo:rustc-env=PREK_LAST_TAG_DISTANCE=0

  --- stderr

  thread 'main' panicked at build.rs:97:35:
  called `Option::unwrap()` on a `None` value
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I am fixing it by using quotes. I also removed that unwrap and made it use if let so I can also install it from my fork.
I did check that all usages of `PREK_LAST_TAG` use options.