### PR TITLE
fix: support py38 for pygrep

### DIFF
--- a/src/languages/pygrep/script.py
+++ b/src/languages/pygrep/script.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import io
 import re


### PR DESCRIPTION
Running pygrep hooks right now with a python 3.8 project interpreter results in the following error:
```
error: Failed to run hook `spdx-licensing`
  caused by: Python script failed with exit code 1: Traceback (most recent call last):
  File "/home/qt/.cache/prek/cache/python/.tmppzuhsu", line 12, in <module>
    filename: str, pattern: Pattern[bytes], multiline: bool, negate: bool, queue: Queue
TypeError: 'type' object is not subscriptable
```
### The problem

re.Pattern was not made subscriptable until python 3.9

### The solution

Make the pygrep file runnable on python 3.8 for pygrep.

In the future it may be benefical to support setting the language_version for pygrep as well, as there are differences in the varying versions of pygrep: https://docs.python.org/3/library/re.html#module-re