### PR TITLE
Fix typo in language-version to language_version

### DIFF
--- a/docs/diff.md
+++ b/docs/diff.md
@@ -6,7 +6,7 @@
 - `prek` implements some common hooks from `pre-commit-hooks` in Rust for better performance.
 - `prek` uses `~/.cache/prek` as the default cache directory for repos, environments and toolchains.
 - `prek` decoupled hook environment from their repositories, allowing shared toolchains and environments across hooks.
-- `prek` supports `language-version` as a semver specifier and automatically installs the required toolchains.
+- `prek` supports `language_version` as a semver specifier and automatically installs the required toolchains.
 
 ## Workspace mode
 


### PR DESCRIPTION
Checking the pre-commit documentation and the source code of prek will reveal that this is named language_version rather than language-version. 

It's a tiny nit but a little confusing otherwise