### PR TITLE
docs(readme): add 'pre-commit-crocodile' to 'prek' users

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ prek is pretty new, but it is already being used or recommend by some projects a
 - [basedpyright](https://github.com/DetachHead/basedpyright/pull/1413)
 - [OpenLineage](https://github.com/OpenLineage/OpenLineage/pull/3965)
 - [Authlib](https://github.com/authlib/authlib/pull/804)
+- [pre-commit-crocodile](https://radiandevcore.gitlab.io/tools/pre-commit-crocodile/)
 
 ## Installation
 


### PR DESCRIPTION
Documentation : https://radiandevcore.gitlab.io/tools/pre-commit-crocodile/

Issues :
* https://gitlab.com/RadianDevCore/tools/pre-commit-crocodile/-/issues/12
* https://gitlab.com/RadianDevCore/tools/pre-commit-crocodile/-/issues/13

With `prek auto-update` being now implemented, I'm migrating to `prek` by default for version 8.0.0,
and will request my coworkers to use it by default if not already :wink: .

Thanks @j178 !