### PR TITLE
fix(run): resolve 'git --no-pager diff' syntax upon failures

### DIFF
--- a/src/cli/run/run.rs
+++ b/src/cli/run/run.rs
@@ -522,8 +522,8 @@ async fn run_hooks(
             "--color=never"
         };
         git::git_cmd("git diff")?
-            .arg("diff")
             .arg("--no-pager")
+            .arg("diff")
             .arg("--no-ext-diff")
             .arg(color)
             .arg("--")


### PR DESCRIPTION
```yaml
All changes made by hooks:
error: invalid option: --no-pager
usage: git diff [<options>] [<commit>] [--] [<path>...]
   or: git diff [<options>] --cached [--merge-base] [<commit>] [--] [<path>...]
   or: git diff [<options>] [--merge-base] <commit> [<commit>...] <commit> [--] [<path>...]
   or: git diff [<options>] <commit>...<commit> [--] [<path>...]
   or: git diff [<options>] <blob> <blob>
   or: git diff [<options>] --no-index [--] <path> <path>
common diff options:
```