### PR TITLE
Update Changelog URL to use 'master' branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 
 [project.urls]
 Repository = "https://github.com/j178/prek"
-Changelog = "https://github.com/j178/prek/blob/main/CHANGELOG.md"
+Changelog = "https://github.com/j178/prek/blob/master/CHANGELOG.md"
 Releases = "https://github.com/j178/prek/releases"
 
 [build-system]


### PR DESCRIPTION
deadlink on the PyPI releases metadata