### PR TITLE
Fix interpreter identification

### DIFF
--- a/src/identify.rs
+++ b/src/identify.rs
@@ -1010,5 +1010,8 @@ mod tests {
 
         let tags = super::tags_from_interpreter("sh");
         assert_eq!(tags, vec!["shell", "sh"]);
+
+        let tags = super::tags_from_interpreter("invalid");
+        assert_eq!(tags, Vec::<&str>::new());
     }
 }


### PR DESCRIPTION
Fixes interpreter identification. For example, a file without extension with the shebang `#!/usr/bin/env sh` is not being identified as a Shell script.

See https://github.com/mondeja/prek-interpreter-identify-bug repository and the next GHA run for reproduction: https://github.com/mondeja/prek-interpreter-identify-bug/actions/runs/18036744469/job/51325321188