### PR TITLE
Add a security policy for reporting vulnerabilities

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+To report a vulnerability in prek, [open a private vulnerability report](https://github.com/j178/prek/security/advisories/new) and you can create a patch on a private fork or, after reporting the problem, our maintainers will fix it as soon as possible.


### PR DESCRIPTION
Following from https://github.com/j178/prek-action/pull/19

It would be great to have the security policy prepared for the prek repository as well.

### Why it matters

Security policies and proper handling of CVEs encourage security researchers to scan the project, because their work will be properly attributed. This leads to increased project visibility and high-quality reviews by independent, specialized peers, which in turn improves the overall quality of the code.
