### PR TITLE
Allow run `--files` with zero args

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -402,7 +402,7 @@ pub(crate) struct RunArgs {
     #[arg(
         long,
         conflicts_with_all = ["all_files", "from_ref", "to_ref"],
-        num_args = 1..,
+        num_args = 0..,
         value_hint = ValueHint::AnyPath)
     ]
     pub(crate) files: Vec<String>,

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -1335,7 +1335,7 @@ fn run_multiple_files() -> Result<()> {
     cwd.child("file1.txt").write_str("Hello, world!")?;
     cwd.child("file2.txt").write_str("Hello, world!")?;
     context.git_add(".");
-    // multiple `--files`
+    // `--files` with multiple files
     cmd_snapshot!(context.filters(), context.run().arg("--files").arg("file1.txt").arg("file2.txt"), @r#"
     success: true
     exit_code: 0
@@ -1348,6 +1348,36 @@ fn run_multiple_files() -> Result<()> {
     ----- stderr -----
     "#);
     Ok(())
+}
+
+/// Test `prek run --files` with no files.
+#[test]
+fn run_no_files() {
+    let context = TestContext::new();
+    context.init_project();
+    context.write_pre_commit_config(indoc::indoc! {r"
+        repos:
+          - repo: local
+            hooks:
+              - id: no-files
+                name: no-files
+                language: system
+                entry: echo
+                verbose: true
+    "});
+    context.git_add(".");
+    // `--files` with no files
+    cmd_snapshot!(context.filters(), context.run().arg("--files"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    no-files.................................................................Passed
+    - hook id: no-files
+    - duration: [TIME]
+      .pre-commit-config.yaml
+
+    ----- stderr -----
+    "#);
 }
 
 /// Test `prek run --directory` flags.


### PR DESCRIPTION
Related to #828

Sorry to bother you! I just remembered that the `nargs='*'` used in `pre-commit` corresponds to clap's `num_args = 0..`, which allows passing an empty argument sequence.

In my use case I collect the list of changed files for each PR using `git diff --name-only --diff-filter=ACMR` (for very large repos like [PaddlePaddle/Paddle](https://github.com/PaddlePaddle/Paddle) it's impractical to run full checks on every PR), and then pass that list to `prek run --files`. If a PR only deletes files, an empty list may be passed to `prek run --files`, which would cause an error.

Sorry for the earlier oversight — I should have noticed this from your reply.