### PR TITLE
Fix autoupdate `rev` rendering for "float-like" version numbers

### DIFF
--- a/src/cli/auto_update.rs
+++ b/src/cli/auto_update.rs
@@ -397,14 +397,6 @@ async fn write_new_config(path: &Path, revisions: &[Option<Revision>]) -> Result
             .expect("Invalid regex")
             .expect("Failed to capture revision line");
 
-        // TODO: preserve the quote style
-        // Naively add the original quotes
-        let new_rev = if !caps[3].is_empty() && !new_rev.contains(&caps[3]) {
-            format!("{}{}{}", &caps[3], new_rev.trim(), &caps[3])
-        } else {
-            new_rev.trim().to_string()
-        };
-
         let comment = if let Some(frozen) = &revision.frozen {
             format!("  # frozen: {frozen}")
         } else if caps[5].trim().starts_with("# frozen:") {


### PR DESCRIPTION
A version number could look like a float, e.g., 0.49 is a valid version number. Serde YAML serialization already renders such version numbers in quotes so types match the expectation. When doing an autoupdate we were explicitly adding more quotes if they were present in the input. This could have caused incorrect quoting if existing quoting clashed with serde's quoting style, e.g., if `"` where used but serde defaulted to quoting with `'`.

This patch removes any extra quoting here and fully defers to serde.

Closes #866.