### PR TITLE
Bump version to 0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## 0.2.6
+## 0.2.7
 
 Released on 2025-10-14.
+
+*This is a re-release of 0.2.6 that fixes an issue where publishing to npmjs.com failed.*
 
 ### Enhancements
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "prek"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anstream",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ tracing = { version = "0.1.40" }
 
 [package]
 name = "prek"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["j178 <hi@j178.dev>"]
 description = "Better `pre-commit`, re-engineered in Rust"
 repository = { workspace = true }

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ On Linux and macOS:
 
 <!-- linux-standalone-install:start -->
 ```bash
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/j178/prek/releases/download/v0.2.6/prek-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/j178/prek/releases/download/v0.2.7/prek-installer.sh | sh
 ```
 <!-- linux-standalone-install:end -->
 
@@ -116,7 +116,7 @@ On Windows:
 
 <!-- windows-standalone-install:start -->
 ```powershell
-powershell -ExecutionPolicy ByPass -c "irm https://github.com/j178/prek/releases/download/v0.2.6/prek-installer.ps1 | iex"
+powershell -ExecutionPolicy ByPass -c "irm https://github.com/j178/prek/releases/download/v0.2.7/prek-installer.ps1 | iex"
 ```
 <!-- windows-standalone-install:end -->
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prek"
-version = "0.2.6"
+version = "0.2.7"
 description = "Better `pre-commit`, re-engineered in Rust"
 authors = [{ name = "j178", email = "hi@j178.dev" }]
 requires-python = ">=3.8"


### PR DESCRIPTION
0.2.6 release failed, due to npm publish failed, try to re-release.