### PR TITLE
Add package metadata for cargo-binstall

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,18 @@ pretty_assertions = { version = "1.4.1" }
 regex = { version = "1.11.0" }
 tempfile = { version = "3.13.0" }
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }{ archive-suffix }"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-fmt = "zip"
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.zip"
+
+[package.metadata.binstall.overrides.aarch64-pc-windows-msvc]
+pkg-fmt = "zip"
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.zip"
+
 [package.metadata.cargo-shear]
 ignored = ["liblzma"]
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,19 @@ mise use prek
 </details>
 
 <details>
+<summary>Cargo binstall</summary>
+
+<!-- cargo-binstall:start -->
+Install pre-compiled binaries from GitHub using Cargo binstall (Rust 1.89+ is required):
+
+```bash
+cargo binstall prek --git https://github.com/j178/prek
+```
+<!-- cargo-binstall:end -->
+
+</details>
+
+<details>
 <summary>Cargo</summary>
 
 <!-- cargo-install:start -->

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -72,6 +72,14 @@ The standalone installer automatically downloads and installs the correct binary
   end="<!-- conda-forge-install:end -->"
 %}
 
+### Install from Pre-Built Binaries
+
+{%
+  include-markdown "../README.md"
+  start="<!-- cargo-binstall:start -->"
+  end="<!-- cargo-binstall:end -->"
+%}
+
 ## Build from Source
 
 {%


### PR DESCRIPTION
- Closes #881

Looks like it works :-)

```sh
cargo binstall --manifest-path prek/Cargo.toml --dry-run prek
```

```
 INFO resolve: Resolving package: 'prek'
 WARN The package prek v0.2.8 (x86_64-unknown-linux-gnu) has been downloaded from github.com
 INFO This will install the following binaries:
 INFO   - prek => /home/louis/.cargo/bin/prek
 INFO Dry-run: Not proceeding to install fetched binaries
 INFO Done in 2.404082213s
```

I've also updated the installation docs:
- mention cargo binstall installation method
- amend outdated Rust version in regular Cargo installation docs (the [rust-toolchain TOML](https://github.com/j178/prek/blob/master/rust-toolchain.toml) now specifies 1.90 not 1.89)