### PR TITLE
feat(debug-statements): implement builtin hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "attribute-derive"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05832cdddc8f2650cc2cc187cc2e952b8c133a48eb055f35211f61ee81502d77"
+dependencies = [
+ "attribute-derive-macro",
+ "derive-where",
+ "manyhow",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "attribute-derive-macro"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7cdbbd4bd005c5d3e2e9c885e6fa575db4f4a3572335b974d8db853b6beb61"
+dependencies = [
+ "collection_literals",
+ "interpolator",
+ "manyhow",
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+ "quote-use",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +381,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,10 +467,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "collection_literals"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2550f75b8cfac212855f6b1885455df8eaee8fe8e246b647d69146142e016084"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "compression-codecs"
@@ -544,6 +603,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -849,6 +919,38 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "get-size-derive2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3814abc7da8ab18d2fd820f5b540b5e39b6af0a32de1bdd7c47576693074843"
+dependencies = [
+ "attribute-derive",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "get-size2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfe2cec5b5ce8fb94dcdb16a1708baa4d0609cc3ce305ca5d3f6f2ffb59baed"
+dependencies = [
+ "compact_str",
+ "get-size-derive2",
+ "hashbrown",
+ "smallvec",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1282,6 +1384,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "interpolator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,6 +1403,18 @@ checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is-macro"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57a3e447e24c22647738e4607f1df1e0ec6f72e16182c4cd199f647cdfb0e4"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1439,6 +1559,29 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "manyhow"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b33efb3ca6d3b07393750d4030418d594ab1139cee518f0dc88db70fec873587"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fce34d199b78b6e6073abf984c9cf5fd3e9330145a93ee0738a7443e371495"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "markdown"
@@ -1635,6 +1778,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1790,10 +1971,12 @@ dependencies = [
  "pretty_assertions",
  "pty",
  "quick-xml 0.38.3",
- "rand",
+ "rand 0.9.2",
  "rayon",
  "regex",
  "reqwest",
+ "ruff_python_ast",
+ "ruff_python_parser",
  "rustc-hash",
  "same-file",
  "semver",
@@ -1825,6 +2008,17 @@ checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
  "yansi",
+]
+
+[[package]]
+name = "proc-macro-utils"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeaf08a13de400bc215877b5bdc088f241b12eb42f0a548d3390dc1c56bb7071"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
 ]
 
 [[package]]
@@ -1909,7 +2103,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1945,6 +2139,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "quote-use"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9619db1197b497a36178cfc736dc96b271fe918875fbf1344c436a7e93d0321e"
+dependencies = [
+ "quote",
+ "quote-use-macros",
+]
+
+[[package]]
+name = "quote-use-macros"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82ebfb7faafadc06a7ab141a6f67bcfb24cb8beb158c6fe933f2f035afa99f35"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1952,12 +2168,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1967,7 +2204,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -2100,6 +2346,73 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ruff_python_ast"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff/?rev=591e9bbccbc4b876cef2a23931581efaeb10a50f#591e9bbccbc4b876cef2a23931581efaeb10a50f"
+dependencies = [
+ "aho-corasick",
+ "bitflags 2.9.4",
+ "compact_str",
+ "get-size2",
+ "is-macro",
+ "itertools",
+ "memchr",
+ "ruff_python_trivia",
+ "ruff_source_file",
+ "ruff_text_size",
+ "rustc-hash",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "ruff_python_parser"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff/?rev=591e9bbccbc4b876cef2a23931581efaeb10a50f#591e9bbccbc4b876cef2a23931581efaeb10a50f"
+dependencies = [
+ "bitflags 2.9.4",
+ "bstr",
+ "compact_str",
+ "get-size2",
+ "memchr",
+ "ruff_python_ast",
+ "ruff_python_trivia",
+ "ruff_text_size",
+ "rustc-hash",
+ "static_assertions",
+ "unicode-ident",
+ "unicode-normalization",
+ "unicode_names2",
+]
+
+[[package]]
+name = "ruff_python_trivia"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff/?rev=591e9bbccbc4b876cef2a23931581efaeb10a50f#591e9bbccbc4b876cef2a23931581efaeb10a50f"
+dependencies = [
+ "itertools",
+ "ruff_source_file",
+ "ruff_text_size",
+ "unicode-ident",
+]
+
+[[package]]
+name = "ruff_source_file"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff/?rev=591e9bbccbc4b876cef2a23931581efaeb10a50f#591e9bbccbc4b876cef2a23931581efaeb10a50f"
+dependencies = [
+ "memchr",
+ "ruff_text_size",
+]
+
+[[package]]
+name = "ruff_text_size"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff/?rev=591e9bbccbc4b876cef2a23931581efaeb10a50f#591e9bbccbc4b876cef2a23931581efaeb10a50f"
+dependencies = [
+ "get-size2",
 ]
 
 [[package]]
@@ -2345,6 +2658,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2399,6 +2718,12 @@ dependencies = [
  "psm",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str_stack"
@@ -2825,6 +3150,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2835,6 +3169,28 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode_names2"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1673eca9782c84de5f81b82e4109dcfb3611c8ba0d52930ec4a9478f547b2dd"
+dependencies = [
+ "phf",
+ "unicode_names2_generator",
+]
+
+[[package]]
+name = "unicode_names2_generator"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91e5b84611016120197efd7dc93ef76774f4e084cd73c9fb3ea4a86c570c56e"
+dependencies = [
+ "getopts",
+ "log",
+ "phf_codegen",
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "unit-prefix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,8 @@ quick-xml = { version = "0.38" }
 rand = { version = "0.9.0" }
 rayon = { version = "1.10.0" }
 reqwest = { version = "0.12.9", default-features = false, features = ["http2", "stream", "json", "rustls-tls-webpki-roots"] }
+ruff_python_ast = { git = "https://github.com/astral-sh/ruff/", rev = "591e9bbccbc4b876cef2a23931581efaeb10a50f" }
+ruff_python_parser = { git = "https://github.com/astral-sh/ruff/", rev = "591e9bbccbc4b876cef2a23931581efaeb10a50f" }
 rustc-hash = { version = "2.1.1" }
 same-file = { version = "1.0.6" }
 semver = { version = "1.0.24", features = ["serde"] }

--- a/src/builtin/pre_commit_hooks/debug_statements.rs
+++ b/src/builtin/pre_commit_hooks/debug_statements.rs
@@ -1,0 +1,411 @@
+use std::fmt::Write;
+use std::path::Path;
+
+use anyhow::Result;
+use futures::StreamExt;
+use ruff_python_ast::visitor::Visitor;
+use ruff_python_ast::{Expr, Stmt};
+use ruff_python_parser::parse_module;
+use rustc_hash::FxHashSet;
+
+use crate::hook::Hook;
+use crate::run::CONCURRENCY;
+
+const DEBUG_STATEMENTS: &[&str] = &[
+    "bpdb",
+    "ipdb",
+    "pdb",
+    "pdbr",
+    "pudb",
+    "pydevd_pycharm",
+    "q",
+    "rdb",
+    "rpdb",
+    "wdb",
+];
+
+#[derive(Debug)]
+struct DebugInfo {
+    line: usize,
+    col: usize,
+    name: String,
+    reason: String,
+}
+
+struct DebugStatementVisitor<'a> {
+    breakpoints: Vec<DebugInfo>,
+    debug_set: FxHashSet<String>,
+    source: &'a str,
+}
+
+impl<'a> DebugStatementVisitor<'a> {
+    fn new(source: &'a str) -> Self {
+        Self {
+            breakpoints: Vec::new(),
+            debug_set: DEBUG_STATEMENTS.iter().map(|s| (*s).to_string()).collect(),
+            source,
+        }
+    }
+
+    fn get_line_col(&self, offset: usize) -> (usize, usize) {
+        let mut line = 1;
+        let mut col = 0;
+
+        for (i, ch) in self.source.bytes().enumerate() {
+            if i == offset {
+                break;
+            }
+            if ch == b'\n' {
+                line += 1;
+                col = 0;
+            } else {
+                col += 1;
+            }
+        }
+
+        (line, col)
+    }
+}
+
+impl Visitor<'_> for DebugStatementVisitor<'_> {
+    fn visit_stmt(&mut self, stmt: &Stmt) {
+        match stmt {
+            Stmt::Import(import) => {
+                for alias in &import.names {
+                    if self.debug_set.contains(alias.name.as_str()) {
+                        let (line, col) = self.get_line_col(import.range.start().to_usize());
+                        self.breakpoints.push(DebugInfo {
+                            line,
+                            col,
+                            name: alias.name.to_string(),
+                            reason: "imported".to_string(),
+                        });
+                    }
+                }
+            }
+            Stmt::ImportFrom(import_from) => {
+                if let Some(module) = &import_from.module {
+                    if self.debug_set.contains(module.as_str()) {
+                        let (line, col) = self.get_line_col(import_from.range.start().to_usize());
+                        self.breakpoints.push(DebugInfo {
+                            line,
+                            col,
+                            name: module.to_string(),
+                            reason: "imported".to_string(),
+                        });
+                    }
+                }
+            }
+            _ => {}
+        }
+        ruff_python_ast::visitor::walk_stmt(self, stmt);
+    }
+
+    fn visit_expr(&mut self, expr: &Expr) {
+        if let Expr::Call(call) = expr {
+            if let Expr::Name(name) = call.func.as_ref() {
+                if name.id.as_str() == "breakpoint" {
+                    let (line, col) = self.get_line_col(call.range.start().to_usize());
+                    self.breakpoints.push(DebugInfo {
+                        line,
+                        col,
+                        name: "breakpoint".to_string(),
+                        reason: "called".to_string(),
+                    });
+                }
+            }
+        }
+        ruff_python_ast::visitor::walk_expr(self, expr);
+    }
+}
+
+pub(crate) async fn debug_statements(hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
+    let mut tasks = futures::stream::iter(filenames)
+        .map(async |filename| check_file(hook.project().relative_path(), filename).await)
+        .buffered(*CONCURRENCY);
+
+    let mut code = 0;
+    let mut output = Vec::new();
+
+    while let Some(result) = tasks.next().await {
+        let (c, o) = result?;
+        code |= c;
+        output.extend(o);
+    }
+
+    Ok((code, output))
+}
+
+async fn check_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)> {
+    let content = fs_err::tokio::read_to_string(file_base.join(filename)).await?;
+
+    let parse_result = parse_module(&content);
+
+    let module = match parse_result {
+        Ok(parsed) => {
+            if !parsed.errors().is_empty() {
+                let mut error_output = format!("{} - Could not parse ast\n\n", filename.display());
+                for error in parsed.errors() {
+                    let _ = writeln!(error_output, "\t{error}");
+                }
+                error_output.push('\n');
+                return Ok((1, error_output.into_bytes()));
+            }
+            parsed.into_syntax()
+        }
+        Err(e) => {
+            let error_message = format!(
+                "{} - Could not parse ast\n\n\t{}\n\n",
+                filename.display(),
+                e
+            );
+            return Ok((1, error_message.into_bytes()));
+        }
+    };
+
+    let mut visitor = DebugStatementVisitor::new(&content);
+    visitor.visit_body(&module.body);
+
+    let mut output = Vec::new();
+    for bp in &visitor.breakpoints {
+        let line = format!(
+            "{}:{}:{}: {} {}\n",
+            filename.display(),
+            bp.line,
+            bp.col,
+            bp.name,
+            bp.reason
+        );
+        output.extend(line.into_bytes());
+    }
+
+    let code = i32::from(!visitor.breakpoints.is_empty());
+
+    Ok((code, output))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    async fn create_test_file(
+        dir: &tempfile::TempDir,
+        name: &str,
+        content: &str,
+    ) -> Result<PathBuf> {
+        let file_path = dir.path().join(name);
+        fs_err::tokio::write(&file_path, content).await?;
+        Ok(file_path)
+    }
+
+    #[tokio::test]
+    async fn test_no_debug_statements() -> Result<()> {
+        let dir = tempdir()?;
+        let content = r#"
+def hello():
+    print("Hello, world!")
+"#;
+        let file_path = create_test_file(&dir, "clean.py", content).await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 0);
+        assert!(output.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_import_pdb() -> Result<()> {
+        let dir = tempdir()?;
+        let content = r"
+import pdb
+
+def debug_func():
+    x = 1
+";
+        let file_path = create_test_file(&dir, "debug.py", content).await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 1);
+        let output_str = String::from_utf8_lossy(&output);
+        assert!(output_str.contains("pdb imported"));
+        assert!(output_str.contains("debug.py:2:"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_import_ipdb() -> Result<()> {
+        let dir = tempdir()?;
+        let content = r"
+import ipdb
+import sys
+";
+        let file_path = create_test_file(&dir, "debug.py", content).await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 1);
+        let output_str = String::from_utf8_lossy(&output);
+        assert!(output_str.contains("ipdb imported"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_from_import() -> Result<()> {
+        let dir = tempdir()?;
+        let content = r"
+from pdb import set_trace
+";
+        let file_path = create_test_file(&dir, "debug.py", content).await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 1);
+        let output_str = String::from_utf8_lossy(&output);
+        assert!(output_str.contains("pdb imported"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_breakpoint_call() -> Result<()> {
+        let dir = tempdir()?;
+        let content = r"
+def debug_func():
+    x = 1
+    breakpoint()
+    return x
+";
+        let file_path = create_test_file(&dir, "debug.py", content).await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 1);
+        let output_str = String::from_utf8_lossy(&output);
+        assert!(output_str.contains("breakpoint called"));
+        assert!(output_str.contains("debug.py:4:"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_multiple_debug_statements() -> Result<()> {
+        let dir = tempdir()?;
+        let content = r"
+import pdb
+import ipdb
+
+def debug_func():
+    breakpoint()
+    x = 1
+";
+        let file_path = create_test_file(&dir, "debug.py", content).await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 1);
+        let output_str = String::from_utf8_lossy(&output);
+        assert!(output_str.contains("pdb imported"));
+        assert!(output_str.contains("ipdb imported"));
+        assert!(output_str.contains("breakpoint called"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_pudb_import() -> Result<()> {
+        let dir = tempdir()?;
+        let content = r"
+import pudb
+";
+        let file_path = create_test_file(&dir, "debug.py", content).await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 1);
+        let output_str = String::from_utf8_lossy(&output);
+        assert!(output_str.contains("pudb imported"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_syntax_error() -> Result<()> {
+        let dir = tempdir()?;
+        let content = r#"
+def broken(
+    print("syntax error")
+"#;
+        let file_path = create_test_file(&dir, "broken.py", content).await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 1);
+        let output_str = String::from_utf8_lossy(&output);
+        assert!(output_str.contains("Could not parse ast"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_multiple_imports_same_line() -> Result<()> {
+        let dir = tempdir()?;
+        let content = r"
+import pdb, ipdb, sys
+";
+        let file_path = create_test_file(&dir, "debug.py", content).await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 1);
+        let output_str = String::from_utf8_lossy(&output);
+        assert!(output_str.contains("pdb imported"));
+        assert!(output_str.contains("ipdb imported"));
+        // Should not contain sys
+        assert!(!output_str.contains("sys imported"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_breakpoint_in_expression() -> Result<()> {
+        let dir = tempdir()?;
+        let content = r#"
+result = breakpoint() or "default"
+"#;
+        let file_path = create_test_file(&dir, "debug.py", content).await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 1);
+        let output_str = String::from_utf8_lossy(&output);
+        assert!(output_str.contains("breakpoint called"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_no_false_positive_breakpoint_string() -> Result<()> {
+        let dir = tempdir()?;
+        let content = r#"
+# This should not trigger
+message = "breakpoint"
+def breakpoint_func():
+    pass
+"#;
+        let file_path = create_test_file(&dir, "clean.py", content).await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 0);
+        assert!(output.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_all_debug_modules() -> Result<()> {
+        let dir = tempdir()?;
+        let content = r"
+import bpdb
+import ipdb
+import pdb
+import pdbr
+import pudb
+import pydevd_pycharm
+import q
+import rdb
+import rpdb
+import wdb
+";
+        let file_path = create_test_file(&dir, "all_debug.py", content).await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 1);
+        let output_str = String::from_utf8_lossy(&output);
+        // Check that all debug modules are detected
+        assert!(output_str.contains("bpdb imported"));
+        assert!(output_str.contains("ipdb imported"));
+        assert!(output_str.contains("pdb imported"));
+        assert!(output_str.contains("pdbr imported"));
+        assert!(output_str.contains("pudb imported"));
+        assert!(output_str.contains("pydevd_pycharm imported"));
+        assert!(output_str.contains("q imported"));
+        assert!(output_str.contains("rdb imported"));
+        assert!(output_str.contains("rpdb imported"));
+        assert!(output_str.contains("wdb imported"));
+        Ok(())
+    }
+}

--- a/src/builtin/pre_commit_hooks/mod.rs
+++ b/src/builtin/pre_commit_hooks/mod.rs
@@ -13,6 +13,7 @@ mod check_symlinks;
 mod check_toml;
 mod check_xml;
 mod check_yaml;
+mod debug_statements;
 mod detect_private_key;
 mod fix_byte_order_marker;
 mod fix_end_of_file;
@@ -22,6 +23,7 @@ mod mixed_line_ending;
 pub(crate) enum Implemented {
     TrailingWhitespace,
     CheckAddedLargeFiles,
+    DebugStatements,
     EndOfFileFixer,
     FixByteOrderMarker,
     CheckJson,
@@ -41,6 +43,7 @@ impl FromStr for Implemented {
         match s {
             "trailing-whitespace" => Ok(Self::TrailingWhitespace),
             "check-added-large-files" => Ok(Self::CheckAddedLargeFiles),
+            "debug-statements" => Ok(Self::DebugStatements),
             "end-of-file-fixer" => Ok(Self::EndOfFileFixer),
             "fix-byte-order-marker" => Ok(Self::FixByteOrderMarker),
             "check-json" => Ok(Self::CheckJson),
@@ -74,6 +77,7 @@ impl Implemented {
             Self::CheckAddedLargeFiles => {
                 check_added_large_files::check_added_large_files(hook, filenames).await
             }
+            Self::DebugStatements => debug_statements::debug_statements(hook, filenames).await,
             Self::EndOfFileFixer => fix_end_of_file::fix_end_of_file(hook, filenames).await,
             Self::FixByteOrderMarker => {
                 fix_byte_order_marker::fix_byte_order_marker(hook, filenames).await


### PR DESCRIPTION
## Description

Following discussion in #880 and initial bug report in #872 (where found prek slower than pre-commit for the `debug-statements` hook in particular, which can be fixed by giving it a Rust port), this PR contributes such a "fast path" hook.

This is a popular hook with 5,000+ repos using it [on grep.app](https://github.com/j178/prek/issues/880#issuecomment-3402811333)

Like #884 this one uses the `ruff_python_parser` crate from ruff to parse the AST and then its closely related crate `ruff_python_ast` to access nodes.

- [x] The extra crate increased compilation time by 3%, from 21.7s to 22.4s (and I would expect this to be negligible difference to the change introduced by `ruff_python_parser` alone in the `check-ast` hook PR in #884)
- [x] Unit test and snapshot test coverage added

[Binary Size Change](https://github.com/j178/prek/actions/runs/18629115264/job/53111276775#step:9:356)
+8.75% (.text: 16.0 MiB → 17.4 MiB)

## Demo

Taking the top hit on grep.app, [wandb/wandb](https://github.com/wandb/wandb/blob/main/.pre-commit-config.yaml)

```sh
gh repo clone wandb/wandb
```

and running the latest release of prek and pre-commit, the `debug-statements` hook runs 26% slower than pre-commit's:

```sh
louis 🌟 ~/tmp/wandb $ pre-commit run -a --verbose
check-toml...............................................................Passed
- hook id: check-toml
- duration: 0.04s
debug-statements.........................................................Passed
- hook id: debug-statements
- duration: 0.19s
louis 🌟 ~/tmp/wandb $ prek run -a --verbose
check-toml...............................................................Passed
- hook id: check-toml
- duration: 0.00s
debug-statements.........................................................Passed
- hook id: debug-statements
- duration: 0.24s
```

After installing this local feature branch, it runs 2x as fast :tada:

```sh
louis 🌟 ~/tmp/wandb $ prek run -a --verbose
check-toml...............................................................Passed
- hook id: check-toml
- duration: 0.00s
debug-statements.........................................................Passed
- hook id: debug-statements
- duration: 0.10s
```