### PR TITLE
feat(check-builtin-literals): implement builtin hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "attribute-derive"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05832cdddc8f2650cc2cc187cc2e952b8c133a48eb055f35211f61ee81502d77"
+dependencies = [
+ "attribute-derive-macro",
+ "derive-where",
+ "manyhow",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "attribute-derive-macro"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7cdbbd4bd005c5d3e2e9c885e6fa575db4f4a3572335b974d8db853b6beb61"
+dependencies = [
+ "collection_literals",
+ "interpolator",
+ "manyhow",
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+ "quote-use",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +381,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,10 +467,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "collection_literals"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2550f75b8cfac212855f6b1885455df8eaee8fe8e246b647d69146142e016084"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "compression-codecs"
@@ -544,6 +603,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -849,6 +919,38 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "get-size-derive2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3814abc7da8ab18d2fd820f5b540b5e39b6af0a32de1bdd7c47576693074843"
+dependencies = [
+ "attribute-derive",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "get-size2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfe2cec5b5ce8fb94dcdb16a1708baa4d0609cc3ce305ca5d3f6f2ffb59baed"
+dependencies = [
+ "compact_str",
+ "get-size-derive2",
+ "hashbrown",
+ "smallvec",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1282,6 +1384,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "interpolator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,6 +1403,18 @@ checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is-macro"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57a3e447e24c22647738e4607f1df1e0ec6f72e16182c4cd199f647cdfb0e4"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1439,6 +1559,29 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "manyhow"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b33efb3ca6d3b07393750d4030418d594ab1139cee518f0dc88db70fec873587"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fce34d199b78b6e6073abf984c9cf5fd3e9330145a93ee0738a7443e371495"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "markdown"
@@ -1635,6 +1778,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1790,10 +1971,12 @@ dependencies = [
  "pretty_assertions",
  "pty",
  "quick-xml 0.38.3",
- "rand",
+ "rand 0.9.2",
  "rayon",
  "regex",
  "reqwest",
+ "ruff_python_ast",
+ "ruff_python_parser",
  "rustc-hash",
  "same-file",
  "semver",
@@ -1825,6 +2008,17 @@ checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
  "yansi",
+]
+
+[[package]]
+name = "proc-macro-utils"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeaf08a13de400bc215877b5bdc088f241b12eb42f0a548d3390dc1c56bb7071"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
 ]
 
 [[package]]
@@ -1909,7 +2103,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1945,6 +2139,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "quote-use"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9619db1197b497a36178cfc736dc96b271fe918875fbf1344c436a7e93d0321e"
+dependencies = [
+ "quote",
+ "quote-use-macros",
+]
+
+[[package]]
+name = "quote-use-macros"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82ebfb7faafadc06a7ab141a6f67bcfb24cb8beb158c6fe933f2f035afa99f35"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1952,12 +2168,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1967,7 +2204,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -2100,6 +2346,73 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ruff_python_ast"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff/?rev=591e9bbccbc4b876cef2a23931581efaeb10a50f#591e9bbccbc4b876cef2a23931581efaeb10a50f"
+dependencies = [
+ "aho-corasick",
+ "bitflags 2.9.4",
+ "compact_str",
+ "get-size2",
+ "is-macro",
+ "itertools",
+ "memchr",
+ "ruff_python_trivia",
+ "ruff_source_file",
+ "ruff_text_size",
+ "rustc-hash",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "ruff_python_parser"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff/?rev=591e9bbccbc4b876cef2a23931581efaeb10a50f#591e9bbccbc4b876cef2a23931581efaeb10a50f"
+dependencies = [
+ "bitflags 2.9.4",
+ "bstr",
+ "compact_str",
+ "get-size2",
+ "memchr",
+ "ruff_python_ast",
+ "ruff_python_trivia",
+ "ruff_text_size",
+ "rustc-hash",
+ "static_assertions",
+ "unicode-ident",
+ "unicode-normalization",
+ "unicode_names2",
+]
+
+[[package]]
+name = "ruff_python_trivia"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff/?rev=591e9bbccbc4b876cef2a23931581efaeb10a50f#591e9bbccbc4b876cef2a23931581efaeb10a50f"
+dependencies = [
+ "itertools",
+ "ruff_source_file",
+ "ruff_text_size",
+ "unicode-ident",
+]
+
+[[package]]
+name = "ruff_source_file"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff/?rev=591e9bbccbc4b876cef2a23931581efaeb10a50f#591e9bbccbc4b876cef2a23931581efaeb10a50f"
+dependencies = [
+ "memchr",
+ "ruff_text_size",
+]
+
+[[package]]
+name = "ruff_text_size"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff/?rev=591e9bbccbc4b876cef2a23931581efaeb10a50f#591e9bbccbc4b876cef2a23931581efaeb10a50f"
+dependencies = [
+ "get-size2",
 ]
 
 [[package]]
@@ -2345,6 +2658,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2399,6 +2718,12 @@ dependencies = [
  "psm",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str_stack"
@@ -2825,6 +3150,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2835,6 +3169,28 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode_names2"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1673eca9782c84de5f81b82e4109dcfb3611c8ba0d52930ec4a9478f547b2dd"
+dependencies = [
+ "phf",
+ "unicode_names2_generator",
+]
+
+[[package]]
+name = "unicode_names2_generator"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91e5b84611016120197efd7dc93ef76774f4e084cd73c9fb3ea4a86c570c56e"
+dependencies = [
+ "getopts",
+ "log",
+ "phf_codegen",
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "unit-prefix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,8 @@ quick-xml = { version = "0.38" }
 rand = { version = "0.9.0" }
 rayon = { version = "1.10.0" }
 reqwest = { version = "0.12.9", default-features = false, features = ["http2", "stream", "json", "rustls-tls-webpki-roots"] }
+ruff_python_ast = { git = "https://github.com/astral-sh/ruff/", rev = "591e9bbccbc4b876cef2a23931581efaeb10a50f" }
+ruff_python_parser = { git = "https://github.com/astral-sh/ruff/", rev = "591e9bbccbc4b876cef2a23931581efaeb10a50f" }
 rustc-hash = { version = "2.1.1" }
 same-file = { version = "1.0.6" }
 semver = { version = "1.0.24", features = ["serde"] }

--- a/src/builtin/pre_commit_hooks/check_builtin_literals.rs
+++ b/src/builtin/pre_commit_hooks/check_builtin_literals.rs
@@ -1,0 +1,401 @@
+use std::fmt::Write;
+use std::path::Path;
+
+use anyhow::Result;
+use clap::Parser;
+use futures::StreamExt;
+use ruff_python_ast::Expr;
+use ruff_python_ast::visitor::Visitor;
+use ruff_python_parser::parse_module;
+use rustc_hash::FxHashSet;
+
+use crate::hook::Hook;
+use crate::run::CONCURRENCY;
+
+const BUILTIN_TYPES: &[(&str, &str)] = &[
+    ("complex", "0j"),
+    ("dict", "{}"),
+    ("float", "0.0"),
+    ("int", "0"),
+    ("list", "[]"),
+    ("str", "''"),
+    ("tuple", "()"),
+];
+
+#[derive(Parser)]
+#[command(disable_help_subcommand = true)]
+#[command(disable_version_flag = true)]
+#[command(disable_help_flag = true)]
+struct Args {
+    #[arg(long, value_delimiter = ',')]
+    ignore: Vec<String>,
+    #[arg(long, default_value = "true", action = clap::ArgAction::SetTrue)]
+    allow_dict_kwargs: bool,
+    #[arg(long = "no-allow-dict-kwargs", action = clap::ArgAction::SetFalse)]
+    no_allow_dict_kwargs: bool,
+}
+
+#[derive(Debug)]
+struct Call {
+    name: String,
+    line: usize,
+    col: usize,
+}
+
+struct BuiltinLiteralsVisitor<'a> {
+    calls: Vec<Call>,
+    ignore: FxHashSet<String>,
+    allow_dict_kwargs: bool,
+    builtin_types: FxHashSet<String>,
+    source: &'a str,
+}
+
+impl<'a> BuiltinLiteralsVisitor<'a> {
+    fn new(source: &'a str, ignore: FxHashSet<String>, allow_dict_kwargs: bool) -> Self {
+        let builtin_types = BUILTIN_TYPES
+            .iter()
+            .map(|(name, _)| (*name).to_string())
+            .collect();
+
+        Self {
+            calls: Vec::new(),
+            ignore,
+            allow_dict_kwargs,
+            builtin_types,
+            source,
+        }
+    }
+
+    fn get_line_col(&self, offset: usize) -> (usize, usize) {
+        let mut line = 1;
+        let mut col = 0;
+
+        for (i, ch) in self.source.bytes().enumerate() {
+            if i == offset {
+                break;
+            }
+            if ch == b'\n' {
+                line += 1;
+                col = 0;
+            } else {
+                col += 1;
+            }
+        }
+
+        (line, col)
+    }
+}
+
+impl Visitor<'_> for BuiltinLiteralsVisitor<'_> {
+    fn visit_expr(&mut self, expr: &Expr) {
+        if let Expr::Call(call) = expr {
+            // Only check if func is a simple Name (not an attribute like foo.bar())
+            if let Expr::Name(name) = call.func.as_ref() {
+                let func_name = name.id.as_str();
+
+                // Check if it's a builtin type we care about
+                if self.builtin_types.contains(func_name) && !self.ignore.contains(func_name) {
+                    // Special handling for dict() with kwargs
+                    if func_name == "dict"
+                        && self.allow_dict_kwargs
+                        && !call.arguments.keywords.is_empty()
+                    {
+                        // Allow dict(foo=bar)
+                    } else if call.arguments.args.is_empty() && call.arguments.keywords.is_empty() {
+                        // Empty call like list() or dict()
+                        let (line, col) = self.get_line_col(call.range.start().to_usize());
+                        self.calls.push(Call {
+                            name: func_name.to_string(),
+                            line,
+                            col,
+                        });
+                    }
+                }
+            }
+        }
+        ruff_python_ast::visitor::walk_expr(self, expr);
+    }
+}
+
+pub(crate) async fn check_builtin_literals(
+    hook: &Hook,
+    filenames: &[&Path],
+) -> Result<(i32, Vec<u8>)> {
+    let args = Args::try_parse_from(hook.entry.resolve(None)?.iter().chain(&hook.args))?;
+
+    let ignore: FxHashSet<String> = args.ignore.into_iter().collect();
+    let allow_dict_kwargs = if args.no_allow_dict_kwargs {
+        false
+    } else {
+        args.allow_dict_kwargs
+    };
+
+    let mut tasks = futures::stream::iter(filenames)
+        .map(|filename| {
+            let ignore = ignore.clone();
+            async move {
+                check_file(
+                    hook.project().relative_path(),
+                    filename,
+                    &ignore,
+                    allow_dict_kwargs,
+                )
+                .await
+            }
+        })
+        .buffered(*CONCURRENCY);
+
+    let mut code = 0;
+    let mut output = Vec::new();
+
+    while let Some(result) = tasks.next().await {
+        let (c, o) = result?;
+        code |= c;
+        output.extend(o);
+    }
+
+    Ok((code, output))
+}
+
+async fn check_file(
+    file_base: &Path,
+    filename: &Path,
+    ignore: &FxHashSet<String>,
+    allow_dict_kwargs: bool,
+) -> Result<(i32, Vec<u8>)> {
+    let content = fs_err::tokio::read_to_string(file_base.join(filename)).await?;
+
+    let parse_result = parse_module(&content);
+
+    let module = match parse_result {
+        Ok(parsed) => {
+            if !parsed.errors().is_empty() {
+                let mut error_output = format!("{} - Could not parse ast\n\n", filename.display());
+                for error in parsed.errors() {
+                    let _ = writeln!(error_output, "\t{error}");
+                }
+                error_output.push('\n');
+                return Ok((1, error_output.into_bytes()));
+            }
+            parsed.into_syntax()
+        }
+        Err(e) => {
+            let error_message = format!(
+                "{} - Could not parse ast\n\n\t{}\n\n",
+                filename.display(),
+                e
+            );
+            return Ok((1, error_message.into_bytes()));
+        }
+    };
+
+    let mut visitor = BuiltinLiteralsVisitor::new(&content, ignore.clone(), allow_dict_kwargs);
+    visitor.visit_body(&module.body);
+
+    let mut output = Vec::new();
+    for call in &visitor.calls {
+        let replacement = BUILTIN_TYPES
+            .iter()
+            .find(|(name, _)| *name == call.name)
+            .map(|(_, repl)| *repl)
+            .unwrap_or("");
+
+        let line = format!(
+            "{}:{}:{}: replace {}() with {}\n",
+            filename.display(),
+            call.line,
+            call.col,
+            call.name,
+            replacement
+        );
+        output.extend(line.into_bytes());
+    }
+
+    let code = i32::from(!visitor.calls.is_empty());
+
+    Ok((code, output))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    async fn create_test_file(
+        dir: &tempfile::TempDir,
+        name: &str,
+        content: &str,
+    ) -> Result<PathBuf> {
+        let file_path = dir.path().join(name);
+        fs_err::tokio::write(&file_path, content).await?;
+        Ok(file_path)
+    }
+
+    #[tokio::test]
+    async fn test_no_builtin_calls() -> Result<()> {
+        let dir = tempdir()?;
+        let content = r"
+x = [1, 2, 3]
+y = {'key': 'value'}
+z = 'string'
+";
+        let file_path = create_test_file(&dir, "clean.py", content).await?;
+        let ignore = FxHashSet::default();
+        let (code, output) = check_file(Path::new(""), &file_path, &ignore, true).await?;
+        assert_eq!(code, 0);
+        assert!(output.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_empty_list_call() -> Result<()> {
+        let dir = tempdir()?;
+        let content = r"
+x = list()
+";
+        let file_path = create_test_file(&dir, "test.py", content).await?;
+        let ignore = FxHashSet::default();
+        let (code, output) = check_file(Path::new(""), &file_path, &ignore, true).await?;
+        assert_eq!(code, 1);
+        let output_str = String::from_utf8_lossy(&output);
+        assert!(output_str.contains("replace list() with []"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_empty_dict_call() -> Result<()> {
+        let dir = tempdir()?;
+        let content = r"
+x = dict()
+";
+        let file_path = create_test_file(&dir, "test.py", content).await?;
+        let ignore = FxHashSet::default();
+        let (code, output) = check_file(Path::new(""), &file_path, &ignore, true).await?;
+        assert_eq!(code, 1);
+        let output_str = String::from_utf8_lossy(&output);
+        assert!(output_str.contains("replace dict() with {}"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dict_with_kwargs_allowed() -> Result<()> {
+        let dir = tempdir()?;
+        let content = r"
+x = dict(foo='bar')
+";
+        let file_path = create_test_file(&dir, "test.py", content).await?;
+        let ignore = FxHashSet::default();
+        let (code, output) = check_file(Path::new(""), &file_path, &ignore, true).await?;
+        assert_eq!(code, 0);
+        assert!(output.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dict_with_kwargs_not_allowed() -> Result<()> {
+        let dir = tempdir()?;
+        let content = r"
+x = dict(foo='bar')
+";
+        let file_path = create_test_file(&dir, "test.py", content).await?;
+        let ignore = FxHashSet::default();
+        let (code, output) = check_file(Path::new(""), &file_path, &ignore, false).await?;
+        assert_eq!(code, 0); // Should still be 0 because it has arguments
+        assert!(output.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_list_with_args() -> Result<()> {
+        let dir = tempdir()?;
+        let content = r"
+x = list([1, 2, 3])
+";
+        let file_path = create_test_file(&dir, "test.py", content).await?;
+        let ignore = FxHashSet::default();
+        let (code, output) = check_file(Path::new(""), &file_path, &ignore, true).await?;
+        assert_eq!(code, 0);
+        assert!(output.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_multiple_builtin_calls() -> Result<()> {
+        let dir = tempdir()?;
+        let content = r"
+x = list()
+y = dict()
+z = tuple()
+";
+        let file_path = create_test_file(&dir, "test.py", content).await?;
+        let ignore = FxHashSet::default();
+        let (code, output) = check_file(Path::new(""), &file_path, &ignore, true).await?;
+        assert_eq!(code, 1);
+        let output_str = String::from_utf8_lossy(&output);
+        assert!(output_str.contains("replace list() with []"));
+        assert!(output_str.contains("replace dict() with {}"));
+        assert!(output_str.contains("replace tuple() with ()"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_ignore_specific_type() -> Result<()> {
+        let dir = tempdir()?;
+        let content = r"
+x = list()
+y = dict()
+";
+        let file_path = create_test_file(&dir, "test.py", content).await?;
+        let mut ignore = FxHashSet::default();
+        ignore.insert("list".to_string());
+        let (code, output) = check_file(Path::new(""), &file_path, &ignore, true).await?;
+        assert_eq!(code, 1);
+        let output_str = String::from_utf8_lossy(&output);
+        assert!(!output_str.contains("list"));
+        assert!(output_str.contains("replace dict() with {}"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_attribute_call_ignored() -> Result<()> {
+        let dir = tempdir()?;
+        let content = r"
+x = builtins.list()
+y = foo.dict()
+";
+        let file_path = create_test_file(&dir, "test.py", content).await?;
+        let ignore = FxHashSet::default();
+        let (code, output) = check_file(Path::new(""), &file_path, &ignore, true).await?;
+        assert_eq!(code, 0);
+        assert!(output.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_all_builtin_types() -> Result<()> {
+        let dir = tempdir()?;
+        let content = r"
+a = complex()
+b = dict()
+c = float()
+d = int()
+e = list()
+f = str()
+g = tuple()
+";
+        let file_path = create_test_file(&dir, "test.py", content).await?;
+        let ignore = FxHashSet::default();
+        let (code, output) = check_file(Path::new(""), &file_path, &ignore, true).await?;
+        assert_eq!(code, 1);
+        let output_str = String::from_utf8_lossy(&output);
+        assert!(output_str.contains("replace complex() with 0j"));
+        assert!(output_str.contains("replace dict() with {}"));
+        assert!(output_str.contains("replace float() with 0.0"));
+        assert!(output_str.contains("replace int() with 0"));
+        assert!(output_str.contains("replace list() with []"));
+        assert!(output_str.contains("replace str() with ''"));
+        assert!(output_str.contains("replace tuple() with ()"));
+        Ok(())
+    }
+}

--- a/src/builtin/pre_commit_hooks/mod.rs
+++ b/src/builtin/pre_commit_hooks/mod.rs
@@ -7,6 +7,7 @@ use tracing::debug;
 use crate::hook::Hook;
 
 mod check_added_large_files;
+mod check_builtin_literals;
 mod check_json;
 mod check_merge_conflict;
 mod check_symlinks;
@@ -22,6 +23,7 @@ mod mixed_line_ending;
 pub(crate) enum Implemented {
     TrailingWhitespace,
     CheckAddedLargeFiles,
+    CheckBuiltinLiterals,
     EndOfFileFixer,
     FixByteOrderMarker,
     CheckJson,
@@ -41,6 +43,7 @@ impl FromStr for Implemented {
         match s {
             "trailing-whitespace" => Ok(Self::TrailingWhitespace),
             "check-added-large-files" => Ok(Self::CheckAddedLargeFiles),
+            "check-builtin-literals" => Ok(Self::CheckBuiltinLiterals),
             "end-of-file-fixer" => Ok(Self::EndOfFileFixer),
             "fix-byte-order-marker" => Ok(Self::FixByteOrderMarker),
             "check-json" => Ok(Self::CheckJson),
@@ -73,6 +76,9 @@ impl Implemented {
             }
             Self::CheckAddedLargeFiles => {
                 check_added_large_files::check_added_large_files(hook, filenames).await
+            }
+            Self::CheckBuiltinLiterals => {
+                check_builtin_literals::check_builtin_literals(hook, filenames).await
             }
             Self::EndOfFileFixer => fix_end_of_file::fix_end_of_file(hook, filenames).await,
             Self::FixByteOrderMarker => {


### PR DESCRIPTION
## Description

I picked this from the checklist of builtin hooks to support in #880 because Apache Airflow is using it, and it's the slowest unported running one of their hooks now.

This hook catches unnecessary builtin type constructor calls and suggests replacing them with their literal equivalents (`list()` to `[]` etc.).

[Binary Size Change](https://github.com/j178/prek/actions/runs/18629086575/job/53111218049#step:9:356)
+9.38% (.text: 16.0 MiB → 17.5 MiB)

## Demo

Running this on `apache/airflow` (who use prek!) takes quite a long time for a hook:

```sh
louis 🌟 ~/tmp/airflow $ prek run -a --config .pre-commit-config.yaml --verbose
Require literal syntax when initializing builtins........................Passed
- hook id: check-builtin-literals
- duration: 0.70s
```

pre-commit is about the same speed (4% faster)

```sh
louis 🌟 ~/tmp/airflow $ pre-commit run -a --config .pre-commit-config.yaml --verbose                                                                                                                               
[WARNING] Unexpected key(s) present at root: minimum_prek_version                                         
Check that merge conflicts are not being committed.......................Passed                           
- hook id: check-merge-conflict                      
- duration: 0.08s                                    
Detect accidentally committed debug statements...........................Passed                           
- hook id: debug-statements                          
- duration: 0.79s                                    
Require literal syntax when initializing builtins........................Passed                           
- hook id: check-builtin-literals                    
- duration: 0.67s        
```

With prek installed from this feature branch, it runs in exactly the same amount of time! And also fails!

```sh
louis 🌟 ~/tmp/airflow $ cargo install --path ~/dev/prek 2>/dev/null
```

```sh
louis 🌟 ~/tmp/airflow $ prek run -a --config .pre-commit-config.yaml --verbose
Require literal syntax when initializing builtins........................Failed
- hook id: check-builtin-literals
- duration: 0.60s
- exit code: 1
  airflow-core/tests/unit/serialization/test_serde.py:97:45: replace list() with []
  airflow-core/tests/unit/utils/test_db_cleanup.py:91:25: replace dict() with {}
  airflow-core/tests/unit/utils/test_db_cleanup.py:115:25: replace dict() with {}
  providers/google/tests/unit/google/cloud/sensors/test_dataproc_metastore.py:111:48: replace dict() with {}
  providers/google/tests/unit/google/cloud/sensors/test_dataproc_metastore.py:111:56: replace list() with []
  providers/google/tests/unit/google/cloud/sensors/test_dataproc_metastore.py:111:64: replace tuple() with ()
  airflow-core/tests/unit/dag_processing/test_collection.py:371:69: replace dict() with {}
  airflow-core/tests/unit/dag_processing/test_collection.py:470:65: replace dict() with {}
  airflow-core/tests/unit/dag_processing/test_collection.py:583:65: replace dict() with {}
  airflow-core/tests/unit/dag_processing/test_collection.py:613:65: replace dict() with {}
  providers/apache/cassandra/tests/unit/apache/cassandra/sensors/test_record.py:38:29: replace dict() with {}
  providers/apache/cassandra/tests/unit/apache/cassandra/sensors/test_record.py:53:29: replace dict() with {}
  providers/apache/cassandra/tests/unit/apache/cassandra/sensors/test_record.py:70:29: replace dict() with {}
  providers/google/tests/unit/google/cloud/transfers/test_sql_to_gcs.py:119:42: replace dict() with {}
  providers/google/tests/unit/google/cloud/transfers/test_sql_to_gcs.py:174:42: replace dict() with {}
  providers/google/tests/unit/google/cloud/transfers/test_sql_to_gcs.py:218:42: replace dict() with {}
  providers/google/tests/unit/google/cloud/transfers/test_sql_to_gcs.py:262:42: replace dict() with {}
  providers/google/tests/unit/google/cloud/transfers/test_sql_to_gcs.py:307:42: replace dict() with {}
  providers/google/tests/unit/google/cloud/transfers/test_sql_to_gcs.py:369:42: replace dict() with {}
  providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_pod_generator.py:748:25: replace dict() with {}
  providers/apache/cassandra/tests/unit/apache/cassandra/sensors/test_table.py:37:29: replace dict() with {}
  providers/apache/cassandra/tests/unit/apache/cassandra/sensors/test_table.py:53:29: replace dict() with {}
  providers/apache/cassandra/tests/unit/apache/cassandra/sensors/test_table.py:67:29: replace dict() with {}
  task-sdk/tests/task_sdk/bases/test_operator.py:881:12: replace dict() with {}
  providers/amazon/src/airflow/providers/amazon/aws/executors/ecs/ecs_executor_config.py:52:17: replace dict() with {}
  providers/amazon/src/airflow/providers/amazon/aws/executors/batch/batch_executor_config.py:48:74: replace dict() with {}
  providers/openlineage/tests/unit/openlineage/test_conf.py:267:11: replace dict() with {}
  providers/apache/hdfs/tests/unit/apache/hdfs/sensors/test_web_hdfs.py:39:29: replace dict() with {}
  providers/apache/hdfs/tests/unit/apache/hdfs/sensors/test_web_hdfs.py:55:29: replace dict() with {}
  providers/apache/hdfs/tests/unit/apache/hdfs/sensors/test_web_hdfs.py:75:29: replace dict() with {}
  providers/apache/hdfs/tests/unit/apache/hdfs/sensors/test_web_hdfs.py:93:29: replace dict() with {}
  dev/breeze/tests/test_selective_checks.py:1173:18: replace tuple() with ()
  providers/amazon/tests/unit/amazon/aws/sensors/test_s3.py:558:36: replace dict() with {}
  providers/amazon/tests/unit/amazon/aws/sensors/test_s3.py:560:36: replace dict() with {}
  providers/amazon/tests/unit/amazon/aws/sensors/test_s3.py:562:32: replace dict() with {}
```

I was confused why this gives different results, but they don't look wrong. In fact they seem to have just been missed by the Python version!

These are all valid hits:

```sh
louis 🌟 ~/tmp/airflow $ rg 'dict\(\)' airflow-core/tests/unit/utils/test_db_cleanup.py
91:            pytest.param(dict(), True, id="not supplied"),
115:            pytest.param(dict(), False, id="not supplied"),
louis 🌟 ~/tmp/airflow $ rg 'dict\(\)' airflow-core/tests/unit/dag_processing/test_collection.py
371:            update_dag_parsing_results_in_db("testing", None, [dag], dict(), None, set(), session)
470:        update_dag_parsing_results_in_db("testing", None, [dag], dict(), parse_duration, set(), session)
583:        update_dag_parsing_results_in_db("testing", None, [dag], dict(), None, set(), session)
613:        update_dag_parsing_results_in_db("testing", None, [dag], dict(), None, set(), session)
```

As well as finding more hits, the Rust version finishes 15% faster, in just 0.60s :tada: