### PR TITLE
Implement `check-symlinks` as builtin hook

### DIFF
--- a/src/builtin/pre_commit_hooks/check_symlinks.rs
+++ b/src/builtin/pre_commit_hooks/check_symlinks.rs
@@ -1,0 +1,166 @@
+use std::path::Path;
+
+use anyhow::Result;
+use futures::StreamExt;
+
+use crate::hook::Hook;
+use crate::run::CONCURRENCY;
+
+pub(crate) async fn check_symlinks(hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
+    let mut tasks = futures::stream::iter(filenames)
+        .map(|filename| check_file(hook.project().relative_path(), filename))
+        .buffered(*CONCURRENCY);
+
+    let mut code = 0;
+    let mut output = Vec::new();
+
+    while let Some(result) = tasks.next().await {
+        let (c, o) = result?;
+        code |= c;
+        output.extend(o);
+    }
+
+    Ok((code, output))
+}
+
+#[allow(clippy::unused_async)]
+async fn check_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)> {
+    let path = file_base.join(filename);
+
+    // Check if it's a symlink and if it's broken
+    if path.is_symlink() && !path.exists() {
+        let error_message = format!("{}: Broken symlink\n", filename.display());
+        return Ok((1, error_message.into_bytes()));
+    }
+
+    Ok((0, Vec::new()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    async fn create_test_file(
+        dir: &tempfile::TempDir,
+        name: &str,
+        content: &[u8],
+    ) -> Result<PathBuf> {
+        let file_path = dir.path().join(name);
+        fs_err::tokio::write(&file_path, content).await?;
+        Ok(file_path)
+    }
+
+    #[tokio::test]
+    async fn test_regular_file() -> Result<()> {
+        let dir = tempdir()?;
+        let content = b"regular file content";
+        let file_path = create_test_file(&dir, "regular.txt", content).await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 0);
+        assert!(output.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn test_valid_symlink_unix() -> Result<()> {
+        let dir = tempdir()?;
+        let target = create_test_file(&dir, "target.txt", b"content").await?;
+        let link_path = dir.path().join("link.txt");
+        tokio::fs::symlink(&target, &link_path).await?;
+
+        let (code, output) = check_file(Path::new(""), &link_path).await?;
+        assert_eq!(code, 0);
+        assert!(output.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn test_broken_symlink_unix() -> Result<()> {
+        let dir = tempdir()?;
+        let link_path = dir.path().join("broken_link.txt");
+        let nonexistent = dir.path().join("nonexistent.txt");
+        tokio::fs::symlink(&nonexistent, &link_path).await?;
+
+        let (code, output) = check_file(Path::new(""), &link_path).await?;
+        assert_eq!(code, 1);
+        assert!(!output.is_empty());
+        let output_str = String::from_utf8_lossy(&output);
+        assert!(output_str.contains("Broken symlink"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[cfg(windows)]
+    async fn test_valid_symlink_windows() -> Result<()> {
+        let dir = tempdir()?;
+        let target = create_test_file(&dir, "target.txt", b"content").await?;
+        let link_path = dir.path().join("link.txt");
+
+        // Windows requires different APIs for file vs directory symlinks
+        tokio::fs::symlink_file(&target, &link_path).await?;
+
+        let (code, output) = check_file(Path::new(""), &link_path).await?;
+        assert_eq!(code, 0);
+        assert!(output.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[cfg(windows)]
+    async fn test_broken_symlink_windows() -> Result<()> {
+        let dir = tempdir()?;
+        let link_path = dir.path().join("broken_link.txt");
+        let nonexistent = dir.path().join("nonexistent.txt");
+
+        // On Windows, symlink creation might require admin privileges
+        // If this fails in CI, the test will be skipped
+        if tokio::fs::symlink_file(&nonexistent, &link_path)
+            .await
+            .is_err()
+        {
+            // Skipping test: insufficient permissions for symlink creation on Windows
+            return Ok(());
+        }
+
+        let (code, output) = check_file(Path::new(""), &link_path).await?;
+        assert_eq!(code, 1);
+        assert!(!output.is_empty());
+        let output_str = String::from_utf8_lossy(&output);
+        assert!(output_str.contains("Broken symlink"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[cfg(target_os = "macos")]
+    async fn test_valid_symlink_macos() -> Result<()> {
+        let dir = tempdir()?;
+        let target = create_test_file(&dir, "target.txt", b"content").await?;
+        let link_path = dir.path().join("link.txt");
+        tokio::fs::symlink(&target, &link_path).await?;
+
+        let (code, output) = check_file(Path::new(""), &link_path).await?;
+        assert_eq!(code, 0);
+        assert!(output.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[cfg(target_os = "macos")]
+    async fn test_broken_symlink_macos() -> Result<()> {
+        let dir = tempdir()?;
+        let link_path = dir.path().join("broken_link.txt");
+        let nonexistent = dir.path().join("nonexistent.txt");
+        tokio::fs::symlink(&nonexistent, &link_path).await?;
+
+        let (code, output) = check_file(Path::new(""), &link_path).await?;
+        assert_eq!(code, 1);
+        assert!(!output.is_empty());
+        let output_str = String::from_utf8_lossy(&output);
+        assert!(output_str.contains("Broken symlink"));
+        Ok(())
+    }
+}

--- a/src/builtin/pre_commit_hooks/mod.rs
+++ b/src/builtin/pre_commit_hooks/mod.rs
@@ -8,6 +8,7 @@ use crate::hook::Hook;
 
 mod check_added_large_files;
 mod check_json;
+mod check_symlinks;
 mod check_toml;
 mod check_yaml;
 mod fix_byte_order_marker;
@@ -21,6 +22,7 @@ pub(crate) enum Implemented {
     EndOfFileFixer,
     FixByteOrderMarker,
     CheckJson,
+    CheckSymlinks,
     CheckToml,
     CheckYaml,
     MixedLineEnding,
@@ -37,6 +39,7 @@ impl FromStr for Implemented {
             "fix-byte-order-marker" => Ok(Self::FixByteOrderMarker),
             "check-json" => Ok(Self::CheckJson),
             "check-toml" => Ok(Self::CheckToml),
+            "check-symlinks" => Ok(Self::CheckSymlinks),
             "check-yaml" => Ok(Self::CheckYaml),
             "mixed-line-ending" => Ok(Self::MixedLineEnding),
             _ => Err(()),
@@ -67,6 +70,7 @@ impl Implemented {
                 fix_byte_order_marker::fix_byte_order_marker(hook, filenames).await
             }
             Self::CheckJson => check_json::check_json(hook, filenames).await,
+            Self::CheckSymlinks => check_symlinks::check_symlinks(hook, filenames).await,
             Self::CheckToml => check_toml::check_toml(hook, filenames).await,
             Self::CheckYaml => check_yaml::check_yaml(hook, filenames).await,
             Self::MixedLineEnding => mixed_line_ending::mixed_line_ending(hook, filenames).await,


### PR DESCRIPTION
## Description

Following #880 this is a fairly widely used hook (2.8k hits on grep.app), and is a reimplementation of this very simple Python hook: [check_symlinks.py](https://github.com/pre-commit/pre-commit-hooks/blob/main/pre_commit_hooks/check_symlinks.py)

I've added what I expect the snapshot tests to be but have to wait for them to run on CI (if the tests are run on a system without the admin privileges to make symlinks on Windows, the test exits).

- [x] No new dependencies
- [x] Unit and snapshot test coverage

## Demo

A repo which uses this is [wandb/wandb](https://github.com/wandb/wandb), so I can demo its speedup there.

```sh
louis 🌟 ~/tmp/wandb $ pre-commit run -a --verbose
check-symlinks...........................................................Passed
- hook id: check-symlinks
- duration: 0.02s
louis 🌟 ~/tmp/wandb $ prek run -a --verbose
check-symlinks...........................................................Passed
- hook id: check-symlinks
- duration: 0.04s
```

Before using this feature branch it's 2x slower than pre-commit

```sh
louis 🌟 ~/tmp/wandb $ prek run -a --verbose
check-symlinks...........................................................Passed
- hook id: check-symlinks
- duration: 0.00s
```

After using this feature branch it runs in an instant :tada: