### PR TITLE
fix: Add pre-commit copyright line to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) 2014 pre-commit dev team: Anthony Sottile, Ken Struys
 Copyright (c) 2024 j178
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
- via #904

Include the original pre-commit copyright to comply with MIT license requirements for derivative works.