### PR TITLE
perf: monitor binary size change in PRs via cargo-bloat workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,15 +133,14 @@ jobs:
                   raise ValueError("Could not find .text section size")
               value, unit = float(match.group(1)), match.group(2)
               multipliers = {'B': 1, 'KiB': 1024, 'MiB': 1024**2, 'GiB': 1024**3, 'TiB': 1024**4}
-              return value * multipliers.get(unit, 1)
+              size = value * multipliers.get(unit, 1)
+              return size, f"{value} {unit}"
 
           pr_text = Path('bloat_pr.txt').read_text()
           base_text = Path('bloat_base.txt').read_text()
 
-          pr_bytes = parse_size(pr_text)
-          base_bytes = parse_size(base_text)
-          pr_size = re.search(r'([\d.]+\s*[KMGT]i?B)', pr_text).group(1)
-          base_size = re.search(r'([\d.]+\s*[KMGT]i?B)', base_text).group(1)
+          pr_bytes, pr_size = parse_size(pr_text)
+          base_bytes, base_size = parse_size(base_text)
 
           pct_change = ((pr_bytes - base_bytes) / base_bytes) * 100
           pct_display = f"{pct_change:+.2f}%"


### PR DESCRIPTION
- As discussed in #917 

Cargo bloat workflow to show the binary size change for PRs in the form of a "Checks" status line

> I came up with a way that shows it in the PR via a check "status" line, see [demo](https://github.com/lmmx/cargo-bloat-action-demo/pull/1) PR and [workflow source](https://github.com/lmmx/cargo-bloat-action-demo/blob/master/.github/workflows/bloat.yml)
> 
> <img width="1523" height="716" alt="Image" src="https://github.com/user-attachments/assets/69c245ce-f529-4ae0-8f98-3d87c0d9a2dd" /> 

 _Originally posted by @lmmx in [#917](https://github.com/j178/prek/issues/917#issuecomment-3418562809)_

I tried it with a status like this, (to save you having to click through to read the result) but it looks like that won't be allowed to run on forks (i.e. only j178's own PRs to this repo would have it, everyone else's would error) so I removed that and now you have to click through to the step summary to see it:

(...)

To see the result you click through to the step summary where it shows up as an "annotation" at the top and a full report below

- [x] Added mold linker and caching so (initial run took 5m)
- [x] Removed check status line (fails for PRs from other repos)
- [x] Rewrote size change calculation in Python