### PR TITLE
Add git tagged executables when on Windows

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -252,6 +252,16 @@ impl TestContext {
             .success();
     }
 
+    pub fn add_file_as_git_executable(&self, path: impl AsRef<OsStr>) {
+        Command::new("git")
+            .arg("add")
+            .arg("--chmod=+x")
+            .arg(path)
+            .current_dir(&self.temp_dir)
+            .assert()
+            .success();
+    }
+
     /// Run `git add`.
     pub fn git_add(&self, path: impl AsRef<OsStr>) {
         Command::new("git")


### PR DESCRIPTION
Closes: https://github.com/j178/prek/issues/928

Adds all files in windows that have been commited as executable using either `git update-index --chmod=-x path/to/file` or `git add --chmod=+x path/to/file`. 

@j178 Not sure whether the test positioning is correct