### PR TITLE
Allow reqwest to use system tls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,6 +484,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpp_demangle"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,6 +745,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1049,6 +1080,22 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1533,6 +1580,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1609,6 +1673,50 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "openssl"
+version = "0.10.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ad14dd45412269e1a30f52ad8f0664f0f4f4a89ee8fe28c3b3527021ebb654"
+dependencies = [
+ "bitflags 2.9.4",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.110"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a9f0075ba3c21b09f8e8b2026584b1d18d49388648f2fbbf3c97ea8deced8e2"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "owo-colors"
@@ -2053,9 +2161,11 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2066,6 +2176,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -2184,10 +2295,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.9.4",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "self-replace"
@@ -2620,6 +2763,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2893,6 +3046,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,10 +39,20 @@ anstream = { version = "0.6.15" }
 anyhow = { version = "1.0.86" }
 astral-tokio-tar = { version = "0.5.1" }
 async-compression = { version = "0.4.18", features = ["gzip", "xz", "tokio"] }
-async_zip = { git = "https://github.com/astral-sh/rs-async-zip", rev = "c909fda63fcafe4af496a07bfda28a5aae97e58d", features = ["deflate", "tokio"] }
-axoupdater = { version = "0.9.0", default-features = false, features = [ "github_releases"], optional = true }
+async_zip = { git = "https://github.com/astral-sh/rs-async-zip", rev = "c909fda63fcafe4af496a07bfda28a5aae97e58d", features = [
+  "deflate",
+  "tokio",
+] }
+axoupdater = { version = "0.9.0", default-features = false, features = [
+  "github_releases",
+], optional = true }
 bstr = { version = "1.11.0" }
-clap = { version = "4.5.16", features = ["derive", "env", "string", "wrap_help"] }
+clap = { version = "4.5.16", features = [
+  "derive",
+  "env",
+  "string",
+  "wrap_help",
+] }
 clap_complete = { version = "4.5.37", features = ["unstable-dynamic"] }
 constants = { workspace = true }
 ctrlc = { version = "3.4.5" }
@@ -67,7 +77,13 @@ path-clean = { version = "1.0.1" }
 quick-xml = { version = "0.38" }
 rand = { version = "0.9.0" }
 rayon = { version = "1.10.0" }
-reqwest = { version = "0.12.9", default-features = false, features = ["http2", "stream", "json", "rustls-tls-webpki-roots"] }
+reqwest = { version = "0.12.9", default-features = false, features = [
+  "http2",
+  "stream",
+  "json",
+  "rustls-tls-webpki-roots",
+  "native-tls",
+] }
 rustc-hash = { version = "2.1.1" }
 same-file = { version = "1.0.6" }
 semver = { version = "1.0.24", features = ["serde"] }
@@ -81,9 +97,20 @@ target-lexicon = { version = "0.13.0" }
 tempfile = { version = "3.13.0" }
 textwrap = { version = "0.16.1" }
 thiserror = { version = "2.0.11" }
-tokio = { version = "1.47.1", features = ["fs", "process", "rt", "sync", "macros"] }
+tokio = { version = "1.47.1", features = [
+  "fs",
+  "process",
+  "rt",
+  "sync",
+  "macros",
+] }
 tokio-util = { version = "0.7.13" }
-toml = { version = "0.9.5", default-features = false, features = ["fast_hash", "parse", "preserve_order", "serde"] }
+toml = { version = "0.9.5", default-features = false, features = [
+  "fast_hash",
+  "parse",
+  "preserve_order",
+  "serde",
+] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 unicode-width = { version = "0.2.0" }
@@ -167,7 +194,7 @@ jod = "jod"
 
 [profile.bench]
 opt-level = 3
-debug = true # used by the profiler
+debug = true  # used by the profiler
 strip = false # keep symbols for the profiler
 
 [profile.release]

--- a/lib/constants/src/env_vars.rs
+++ b/lib/constants/src/env_vars.rs
@@ -18,6 +18,7 @@ impl EnvVars {
     pub const PREK_NO_CONCURRENCY: &'static str = "PREK_NO_CONCURRENCY";
     pub const PREK_NO_FAST_PATH: &'static str = "PREK_NO_FAST_PATH";
     pub const PREK_UV_SOURCE: &'static str = "PREK_UV_SOURCE";
+    pub const PREK_REQWEST_SYSTEM_TLS: &'static str = "PREK_REQWEST_SYSTEM_TLS";
 
     // PREK internal environment variables
     pub const PREK_INTERNAL__TEST_DIR: &'static str = "PREK_INTERNAL__TEST_DIR";

--- a/src/languages/golang/installer.rs
+++ b/src/languages/golang/installer.rs
@@ -13,10 +13,10 @@ use tracing::{debug, trace, warn};
 
 use crate::fs::LockedFile;
 use crate::git;
-use crate::languages::download_and_extract;
 use crate::languages::golang::GoRequest;
 use crate::languages::golang::golang::bin_dir;
 use crate::languages::golang::version::GoVersion;
+use crate::languages::{create_reqwest_client, download_and_extract};
 use crate::process::Cmd;
 use crate::store::Store;
 
@@ -107,7 +107,7 @@ impl GoInstaller {
     pub(crate) fn new(root: PathBuf) -> Self {
         Self {
             root,
-            client: Client::new(),
+            client: create_reqwest_client(),
         }
     }
 

--- a/src/languages/node/installer.rs
+++ b/src/languages/node/installer.rs
@@ -13,9 +13,9 @@ use target_lexicon::{Architecture, HOST, OperatingSystem};
 use tracing::{debug, trace, warn};
 
 use crate::fs::LockedFile;
-use crate::languages::download_and_extract;
 use crate::languages::node::NodeRequest;
 use crate::languages::node::version::NodeVersion;
+use crate::languages::{create_reqwest_client, download_and_extract};
 use crate::process::Cmd;
 use crate::store::Store;
 
@@ -103,7 +103,7 @@ impl NodeInstaller {
     pub(crate) fn new(root: PathBuf) -> Self {
         Self {
             root,
-            client: Client::new(),
+            client: create_reqwest_client(),
         }
     }
 

--- a/src/languages/python/uv.rs
+++ b/src/languages/python/uv.rs
@@ -14,7 +14,7 @@ use tracing::{debug, trace, warn};
 use constants::env_vars::EnvVars;
 
 use crate::fs::LockedFile;
-use crate::languages::download_and_extract;
+use crate::languages::{create_reqwest_client, download_and_extract};
 use crate::process::Cmd;
 use crate::store::{CacheBucket, Store};
 use crate::version;
@@ -157,7 +157,7 @@ impl InstallSource {
             "https://github.com/astral-sh/uv/releases/download/{CUR_UV_VERSION}/{archive_name}"
         );
 
-        let client = reqwest::Client::new();
+        let client = create_reqwest_client();
         download_and_extract(
             &client,
             &download_url,
@@ -195,7 +195,7 @@ impl InstallSource {
         let wheel_name = format!("uv-{CUR_UV_VERSION}-py3-none-{platform_tag}.whl");
 
         // Use PyPI JSON API instead of parsing HTML
-        let client = reqwest::Client::new();
+        let client = create_reqwest_client();
         let api_url = match source {
             PyPiMirror::Pypi => format!("https://pypi.org/pypi/uv/{CUR_UV_VERSION}/json"),
             // For mirrors, we'll fall back to simple API approach
@@ -252,7 +252,7 @@ impl InstallSource {
         let wheel_name = format!("uv-{CUR_UV_VERSION}-py3-none-{platform_tag}.whl");
 
         let simple_url = format!("{}uv/", source.url());
-        let client = reqwest::Client::new();
+        let client = create_reqwest_client();
 
         debug!("Fetching from simple API: {}", simple_url);
         let response = client
@@ -441,7 +441,7 @@ impl Uv {
             Ok(best)
         }
 
-        let client = reqwest::Client::new();
+        let client = create_reqwest_client();
         let source = tokio::select! {
                 Ok(true) = check_github(&client) => InstallSource::GitHub,
                 Ok(source) = select_best_pypi(&client) => InstallSource::PyPi(source),


### PR DESCRIPTION
Trying to replace pre-commit with prek in a work environment where custom self signed certificates are required due to tls inspection, this PR adds an additional feature (native-tls) to the reqwest crate and additional environment variable PREK_REQWEST_SYSTEM_TLS, when this variable is set to true reqwest will use system trust store rather than the one packaged in rustls-tls-webpki-roots.  This allows the auto installation of UV, Node etc in an environment where custom trusted certificates are required for download.