### PR TITLE
Fix compatibility with older luarocks

### DIFF
--- a/src/languages/lua.rs
+++ b/src/languages/lua.rs
@@ -38,7 +38,7 @@ pub(crate) async fn query_lua_info() -> Result<LuaInfo> {
 
     let stdout = Cmd::new("luarocks", "get lua executable")
         .arg("config")
-        .arg("LUA")
+        .arg("variables.LUA")
         .check(true)
         .output()
         .await?


### PR DESCRIPTION
Closes #966 

Seems the `luarocks config LUA` usage is added in luarocks 3.12.2 in https://github.com/luarocks/luarocks/pull/1620