### PR TITLE
Refactor `identify` using smallvec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1829,6 +1829,7 @@ dependencies = [
  "serde_stacker",
  "serde_yaml",
  "shlex",
+ "smallvec",
  "target-lexicon",
  "tempfile",
  "textwrap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ serde_json = { version = "1.0.132", features = ["unbounded_depth"] }
 serde_stacker = { version = "0.1.12" }
 serde_yaml = { version = "0.9.34" }
 shlex = { version = "1.3.0" }
+smallvec = { version = "1.15.1" }
 target-lexicon = { version = "0.13.0" }
 tempfile = { version = "3.13.0" }
 textwrap = { version = "0.16.1" }

--- a/src/cli/run/filter.rs
+++ b/src/cli/run/filter.rs
@@ -13,7 +13,7 @@ use crate::config::Stage;
 use crate::fs::normalize_path;
 use crate::git::GIT_ROOT;
 use crate::hook::Hook;
-use crate::identify::tags_from_path;
+use crate::identify::{TagSet, tags_from_path};
 use crate::workspace::Project;
 use crate::{fs, git, warn_user};
 
@@ -66,18 +66,14 @@ impl<'a> FileTagFilter<'a> {
         }
     }
 
-    pub(crate) fn filter(&self, file_types: &[&str]) -> bool {
-        if !self.all.is_empty() && !self.all.iter().all(|t| file_types.contains(&t.as_str())) {
+    pub(crate) fn filter(&self, file_types: &TagSet) -> bool {
+        if !self.all.is_empty() && !self.all.iter().all(|t| file_types.contains(t.as_str())) {
             return false;
         }
-        if !self.any.is_empty() && !self.any.iter().any(|t| file_types.contains(&t.as_str())) {
+        if !self.any.is_empty() && !self.any.iter().any(|t| file_types.contains(t.as_str())) {
             return false;
         }
-        if self
-            .exclude
-            .iter()
-            .any(|t| file_types.contains(&t.as_str()))
-        {
+        if self.exclude.iter().any(|t| file_types.contains(t.as_str())) {
             return false;
         }
         true


### PR DESCRIPTION
```console
❯ hyperfine --warmup 3 'prek run -a trailing-whitespace' './target/release/prek run -a trailing-whitespace'
Benchmark 1: prek run -a trailing-whitespace
  Time (mean ± σ):      56.6 ms ±   7.8 ms    [User: 28.1 ms, System: 35.7 ms]
  Range (min … max):    48.0 ms …  73.0 ms    37 runs

Benchmark 2: ./target/release/prek run -a trailing-whitespace
  Time (mean ± σ):      51.0 ms ±   2.6 ms    [User: 28.1 ms, System: 35.3 ms]
  Range (min … max):    48.1 ms …  61.5 ms    46 runs

Summary
  ./target/release/prek run -a trailing-whitespace ran
    1.11 ± 0.16 times faster than prek run -a trailing-whitespace
```
