### PR TITLE
Support `PREK_CONTAINER_RUNTIME=podman` to override container runtime

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,9 +29,9 @@ Specify the minimum required version of prek for the configuration. If the insta
 
 Example:
 
-```yaml
-minimum_prek_version: "0.2.0"
-```
+  ```yaml
+  minimum_prek_version: '0.2.0'
+  ```
 
 The original `minimum_pre_commit_version` option has no effect and gets ignored in prek.
 
@@ -47,19 +47,24 @@ Prek supports the following environment variables:
 - `PREK_NO_FAST_PATH` — Disable Rust-native built-in hooks; always use the original hook implementation. See [Built-in Fast Hooks](builtin.md) for details.
 
 - `PREK_UV_SOURCE` — Control how uv (Python package installer) is installed. Options:
-  - `github` (download from GitHub releases)
-  - `pypi` (install from PyPI)
-  - `tuna` (use Tsinghua University mirror)
-  - `aliyun` (use Alibaba Cloud mirror)
-  - `tencent` (use Tencent Cloud mirror)
-  - `pip` (install via pip)
-  - a custom PyPI mirror URL
 
-  If not set, prek automatically selects the best available source.
+    - `github` (download from GitHub releases)
+    - `pypi` (install from PyPI)
+    - `tuna` (use Tsinghua University mirror)
+    - `aliyun` (use Alibaba Cloud mirror)
+    - `tencent` (use Tencent Cloud mirror)
+    - `pip` (install via pip)
+    - a custom PyPI mirror URL
+
+    If not set, prek automatically selects the best available source.
 
 - `PREK_NATIVE_TLS` - Use system's trusted store instead of the bundled `webpki-roots` crate.
 
-- `PREK_CONTAINER_RUNTIME` - Overrides container runtime detection and used container runtime specified, supported values `docker` or `podman`.
+- `PREK_CONTAINER_RUNTIME` - Specify the container runtime to use for container-based hooks (e.g., `docker`, `docker_image`). Options:
+
+    - `auto` (default, auto-detect available runtime)
+    - `docker`
+    - `podman`
 
 Compatibility fallbacks:
 

--- a/tests/languages/docker_image.rs
+++ b/tests/languages/docker_image.rs
@@ -1,30 +1,8 @@
-use anyhow::{Result, bail};
+use anyhow::Result;
 use assert_cmd::Command;
 use assert_fs::fixture::{FileWriteStr, PathChild};
-use prek_consts::env_vars::EnvVars;
 
 use crate::common::{TestContext, cmd_snapshot};
-
-fn detect_container_runtime() -> Result<String> {
-    let podman = which::which("podman");
-    let docker = which::which("docker");
-
-    if let Some(val) = EnvVars::var_os(EnvVars::PREK_CONTAINER_RUNTIME)
-        && let Some(val) = val.to_ascii_lowercase().to_str()
-    {
-        if val == "docker" || val == "podman" {
-            return Ok(val.to_owned());
-        }
-    }
-
-    if let Ok(_p) = docker {
-        return Ok("docker".to_owned());
-    } else if let Ok(_p) = podman {
-        return Ok("podman".to_owned());
-    }
-
-    bail!("No container runtime detected");
-}
 
 #[test]
 fn docker_image() -> Result<()> {
@@ -40,7 +18,7 @@ fn docker_image() -> Result<()> {
     "})?;
 
     // Use fully qualified image name for Podman/Docker compatibility
-    Command::new(detect_container_runtime()?)
+    Command::new("docker")
         .args(["pull", "docker.io/zricethezav/gitleaks:v8.21.2"])
         .assert()
         .success();


### PR DESCRIPTION
use both docker and podman runtimes

1. if only docker on path use docker runtime
2. if only podman on path use podman runtime
3. if both docker and podman on path prefer docker
4. If PREK_CONTAINER_RUNTIME set use that runtime, currently supports docker and podman