### PR TITLE
Fix grammar in install message: use past tense 'moved'

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -153,7 +153,7 @@ fn install_hook_script(
                 fs_err::rename(&hook_path, &legacy_path)?;
                 writeln!(
                     printer.stdout(),
-                    "Hook already exists at `{}`, move it to `{}`",
+                    "Hook already exists at `{}`, moved it to `{}`",
                     hook_path.user_display().cyan(),
                     legacy_path.user_display().yellow()
                 )?;

--- a/tests/install.rs
+++ b/tests/install.rs
@@ -70,7 +70,7 @@ fn install() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    Hook already exists at `.git/hooks/pre-commit`, move it to `.git/hooks/pre-commit.legacy`
+    Hook already exists at `.git/hooks/pre-commit`, moved it to `.git/hooks/pre-commit.legacy`
     prek installed at `.git/hooks/pre-commit`
     prek installed at `.git/hooks/post-commit`
 


### PR DESCRIPTION
## Summary
- fixes grammar in install output message to use past tense "moved" instead of imperative "move"
- updates test snapshot to match the corrected message

## Context
The install command automatically moves existing hook files to `.legacy` backups. The message was phrasing this as an instruction ("move it to") when it should describe what already happened ("moved it to").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### when i encountered this
```
» uvx prek install
Hook already exists at `.git/hooks/pre-commit`, move it to `.git/hooks/pre-commit.legacy`
prek installed at `.git/hooks/pre-commit`
» cat .git/hooks/pre-commit.legacy
#!/usr/bin/env bash
# File generated by pre-commit: https://pre-commit.com
# ID: 138fd403232d2ddd5efb44317e38bf03

# start templated
INSTALL_PYTHON=/Users/nate/.cache/uv/archive-v0/0j_RvfyWcB7tjAO5XaILd/bin/python
ARGS=(hook-impl --config=.pre-commit-config.yaml --hook-type=pre-commit)
# end templated

HERE="$(cd "$(dirname "$0")" && pwd)"
ARGS+=(--hook-dir "$HERE" -- "$@")

if [ -x "$INSTALL_PYTHON" ]; then
    exec "$INSTALL_PYTHON" -mpre_commit "${ARGS[@]}"
elif command -v pre-commit > /dev/null; then
    exec pre-commit "${ARGS[@]}"
else
    echo '`pre-commit` not found.  Did you forget to activate your virtualenv?' 1>&2
    exit 1
fi
```