### PR TITLE
Revert "Use mimalloc and tikv-jemallocator as global allocator (#1082)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1442,16 +1442,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "libredox"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1548,15 +1538,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "mimalloc"
-version = "0.1.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
-dependencies = [
- "libmimalloc-sys",
 ]
 
 [[package]]
@@ -1877,7 +1858,6 @@ dependencies = [
  "liblzma",
  "markdown",
  "memchr",
- "mimalloc",
  "owo-colors",
  "path-clean",
  "pprof",
@@ -1905,7 +1885,6 @@ dependencies = [
  "tempfile",
  "textwrap",
  "thiserror 2.0.17",
- "tikv-jemallocator",
  "tokio",
  "tokio-util",
  "toml",
@@ -2725,26 +2704,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "tikv-jemalloc-sys"
-version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,12 +105,6 @@ prek-pty = { workspace = true }
 libc = { version = "0.2.164" }
 pprof = { version = "0.15.0", optional = true }
 
-[target.'cfg(all(target_os = "windows"))'.dependencies]
-mimalloc = { version = "0.1.43" }
-
-[target.'cfg(all(not(target_os = "windows"), not(target_os = "openbsd"), not(target_os = "freebsd"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64")))'.dependencies]
-tikv-jemallocator = { version = "0.6.0" }
-
 [build-dependencies]
 fs-err = { version = "3.1.0" }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,23 +45,6 @@ mod version;
 mod warnings;
 mod workspace;
 
-#[cfg(target_os = "windows")]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
-#[cfg(all(
-    not(target_os = "windows"),
-    not(target_os = "openbsd"),
-    not(target_os = "freebsd"),
-    any(
-        target_arch = "x86_64",
-        target_arch = "aarch64",
-        target_arch = "powerpc64"
-    )
-))]
-#[global_allocator]
-static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
-
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Level {
     /// Suppress all tracing output by default (overridable by `RUST_LOG`).


### PR DESCRIPTION
This reverts commit a670b814b2f5e91dc4500cd913446f4001e2c427.

I missed that this caused the binary size to increase by 27%. I don't think this is worth it.

> 📦 Cargo Bloat Comparison
> Binary size change: +27.16% (16.2 MiB → 20.6 MiB)