### PR TITLE
Fix `prek init-template-dir` fails in non-git repo

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -193,7 +193,6 @@ fn install_hook_script(
 
     args.push(format!("--hook-type={}", hook_type.as_str()));
 
-    let git_root = GIT_ROOT.as_ref()?;
     let mut hint = format!("prek installed at `{}`", hook_path.user_display().cyan());
 
     // Prefer explicit config path if given (non-workspace mode).
@@ -205,6 +204,7 @@ fn install_hook_script(
 
         write!(hint, " with specified config `{}`", config.display().cyan())?;
     } else if let Some(project) = project {
+        let git_root = GIT_ROOT.as_ref()?;
         let project_path = project.path();
         let relative_path = project_path.strip_prefix(git_root).unwrap_or(project_path);
         if !relative_path.as_os_str().is_empty() {

--- a/tests/install.rs
+++ b/tests/install.rs
@@ -558,6 +558,22 @@ fn init_template_dir() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Tests `prek init-template-dir` in a non-git repository.
+#[test]
+fn init_template_dir_non_git_repo() {
+    let context = TestContext::new();
+
+    cmd_snapshot!(context.filters(), context.command().arg("init-template-dir").arg(".git"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    prek installed at `.git/hooks/pre-commit`
+
+    ----- stderr -----
+    warning: git config `init.templateDir` not set to the target directory, try `git config --global init.templateDir '.git'`
+    "#);
+}
+
 #[test]
 fn workspace_install() -> anyhow::Result<()> {
     let context = TestContext::new();


### PR DESCRIPTION
Closes #1092 