### PR TITLE
Remove completion subcommand from shell completion docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -127,7 +127,7 @@ COMPLETE=bash prek > /etc/bash_completion.d/prek
 ### Zsh
 
 ```bash
-COMPLETE=zsh prek completion > "${fpath[1]}/_prek"
+COMPLETE=zsh prek > "${fpath[1]}/_prek"
 ```
 
 ### Fish


### PR DESCRIPTION
There seems to be no `completion` subcommand the docs for and the other shells don't mention it either.