### PR TITLE
Support `language: dart`

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,7 +2,7 @@
 # Exclude heavy language-specific integration tests from the main CI runs.
 # Keep this as a deny-list so new language test modules run in ci-core until
 # they are deliberately moved to the language-test matrix.
-default-filter = "not binary_id(prek::languages) or (binary_id(prek::languages) and not (test(bun::) or test(deno::) or test(docker::) or test(docker_image::) or test(dotnet::) or test(golang::) or test(haskell::) or test(julia::) or test(lua::) or test(node::) or test(python::) or test(ruby::) or test(rust::) or test(swift::)))"
+default-filter = "not binary_id(prek::languages) or (binary_id(prek::languages) and not (test(bun::) or test(dart::) or test(deno::) or test(docker::) or test(docker_image::) or test(dotnet::) or test(golang::) or test(haskell::) or test(julia::) or test(lua::) or test(node::) or test(python::) or test(ruby::) or test(rust::) or test(swift::)))"
 status-level = "skip"
 final-status-level = "slow"
 failure-output = "immediate"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ env:
   JULIA_VERSION: "1.12.4"
   DOTNET_VERSION: "10.0"
   DENO_VERSION: "2"
+  DART_VERSION: "3.10.4"
 
   # Cargo env vars
   CARGO_INCREMENTAL: 0
@@ -413,56 +414,56 @@ jobs:
         include:
           - os: ubuntu-latest
             group: 1
-            languages: bun deno docker
-            filter: test(bun::) or test(deno::) or test(docker::) or test(docker_image::)
+            languages: bun dart deno
+            filter: test(bun::) or test(dart::) or test(deno::)
           - os: ubuntu-latest
             group: 2
-            languages: dotnet golang haskell
-            filter: test(dotnet::) or test(golang::) or test(haskell::)
+            languages: docker dotnet golang
+            filter: test(docker::) or test(docker_image::) or test(dotnet::) or test(golang::)
           - os: ubuntu-latest
             group: 3
-            languages: julia lua node
-            filter: test(julia::) or test(lua::) or test(node::)
+            languages: haskell julia lua
+            filter: test(haskell::) or test(julia::) or test(lua::)
           - os: ubuntu-latest
             group: 4
-            languages: python ruby rust
-            filter: test(python::) or test(ruby::) or test(rust::)
-          - os: ubuntu-latest
-            group: 5
-            languages: swift
-            filter: test(swift::)
-          - os: macos-latest
-            group: 1
-            languages: bun deno dotnet
-            filter: test(bun::) or test(deno::) or test(dotnet::)
-          - os: macos-latest
-            group: 2
-            languages: golang julia lua
-            filter: test(golang::) or test(julia::) or test(lua::)
-          - os: macos-latest
-            group: 3
             languages: node python ruby
             filter: test(node::) or test(python::) or test(ruby::)
-          - os: macos-latest
-            group: 4
+          - os: ubuntu-latest
+            group: 5
             languages: rust swift
             filter: test(rust::) or test(swift::)
-          - os: windows-latest
+          - os: macos-latest
             group: 1
-            languages: bun deno dotnet
-            filter: test(bun::) or test(deno::) or test(dotnet::)
-          - os: windows-latest
+            languages: bun dart deno
+            filter: test(bun::) or test(dart::) or test(deno::)
+          - os: macos-latest
             group: 2
-            languages: golang haskell julia
-            filter: test(golang::) or test(haskell::) or test(julia::)
-          - os: windows-latest
+            languages: dotnet golang julia
+            filter: test(dotnet::) or test(golang::) or test(julia::)
+          - os: macos-latest
             group: 3
             languages: lua node python
             filter: test(lua::) or test(node::) or test(python::)
+          - os: macos-latest
+            group: 4
+            languages: ruby rust swift
+            filter: test(ruby::) or test(rust::) or test(swift::)
+          - os: windows-latest
+            group: 1
+            languages: bun dart deno
+            filter: test(bun::) or test(dart::) or test(deno::)
+          - os: windows-latest
+            group: 2
+            languages: dotnet golang haskell
+            filter: test(dotnet::) or test(golang::) or test(haskell::)
+          - os: windows-latest
+            group: 3
+            languages: julia lua node
+            filter: test(julia::) or test(lua::) or test(node::)
           - os: windows-latest
             group: 4
-            languages: ruby rust
-            filter: test(ruby::) or test(rust::)
+            languages: python ruby rust
+            filter: test(python::) or test(ruby::) or test(rust::)
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -549,6 +550,12 @@ jobs:
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version: ${{ env.DENO_VERSION }}
+
+      - name: "Install Dart"
+        if: ${{ contains(format(' {0} ', matrix.languages), ' dart ') }}
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672 # v1.6.5
+        with:
+          sdk: ${{ env.DART_VERSION }}
 
       - name: "Install GHC and Cabal"
         if: ${{ contains(format(' {0} ', matrix.languages), ' haskell ') }}

--- a/crates/prek-consts/src/env_vars.rs
+++ b/crates/prek-consts/src/env_vars.rs
@@ -85,6 +85,9 @@ impl EnvVars {
     pub const LUA_PATH: &'static str = "LUA_PATH";
     pub const LUA_CPATH: &'static str = "LUA_CPATH";
 
+    // Dart related
+    pub const PUB_CACHE: &'static str = "PUB_CACHE";
+
     // Ruby related
     pub const PREK_RUBY_MIRROR: &'static str = "PREK_RUBY_MIRROR";
     pub const GEM_HOME: &'static str = "GEM_HOME";

--- a/crates/prek/src/hook_entry.rs
+++ b/crates/prek/src/hook_entry.rs
@@ -33,6 +33,10 @@ impl PreparedHookEntry {
     pub(crate) fn argv(&self) -> &[String] {
         &self.argv
     }
+
+    pub(crate) fn argv_mut(&mut self) -> &mut Vec<String> {
+        &mut self.argv
+    }
 }
 
 impl Deref for PreparedHookEntry {

--- a/crates/prek/src/languages/dart.rs
+++ b/crates/prek/src/languages/dart.rs
@@ -1,3 +1,17 @@
+//! A Dart package is described by `pubspec.yaml`. The package `name` is what
+//! other packages depend on, `dependencies` are resolved by `dart pub get`, and
+//! `executables` declares command names that map to Dart files under `bin/`.
+//! For executable entries, Dart treats a null value as "use the command name as
+//! the entrypoint"; this module also treats an empty string that way.
+//!
+//! `dart pub get` writes `.dart_tool/package_config.json`, which is the package
+//! resolver map used by the Dart VM. `prek` creates a pubspec in the hook env,
+//! runs `dart pub get` there with `PUB_CACHE` pointed at the env, and passes the
+//! generated package config to hook commands that run `dart run` or direct
+//! `.dart` scripts.
+
+use std::collections::BTreeMap;
+use std::env::consts::EXE_EXTENSION;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::str;
@@ -7,7 +21,7 @@ use anyhow::{Context, Result};
 use prek_consts::env_vars::EnvVars;
 use prek_consts::prepend_paths;
 use semver::Version;
-use serde_json::json;
+use serde::{Deserialize, Serialize};
 use tracing::debug;
 
 use crate::cli::reporter::{HookInstallReporter, HookRunReporter};
@@ -20,48 +34,78 @@ use crate::store::Store;
 #[derive(Debug, Copy, Clone)]
 pub(crate) struct Dart;
 
-pub(crate) struct DartInfo {
-    pub(crate) version: Version,
-    pub(crate) executable: PathBuf,
+const PUBSPEC_YAML: &str = "pubspec.yaml";
+
+/// Dart package manifest data from `pubspec.yaml`.
+///
+/// Format reference: <https://dart.dev/tools/pub/pubspec>.
+#[derive(Debug, Deserialize, Serialize)]
+struct Pubspec {
+    name: String,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    environment: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    dependencies: BTreeMap<String, PubspecDependency>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    executables: BTreeMap<String, PubspecExecutable>,
 }
 
-#[derive(Debug)]
-struct PubspecInfo {
-    package_name: String,
-    executables: Vec<ExecutableInfo>,
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+enum PubspecExecutable {
+    Entrypoint(String),
+    Default,
 }
 
-#[derive(Debug)]
-struct ExecutableInfo {
-    entrypoint: String,
-    output_name: String,
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+enum PubspecDependency {
+    Version(String),
+    Path { path: PathBuf },
 }
 
-pub(crate) async fn query_dart_info() -> Result<DartInfo> {
-    let executable = which::which("dart")
+impl PubspecExecutable {
+    /// Convert Dart's executable shorthand into the entrypoint name under `bin/`.
+    fn into_entrypoint(self, output_name: &str) -> String {
+        match self {
+            Self::Entrypoint(entrypoint) if !entrypoint.is_empty() => entrypoint,
+            Self::Entrypoint(_) | Self::Default => output_name.to_string(),
+        }
+    }
+}
+
+/// Resolve the Dart binary that should own this hook environment.
+fn find_dart_binary() -> Result<PathBuf> {
+    let dart = which::which("dart")
         .context("Failed to locate dart executable. Is Dart installed and available in PATH?")?;
-    debug!("Found dart executable at: {}", executable.display());
+    Ok(dart)
+}
 
-    let stdout = Cmd::new(&executable, "get dart version")
+/// Query the SDK version from a specific Dart binary.
+pub(crate) async fn query_dart_info(dart: &Path) -> Result<Version> {
+    let output = Cmd::new(dart, "get dart version")
         .arg("--version")
         .check(true)
         .output()
-        .await?
-        .stdout;
+        .await?;
 
-    let version = str::from_utf8(&stdout)
-        .context("Failed to parse `dart --version` output as UTF-8")?
+    let stdout =
+        str::from_utf8(&output.stdout).context("Failed to parse `dart --version` stdout")?;
+    let version = stdout
         .lines()
-        .find(|line| line.contains("Dart SDK version:"))
-        .and_then(|line| line.split_whitespace().nth(3))
-        .context("Failed to extract Dart version from output")?
-        .trim();
-    let version = Version::parse(version).context("Failed to parse Dart version")?;
+        .find_map(|line| {
+            line.trim()
+                .strip_prefix("Dart SDK version:")?
+                .split_ascii_whitespace()
+                .next()
+        })
+        .with_context(|| {
+            format!("Failed to extract Dart SDK version from `dart --version` stdout: {stdout:?}")
+        })?;
+    let version = Version::parse(version)
+        .with_context(|| format!("Failed to parse Dart SDK version `{version}`"))?;
 
-    Ok(DartInfo {
-        version,
-        executable,
-    })
+    Ok(version)
 }
 
 impl LanguageImpl for Dart {
@@ -81,35 +125,32 @@ impl LanguageImpl for Dart {
 
         debug!(%hook, target = %info.env_path.display(), "Installing Dart environment");
 
-        let dart_info = query_dart_info()
-            .await
-            .context("Failed to query Dart info")?;
+        let dart = find_dart_binary()?;
+        let dart_version = query_dart_info(&dart).await?;
 
-        let pubspec_source = if let Some(repo_path) = hook.repo_path() {
-            Self::has_pubspec(repo_path).then_some(repo_path)
-        } else {
-            Self::has_pubspec(hook.work_dir()).then_some(hook.work_dir())
-        };
-
-        if let Some(source_path) = pubspec_source {
-            Self::install_from_pubspec(
-                &dart_info.executable,
+        let source_path = hook.repo_path().unwrap_or_else(|| hook.work_dir());
+        if source_path.join(PUBSPEC_YAML).exists() {
+            install_from_pubspec(
+                &dart,
                 &info.env_path,
                 source_path,
                 &hook.additional_dependencies,
             )
             .await?;
         } else if !hook.additional_dependencies.is_empty() {
-            Self::install_additional_dependencies(
-                &dart_info.executable,
+            install_package_config(
+                &dart,
                 &info.env_path,
+                None,
+                None,
                 &hook.additional_dependencies,
             )
-            .await?;
+            .await
+            .context("Failed to install Dart additional dependencies")?;
         }
 
-        info.with_toolchain(dart_info.executable)
-            .with_language_version(dart_info.version);
+        info.with_toolchain(dart)
+            .with_language_version(dart_version);
         info.persist_env_path();
 
         reporter.on_install_complete(progress);
@@ -121,23 +162,22 @@ impl LanguageImpl for Dart {
     }
 
     async fn check_health(&self, info: &InstallInfo) -> Result<()> {
-        let current_dart_info = query_dart_info()
-            .await
-            .context("Failed to query current Dart info")?;
+        let dart = find_dart_binary()?;
+        let current_dart_version = query_dart_info(&dart).await?;
 
-        if current_dart_info.version != info.language_version {
+        if current_dart_version != info.language_version {
             anyhow::bail!(
                 "Dart version mismatch: expected `{}`, found `{}`",
                 info.language_version,
-                current_dart_info.version
+                current_dart_version
             );
         }
 
-        if current_dart_info.executable != info.toolchain {
+        if dart != info.toolchain {
             anyhow::bail!(
                 "Dart executable mismatch: expected `{}`, found `{}`",
                 info.toolchain.display(),
-                current_dart_info.executable.display()
+                dart.display()
             );
         }
 
@@ -154,10 +194,21 @@ impl LanguageImpl for Dart {
         let progress = reporter.on_run_start(hook, filenames.len());
 
         let env_dir = hook.env_path().expect("Dart must have env path");
-        let new_path = prepend_paths(&[&env_dir.join("bin")]).context("Failed to join PATH")?;
-        let packages_path = Self::package_config_path(env_dir);
+        let bin_path = bin_path(env_dir);
+        let new_path = prepend_paths(&[&bin_path]).context("Failed to join PATH")?;
+        let packages_path = package_config_path(env_dir);
+
         let mut entry = hook.entry.resolve(Some(&new_path), store)?;
-        Self::with_packages_file(entry.argv_mut(), &packages_path);
+        // `dart pub get` writes the hook env's dependency graph here. Inject it
+        // so `dart run` and direct scripts resolve hook deps from this env
+        // instead of the package config in the hook work dir.
+        if packages_path.exists()
+            && let Some(index) = packages_arg_insert_position(entry.argv())
+        {
+            entry
+                .argv_mut()
+                .insert(index, format!("--packages={}", packages_path.display()));
+        }
 
         let run = async |batch: &[&Path]| {
             let mut output = Cmd::new(&entry[0], "run dart command")
@@ -195,256 +246,251 @@ impl LanguageImpl for Dart {
     }
 }
 
-impl Dart {
-    fn package_config_path(env_path: &Path) -> PathBuf {
-        env_path.join(".dart_tool").join("package_config.json")
+/// Return the env directory containing compiled Dart executables.
+fn bin_path(env_path: &Path) -> PathBuf {
+    env_path.join("bin")
+}
+
+/// Return the package config generated by `dart pub get` inside an env.
+fn package_config_path(env_path: &Path) -> PathBuf {
+    env_path.join(".dart_tool").join("package_config.json")
+}
+
+/// Return the argv position where `--packages=...` should be inserted.
+fn packages_arg_insert_position(entry: &[String]) -> Option<usize> {
+    fn is_dart_binary(arg: &str) -> bool {
+        Path::new(arg)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| matches!(name, "dart" | "dart.exe"))
     }
 
-    fn with_packages_file(entry: &mut Vec<String>, packages_path: &Path) {
-        if !packages_path.exists() || entry.is_empty() {
-            return;
-        }
-
-        let Some(dart_index) = entry.iter().position(|arg| {
-            Path::new(arg)
-                .file_name()
-                .and_then(|name| name.to_str())
-                .is_some_and(|name| name == "dart" || name == "dart.exe")
-        }) else {
-            return;
-        };
-        if entry
-            .iter()
-            .any(|arg| arg == "-p" || arg.starts_with("--packages="))
-        {
-            return;
-        }
-
-        let Some(target_index) = entry
-            .iter()
-            .enumerate()
-            .skip(dart_index + 1)
-            .find_map(|(index, arg)| (!arg.starts_with('-')).then_some((index, arg)))
-        else {
-            return;
-        };
-
-        let (_, target) = target_index;
-        if *target != "run"
-            && !Path::new(target)
-                .extension()
-                .is_some_and(|ext| ext.eq_ignore_ascii_case("dart"))
-        {
-            return;
-        }
-
-        let (index, _) = target_index;
-        entry.insert(index, format!("--packages={}", packages_path.display()));
+    fn has_packages_arg(arg: &str) -> bool {
+        arg == "-p" || arg == "--packages" || arg.starts_with("--packages=")
     }
 
-    fn read_pubspec_info(pubspec_path: &Path) -> Result<PubspecInfo> {
-        let pubspec_content =
-            fs_err::read_to_string(pubspec_path).context("Failed to read pubspec.yaml")?;
-        let pubspec: serde_json::Value =
-            serde_saphyr::from_str(&pubspec_content).context("Failed to parse pubspec.yaml")?;
-
-        let package_name = pubspec
-            .get("name")
-            .and_then(serde_json::Value::as_str)
-            .context("pubspec.yaml must define a package name")?
-            .to_string();
-
-        let executables = match pubspec.get("executables") {
-            None => Vec::new(),
-            Some(executables) => {
-                let executables = executables
-                    .as_object()
-                    .context("pubspec.yaml executables must be a mapping")?;
-
-                executables
-                    .iter()
-                    .map(|(output_name, value)| {
-                        let entrypoint = match value {
-                            serde_json::Value::Null => output_name.clone(),
-                            serde_json::Value::String(entrypoint) if !entrypoint.is_empty() => {
-                                entrypoint.clone()
-                            }
-                            serde_json::Value::String(_) => output_name.clone(),
-                            _ => anyhow::bail!(
-                                "pubspec.yaml executable `{output_name}` must map to a string or null"
-                            ),
-                        };
-
-                        Ok(ExecutableInfo {
-                            entrypoint,
-                            output_name: output_name.clone(),
-                        })
-                    })
-                    .collect::<Result<Vec<_>>>()?
-            }
-        };
-
-        Ok(PubspecInfo {
-            package_name,
-            executables,
-        })
+    fn is_dart_script(arg: &str) -> bool {
+        Path::new(arg)
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("dart"))
     }
 
-    async fn compile_executables(
-        dart: &Path,
-        source_path: &Path,
-        bin_out_dir: &Path,
-        packages_path: &Path,
-        executables: &[ExecutableInfo],
-    ) -> Result<()> {
-        if executables.is_empty() {
-            return Ok(());
-        }
+    let dart_index = entry.iter().position(|arg| is_dart_binary(arg))?;
 
-        fs_err::create_dir_all(bin_out_dir).context("Failed to create bin output directory")?;
-
-        for executable in executables {
-            let mut relative_entrypoint = PathBuf::from(&executable.entrypoint);
-            if relative_entrypoint.extension().is_none() {
-                relative_entrypoint.set_extension("dart");
-            }
-            let source_file = source_path.join("bin").join(relative_entrypoint);
-            if !source_file.exists() {
-                debug!(
-                    "Skipping executable '{}': source file not found",
-                    executable.output_name
-                );
-                continue;
-            }
-
-            let output_path = if cfg!(windows) {
-                bin_out_dir.join(format!("{}.exe", executable.output_name))
-            } else {
-                bin_out_dir.join(&executable.output_name)
-            };
-
-            debug!(
-                "Compiling executable '{exe_name}': {source} -> {output}",
-                exe_name = executable.output_name,
-                source = source_file.display(),
-                output = output_path.display(),
-            );
-
-            Cmd::new(dart, "dart compile exe")
-                .arg("compile")
-                .arg("exe")
-                .arg(format!("--packages={}", packages_path.display()))
-                .arg(&source_file)
-                .arg("--output")
-                .arg(&output_path)
-                .check(true)
-                .output()
-                .await
-                .with_context(|| {
-                    format!("Failed to compile executable '{}'", executable.output_name)
-                })?;
-        }
-
-        Ok(())
+    // Respect an explicit package config from the hook author.
+    if entry.iter().any(|arg| has_packages_arg(arg)) {
+        return None;
     }
 
-    fn build_env_pubspec(
-        source_path: Option<&Path>,
-        package_name: Option<&str>,
-        dependencies: &rustc_hash::FxHashSet<String>,
-    ) -> Result<String> {
-        let mut resolved_dependencies = serde_json::Map::new();
+    let (target_index, target) = entry
+        .iter()
+        .enumerate()
+        .skip(dart_index + 1)
+        .find_map(|(index, arg)| (!arg.starts_with('-')).then_some((index, arg)))?;
 
-        for dep in dependencies {
-            if let Some((package, version)) = dep.split_once(':') {
-                resolved_dependencies.insert(package.to_string(), json!(version));
-            } else {
-                resolved_dependencies.insert(dep.clone(), json!("any"));
-            }
-        }
+    // Dart expects `--packages` before the `run` subcommand or script target.
+    (target == "run" || is_dart_script(target)).then_some(target_index)
+}
 
-        if let (Some(source_path), Some(package_name)) = (source_path, package_name) {
-            resolved_dependencies.insert(
-                package_name.to_string(),
-                json!({ "path": source_path.to_string_lossy().to_string() }),
-            );
-        }
-
-        let pubspec = json!({
-            "name": "prek_dart_env",
-            "environment": {
-                "sdk": ">=2.12.0 <4.0.0"
-            },
-            "dependencies": resolved_dependencies,
-        });
-
-        serde_saphyr::to_string(&pubspec).context("Failed to build pubspec.yaml")
+/// Compile declared package executables into the hook env's `bin` directory.
+async fn compile_executables(
+    dart: &Path,
+    source_path: &Path,
+    bin_dir: &Path,
+    packages_path: &Path,
+    executables: BTreeMap<String, PubspecExecutable>,
+) -> Result<()> {
+    if executables.is_empty() {
+        return Ok(());
     }
 
-    async fn install_package_config(
-        dart: &Path,
-        env_path: &Path,
-        source_path: Option<&Path>,
-        package_name: Option<&str>,
-        dependencies: &rustc_hash::FxHashSet<String>,
-    ) -> Result<()> {
-        let pubspec_content = Self::build_env_pubspec(source_path, package_name, dependencies)?;
-        let pubspec_path = env_path.join("pubspec.yaml");
-        fs_err::tokio::write(&pubspec_path, pubspec_content).await?;
+    fs_err::create_dir_all(bin_dir)?;
 
-        Cmd::new(dart, "dart pub get")
-            .current_dir(env_path)
-            .env(EnvVars::PUB_CACHE, env_path)
-            .arg("pub")
-            .arg("get")
+    for (output_name, executable) in executables {
+        let entrypoint = executable.into_entrypoint(&output_name);
+        let mut relative_entrypoint = PathBuf::from(&entrypoint);
+        if relative_entrypoint.extension().is_none() {
+            relative_entrypoint.set_extension("dart");
+        }
+        let source_file = source_path.join("bin").join(relative_entrypoint);
+        if !source_file.exists() {
+            debug!("Skipping executable `{output_name}`: source file not found");
+            continue;
+        }
+
+        let output_path = bin_dir.join(&output_name).with_extension(EXE_EXTENSION);
+
+        debug!(
+            "Compiling executable `{output_name}`: {source} -> {output}",
+            source = source_file.display(),
+            output = output_path.display(),
+        );
+
+        Cmd::new(dart, "dart compile exe")
+            .arg("compile")
+            .arg("exe")
+            .arg(format!("--packages={}", packages_path.display()))
+            .arg(&source_file)
+            .arg("--output")
+            .arg(&output_path)
             .check(true)
             .output()
-            .await
-            .context("Failed to run dart pub get")?;
-
-        Ok(())
+            .await?;
     }
 
-    async fn install_from_pubspec(
-        dart: &Path,
-        env_path: &Path,
-        source_path: &Path,
-        dependencies: &rustc_hash::FxHashSet<String>,
-    ) -> Result<()> {
-        let pubspec_info = Self::read_pubspec_info(&source_path.join("pubspec.yaml"))?;
-        Self::install_package_config(
-            dart,
-            env_path,
-            Some(source_path),
-            Some(&pubspec_info.package_name),
-            dependencies,
-        )
+    Ok(())
+}
+
+/// Build the synthetic pubspec used to resolve the hook's Dart dependencies.
+fn build_env_pubspec(
+    source_path: Option<&Path>,
+    package_name: Option<&str>,
+    dependencies: &rustc_hash::FxHashSet<String>,
+) -> Result<String> {
+    let mut resolved_dependencies = BTreeMap::new();
+
+    let mut dependencies = dependencies.iter().collect::<Vec<_>>();
+    dependencies.sort_unstable();
+
+    for dep in dependencies {
+        if let Some((package, version)) = dep.split_once(':') {
+            resolved_dependencies.insert(
+                package.to_string(),
+                PubspecDependency::Version(version.to_string()),
+            );
+        } else {
+            resolved_dependencies
+                .insert(dep.clone(), PubspecDependency::Version("any".to_string()));
+        }
+    }
+
+    if let (Some(source_path), Some(package_name)) = (source_path, package_name) {
+        resolved_dependencies.insert(
+            package_name.to_string(),
+            PubspecDependency::Path {
+                path: source_path.to_path_buf(),
+            },
+        );
+    }
+
+    let pubspec = Pubspec {
+        name: "prek_dart_env".to_string(),
+        environment: BTreeMap::from([("sdk".to_string(), ">=2.12.0 <4.0.0".to_string())]),
+        dependencies: resolved_dependencies,
+        executables: BTreeMap::new(),
+    };
+
+    Ok(serde_saphyr::to_string(&pubspec)?)
+}
+
+/// Write the synthetic pubspec and resolve it into a package config.
+async fn install_package_config(
+    dart: &Path,
+    env_path: &Path,
+    source_path: Option<&Path>,
+    package_name: Option<&str>,
+    dependencies: &rustc_hash::FxHashSet<String>,
+) -> Result<()> {
+    let pubspec_content = build_env_pubspec(source_path, package_name, dependencies)?;
+    let pubspec_path = env_path.join(PUBSPEC_YAML);
+    fs_err::tokio::write(&pubspec_path, pubspec_content).await?;
+
+    Cmd::new(dart, "dart pub get")
+        .current_dir(env_path)
+        .env(EnvVars::PUB_CACHE, env_path)
+        .arg("pub")
+        .arg("get")
+        .check(true)
+        .output()
         .await?;
 
-        let bin_out_dir = env_path.join("bin");
-        Self::compile_executables(
-            dart,
-            source_path,
-            &bin_out_dir,
-            &Self::package_config_path(env_path),
-            &pubspec_info.executables,
-        )
-        .await?;
+    Ok(())
+}
+
+/// Install a local Dart package hook and compile its declared executables.
+async fn install_from_pubspec(
+    dart: &Path,
+    env_path: &Path,
+    source_path: &Path,
+    dependencies: &rustc_hash::FxHashSet<String>,
+) -> Result<()> {
+    let pubspec_path = source_path.join(PUBSPEC_YAML);
+    let pubspec_content = fs_err::read_to_string(&pubspec_path)?;
+    let pubspec: Pubspec = serde_saphyr::from_str(&pubspec_content)?;
+
+    install_package_config(
+        dart,
+        env_path,
+        Some(source_path),
+        Some(&pubspec.name),
+        dependencies,
+    )
+    .await
+    .context("Failed to install Dart pubspec dependencies")?;
+
+    compile_executables(
+        dart,
+        source_path,
+        &bin_path(env_path),
+        &package_config_path(env_path),
+        pubspec.executables,
+    )
+    .await
+    .context("Failed to compile Dart pubspec executables")?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+    use std::path::PathBuf;
+
+    fn strings(values: &[&str]) -> Vec<String> {
+        values.iter().map(ToString::to_string).collect()
+    }
+
+    fn pubspec_file(content: &str) -> Result<(tempfile::TempDir, PathBuf)> {
+        let temp_dir = tempfile::tempdir()?;
+        let pubspec_path = temp_dir.path().join(PUBSPEC_YAML);
+        fs_err::write(&pubspec_path, content)?;
+        Ok((temp_dir, pubspec_path))
+    }
+
+    #[test]
+    fn packages_arg_insert_position_inserts_before_dart_run() {
+        let entry = strings(&["/usr/bin/dart", "run", "bin/hook.dart"]);
+
+        assert_eq!(packages_arg_insert_position(&entry), Some(1));
+    }
+
+    #[test]
+    fn packages_arg_insert_position_keeps_existing_packages_arg() {
+        assert_eq!(
+            packages_arg_insert_position(&strings(&["dart", "--packages=custom", "run"])),
+            None
+        );
+        assert_eq!(
+            packages_arg_insert_position(&strings(&["dart", "--packages", "custom", "run"])),
+            None
+        );
+    }
+
+    #[test]
+    fn build_env_pubspec_serializes_path_dependency() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let dependencies = rustc_hash::FxHashSet::default();
+
+        let content = build_env_pubspec(Some(temp_dir.path()), Some("sample"), &dependencies)?;
+        let pubspec = serde_saphyr::from_str::<serde_json::Value>(&content)?;
+        let path = temp_dir.path().to_string_lossy();
+
+        assert_eq!(
+            pubspec["dependencies"]["sample"]["path"].as_str(),
+            Some(path.as_ref())
+        );
 
         Ok(())
-    }
-
-    async fn install_additional_dependencies(
-        dart: &Path,
-        env_path: &Path,
-        dependencies: &rustc_hash::FxHashSet<String>,
-    ) -> Result<()> {
-        Self::install_package_config(dart, env_path, None, None, dependencies)
-            .await
-            .context("Failed to run dart pub get for additional dependencies")
-    }
-
-    fn has_pubspec(repo_path: &Path) -> bool {
-        repo_path.join("pubspec.yaml").exists()
     }
 }

--- a/crates/prek/src/languages/dart.rs
+++ b/crates/prek/src/languages/dart.rs
@@ -1,4 +1,3 @@
-use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::str;
@@ -8,6 +7,7 @@ use anyhow::{Context, Result};
 use prek_consts::env_vars::EnvVars;
 use prek_consts::prepend_paths;
 use semver::Version;
+use serde_json::json;
 use tracing::debug;
 
 use crate::cli::reporter::{HookInstallReporter, HookRunReporter};
@@ -23,6 +23,18 @@ pub(crate) struct Dart;
 pub(crate) struct DartInfo {
     pub(crate) version: Version,
     pub(crate) executable: PathBuf,
+}
+
+#[derive(Debug)]
+struct PubspecInfo {
+    package_name: String,
+    executables: Vec<ExecutableInfo>,
+}
+
+#[derive(Debug)]
+struct ExecutableInfo {
+    entrypoint: String,
+    output_name: String,
 }
 
 pub(crate) async fn query_dart_info() -> Result<DartInfo> {
@@ -80,10 +92,14 @@ impl LanguageImpl for Dart {
         };
 
         if let Some(source_path) = pubspec_source {
-            Self::install_from_pubspec(&dart_info.executable, &info.env_path, source_path).await?;
-        }
-
-        if !hook.additional_dependencies.is_empty() {
+            Self::install_from_pubspec(
+                &dart_info.executable,
+                &info.env_path,
+                source_path,
+                &hook.additional_dependencies,
+            )
+            .await?;
+        } else if !hook.additional_dependencies.is_empty() {
             Self::install_additional_dependencies(
                 &dart_info.executable,
                 &info.env_path,
@@ -139,9 +155,9 @@ impl LanguageImpl for Dart {
 
         let env_dir = hook.env_path().expect("Dart must have env path");
         let new_path = prepend_paths(&[&env_dir.join("bin")]).context("Failed to join PATH")?;
-        let entry = hook.entry.resolve(Some(&new_path), store)?;
-
-        Self::setup_package_config(env_dir, hook.work_dir())?;
+        let packages_path = Self::package_config_path(env_dir);
+        let mut entry = hook.entry.resolve(Some(&new_path), store)?;
+        Self::with_packages_file(entry.argv_mut(), &packages_path);
 
         let run = async |batch: &[&Path]| {
             let mut output = Cmd::new(&entry[0], "run dart command")
@@ -164,7 +180,7 @@ impl LanguageImpl for Dart {
             anyhow::Ok((code, output.stdout))
         };
 
-        let results = run_by_batch(hook, filenames, &entry, run).await?;
+        let results = run_by_batch(hook, filenames, entry.argv(), run).await?;
 
         reporter.on_run_complete(progress);
 
@@ -180,127 +196,199 @@ impl LanguageImpl for Dart {
 }
 
 impl Dart {
-    fn setup_package_config(env_dir: &Path, work_dir: &Path) -> Result<()> {
-        let env_package_config = env_dir.join(".dart_tool").join("package_config.json");
-        if env_package_config.exists() {
-            let work_dart_tool = work_dir.join(".dart_tool");
-            fs_err::create_dir_all(&work_dart_tool)
-                .context("Failed to create .dart_tool directory in work_dir")?;
-            let work_package_config = work_dart_tool.join("package_config.json");
-            fs_err::copy(&env_package_config, &work_package_config)
-                .context("Failed to copy package_config.json to work_dir")?;
-        }
-        Ok(())
+    fn package_config_path(env_path: &Path) -> PathBuf {
+        env_path.join(".dart_tool").join("package_config.json")
     }
 
-    async fn compile_executables(
-        dart: &Path,
-        pubspec_path: &Path,
-        bin_src_dir: &Path,
-        bin_out_dir: &Path,
-        pub_cache: &Path,
-    ) -> Result<()> {
+    fn with_packages_file(entry: &mut Vec<String>, packages_path: &Path) {
+        if !packages_path.exists() || entry.is_empty() {
+            return;
+        }
+
+        let Some(dart_index) = entry.iter().position(|arg| {
+            Path::new(arg)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name == "dart" || name == "dart.exe")
+        }) else {
+            return;
+        };
+        if entry
+            .iter()
+            .any(|arg| arg == "-p" || arg.starts_with("--packages="))
+        {
+            return;
+        }
+
+        let Some(target_index) = entry
+            .iter()
+            .enumerate()
+            .skip(dart_index + 1)
+            .find_map(|(index, arg)| (!arg.starts_with('-')).then_some((index, arg)))
+        else {
+            return;
+        };
+
+        let (_, target) = target_index;
+        if *target != "run"
+            && !Path::new(target)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("dart"))
+        {
+            return;
+        }
+
+        let (index, _) = target_index;
+        entry.insert(index, format!("--packages={}", packages_path.display()));
+    }
+
+    fn read_pubspec_info(pubspec_path: &Path) -> Result<PubspecInfo> {
         let pubspec_content =
             fs_err::read_to_string(pubspec_path).context("Failed to read pubspec.yaml")?;
         let pubspec: serde_json::Value =
             serde_saphyr::from_str(&pubspec_content).context("Failed to parse pubspec.yaml")?;
 
-        let Some(executables) = pubspec
-            .get("executables")
-            .and_then(serde_json::Value::as_object)
-        else {
-            return Ok(());
+        let package_name = pubspec
+            .get("name")
+            .and_then(serde_json::Value::as_str)
+            .context("pubspec.yaml must define a package name")?
+            .to_string();
+
+        let executables = match pubspec.get("executables") {
+            None => Vec::new(),
+            Some(executables) => {
+                let executables = executables
+                    .as_object()
+                    .context("pubspec.yaml executables must be a mapping")?;
+
+                executables
+                    .iter()
+                    .map(|(output_name, value)| {
+                        let entrypoint = match value {
+                            serde_json::Value::Null => output_name.clone(),
+                            serde_json::Value::String(entrypoint) if !entrypoint.is_empty() => {
+                                entrypoint.clone()
+                            }
+                            serde_json::Value::String(_) => output_name.clone(),
+                            _ => anyhow::bail!(
+                                "pubspec.yaml executable `{output_name}` must map to a string or null"
+                            ),
+                        };
+
+                        Ok(ExecutableInfo {
+                            entrypoint,
+                            output_name: output_name.clone(),
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?
+            }
         };
+
+        Ok(PubspecInfo {
+            package_name,
+            executables,
+        })
+    }
+
+    async fn compile_executables(
+        dart: &Path,
+        source_path: &Path,
+        bin_out_dir: &Path,
+        packages_path: &Path,
+        executables: &[ExecutableInfo],
+    ) -> Result<()> {
+        if executables.is_empty() {
+            return Ok(());
+        }
 
         fs_err::create_dir_all(bin_out_dir).context("Failed to create bin output directory")?;
 
-        for exe_name in executables.keys() {
-            let source_file = bin_src_dir.join(format!("{exe_name}.dart"));
+        for executable in executables {
+            let mut relative_entrypoint = PathBuf::from(&executable.entrypoint);
+            if relative_entrypoint.extension().is_none() {
+                relative_entrypoint.set_extension("dart");
+            }
+            let source_file = source_path.join("bin").join(relative_entrypoint);
             if !source_file.exists() {
-                debug!("Skipping executable '{exe_name}': source file not found");
+                debug!(
+                    "Skipping executable '{}': source file not found",
+                    executable.output_name
+                );
                 continue;
             }
 
             let output_path = if cfg!(windows) {
-                bin_out_dir.join(format!("{exe_name}.exe"))
+                bin_out_dir.join(format!("{}.exe", executable.output_name))
             } else {
-                bin_out_dir.join(exe_name)
+                bin_out_dir.join(&executable.output_name)
             };
 
             debug!(
-                "Compiling executable '{exe_name}': {} -> {}",
-                source_file.display(),
-                output_path.display()
+                "Compiling executable '{exe_name}': {source} -> {output}",
+                exe_name = executable.output_name,
+                source = source_file.display(),
+                output = output_path.display(),
             );
 
             Cmd::new(dart, "dart compile exe")
                 .arg("compile")
                 .arg("exe")
+                .arg(format!("--packages={}", packages_path.display()))
                 .arg(&source_file)
                 .arg("--output")
                 .arg(&output_path)
-                .env(EnvVars::PUB_CACHE, pub_cache)
                 .check(true)
                 .output()
                 .await
-                .with_context(|| format!("Failed to compile executable '{exe_name}'"))?;
+                .with_context(|| {
+                    format!("Failed to compile executable '{}'", executable.output_name)
+                })?;
         }
 
         Ok(())
     }
 
-    async fn install_from_pubspec(dart: &Path, env_path: &Path, repo_path: &Path) -> Result<()> {
-        Cmd::new(dart, "dart pub get")
-            .current_dir(repo_path)
-            .env(EnvVars::PUB_CACHE, env_path)
-            .arg("pub")
-            .arg("get")
-            .check(true)
-            .output()
-            .await
-            .context("Failed to run dart pub get")?;
-
-        let source_package_config = repo_path.join(".dart_tool").join("package_config.json");
-        if source_package_config.exists() {
-            let env_dart_tool = env_path.join(".dart_tool");
-            fs_err::create_dir_all(&env_dart_tool)
-                .context("Failed to create Dart cache directory in env_path")?;
-            fs_err::copy(
-                &source_package_config,
-                env_dart_tool.join("package_config.json"),
-            )
-            .context("Failed to copy package_config.json to env_path")?;
-        }
-
-        let pubspec_path = repo_path.join("pubspec.yaml");
-        let bin_src_dir = repo_path.join("bin");
-        let bin_out_dir = env_path.join("bin");
-        Self::compile_executables(dart, &pubspec_path, &bin_src_dir, &bin_out_dir, env_path)
-            .await?;
-
-        Ok(())
-    }
-
-    async fn install_additional_dependencies(
-        dart: &Path,
-        env_path: &Path,
+    fn build_env_pubspec(
+        source_path: Option<&Path>,
+        package_name: Option<&str>,
         dependencies: &rustc_hash::FxHashSet<String>,
-    ) -> Result<()> {
-        let mut pubspec_content = indoc::formatdoc! {"
-            name: prek_dart_env
-            environment:
-              sdk: '>=2.12.0 <4.0.0'
-            dependencies:
-        "};
+    ) -> Result<String> {
+        let mut resolved_dependencies = serde_json::Map::new();
 
         for dep in dependencies {
             if let Some((package, version)) = dep.split_once(':') {
-                writeln!(pubspec_content, "  {package}: {version}")?;
+                resolved_dependencies.insert(package.to_string(), json!(version));
             } else {
-                writeln!(pubspec_content, "  {dep}: any")?;
+                resolved_dependencies.insert(dep.clone(), json!("any"));
             }
         }
 
+        if let (Some(source_path), Some(package_name)) = (source_path, package_name) {
+            resolved_dependencies.insert(
+                package_name.to_string(),
+                json!({ "path": source_path.to_string_lossy().to_string() }),
+            );
+        }
+
+        let pubspec = json!({
+            "name": "prek_dart_env",
+            "environment": {
+                "sdk": ">=2.12.0 <4.0.0"
+            },
+            "dependencies": resolved_dependencies,
+        });
+
+        serde_saphyr::to_string(&pubspec).context("Failed to build pubspec.yaml")
+    }
+
+    async fn install_package_config(
+        dart: &Path,
+        env_path: &Path,
+        source_path: Option<&Path>,
+        package_name: Option<&str>,
+        dependencies: &rustc_hash::FxHashSet<String>,
+    ) -> Result<()> {
+        let pubspec_content = Self::build_env_pubspec(source_path, package_name, dependencies)?;
         let pubspec_path = env_path.join("pubspec.yaml");
         fs_err::tokio::write(&pubspec_path, pubspec_content).await?;
 
@@ -312,9 +400,48 @@ impl Dart {
             .check(true)
             .output()
             .await
-            .context("Failed to run dart pub get for additional dependencies")?;
+            .context("Failed to run dart pub get")?;
 
         Ok(())
+    }
+
+    async fn install_from_pubspec(
+        dart: &Path,
+        env_path: &Path,
+        source_path: &Path,
+        dependencies: &rustc_hash::FxHashSet<String>,
+    ) -> Result<()> {
+        let pubspec_info = Self::read_pubspec_info(&source_path.join("pubspec.yaml"))?;
+        Self::install_package_config(
+            dart,
+            env_path,
+            Some(source_path),
+            Some(&pubspec_info.package_name),
+            dependencies,
+        )
+        .await?;
+
+        let bin_out_dir = env_path.join("bin");
+        Self::compile_executables(
+            dart,
+            source_path,
+            &bin_out_dir,
+            &Self::package_config_path(env_path),
+            &pubspec_info.executables,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn install_additional_dependencies(
+        dart: &Path,
+        env_path: &Path,
+        dependencies: &rustc_hash::FxHashSet<String>,
+    ) -> Result<()> {
+        Self::install_package_config(dart, env_path, None, None, dependencies)
+            .await
+            .context("Failed to run dart pub get for additional dependencies")
     }
 
     fn has_pubspec(repo_path: &Path) -> bool {

--- a/crates/prek/src/languages/dart.rs
+++ b/crates/prek/src/languages/dart.rs
@@ -245,24 +245,28 @@ fn packages_arg_insert_position(entry: &[String], hook_args: &[String]) -> Optio
 
     let dart_index = entry.iter().position(|arg| is_dart_binary(arg))?;
 
-    // Respect an explicit package config from the hook author.
-    if entry
-        .iter()
-        .chain(hook_args)
-        .any(|arg| has_packages_arg(arg))
-    {
-        return None;
-    }
-
-    let (target_index, target) = entry
+    for (index, arg) in entry
         .iter()
         .chain(hook_args)
         .enumerate()
         .skip(dart_index + 1)
-        .find_map(|(index, arg)| (!arg.starts_with('-')).then_some((index, arg)))?;
+    {
+        // Respect an explicit package config only while still parsing Dart VM
+        // options. After `run` or a script target, this may be a hook argument.
+        if has_packages_arg(arg) {
+            return None;
+        }
 
-    // `--packages` is a VM flag, so place it before `run` or a script target.
-    (target == "run" || is_dart_script(target)).then_some(target_index.min(entry.len()))
+        if !arg.starts_with('-') {
+            // `--packages` is a VM flag, so place it before `run` or a script target.
+            if arg != "run" && !is_dart_script(arg) {
+                return None;
+            }
+            return Some(index.min(entry.len()));
+        }
+    }
+
+    None
 }
 
 /// Compile declared package executables into the hook env's `bin` directory.
@@ -445,6 +449,28 @@ mod tests {
                 &strings(&["--packages=custom", "run"])
             ),
             None
+        );
+    }
+
+    #[test]
+    fn packages_arg_insert_position_only_checks_vm_options_for_packages_arg() {
+        assert_eq!(
+            packages_arg_insert_position(&strings(&["dart", "run", "tool.dart", "-p"]), &[]),
+            Some(1)
+        );
+        assert_eq!(
+            packages_arg_insert_position(
+                &strings(&["dart", "tool.dart", "--packages=script-value"]),
+                &[]
+            ),
+            Some(1)
+        );
+        assert_eq!(
+            packages_arg_insert_position(
+                &strings(&["dart"]),
+                &strings(&["run", "tool.dart", "--packages=script-value"])
+            ),
+            Some(1)
         );
     }
 

--- a/crates/prek/src/languages/dart.rs
+++ b/crates/prek/src/languages/dart.rs
@@ -14,13 +14,11 @@ use std::collections::BTreeMap;
 use std::env::consts::EXE_EXTENSION;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::str;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use prek_consts::env_vars::EnvVars;
 use prek_consts::prepend_paths;
-use semver::Version;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
@@ -81,33 +79,6 @@ fn find_dart_binary() -> Result<PathBuf> {
     Ok(dart)
 }
 
-/// Query the SDK version from a specific Dart binary.
-pub(crate) async fn query_dart_info(dart: &Path) -> Result<Version> {
-    let output = Cmd::new(dart, "get dart version")
-        .arg("--version")
-        .check(true)
-        .output()
-        .await?;
-
-    let stdout =
-        str::from_utf8(&output.stdout).context("Failed to parse `dart --version` stdout")?;
-    let version = stdout
-        .lines()
-        .find_map(|line| {
-            line.trim()
-                .strip_prefix("Dart SDK version:")?
-                .split_ascii_whitespace()
-                .next()
-        })
-        .with_context(|| {
-            format!("Failed to extract Dart SDK version from `dart --version` stdout: {stdout:?}")
-        })?;
-    let version = Version::parse(version)
-        .with_context(|| format!("Failed to parse Dart SDK version `{version}`"))?;
-
-    Ok(version)
-}
-
 impl LanguageImpl for Dart {
     async fn install(
         &self,
@@ -126,7 +97,6 @@ impl LanguageImpl for Dart {
         debug!(%hook, target = %info.env_path.display(), "Installing Dart environment");
 
         let dart = find_dart_binary()?;
-        let dart_version = query_dart_info(&dart).await?;
 
         let source_path = hook.repo_path().unwrap_or_else(|| hook.work_dir());
         if source_path.join(PUBSPEC_YAML).exists() {
@@ -149,8 +119,7 @@ impl LanguageImpl for Dart {
             .context("Failed to install Dart additional dependencies")?;
         }
 
-        info.with_toolchain(dart)
-            .with_language_version(dart_version);
+        info.with_toolchain(dart);
         info.persist_env_path();
 
         reporter.on_install_complete(progress);
@@ -163,15 +132,6 @@ impl LanguageImpl for Dart {
 
     async fn check_health(&self, info: &InstallInfo) -> Result<()> {
         let dart = find_dart_binary()?;
-        let current_dart_version = query_dart_info(&dart).await?;
-
-        if current_dart_version != info.language_version {
-            anyhow::bail!(
-                "Dart version mismatch: expected `{}`, found `{}`",
-                info.language_version,
-                current_dart_version
-            );
-        }
 
         if dart != info.toolchain {
             anyhow::bail!(
@@ -346,7 +306,7 @@ fn build_env_pubspec(
     source_path: Option<&Path>,
     package_name: Option<&str>,
     dependencies: &rustc_hash::FxHashSet<String>,
-) -> Result<String> {
+) -> Pubspec {
     let mut resolved_dependencies = BTreeMap::new();
 
     let mut dependencies = dependencies.iter().collect::<Vec<_>>();
@@ -373,14 +333,12 @@ fn build_env_pubspec(
         );
     }
 
-    let pubspec = Pubspec {
+    Pubspec {
         name: "prek_dart_env".to_string(),
         environment: BTreeMap::from([("sdk".to_string(), ">=2.12.0 <4.0.0".to_string())]),
         dependencies: resolved_dependencies,
         executables: BTreeMap::new(),
-    };
-
-    Ok(serde_saphyr::to_string(&pubspec)?)
+    }
 }
 
 /// Write the synthetic pubspec and resolve it into a package config.
@@ -391,7 +349,8 @@ async fn install_package_config(
     package_name: Option<&str>,
     dependencies: &rustc_hash::FxHashSet<String>,
 ) -> Result<()> {
-    let pubspec_content = build_env_pubspec(source_path, package_name, dependencies)?;
+    let pubspec = build_env_pubspec(source_path, package_name, dependencies);
+    let pubspec_content = serde_saphyr::to_string(&pubspec)?;
     let pubspec_path = env_path.join(PUBSPEC_YAML);
     fs_err::tokio::write(&pubspec_path, pubspec_content).await?;
 
@@ -482,14 +441,12 @@ mod tests {
         let temp_dir = tempfile::tempdir()?;
         let dependencies = rustc_hash::FxHashSet::default();
 
-        let content = build_env_pubspec(Some(temp_dir.path()), Some("sample"), &dependencies)?;
-        let pubspec = serde_saphyr::from_str::<serde_json::Value>(&content)?;
-        let path = temp_dir.path().to_string_lossy();
+        let pubspec = build_env_pubspec(Some(temp_dir.path()), Some("sample"), &dependencies);
 
-        assert_eq!(
-            pubspec["dependencies"]["sample"]["path"].as_str(),
-            Some(path.as_ref())
-        );
+        match pubspec.dependencies.get("sample") {
+            Some(PubspecDependency::Path { path }) => assert_eq!(path, temp_dir.path()),
+            dependency => panic!("expected path dependency, got {dependency:?}"),
+        }
 
         Ok(())
     }

--- a/crates/prek/src/languages/dart.rs
+++ b/crates/prek/src/languages/dart.rs
@@ -1,0 +1,323 @@
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::str;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use prek_consts::env_vars::EnvVars;
+use prek_consts::prepend_paths;
+use semver::Version;
+use tracing::debug;
+
+use crate::cli::reporter::{HookInstallReporter, HookRunReporter};
+use crate::hook::{Hook, InstallInfo, InstalledHook};
+use crate::languages::LanguageImpl;
+use crate::process::Cmd;
+use crate::run::run_by_batch;
+use crate::store::Store;
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct Dart;
+
+pub(crate) struct DartInfo {
+    pub(crate) version: Version,
+    pub(crate) executable: PathBuf,
+}
+
+pub(crate) async fn query_dart_info() -> Result<DartInfo> {
+    let executable = which::which("dart")
+        .context("Failed to locate dart executable. Is Dart installed and available in PATH?")?;
+    debug!("Found dart executable at: {}", executable.display());
+
+    let stdout = Cmd::new(&executable, "get dart version")
+        .arg("--version")
+        .check(true)
+        .output()
+        .await?
+        .stdout;
+
+    let version = str::from_utf8(&stdout)
+        .context("Failed to parse `dart --version` output as UTF-8")?
+        .lines()
+        .find(|line| line.contains("Dart SDK version:"))
+        .and_then(|line| line.split_whitespace().nth(3))
+        .context("Failed to extract Dart version from output")?
+        .trim();
+    let version = Version::parse(version).context("Failed to parse Dart version")?;
+
+    Ok(DartInfo {
+        version,
+        executable,
+    })
+}
+
+impl LanguageImpl for Dart {
+    async fn install(
+        &self,
+        hook: Arc<Hook>,
+        store: &Store,
+        reporter: &HookInstallReporter,
+    ) -> Result<InstalledHook> {
+        let progress = reporter.on_install_start(&hook);
+
+        let mut info = InstallInfo::new(
+            hook.language,
+            hook.env_key_dependencies().clone(),
+            &store.hooks_dir(),
+        )?;
+
+        debug!(%hook, target = %info.env_path.display(), "Installing Dart environment");
+
+        let dart_info = query_dart_info()
+            .await
+            .context("Failed to query Dart info")?;
+
+        let pubspec_source = if let Some(repo_path) = hook.repo_path() {
+            Self::has_pubspec(repo_path).then_some(repo_path)
+        } else {
+            Self::has_pubspec(hook.work_dir()).then_some(hook.work_dir())
+        };
+
+        if let Some(source_path) = pubspec_source {
+            Self::install_from_pubspec(&dart_info.executable, &info.env_path, source_path).await?;
+        }
+
+        if !hook.additional_dependencies.is_empty() {
+            Self::install_additional_dependencies(
+                &dart_info.executable,
+                &info.env_path,
+                &hook.additional_dependencies,
+            )
+            .await?;
+        }
+
+        info.with_toolchain(dart_info.executable)
+            .with_language_version(dart_info.version);
+        info.persist_env_path();
+
+        reporter.on_install_complete(progress);
+
+        Ok(InstalledHook::Installed {
+            hook,
+            info: Arc::new(info),
+        })
+    }
+
+    async fn check_health(&self, info: &InstallInfo) -> Result<()> {
+        let current_dart_info = query_dart_info()
+            .await
+            .context("Failed to query current Dart info")?;
+
+        if current_dart_info.version != info.language_version {
+            anyhow::bail!(
+                "Dart version mismatch: expected `{}`, found `{}`",
+                info.language_version,
+                current_dart_info.version
+            );
+        }
+
+        if current_dart_info.executable != info.toolchain {
+            anyhow::bail!(
+                "Dart executable mismatch: expected `{}`, found `{}`",
+                info.toolchain.display(),
+                current_dart_info.executable.display()
+            );
+        }
+
+        Ok(())
+    }
+
+    async fn run(
+        &self,
+        hook: &InstalledHook,
+        filenames: &[&Path],
+        store: &Store,
+        reporter: &HookRunReporter,
+    ) -> Result<(i32, Vec<u8>)> {
+        let progress = reporter.on_run_start(hook, filenames.len());
+
+        let env_dir = hook.env_path().expect("Dart must have env path");
+        let new_path = prepend_paths(&[&env_dir.join("bin")]).context("Failed to join PATH")?;
+        let entry = hook.entry.resolve(Some(&new_path), store)?;
+
+        Self::setup_package_config(env_dir, hook.work_dir())?;
+
+        let run = async |batch: &[&Path]| {
+            let mut output = Cmd::new(&entry[0], "run dart command")
+                .current_dir(hook.work_dir())
+                .args(&entry[1..])
+                .env(EnvVars::PATH, &new_path)
+                .env(EnvVars::PUB_CACHE, env_dir)
+                .envs(&hook.env)
+                .args(&hook.args)
+                .args(batch)
+                .check(false)
+                .stdin(Stdio::null())
+                .pty_output()
+                .await?;
+
+            reporter.on_run_progress(progress, batch.len() as u64);
+
+            output.stdout.extend(output.stderr);
+            let code = output.status.code().unwrap_or(1);
+            anyhow::Ok((code, output.stdout))
+        };
+
+        let results = run_by_batch(hook, filenames, &entry, run).await?;
+
+        reporter.on_run_complete(progress);
+
+        let mut combined_status = 0;
+        let mut combined_output = Vec::new();
+        for (code, output) in results {
+            combined_status |= code;
+            combined_output.extend(output);
+        }
+
+        Ok((combined_status, combined_output))
+    }
+}
+
+impl Dart {
+    fn setup_package_config(env_dir: &Path, work_dir: &Path) -> Result<()> {
+        let env_package_config = env_dir.join(".dart_tool").join("package_config.json");
+        if env_package_config.exists() {
+            let work_dart_tool = work_dir.join(".dart_tool");
+            fs_err::create_dir_all(&work_dart_tool)
+                .context("Failed to create .dart_tool directory in work_dir")?;
+            let work_package_config = work_dart_tool.join("package_config.json");
+            fs_err::copy(&env_package_config, &work_package_config)
+                .context("Failed to copy package_config.json to work_dir")?;
+        }
+        Ok(())
+    }
+
+    async fn compile_executables(
+        dart: &Path,
+        pubspec_path: &Path,
+        bin_src_dir: &Path,
+        bin_out_dir: &Path,
+        pub_cache: &Path,
+    ) -> Result<()> {
+        let pubspec_content =
+            fs_err::read_to_string(pubspec_path).context("Failed to read pubspec.yaml")?;
+        let pubspec: serde_json::Value =
+            serde_saphyr::from_str(&pubspec_content).context("Failed to parse pubspec.yaml")?;
+
+        let Some(executables) = pubspec
+            .get("executables")
+            .and_then(serde_json::Value::as_object)
+        else {
+            return Ok(());
+        };
+
+        fs_err::create_dir_all(bin_out_dir).context("Failed to create bin output directory")?;
+
+        for exe_name in executables.keys() {
+            let source_file = bin_src_dir.join(format!("{exe_name}.dart"));
+            if !source_file.exists() {
+                debug!("Skipping executable '{exe_name}': source file not found");
+                continue;
+            }
+
+            let output_path = if cfg!(windows) {
+                bin_out_dir.join(format!("{exe_name}.exe"))
+            } else {
+                bin_out_dir.join(exe_name)
+            };
+
+            debug!(
+                "Compiling executable '{exe_name}': {} -> {}",
+                source_file.display(),
+                output_path.display()
+            );
+
+            Cmd::new(dart, "dart compile exe")
+                .arg("compile")
+                .arg("exe")
+                .arg(&source_file)
+                .arg("--output")
+                .arg(&output_path)
+                .env(EnvVars::PUB_CACHE, pub_cache)
+                .check(true)
+                .output()
+                .await
+                .with_context(|| format!("Failed to compile executable '{exe_name}'"))?;
+        }
+
+        Ok(())
+    }
+
+    async fn install_from_pubspec(dart: &Path, env_path: &Path, repo_path: &Path) -> Result<()> {
+        Cmd::new(dart, "dart pub get")
+            .current_dir(repo_path)
+            .env(EnvVars::PUB_CACHE, env_path)
+            .arg("pub")
+            .arg("get")
+            .check(true)
+            .output()
+            .await
+            .context("Failed to run dart pub get")?;
+
+        let source_package_config = repo_path.join(".dart_tool").join("package_config.json");
+        if source_package_config.exists() {
+            let env_dart_tool = env_path.join(".dart_tool");
+            fs_err::create_dir_all(&env_dart_tool)
+                .context("Failed to create Dart cache directory in env_path")?;
+            fs_err::copy(
+                &source_package_config,
+                env_dart_tool.join("package_config.json"),
+            )
+            .context("Failed to copy package_config.json to env_path")?;
+        }
+
+        let pubspec_path = repo_path.join("pubspec.yaml");
+        let bin_src_dir = repo_path.join("bin");
+        let bin_out_dir = env_path.join("bin");
+        Self::compile_executables(dart, &pubspec_path, &bin_src_dir, &bin_out_dir, env_path)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn install_additional_dependencies(
+        dart: &Path,
+        env_path: &Path,
+        dependencies: &rustc_hash::FxHashSet<String>,
+    ) -> Result<()> {
+        let mut pubspec_content = indoc::formatdoc! {"
+            name: prek_dart_env
+            environment:
+              sdk: '>=2.12.0 <4.0.0'
+            dependencies:
+        "};
+
+        for dep in dependencies {
+            if let Some((package, version)) = dep.split_once(':') {
+                writeln!(pubspec_content, "  {package}: {version}")?;
+            } else {
+                writeln!(pubspec_content, "  {dep}: any")?;
+            }
+        }
+
+        let pubspec_path = env_path.join("pubspec.yaml");
+        fs_err::tokio::write(&pubspec_path, pubspec_content).await?;
+
+        Cmd::new(dart, "dart pub get")
+            .current_dir(env_path)
+            .env(EnvVars::PUB_CACHE, env_path)
+            .arg("pub")
+            .arg("get")
+            .check(true)
+            .output()
+            .await
+            .context("Failed to run dart pub get for additional dependencies")?;
+
+        Ok(())
+    }
+
+    fn has_pubspec(repo_path: &Path) -> bool {
+        repo_path.join("pubspec.yaml").exists()
+    }
+}

--- a/crates/prek/src/languages/dart.rs
+++ b/crates/prek/src/languages/dart.rs
@@ -40,9 +40,17 @@ const PUBSPEC_YAML: &str = "pubspec.yaml";
 #[derive(Debug, Deserialize, Serialize)]
 struct Pubspec {
     name: String,
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    #[serde(
+        default,
+        skip_deserializing,
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
     environment: BTreeMap<String, String>,
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    #[serde(
+        default,
+        skip_deserializing,
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
     dependencies: BTreeMap<String, PubspecDependency>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     executables: BTreeMap<String, PubspecExecutable>,
@@ -404,17 +412,9 @@ async fn install_from_pubspec(
 mod tests {
     use super::*;
     use anyhow::Result;
-    use std::path::PathBuf;
 
     fn strings(values: &[&str]) -> Vec<String> {
         values.iter().map(ToString::to_string).collect()
-    }
-
-    fn pubspec_file(content: &str) -> Result<(tempfile::TempDir, PathBuf)> {
-        let temp_dir = tempfile::tempdir()?;
-        let pubspec_path = temp_dir.path().join(PUBSPEC_YAML);
-        fs_err::write(&pubspec_path, content)?;
-        Ok((temp_dir, pubspec_path))
     }
 
     #[test]
@@ -447,6 +447,30 @@ mod tests {
             Some(PubspecDependency::Path { path }) => assert_eq!(path, temp_dir.path()),
             dependency => panic!("expected path dependency, got {dependency:?}"),
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn pubspec_deserialization_ignores_unread_fields() -> Result<()> {
+        let pubspec: Pubspec = serde_saphyr::from_str(indoc::indoc! {r"
+            name: sample
+            environment:
+              sdk: '>=2.17.0 <4.0.0'
+            dependencies:
+              hosted_dep:
+                hosted: https://pub.dev
+                version: ^1.0.0
+              sdk_dep:
+                sdk: flutter
+            executables:
+              sample:
+        "})?;
+
+        assert_eq!(pubspec.name, "sample");
+        assert!(pubspec.environment.is_empty());
+        assert!(pubspec.dependencies.is_empty());
+        assert!(pubspec.executables.contains_key("sample"));
 
         Ok(())
     }

--- a/crates/prek/src/languages/dart.rs
+++ b/crates/prek/src/languages/dart.rs
@@ -167,11 +167,11 @@ impl LanguageImpl for Dart {
         let packages_path = package_config_path(env_dir);
 
         let mut entry = hook.entry.resolve(Some(&new_path), store)?;
-        // `dart pub get` writes the hook env's dependency graph here. Inject it
-        // so `dart run` and direct scripts resolve hook deps from this env
-        // instead of the package config in the hook work dir.
+        // `dart pub get` writes the hook env's dependency graph here. Dart's
+        // VM-level `--packages` flag makes `Platform.packageConfig` and package
+        // imports resolve against this env instead of the hook work dir.
         if packages_path.exists()
-            && let Some(index) = packages_arg_insert_position(entry.argv())
+            && let Some(index) = packages_arg_insert_position(entry.argv(), &hook.args)
         {
             entry
                 .argv_mut()
@@ -224,8 +224,8 @@ fn package_config_path(env_path: &Path) -> PathBuf {
     env_path.join(".dart_tool").join("package_config.json")
 }
 
-/// Return the argv position where `--packages=...` should be inserted.
-fn packages_arg_insert_position(entry: &[String]) -> Option<usize> {
+/// Return the `entry` argv position where `--packages=...` should be inserted.
+fn packages_arg_insert_position(entry: &[String], hook_args: &[String]) -> Option<usize> {
     fn is_dart_binary(arg: &str) -> bool {
         Path::new(arg)
             .file_name()
@@ -246,18 +246,23 @@ fn packages_arg_insert_position(entry: &[String]) -> Option<usize> {
     let dart_index = entry.iter().position(|arg| is_dart_binary(arg))?;
 
     // Respect an explicit package config from the hook author.
-    if entry.iter().any(|arg| has_packages_arg(arg)) {
+    if entry
+        .iter()
+        .chain(hook_args)
+        .any(|arg| has_packages_arg(arg))
+    {
         return None;
     }
 
     let (target_index, target) = entry
         .iter()
+        .chain(hook_args)
         .enumerate()
         .skip(dart_index + 1)
         .find_map(|(index, arg)| (!arg.starts_with('-')).then_some((index, arg)))?;
 
-    // Dart expects `--packages` before the `run` subcommand or script target.
-    (target == "run" || is_dart_script(target)).then_some(target_index)
+    // `--packages` is a VM flag, so place it before `run` or a script target.
+    (target == "run" || is_dart_script(target)).then_some(target_index.min(entry.len()))
 }
 
 /// Compile declared package executables into the hook env's `bin` directory.
@@ -421,18 +426,44 @@ mod tests {
     fn packages_arg_insert_position_inserts_before_dart_run() {
         let entry = strings(&["/usr/bin/dart", "run", "bin/hook.dart"]);
 
-        assert_eq!(packages_arg_insert_position(&entry), Some(1));
+        assert_eq!(packages_arg_insert_position(&entry, &[]), Some(1));
     }
 
     #[test]
     fn packages_arg_insert_position_keeps_existing_packages_arg() {
         assert_eq!(
-            packages_arg_insert_position(&strings(&["dart", "--packages=custom", "run"])),
+            packages_arg_insert_position(&strings(&["dart", "--packages=custom", "run"]), &[]),
             None
         );
         assert_eq!(
-            packages_arg_insert_position(&strings(&["dart", "--packages", "custom", "run"])),
+            packages_arg_insert_position(&strings(&["dart", "--packages", "custom", "run"]), &[]),
             None
+        );
+        assert_eq!(
+            packages_arg_insert_position(
+                &strings(&["dart"]),
+                &strings(&["--packages=custom", "run"])
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn packages_arg_insert_position_checks_hook_args() {
+        assert_eq!(
+            packages_arg_insert_position(&strings(&["dart"]), &strings(&["run", "bin/hook.dart"])),
+            Some(1)
+        );
+        assert_eq!(
+            packages_arg_insert_position(&strings(&["dart"]), &strings(&["bin/hook.dart"])),
+            Some(1)
+        );
+        assert_eq!(
+            packages_arg_insert_position(
+                &strings(&["dart", "--enable-asserts"]),
+                &strings(&["run", "bin/hook.dart"])
+            ),
+            Some(2)
         );
     }
 

--- a/crates/prek/src/languages/mod.rs
+++ b/crates/prek/src/languages/mod.rs
@@ -190,7 +190,6 @@ impl Language {
     pub(crate) fn shell_support(self) -> ShellSupport {
         match self {
             Self::Bun
-            | Self::Dart
             | Self::Deno
             | Self::Dotnet
             | Self::Golang
@@ -205,6 +204,9 @@ impl Language {
             Self::Conda | Self::Coursier | Self::Perl | Self::R => {
                 ShellSupport::Unsupported("no runner is implemented yet")
             }
+            Self::Dart => ShellSupport::Unsupported(
+                "`--packages` injection requires the resolved argv to contain `dart` directly",
+            ),
             Self::Docker | Self::DockerImage => ShellSupport::Unsupported(
                 "`entry` participates in container image or entrypoint selection",
             ),

--- a/crates/prek/src/languages/mod.rs
+++ b/crates/prek/src/languages/mod.rs
@@ -16,6 +16,7 @@ use crate::hooks;
 use crate::store::{CacheBucket, Store, ToolBucket};
 
 mod bun;
+mod dart;
 mod deno;
 mod docker;
 mod docker_image;
@@ -36,6 +37,7 @@ mod system;
 pub(crate) mod version;
 
 static BUN: bun::Bun = bun::Bun;
+static DART: dart::Dart = dart::Dart;
 static DENO: deno::Deno = deno::Deno;
 static DOCKER: docker::Docker = docker::Docker;
 static DOCKER_IMAGE: docker_image::DockerImage = docker_image::DockerImage;
@@ -138,6 +140,7 @@ impl Language {
     pub(crate) fn supported(lang: Language) -> bool {
         match lang {
             Self::Bun
+            | Self::Dart
             | Self::Deno
             | Self::Docker
             | Self::DockerImage
@@ -155,7 +158,7 @@ impl Language {
             | Self::Script
             | Self::Swift
             | Self::System => true,
-            Self::Conda | Self::Coursier | Self::Dart | Self::Perl | Self::R => false,
+            Self::Conda | Self::Coursier | Self::Perl | Self::R => false,
         }
     }
 
@@ -187,6 +190,7 @@ impl Language {
     pub(crate) fn shell_support(self) -> ShellSupport {
         match self {
             Self::Bun
+            | Self::Dart
             | Self::Deno
             | Self::Dotnet
             | Self::Golang
@@ -198,7 +202,7 @@ impl Language {
             | Self::Script
             | Self::Swift
             | Self::System => ShellSupport::Supported,
-            Self::Conda | Self::Coursier | Self::Dart | Self::Perl | Self::R => {
+            Self::Conda | Self::Coursier | Self::Perl | Self::R => {
                 ShellSupport::Unsupported("no runner is implemented yet")
             }
             Self::Docker | Self::DockerImage => ShellSupport::Unsupported(
@@ -336,6 +340,7 @@ impl Language {
         reporter: &HookInstallReporter,
     ) -> Result<InstalledHook> {
         match self {
+            Self::Dart => DART.install(hook, store, reporter).await,
             Self::Bun => BUN.install(hook, store, reporter).await,
             Self::Deno => DENO.install(hook, store, reporter).await,
             Self::Docker => DOCKER.install(hook, store, reporter).await,
@@ -354,7 +359,7 @@ impl Language {
             Self::Script => SCRIPT.install(hook, store, reporter).await,
             Self::Swift => SWIFT.install(hook, store, reporter).await,
             Self::System => SYSTEM.install(hook, store, reporter).await,
-            Self::Conda | Self::Coursier | Self::Dart | Self::Perl | Self::R => {
+            Self::Conda | Self::Coursier | Self::Perl | Self::R => {
                 UNIMPLEMENTED.install(hook, store, reporter).await
             }
         }
@@ -362,6 +367,7 @@ impl Language {
 
     pub(crate) async fn check_health(&self, info: &InstallInfo) -> Result<()> {
         match self {
+            Self::Dart => DART.check_health(info).await,
             Self::Bun => BUN.check_health(info).await,
             Self::Deno => DENO.check_health(info).await,
             Self::Docker => DOCKER.check_health(info).await,
@@ -380,7 +386,7 @@ impl Language {
             Self::Script => SCRIPT.check_health(info).await,
             Self::Swift => SWIFT.check_health(info).await,
             Self::System => SYSTEM.check_health(info).await,
-            Self::Conda | Self::Coursier | Self::Dart | Self::Perl | Self::R => {
+            Self::Conda | Self::Coursier | Self::Perl | Self::R => {
                 UNIMPLEMENTED.check_health(info).await
             }
         }
@@ -417,6 +423,7 @@ impl Language {
         }
 
         match self {
+            Self::Dart => DART.run(hook, filenames, store, reporter).await,
             Self::Bun => BUN.run(hook, filenames, store, reporter).await,
             Self::Deno => DENO.run(hook, filenames, store, reporter).await,
             Self::Docker => DOCKER.run(hook, filenames, store, reporter).await,
@@ -435,7 +442,7 @@ impl Language {
             Self::Script => SCRIPT.run(hook, filenames, store, reporter).await,
             Self::Swift => SWIFT.run(hook, filenames, store, reporter).await,
             Self::System => SYSTEM.run(hook, filenames, store, reporter).await,
-            Self::Conda | Self::Coursier | Self::Dart | Self::Perl | Self::R => {
+            Self::Conda | Self::Coursier | Self::Perl | Self::R => {
                 UNIMPLEMENTED.run(hook, filenames, store, reporter).await
             }
         }

--- a/crates/prek/tests/common/mod.rs
+++ b/crates/prek/tests/common/mod.rs
@@ -417,8 +417,6 @@ pub const INSTA_FILTERS: &[(&str, &str)] = &[
     (r"\b(\d+\.)?\d+(ms|s)\b", "[TIME]"),
     // Dart SDK version output (handles Flutter SDK too)
     (r"Dart SDK version: .*", "Dart SDK version: [VERSION]"),
-    // Windows shebang interpreter
-    (r"#!/bin/sh", "#!/usr/bin/env bash"),
     // Strip non-deterministic lock contention warnings from parallel test execution
     (r"(?m)^warning: Waiting to acquire lock.*\n", ""),
 ];

--- a/crates/prek/tests/common/mod.rs
+++ b/crates/prek/tests/common/mod.rs
@@ -415,6 +415,10 @@ pub const INSTA_FILTERS: &[(&str, &str)] = &[
     ),
     // Time seconds
     (r"\b(\d+\.)?\d+(ms|s)\b", "[TIME]"),
+    // Dart SDK version output (handles Flutter SDK too)
+    (r"Dart SDK version: .*", "Dart SDK version: [VERSION]"),
+    // Windows shebang interpreter
+    (r"#!/bin/sh", "#!/usr/bin/env bash"),
     // Strip non-deterministic lock contention warnings from parallel test execution
     (r"(?m)^warning: Waiting to acquire lock.*\n", ""),
 ];

--- a/crates/prek/tests/common/mod.rs
+++ b/crates/prek/tests/common/mod.rs
@@ -415,8 +415,6 @@ pub const INSTA_FILTERS: &[(&str, &str)] = &[
     ),
     // Time seconds
     (r"\b(\d+\.)?\d+(ms|s)\b", "[TIME]"),
-    // Dart SDK version output (handles Flutter SDK too)
-    (r"Dart SDK version: .*", "Dart SDK version: [VERSION]"),
     // Strip non-deterministic lock contention warnings from parallel test execution
     (r"(?m)^warning: Waiting to acquire lock.*\n", ""),
 ];

--- a/crates/prek/tests/languages/dart.rs
+++ b/crates/prek/tests/languages/dart.rs
@@ -593,14 +593,14 @@ fn dart_environment() {
 }
 
 #[test]
-#[ignore = "Requires prek-test-repos/dart-hooks to be created"]
+// Temporarily hosted under Lutra-Fs until upstream fixture repo access is available.
 fn remote_hook() {
     let context = TestContext::new();
     context.init_project();
 
     context.write_pre_commit_config(indoc::indoc! {r"
         repos:
-          - repo: https://github.com/prek-test-repos/dart-hooks
+          - repo: https://github.com/Lutra-Fs/dart-hooks
             rev: v1.0.0
             hooks:
               - id: dart-hooks

--- a/crates/prek/tests/languages/dart.rs
+++ b/crates/prek/tests/languages/dart.rs
@@ -601,7 +601,7 @@ fn remote_hook() {
     context.write_pre_commit_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/Lutra-Fs/dart-hooks
-            rev: v1.0.0
+            rev: v1.1.0
             hooks:
               - id: dart-hooks
                 always_run: true

--- a/crates/prek/tests/languages/dart.rs
+++ b/crates/prek/tests/languages/dart.rs
@@ -307,6 +307,86 @@ fn with_pubspec() -> anyhow::Result<()> {
     ----- stderr -----
     ");
 
+    assert!(
+        !context.work_dir().path().join(".dart_tool").exists(),
+        "Dart hooks should not mutate the checkout with .dart_tool"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn with_pubspec_and_additional_dependencies() -> anyhow::Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: dart
+                name: dart
+                language: dart
+                entry: dart ./bin/hello.dart
+                additional_dependencies: ["path"]
+                always_run: true
+                verbose: true
+                pass_filenames: false
+    "#});
+
+    context
+        .work_dir()
+        .child("pubspec.yaml")
+        .write_str(indoc::indoc! {r#"
+            name: test_package
+            description: A test package
+            version: 1.0.0
+            environment:
+              sdk: '>=2.17.0 <4.0.0'
+        "#})?;
+
+    std::fs::create_dir(context.work_dir().join("bin"))?;
+    std::fs::create_dir(context.work_dir().join("lib"))?;
+    context
+        .work_dir()
+        .child("lib")
+        .child("greeting.dart")
+        .write_str(indoc::indoc! {r#"
+            String greet(String subject) => 'Hello $subject!';
+        "#})?;
+    context
+        .work_dir()
+        .child("bin")
+        .child("hello.dart")
+        .write_str(indoc::indoc! {r#"
+            import 'package:path/path.dart' as p;
+            import 'package:test_package/greeting.dart';
+
+            void main() {
+              print(greet(p.posix.join('Dart', 'Hooks')));
+            }
+        "#})?;
+
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    dart.....................................................................Passed
+    - hook id: dart
+    - duration: [TIME]
+
+      Hello Dart/Hooks!
+
+    ----- stderr -----
+    ");
+
+    assert!(
+        !context.work_dir().path().join(".dart_tool").exists(),
+        "Dart hooks should not mutate the checkout with .dart_tool"
+    );
+
     Ok(())
 }
 
@@ -401,6 +481,65 @@ fn additional_dependencies_with_version() {
 
     ----- stderr -----
     ");
+}
+
+#[test]
+fn executable_alias() -> anyhow::Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    context.write_pre_commit_config(indoc::indoc! {r"
+        repos:
+          - repo: local
+            hooks:
+              - id: dart
+                name: dart
+                language: dart
+                entry: cli
+                always_run: true
+                verbose: true
+                pass_filenames: false
+    "});
+
+    context
+        .work_dir()
+        .child("pubspec.yaml")
+        .write_str(indoc::indoc! {r#"
+            name: aliased_dart_tool
+            environment:
+              sdk: '>=2.17.0 <4.0.0'
+
+            executables:
+              cli: hello
+        "#})?;
+
+    std::fs::create_dir(context.work_dir().join("bin"))?;
+    context
+        .work_dir()
+        .child("bin")
+        .child("hello.dart")
+        .write_str(indoc::indoc! {r#"
+            void main() {
+              print('alias executable works');
+            }
+        "#})?;
+
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    dart.....................................................................Passed
+    - hook id: dart
+    - duration: [TIME]
+
+      alias executable works
+
+    ----- stderr -----
+    ");
+
+    Ok(())
 }
 
 #[test]

--- a/crates/prek/tests/languages/dart.rs
+++ b/crates/prek/tests/languages/dart.rs
@@ -1,0 +1,486 @@
+#![allow(clippy::needless_raw_string_hashes)]
+
+use assert_fs::fixture::{FileWriteStr, PathChild};
+
+use crate::common::{TestContext, cmd_snapshot};
+
+#[test]
+fn health_check() {
+    let context = TestContext::new();
+    context.init_project();
+
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: dart
+                name: dart
+                language: dart
+                entry: dart --version
+                always_run: true
+                verbose: true
+                pass_filenames: false
+    "#});
+
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    dart.....................................................................Passed
+    - hook id: dart
+    - duration: [TIME]
+
+      Dart SDK version: [VERSION]
+
+    ----- stderr -----
+    ");
+
+    cmd_snapshot!(context.filters(), context.run(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    dart.....................................................................Passed
+    - hook id: dart
+    - duration: [TIME]
+
+      Dart SDK version: [VERSION]
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn language_version() {
+    let context = TestContext::new();
+    context.init_project();
+    context.write_pre_commit_config(indoc::indoc! {r"
+        repos:
+          - repo: local
+            hooks:
+              - id: local
+                name: local
+                language: dart
+                entry: dart --version
+                language_version: '3.0'
+                always_run: true
+                verbose: true
+                pass_filenames: false
+    "});
+
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run(), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to init hooks
+      caused by: Invalid hook `local`
+      caused by: Hook specified `language_version: 3.0` but the language `dart` does not support toolchain installation for now
+    ");
+}
+
+#[test]
+fn hook_stderr() -> anyhow::Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    context.write_pre_commit_config(indoc::indoc! {r"
+        repos:
+          - repo: local
+            hooks:
+              - id: local
+                name: local
+                language: dart
+                entry: dart ./hook.dart
+    "});
+
+    context
+        .work_dir()
+        .child("hook.dart")
+        .write_str(indoc::indoc! {r#"
+            import 'dart:io';
+            void main() {
+              stderr.writeln('Error from Dart hook');
+              exit(1);
+            }
+        "#})?;
+
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run(), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    local....................................................................Failed
+    - hook id: local
+    - exit code: 1
+
+      Error from Dart hook
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn script_with_files() -> anyhow::Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    context.write_pre_commit_config(indoc::indoc! {r"
+        repos:
+          - repo: local
+            hooks:
+              - id: dart
+                name: dart
+                language: dart
+                entry: dart ./script.dart
+                verbose: true
+    "});
+
+    context
+        .work_dir()
+        .child("script.dart")
+        .write_str(indoc::indoc! {r#"
+            import 'dart:io';
+            void main(List<String> args) {
+              for (var arg in args) {
+                print('Processing file: $arg');
+              }
+            }
+        "#})?;
+
+    context
+        .work_dir()
+        .child("test1.dart")
+        .write_str("void main() { print('test1'); }")?;
+
+    context
+        .work_dir()
+        .child("test2.dart")
+        .write_str("void main() { print('test2'); }")?;
+
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    dart.....................................................................Passed
+    - hook id: dart
+    - duration: [TIME]
+
+      Processing file: script.dart
+      Processing file: .pre-commit-config.yaml
+      Processing file: test2.dart
+      Processing file: test1.dart
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn with_pubspec_and_dependencies() -> anyhow::Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    context.write_pre_commit_config(indoc::indoc! {r"
+        repos:
+          - repo: local
+            hooks:
+              - id: dart
+                name: dart
+                language: dart
+                entry: hello-world-dart
+                always_run: true
+                verbose: true
+                pass_filenames: false
+    "});
+
+    context
+        .work_dir()
+        .child("pubspec.yaml")
+        .write_str(indoc::indoc! {r#"
+            environment:
+              sdk: '>=2.17.0 <4.0.0'
+
+            name: hello_world_dart
+
+            executables:
+                hello-world-dart:
+
+            dependencies:
+              ansicolor: ^2.0.1
+        "#})?;
+
+    std::fs::create_dir(context.work_dir().join("bin"))?;
+    context
+        .work_dir()
+        .child("bin")
+        .child("hello-world-dart.dart")
+        .write_str(indoc::indoc! {r#"
+            import 'package:ansicolor/ansicolor.dart';
+
+            void main() {
+                AnsiPen pen = new AnsiPen()..red();
+                print("hello hello " + pen("world"));
+            }
+        "#})?;
+
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    dart.....................................................................Passed
+    - hook id: dart
+    - duration: [TIME]
+
+      hello hello world
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn with_pubspec() -> anyhow::Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    context.write_pre_commit_config(indoc::indoc! {r"
+        repos:
+          - repo: local
+            hooks:
+              - id: dart
+                name: dart
+                language: dart
+                entry: dart ./bin/hello.dart
+                always_run: true
+                verbose: true
+                pass_filenames: false
+    "});
+
+    context
+        .work_dir()
+        .child("pubspec.yaml")
+        .write_str(indoc::indoc! {r#"
+            name: test_package
+            description: A test package
+            version: 1.0.0
+            environment:
+              sdk: '>=2.17.0 <4.0.0'
+        "#})?;
+
+    std::fs::create_dir(context.work_dir().join("bin"))?;
+    context
+        .work_dir()
+        .child("bin")
+        .child("hello.dart")
+        .write_str(indoc::indoc! {r#"
+            void main() {
+              print('Hello from Dart package!');
+            }
+        "#})?;
+
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    dart.....................................................................Passed
+    - hook id: dart
+    - duration: [TIME]
+
+      Hello from Dart package!
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn additional_dependencies() {
+    let context = TestContext::new();
+    context.init_project();
+
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: dart
+                name: dart
+                language: dart
+                entry: dart ./test_path.dart
+                additional_dependencies: ["path"]
+                always_run: true
+                verbose: true
+                pass_filenames: false
+    "#});
+
+    context
+        .work_dir()
+        .child("test_path.dart")
+        .write_str(indoc::indoc! {r#"
+            import 'package:path/path.dart' as p;
+            void main() {
+              var joined = p.join('foo', 'bar', 'baz.txt');
+              print('Joined path: $joined');
+            }
+        "#})
+        .unwrap();
+
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    dart.....................................................................Passed
+    - hook id: dart
+    - duration: [TIME]
+
+      Joined path: foo/bar/baz.txt
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn additional_dependencies_with_version() {
+    let context = TestContext::new();
+    context.init_project();
+
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: dart
+                name: dart
+                language: dart
+                entry: dart ./test_path.dart
+                additional_dependencies: ["path:1.8.0"]
+                always_run: true
+                verbose: true
+                pass_filenames: false
+    "#});
+
+    context
+        .work_dir()
+        .child("test_path.dart")
+        .write_str(indoc::indoc! {r#"
+            import 'package:path/path.dart' as p;
+            void main() {
+              print('Using path package');
+            }
+        "#})
+        .unwrap();
+
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    dart.....................................................................Passed
+    - hook id: dart
+    - duration: [TIME]
+
+      Using path package
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn dart_environment() {
+    let context = TestContext::new();
+    context.init_project();
+
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: dart
+                name: dart
+                language: dart
+                entry: dart ./env_test.dart
+                always_run: true
+                verbose: true
+                pass_filenames: false
+    "#});
+
+    context
+        .work_dir()
+        .child("env_test.dart")
+        .write_str(indoc::indoc! {r#"
+            import 'dart:io';
+            void main() {
+              var pubCache = Platform.environment['PUB_CACHE'];
+              if (pubCache != null) {
+                print('PUB_CACHE is set: ${pubCache.isNotEmpty}');
+              } else {
+                print('PUB_CACHE is not set');
+              }
+            }
+        "#})
+        .unwrap();
+
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    dart.....................................................................Passed
+    - hook id: dart
+    - duration: [TIME]
+
+      PUB_CACHE is set: true
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+#[ignore = "Requires prek-test-repos/dart-hooks to be created"]
+fn remote_hook() {
+    let context = TestContext::new();
+    context.init_project();
+
+    context.write_pre_commit_config(indoc::indoc! {r"
+        repos:
+          - repo: https://github.com/prek-test-repos/dart-hooks
+            rev: v1.0.0
+            hooks:
+              - id: dart-hooks
+                always_run: true
+                verbose: true
+    "});
+
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    dart-hooks...............................................................Passed
+    - hook id: dart-hooks
+    - duration: [TIME]
+
+      this is a dart remote hook
+
+    ----- stderr -----
+    ");
+}

--- a/crates/prek/tests/languages/dart.rs
+++ b/crates/prek/tests/languages/dart.rs
@@ -597,14 +597,13 @@ fn dart_environment() {
 }
 
 #[test]
-// Temporarily hosted under Lutra-Fs until upstream fixture repo access is available.
 fn remote_hook() {
     let context = TestContext::new();
     context.init_project();
 
     context.write_pre_commit_config(indoc::indoc! {r"
         repos:
-          - repo: https://github.com/Lutra-Fs/dart-hooks
+          - repo: https://github.com/prek-test-repos/dart-hooks
             rev: v1.1.0
             hooks:
               - id: dart-hooks

--- a/crates/prek/tests/languages/dart.rs
+++ b/crates/prek/tests/languages/dart.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::needless_raw_string_hashes)]
-
 use assert_fs::fixture::{FileWriteStr, PathChild};
 
 use crate::common::{TestContext, cmd_snapshot};
@@ -9,7 +7,7 @@ fn health_check() {
     let context = TestContext::new();
     context.init_project();
 
-    context.write_pre_commit_config(indoc::indoc! {r#"
+    context.write_pre_commit_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -20,11 +18,17 @@ fn health_check() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "#});
+    "});
 
     context.git_add(".");
 
-    cmd_snapshot!(context.filters(), context.run(), @r"
+    let filters = context
+        .filters()
+        .into_iter()
+        .chain([(r"Dart SDK version: .*", "Dart SDK version: [VERSION]")])
+        .collect::<Vec<_>>();
+
+    cmd_snapshot!(filters.clone(), context.run(), @r"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -37,7 +41,7 @@ fn health_check() {
     ----- stderr -----
     ");
 
-    cmd_snapshot!(context.filters(), context.run(), @r"
+    cmd_snapshot!(filters, context.run(), @r"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -101,13 +105,13 @@ fn hook_stderr() -> anyhow::Result<()> {
     context
         .work_dir()
         .child("hook.dart")
-        .write_str(indoc::indoc! {r#"
+        .write_str(indoc::indoc! {r"
             import 'dart:io';
             void main() {
               stderr.writeln('Error from Dart hook');
               exit(1);
             }
-        "#})?;
+        "})?;
 
     context.git_add(".");
 
@@ -146,14 +150,14 @@ fn script_with_files() -> anyhow::Result<()> {
     context
         .work_dir()
         .child("script.dart")
-        .write_str(indoc::indoc! {r#"
+        .write_str(indoc::indoc! {r"
             import 'dart:io';
             void main(List<String> args) {
               for (var arg in args) {
                 print('Processing file: $arg');
               }
             }
-        "#})?;
+        "})?;
 
     context
         .work_dir()
@@ -207,7 +211,7 @@ fn with_pubspec_and_dependencies() -> anyhow::Result<()> {
     context
         .work_dir()
         .child("pubspec.yaml")
-        .write_str(indoc::indoc! {r#"
+        .write_str(indoc::indoc! {r"
             environment:
               sdk: '>=2.17.0 <4.0.0'
 
@@ -218,7 +222,7 @@ fn with_pubspec_and_dependencies() -> anyhow::Result<()> {
 
             dependencies:
               ansicolor: ^2.0.1
-        "#})?;
+        "})?;
 
     std::fs::create_dir(context.work_dir().join("bin"))?;
     context
@@ -273,24 +277,24 @@ fn with_pubspec() -> anyhow::Result<()> {
     context
         .work_dir()
         .child("pubspec.yaml")
-        .write_str(indoc::indoc! {r#"
+        .write_str(indoc::indoc! {r"
             name: test_package
             description: A test package
             version: 1.0.0
             environment:
               sdk: '>=2.17.0 <4.0.0'
-        "#})?;
+        "})?;
 
     std::fs::create_dir(context.work_dir().join("bin"))?;
     context
         .work_dir()
         .child("bin")
         .child("hello.dart")
-        .write_str(indoc::indoc! {r#"
+        .write_str(indoc::indoc! {r"
             void main() {
               print('Hello from Dart package!');
             }
-        "#})?;
+        "})?;
 
     context.git_add(".");
 
@@ -337,13 +341,13 @@ fn with_pubspec_and_additional_dependencies() -> anyhow::Result<()> {
     context
         .work_dir()
         .child("pubspec.yaml")
-        .write_str(indoc::indoc! {r#"
+        .write_str(indoc::indoc! {r"
             name: test_package
             description: A test package
             version: 1.0.0
             environment:
               sdk: '>=2.17.0 <4.0.0'
-        "#})?;
+        "})?;
 
     std::fs::create_dir(context.work_dir().join("bin"))?;
     std::fs::create_dir(context.work_dir().join("lib"))?;
@@ -351,21 +355,21 @@ fn with_pubspec_and_additional_dependencies() -> anyhow::Result<()> {
         .work_dir()
         .child("lib")
         .child("greeting.dart")
-        .write_str(indoc::indoc! {r#"
+        .write_str(indoc::indoc! {r"
             String greet(String subject) => 'Hello $subject!';
-        "#})?;
+        "})?;
     context
         .work_dir()
         .child("bin")
         .child("hello.dart")
-        .write_str(indoc::indoc! {r#"
+        .write_str(indoc::indoc! {r"
             import 'package:path/path.dart' as p;
             import 'package:test_package/greeting.dart';
 
             void main() {
               print(greet(p.posix.join('Dart', 'Hooks')));
             }
-        "#})?;
+        "})?;
 
     context.git_add(".");
 
@@ -412,13 +416,13 @@ fn additional_dependencies() {
     context
         .work_dir()
         .child("test_path.dart")
-        .write_str(indoc::indoc! {r#"
+        .write_str(indoc::indoc! {r"
             import 'package:path/path.dart' as p;
             void main() {
               var joined = p.join('foo', 'bar', 'baz.txt');
               print('Joined path: $joined');
             }
-        "#})
+        "})
         .unwrap();
 
     context.git_add(".");
@@ -459,12 +463,12 @@ fn additional_dependencies_with_version() {
     context
         .work_dir()
         .child("test_path.dart")
-        .write_str(indoc::indoc! {r#"
+        .write_str(indoc::indoc! {r"
             import 'package:path/path.dart' as p;
             void main() {
               print('Using path package');
             }
-        "#})
+        "})
         .unwrap();
 
     context.git_add(".");
@@ -504,25 +508,25 @@ fn executable_alias() -> anyhow::Result<()> {
     context
         .work_dir()
         .child("pubspec.yaml")
-        .write_str(indoc::indoc! {r#"
+        .write_str(indoc::indoc! {r"
             name: aliased_dart_tool
             environment:
               sdk: '>=2.17.0 <4.0.0'
 
             executables:
               cli: hello
-        "#})?;
+        "})?;
 
     std::fs::create_dir(context.work_dir().join("bin"))?;
     context
         .work_dir()
         .child("bin")
         .child("hello.dart")
-        .write_str(indoc::indoc! {r#"
+        .write_str(indoc::indoc! {r"
             void main() {
               print('alias executable works');
             }
-        "#})?;
+        "})?;
 
     context.git_add(".");
 
@@ -547,7 +551,7 @@ fn dart_environment() {
     let context = TestContext::new();
     context.init_project();
 
-    context.write_pre_commit_config(indoc::indoc! {r#"
+    context.write_pre_commit_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -558,12 +562,12 @@ fn dart_environment() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "#});
+    "});
 
     context
         .work_dir()
         .child("env_test.dart")
-        .write_str(indoc::indoc! {r#"
+        .write_str(indoc::indoc! {r"
             import 'dart:io';
             void main() {
               var pubCache = Platform.environment['PUB_CACHE'];
@@ -573,7 +577,7 @@ fn dart_environment() {
                 print('PUB_CACHE is not set');
               }
             }
-        "#})
+        "})
         .unwrap();
 
     context.git_add(".");

--- a/crates/prek/tests/languages/dart.rs
+++ b/crates/prek/tests/languages/dart.rs
@@ -3,59 +3,6 @@ use assert_fs::fixture::{FileWriteStr, PathChild};
 use crate::common::{TestContext, cmd_snapshot};
 
 #[test]
-fn health_check() {
-    let context = TestContext::new();
-    context.init_project();
-
-    context.write_pre_commit_config(indoc::indoc! {r"
-        repos:
-          - repo: local
-            hooks:
-              - id: dart
-                name: dart
-                language: dart
-                entry: dart --version
-                always_run: true
-                verbose: true
-                pass_filenames: false
-    "});
-
-    context.git_add(".");
-
-    let filters = context
-        .filters()
-        .into_iter()
-        .chain([(r"Dart SDK version: .*", "Dart SDK version: [VERSION]")])
-        .collect::<Vec<_>>();
-
-    cmd_snapshot!(filters.clone(), context.run(), @r"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    dart.....................................................................Passed
-    - hook id: dart
-    - duration: [TIME]
-
-      Dart SDK version: [VERSION]
-
-    ----- stderr -----
-    ");
-
-    cmd_snapshot!(filters, context.run(), @r"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    dart.....................................................................Passed
-    - hook id: dart
-    - duration: [TIME]
-
-      Dart SDK version: [VERSION]
-
-    ----- stderr -----
-    ");
-}
-
-#[test]
 fn language_version() {
     let context = TestContext::new();
     context.init_project();

--- a/crates/prek/tests/languages/main.rs
+++ b/crates/prek/tests/languages/main.rs
@@ -2,6 +2,7 @@
 mod common;
 
 mod bun;
+mod dart;
 mod deno;
 #[cfg(all(feature = "docker", target_os = "linux"))]
 mod docker;

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -78,9 +78,61 @@ Tracking: [#53](https://github.com/j178/prek/issues/53)
 
 ### dart
 
-**Status in prek:** Not supported yet.
+**Status in prek:** ✅ Supported.
 
-Tracking: [#51](https://github.com/j178/prek/issues/51)
+prek runs Dart hooks with a system-installed `dart` executable.
+
+Dart hooks can run plain Dart commands, repository scripts, or package
+executables:
+
+- `entry: dart --version`
+- `entry: dart ./tool/hook.dart`
+- `entry: dart run bin/hook.dart`
+- `entry: my-package-executable`
+
+If the hook repository contains `pubspec.yaml`, prek uses it to resolve package
+dependencies and declared executables. `additional_dependencies` are supported
+for both package hooks and standalone Dart scripts.
+
+#### `pubspec.yaml` executables
+
+For package hooks, executables declared in `pubspec.yaml` can be used as hook
+entries. The executable key is the command name:
+
+```yaml
+name: my_dart_hooks
+
+executables:
+  my-hook:
+  aliased-hook: tool/main
+```
+
+`my-hook` resolves to `bin/my-hook.dart`. `aliased-hook` resolves to
+`bin/tool/main.dart`. Empty or null executable values use the executable key as
+the entrypoint name, matching Dart's pub behavior.
+
+#### `additional_dependencies`
+
+Use `package` for the latest compatible version or `package:version` to pin a
+version:
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: dart-hook
+        name: Dart hook
+        language: dart
+        entry: dart ./bin/hook.dart
+        additional_dependencies:
+          - path
+          - args:2.7.0
+```
+
+#### `language_version`
+
+Dart does not support managed toolchain installation today. It uses the system
+`dart` executable, and explicit Dart version requests are rejected.
 
 ### docker
 

--- a/docs/proposals/hook-shell.md
+++ b/docs/proposals/hook-shell.md
@@ -167,10 +167,11 @@ the hook command on the host.
     | Language | Why `shell` is unsupported |
     | -- | -- |
     | `docker`, `docker_image` | `entry` participates in container image or entrypoint selection instead of direct host process execution. |
+    | `dart` | Dart package config injection requires `entry` to resolve to a direct `dart` command. |
     | `fail` | `entry` is the failure message body. |
     | `julia`, `rust` | `entry` participates in install/runtime package resolution and is split before execution. |
     | `pygrep` | `entry` is the regex pattern. |
-    | `conda`, `coursier`, `dart`, `perl`, `r` | The language backend is not implemented yet. |
+    | `conda`, `coursier`, `perl`, `r` | The language backend is not implemented yet. |
 
     Predefined `repo: meta` and `repo: builtin` hooks should reject `shell` as
     well, because their entries are owned by prek.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -648,10 +648,11 @@ When `shell` is set, `entry` is treated as source for that shell. `prek` writes 
     | Language | Why `shell` is unsupported |
     | -- | -- |
     | `docker`, `docker_image` | `entry` participates in container image or entrypoint selection instead of direct host process execution. |
+    | `dart` | Dart package config injection requires `entry` to resolve to a direct `dart` command. |
     | `fail` | `entry` is the failure message body. |
     | `julia`, `rust` | `entry` participates in install/runtime package resolution and is split before execution. |
     | `pygrep` | `entry` is the regex pattern. |
-    | `conda`, `coursier`, `dart`, `perl`, `r` | The language backend is not implemented yet. |
+    | `conda`, `coursier`, `perl`, `r` | The language backend is not implemented yet. |
 
 ### `language`
 


### PR DESCRIPTION
Implements full Dart language support following TDD approach:

- Migrated tests from pre-commit's test suite
- Implemented Dart language handler in src/languages/dart.rs
  - System Dart installation detection
  - pubspec.yaml dependency installation via `dart pub get`
  - Additional dependencies via `dart pub cache add`
  - Environment setup with PUB_CACHE
- Added comprehensive test suite covering:
  - Health checks
  - Script execution with file arguments
  - pubspec.yaml handling
  - Additional dependencies (with and without versions)
  - Environment variable setup
  - Error handling
- Updated documentation in docs/todo.md

Language features:
- Uses system-installed Dart (no version management)
- Supports additional_dependencies
- Supports environment setup
- Compatible with pre-commit Dart hooks

Closes #51