### PR TITLE
Prevent color output when redirecting stdout to a file

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -82,6 +82,16 @@ pub enum ColorChoice {
     Never,
 }
 
+impl From<ColorChoice> for anstream::ColorChoice {
+    fn from(value: ColorChoice) -> Self {
+        match value {
+            ColorChoice::Auto => Self::Auto,
+            ColorChoice::Always => Self::Always,
+            ColorChoice::Never => Self::Never,
+        }
+    }
+}
+
 const STYLES: Styles = Styles::styled()
     .header(AnsiColor::Green.on_default().effects(Effects::BOLD))
     .usage(AnsiColor::Green.on_default().effects(Effects::BOLD))

--- a/src/cli/run/run.rs
+++ b/src/cli/run/run.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, LazyLock};
 use anyhow::{Context, Result};
 use futures::stream::{FuturesUnordered, StreamExt};
 use owo_colors::{OwoColorize, Style};
+use prek_consts::env_vars::EnvVars;
 use rand::SeedableRng;
 use rand::prelude::{SliceRandom, StdRng};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -14,8 +15,6 @@ use tokio::io::AsyncWriteExt;
 use tokio::sync::{OnceCell, Semaphore};
 use tracing::{debug, trace, warn};
 use unicode_width::UnicodeWidthStr;
-
-use prek_consts::env_vars::EnvVars;
 
 use crate::cli::reporter::{HookInitReporter, HookInstallReporter};
 use crate::cli::run::keeper::WorkTreeKeeper;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::process::ExitCode;
 use std::str::FromStr;
 use std::sync::Mutex;
 
-use anstream::{StripStream, eprintln};
+use anstream::{ColorChoice, StripStream, eprintln};
 use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser};
 use clap_complete::CompleteEnv;
@@ -22,7 +22,7 @@ use crate::cli::{CacheCommand, CacheNamespace, Cli, Command, ExitStatus};
 #[cfg(feature = "self-update")]
 use crate::cli::{SelfCommand, SelfNamespace, SelfUpdateArgs};
 use crate::printer::Printer;
-use crate::run::{USE_COLOR, write_color_choice};
+use crate::run::USE_COLOR;
 use crate::store::Store;
 
 mod archive;
@@ -138,7 +138,10 @@ fn setup_logging(level: Level, log_file: LogFile, store: &Store) -> Result<()> {
 }
 
 async fn run(mut cli: Cli) -> Result<ExitStatus> {
-    write_color_choice(cli.globals.color);
+    // Enabled ANSI colors on Windows.
+    let _ = anstyle_query::windows::enable_ansi_colors();
+
+    ColorChoice::write_global(cli.globals.color.into());
 
     let store = Store::from_settings()?;
     let log_file = LogFile::from_args(cli.globals.log_file.clone(), cli.globals.no_log_file);

--- a/src/run.rs
+++ b/src/run.rs
@@ -4,59 +4,19 @@ use std::path::Path;
 use std::sync::LazyLock;
 
 use anstream::ColorChoice;
-use anstream::stream::IsTerminal;
 use futures::StreamExt;
 use prek_consts::env_vars::EnvVars;
 use tracing::trace;
 
-use crate::cli;
 use crate::hook::Hook;
 
-fn detect_color_choice(color: cli::ColorChoice) -> bool {
-    match color {
-        cli::ColorChoice::Always => true,
-        cli::ColorChoice::Never => false,
-        cli::ColorChoice::Auto => {
-            let mut term_supports_color = anstyle_query::term_supports_color();
-            if !term_supports_color {
-                if let Some(enabled) = anstyle_query::windows::enable_ansi_colors() {
-                    term_supports_color = enabled;
-                }
-            }
-
-            // Inline the logic from `anstream::choice()`.
-            let clicolor = anstyle_query::clicolor();
-            let clicolor_enabled = clicolor.unwrap_or(false);
-            let clicolor_disabled = !clicolor.unwrap_or(true);
-            if anstyle_query::no_color() {
-                false
-            } else if anstyle_query::clicolor_force() {
-                true
-            } else if clicolor_disabled {
-                false
-            } else {
-                std::io::stderr().is_terminal()
-                    && (term_supports_color || clicolor_enabled || anstyle_query::is_ci())
-            }
-        }
-    }
-}
-
-pub(crate) fn write_color_choice(choice: cli::ColorChoice) {
-    let enabled = detect_color_choice(choice);
-
-    ColorChoice::write_global(if enabled {
-        ColorChoice::Always
-    } else {
-        ColorChoice::Never
+pub(crate) static USE_COLOR: LazyLock<bool> =
+    LazyLock::new(|| match anstream::Stderr::choice(&std::io::stderr()) {
+        ColorChoice::Always | ColorChoice::AlwaysAnsi => true,
+        ColorChoice::Never => false,
+        // We just asked anstream for a choice, that can't be auto
+        ColorChoice::Auto => unreachable!(),
     });
-}
-
-pub(crate) static USE_COLOR: LazyLock<bool> = LazyLock::new(|| match ColorChoice::global() {
-    ColorChoice::Always | ColorChoice::AlwaysAnsi => true,
-    ColorChoice::Never => false,
-    ColorChoice::Auto => unreachable!(),
-});
 
 pub(crate) static CONCURRENCY: LazyLock<usize> = LazyLock::new(|| {
     if EnvVars::is_set(EnvVars::PREK_NO_CONCURRENCY) {


### PR DESCRIPTION
Reverts most changes from #1123, we only need `anstyle_query::windows::enable_ansi_colors()`