### PR TITLE
Make go module cache read-writeable (thus deletable)

### DIFF
--- a/crates/prek-consts/src/env_vars.rs
+++ b/crates/prek-consts/src/env_vars.rs
@@ -52,6 +52,7 @@ impl EnvVars {
     pub const GOROOT: &'static str = "GOROOT";
     pub const GOPATH: &'static str = "GOPATH";
     pub const GOBIN: &'static str = "GOBIN";
+    pub const GOFLAGS: &'static str = "GOFLAGS";
 
     // Lua related
     pub const LUA_PATH: &'static str = "LUA_PATH";

--- a/src/languages/golang/golang.rs
+++ b/src/languages/golang/golang.rs
@@ -79,7 +79,7 @@ impl LanguageImpl for Golang {
                     .env(EnvVars::GOTOOLCHAIN, "local")
                     .env(EnvVars::GOROOT, go_root)
                     .env(EnvVars::GOBIN, bin_dir(&info.env_path))
-                    .env("GOFLAGS", "-modcacherw")
+                    .env(EnvVars::GOFLAGS, "-modcacherw")
                     .env(EnvVars::GOPATH, &go_cache);
                 cmd
             }
@@ -148,6 +148,7 @@ impl LanguageImpl for Golang {
                 .env(EnvVars::PATH, &new_path)
                 .env(EnvVars::GOTOOLCHAIN, "local")
                 .env(EnvVars::GOBIN, &go_bin)
+                .env(EnvVars::GOFLAGS, "-modcacherw")
                 .envs(go_envs.iter().copied())
                 .args(&hook.args)
                 .args(batch)


### PR DESCRIPTION
Closes #1163

The `~/.cache/prek/` module checkouts are used directly (whereas originally [pre-commit](https://github.com/pre-commit/pre-commit/blob/main/pre_commit/languages/golang.py) made a different GOPATH to avoid triggering 'module mode' as I understand), which leads to a side effect where you get read-only module caches, which can be avoided by setting `-modcacherw` ([source](https://go.dev/ref/mod#build-commands)).

This PR sets that env var for people using non-system Golang.