### PR TITLE
feat: add pyproject.toml config provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,8 +717,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
 dependencies = [
  "atomic",
+ "parking_lot",
  "pear",
  "serde",
+ "tempfile",
  "toml 0.8.23",
  "uncased",
  "version_check",
@@ -1724,6 +1726,29 @@ name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link 0.2.1",
+]
 
 [[package]]
 name = "path-clean"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -95,7 +95,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -193,6 +193,15 @@ dependencies = [
  "futures-io",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -671,7 +680,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -700,6 +709,20 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "pear",
+ "serde",
+ "toml 0.8.23",
+ "uncased",
+ "version_check",
+]
 
 [[package]]
 name = "filetime"
@@ -1279,6 +1302,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
 name = "insta"
 version = "1.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,7 +1355,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1611,7 +1640,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1701,6 +1730,29 @@ name = "path-clean"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
+
+[[package]]
+name = "pear"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1842,6 +1894,7 @@ dependencies = [
  "dunce",
  "etcetera",
  "fancy-regex",
+ "figment",
  "fs-err",
  "futures",
  "hex",
@@ -1885,7 +1938,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tokio-util",
- "toml",
+ "toml 0.9.8",
  "tracing",
  "tracing-subscriber",
  "unicode-width 0.2.2",
@@ -1925,6 +1978,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -2209,7 +2275,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2384,6 +2450,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
@@ -2516,7 +2591,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -2608,7 +2682,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2776,6 +2850,18 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
@@ -2783,11 +2869,20 @@ dependencies = [
  "foldhash",
  "indexmap",
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.0.3",
+ "toml_datetime 0.7.3",
  "toml_parser",
  "toml_writer",
  "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2800,6 +2895,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2807,6 +2916,12 @@ checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -2925,6 +3040,15 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-id"
@@ -3202,7 +3326,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3498,6 +3622,9 @@ name = "winnow"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winsafe"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,17 +711,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "figment"
-version = "0.10.19"
+name = "figment2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+checksum = "5856dd39567e93bf4d63221875c25f620747163d1e8073b4b54d066051d2093d"
 dependencies = [
  "atomic",
  "parking_lot",
- "pear",
  "serde",
  "tempfile",
- "toml 0.8.23",
+ "toml_edit",
  "uncased",
  "version_check",
 ]
@@ -1304,12 +1303,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inlinable_string"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
-
-[[package]]
 name = "insta"
 version = "1.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1757,29 +1750,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
-name = "pear"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
-dependencies = [
- "inlinable_string",
- "pear_codegen",
- "yansi",
-]
-
-[[package]]
-name = "pear_codegen"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
-dependencies = [
- "proc-macro2",
- "proc-macro2-diagnostics",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1919,7 +1889,7 @@ dependencies = [
  "dunce",
  "etcetera",
  "fancy-regex",
- "figment",
+ "figment2",
  "fs-err",
  "futures",
  "hex",
@@ -1963,7 +1933,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tokio-util",
- "toml 0.9.8",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "unicode-width 0.2.2",
@@ -2003,19 +1973,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proc-macro2-diagnostics"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
- "yansi",
 ]
 
 [[package]]
@@ -2475,15 +2432,6 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
@@ -2875,18 +2823,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit",
-]
-
-[[package]]
-name = "toml"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
@@ -2894,20 +2830,11 @@ dependencies = [
  "foldhash",
  "indexmap",
  "serde_core",
- "serde_spanned 1.0.3",
- "toml_datetime 0.7.3",
+ "serde_spanned",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
  "winnow",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -2921,15 +2848,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
 dependencies = [
  "indexmap",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
  "winnow",
 ]
 
@@ -2941,12 +2868,6 @@ checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
 dependencies = [
  "winnow",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,15 +196,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,21 +700,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "figment2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5856dd39567e93bf4d63221875c25f620747163d1e8073b4b54d066051d2093d"
-dependencies = [
- "atomic",
- "parking_lot",
- "serde",
- "tempfile",
- "toml_edit",
- "uncased",
- "version_check",
-]
 
 [[package]]
 name = "filetime"
@@ -1721,29 +1697,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "path-clean"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,7 +1842,6 @@ dependencies = [
  "dunce",
  "etcetera",
  "fancy-regex",
- "figment2",
  "fs-err",
  "futures",
  "hex",
@@ -2847,20 +2799,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.23.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
-dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned",
- "toml_datetime",
- "toml_parser",
- "winnow",
-]
-
-[[package]]
 name = "toml_parser"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2986,15 +2924,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "uncased"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
-dependencies = [
- "version_check",
-]
 
 [[package]]
 name = "unicode-id"
@@ -3568,9 +3497,6 @@ name = "winnow"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winsafe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ fs-err = { version = "3.1.0" }
 assert_cmd = { version = "2.0.16", features = ["color"] }
 assert_fs = { version = "1.1.2" }
 etcetera = { version = "0.11.0" }
+figment = { version = "0.10.19", features = ["test"] }
 insta = { version = "1.40.0", features = ["filters"] }
 insta-cmd = { version = "0.6.0" }
 markdown = { version = "1.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,6 @@ tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 unicode-width = { version = "0.2.0" }
 walkdir = { version = "2.5.0" }
 which = { version = "8.0.0" }
-figment = { package = "figment2", version = "0.11.0", features = ["env", "toml"] }
 
 [target.'cfg(unix)'.dependencies]
 prek-pty = { workspace = true }
@@ -112,7 +111,6 @@ fs-err = { version = "3.1.0" }
 assert_cmd = { version = "2.0.16", features = ["color"] }
 assert_fs = { version = "1.1.2" }
 etcetera = { version = "0.11.0" }
-figment = { package = "figment2", version = "0.11.0", features = ["test"] }
 insta = { version = "1.40.0", features = ["filters"] }
 insta-cmd = { version = "0.6.0" }
 markdown = { version = "1.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 unicode-width = { version = "0.2.0" }
 walkdir = { version = "2.5.0" }
 which = { version = "8.0.0" }
-figment = { version = "0.10.19", features = ["env", "toml"] }
+figment = { package = "figment2", version = "0.11.0", features = ["env", "toml"] }
 
 [target.'cfg(unix)'.dependencies]
 prek-pty = { workspace = true }
@@ -112,7 +112,7 @@ fs-err = { version = "3.1.0" }
 assert_cmd = { version = "2.0.16", features = ["color"] }
 assert_fs = { version = "1.1.2" }
 etcetera = { version = "0.11.0" }
-figment = { version = "0.10.19", features = ["test"] }
+figment = { package = "figment2", version = "0.11.0", features = ["test"] }
 insta = { version = "1.40.0", features = ["filters"] }
 insta-cmd = { version = "0.6.0" }
 markdown = { version = "1.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 unicode-width = { version = "0.2.0" }
 walkdir = { version = "2.5.0" }
 which = { version = "8.0.0" }
+figment = { version = "0.10.19", features = ["env", "toml"] }
 
 [target.'cfg(unix)'.dependencies]
 prek-pty = { workspace = true }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -60,7 +60,7 @@ prek install [OPTIONS] [HOOK|PROJECT]...
 <dl class="cli-reference"><dt id="prek-install--allow-missing-config"><a href="#prek-install--allow-missing-config"><code>--allow-missing-config</code></a></dt><dd><p>Allow a missing <code>pre-commit</code> configuration file</p>
 </dd><dt id="prek-install--cd"><a href="#prek-install--cd"><code>--cd</code></a>, <code>-C</code> <i>dir</i></dt><dd><p>Change to directory before running</p>
 </dd><dt id="prek-install--color"><a href="#prek-install--color"><code>--color</code></a> <i>color</i></dt><dd><p>Whether to use color in output</p>
-<p>May also be set with the <code>PREK_COLOR</code> environment variable.</p><p>[default: auto]</p><p>Possible values:</p>
+<p>Possible values:</p>
 <ul>
 <li><code>auto</code>:  Enables colored output only when the output is going to a terminal or TTY with support</li>
 <li><code>always</code>:  Enables colored output regardless of the detected environment</li>
@@ -127,7 +127,7 @@ prek install-hooks [OPTIONS] [HOOK|PROJECT]...
 
 <dl class="cli-reference"><dt id="prek-install-hooks--cd"><a href="#prek-install-hooks--cd"><code>--cd</code></a>, <code>-C</code> <i>dir</i></dt><dd><p>Change to directory before running</p>
 </dd><dt id="prek-install-hooks--color"><a href="#prek-install-hooks--color"><code>--color</code></a> <i>color</i></dt><dd><p>Whether to use color in output</p>
-<p>May also be set with the <code>PREK_COLOR</code> environment variable.</p><p>[default: auto]</p><p>Possible values:</p>
+<p>Possible values:</p>
 <ul>
 <li><code>auto</code>:  Enables colored output only when the output is going to a terminal or TTY with support</li>
 <li><code>always</code>:  Enables colored output regardless of the detected environment</li>
@@ -191,7 +191,7 @@ prek run [OPTIONS] [HOOK|PROJECT]...
 <dl class="cli-reference"><dt id="prek-run--all-files"><a href="#prek-run--all-files"><code>--all-files</code></a>, <code>-a</code></dt><dd><p>Run on all files in the repo</p>
 </dd><dt id="prek-run--cd"><a href="#prek-run--cd"><code>--cd</code></a>, <code>-C</code> <i>dir</i></dt><dd><p>Change to directory before running</p>
 </dd><dt id="prek-run--color"><a href="#prek-run--color"><code>--color</code></a> <i>color</i></dt><dd><p>Whether to use color in output</p>
-<p>May also be set with the <code>PREK_COLOR</code> environment variable.</p><p>[default: auto]</p><p>Possible values:</p>
+<p>Possible values:</p>
 <ul>
 <li><code>auto</code>:  Enables colored output only when the output is going to a terminal or TTY with support</li>
 <li><code>always</code>:  Enables colored output regardless of the detected environment</li>
@@ -277,7 +277,7 @@ prek list [OPTIONS] [HOOK|PROJECT]...
 
 <dl class="cli-reference"><dt id="prek-list--cd"><a href="#prek-list--cd"><code>--cd</code></a>, <code>-C</code> <i>dir</i></dt><dd><p>Change to directory before running</p>
 </dd><dt id="prek-list--color"><a href="#prek-list--color"><code>--color</code></a> <i>color</i></dt><dd><p>Whether to use color in output</p>
-<p>May also be set with the <code>PREK_COLOR</code> environment variable.</p><p>[default: auto]</p><p>Possible values:</p>
+<p>Possible values:</p>
 <ul>
 <li><code>auto</code>:  Enables colored output only when the output is going to a terminal or TTY with support</li>
 <li><code>always</code>:  Enables colored output regardless of the detected environment</li>
@@ -364,7 +364,7 @@ prek uninstall [OPTIONS]
 
 <dl class="cli-reference"><dt id="prek-uninstall--cd"><a href="#prek-uninstall--cd"><code>--cd</code></a>, <code>-C</code> <i>dir</i></dt><dd><p>Change to directory before running</p>
 </dd><dt id="prek-uninstall--color"><a href="#prek-uninstall--color"><code>--color</code></a> <i>color</i></dt><dd><p>Whether to use color in output</p>
-<p>May also be set with the <code>PREK_COLOR</code> environment variable.</p><p>[default: auto]</p><p>Possible values:</p>
+<p>Possible values:</p>
 <ul>
 <li><code>auto</code>:  Enables colored output only when the output is going to a terminal or TTY with support</li>
 <li><code>always</code>:  Enables colored output regardless of the detected environment</li>
@@ -400,7 +400,7 @@ prek validate-config [OPTIONS] [CONFIG]...
 
 <dl class="cli-reference"><dt id="prek-validate-config--cd"><a href="#prek-validate-config--cd"><code>--cd</code></a>, <code>-C</code> <i>dir</i></dt><dd><p>Change to directory before running</p>
 </dd><dt id="prek-validate-config--color"><a href="#prek-validate-config--color"><code>--color</code></a> <i>color</i></dt><dd><p>Whether to use color in output</p>
-<p>May also be set with the <code>PREK_COLOR</code> environment variable.</p><p>[default: auto]</p><p>Possible values:</p>
+<p>Possible values:</p>
 <ul>
 <li><code>auto</code>:  Enables colored output only when the output is going to a terminal or TTY with support</li>
 <li><code>always</code>:  Enables colored output regardless of the detected environment</li>
@@ -436,7 +436,7 @@ prek validate-manifest [OPTIONS] [MANIFEST]...
 
 <dl class="cli-reference"><dt id="prek-validate-manifest--cd"><a href="#prek-validate-manifest--cd"><code>--cd</code></a>, <code>-C</code> <i>dir</i></dt><dd><p>Change to directory before running</p>
 </dd><dt id="prek-validate-manifest--color"><a href="#prek-validate-manifest--color"><code>--color</code></a> <i>color</i></dt><dd><p>Whether to use color in output</p>
-<p>May also be set with the <code>PREK_COLOR</code> environment variable.</p><p>[default: auto]</p><p>Possible values:</p>
+<p>Possible values:</p>
 <ul>
 <li><code>auto</code>:  Enables colored output only when the output is going to a terminal or TTY with support</li>
 <li><code>always</code>:  Enables colored output regardless of the detected environment</li>
@@ -467,7 +467,7 @@ prek sample-config [OPTIONS]
 
 <dl class="cli-reference"><dt id="prek-sample-config--cd"><a href="#prek-sample-config--cd"><code>--cd</code></a>, <code>-C</code> <i>dir</i></dt><dd><p>Change to directory before running</p>
 </dd><dt id="prek-sample-config--color"><a href="#prek-sample-config--color"><code>--color</code></a> <i>color</i></dt><dd><p>Whether to use color in output</p>
-<p>May also be set with the <code>PREK_COLOR</code> environment variable.</p><p>[default: auto]</p><p>Possible values:</p>
+<p>Possible values:</p>
 <ul>
 <li><code>auto</code>:  Enables colored output only when the output is going to a terminal or TTY with support</li>
 <li><code>always</code>:  Enables colored output regardless of the detected environment</li>
@@ -500,7 +500,7 @@ prek auto-update [OPTIONS]
 <dl class="cli-reference"><dt id="prek-auto-update--bleeding-edge"><a href="#prek-auto-update--bleeding-edge"><code>--bleeding-edge</code></a></dt><dd><p>Update to the bleeding edge of the default branch instead of the latest tagged version</p>
 </dd><dt id="prek-auto-update--cd"><a href="#prek-auto-update--cd"><code>--cd</code></a>, <code>-C</code> <i>dir</i></dt><dd><p>Change to directory before running</p>
 </dd><dt id="prek-auto-update--color"><a href="#prek-auto-update--color"><code>--color</code></a> <i>color</i></dt><dd><p>Whether to use color in output</p>
-<p>May also be set with the <code>PREK_COLOR</code> environment variable.</p><p>[default: auto]</p><p>Possible values:</p>
+<p>Possible values:</p>
 <ul>
 <li><code>auto</code>:  Enables colored output only when the output is going to a terminal or TTY with support</li>
 <li><code>always</code>:  Enables colored output regardless of the detected environment</li>
@@ -553,7 +553,7 @@ prek cache dir [OPTIONS]
 
 <dl class="cli-reference"><dt id="prek-cache-dir--cd"><a href="#prek-cache-dir--cd"><code>--cd</code></a>, <code>-C</code> <i>dir</i></dt><dd><p>Change to directory before running</p>
 </dd><dt id="prek-cache-dir--color"><a href="#prek-cache-dir--color"><code>--color</code></a> <i>color</i></dt><dd><p>Whether to use color in output</p>
-<p>May also be set with the <code>PREK_COLOR</code> environment variable.</p><p>[default: auto]</p><p>Possible values:</p>
+<p>Possible values:</p>
 <ul>
 <li><code>auto</code>:  Enables colored output only when the output is going to a terminal or TTY with support</li>
 <li><code>always</code>:  Enables colored output regardless of the detected environment</li>
@@ -584,7 +584,7 @@ prek cache gc [OPTIONS]
 
 <dl class="cli-reference"><dt id="prek-cache-gc--cd"><a href="#prek-cache-gc--cd"><code>--cd</code></a>, <code>-C</code> <i>dir</i></dt><dd><p>Change to directory before running</p>
 </dd><dt id="prek-cache-gc--color"><a href="#prek-cache-gc--color"><code>--color</code></a> <i>color</i></dt><dd><p>Whether to use color in output</p>
-<p>May also be set with the <code>PREK_COLOR</code> environment variable.</p><p>[default: auto]</p><p>Possible values:</p>
+<p>Possible values:</p>
 <ul>
 <li><code>auto</code>:  Enables colored output only when the output is going to a terminal or TTY with support</li>
 <li><code>always</code>:  Enables colored output regardless of the detected environment</li>
@@ -615,7 +615,7 @@ prek cache clean [OPTIONS]
 
 <dl class="cli-reference"><dt id="prek-cache-clean--cd"><a href="#prek-cache-clean--cd"><code>--cd</code></a>, <code>-C</code> <i>dir</i></dt><dd><p>Change to directory before running</p>
 </dd><dt id="prek-cache-clean--color"><a href="#prek-cache-clean--color"><code>--color</code></a> <i>color</i></dt><dd><p>Whether to use color in output</p>
-<p>May also be set with the <code>PREK_COLOR</code> environment variable.</p><p>[default: auto]</p><p>Possible values:</p>
+<p>Possible values:</p>
 <ul>
 <li><code>auto</code>:  Enables colored output only when the output is going to a terminal or TTY with support</li>
 <li><code>always</code>:  Enables colored output regardless of the detected environment</li>
@@ -683,7 +683,7 @@ prek init-template-dir [OPTIONS] <DIRECTORY>
 
 <dl class="cli-reference"><dt id="prek-init-template-dir--cd"><a href="#prek-init-template-dir--cd"><code>--cd</code></a>, <code>-C</code> <i>dir</i></dt><dd><p>Change to directory before running</p>
 </dd><dt id="prek-init-template-dir--color"><a href="#prek-init-template-dir--color"><code>--color</code></a> <i>color</i></dt><dd><p>Whether to use color in output</p>
-<p>May also be set with the <code>PREK_COLOR</code> environment variable.</p><p>[default: auto]</p><p>Possible values:</p>
+<p>Possible values:</p>
 <ul>
 <li><code>auto</code>:  Enables colored output only when the output is going to a terminal or TTY with support</li>
 <li><code>always</code>:  Enables colored output regardless of the detected environment</li>
@@ -748,7 +748,7 @@ prek try-repo [OPTIONS] <REPO> [HOOK|PROJECT]...
 <dl class="cli-reference"><dt id="prek-try-repo--all-files"><a href="#prek-try-repo--all-files"><code>--all-files</code></a>, <code>-a</code></dt><dd><p>Run on all files in the repo</p>
 </dd><dt id="prek-try-repo--cd"><a href="#prek-try-repo--cd"><code>--cd</code></a>, <code>-C</code> <i>dir</i></dt><dd><p>Change to directory before running</p>
 </dd><dt id="prek-try-repo--color"><a href="#prek-try-repo--color"><code>--color</code></a> <i>color</i></dt><dd><p>Whether to use color in output</p>
-<p>May also be set with the <code>PREK_COLOR</code> environment variable.</p><p>[default: auto]</p><p>Possible values:</p>
+<p>Possible values:</p>
 <ul>
 <li><code>auto</code>:  Enables colored output only when the output is going to a terminal or TTY with support</li>
 <li><code>always</code>:  Enables colored output regardless of the detected environment</li>
@@ -837,7 +837,7 @@ prek self update [OPTIONS] [TARGET_VERSION]
 
 <dl class="cli-reference"><dt id="prek-self-update--cd"><a href="#prek-self-update--cd"><code>--cd</code></a>, <code>-C</code> <i>dir</i></dt><dd><p>Change to directory before running</p>
 </dd><dt id="prek-self-update--color"><a href="#prek-self-update--color"><code>--color</code></a> <i>color</i></dt><dd><p>Whether to use color in output</p>
-<p>May also be set with the <code>PREK_COLOR</code> environment variable.</p><p>[default: auto]</p><p>Possible values:</p>
+<p>Possible values:</p>
 <ul>
 <li><code>auto</code>:  Enables colored output only when the output is going to a terminal or TTY with support</li>
 <li><code>always</code>:  Enables colored output regardless of the detected environment</li>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -646,7 +646,7 @@ prek cache size [OPTIONS]
 
 <dl class="cli-reference"><dt id="prek-cache-size--cd"><a href="#prek-cache-size--cd"><code>--cd</code></a>, <code>-C</code> <i>dir</i></dt><dd><p>Change to directory before running</p>
 </dd><dt id="prek-cache-size--color"><a href="#prek-cache-size--color"><code>--color</code></a> <i>color</i></dt><dd><p>Whether to use color in output</p>
-<p>May also be set with the <code>PREK_COLOR</code> environment variable.</p><p>[default: auto]</p><p>Possible values:</p>
+<p>Possible values:</p>
 <ul>
 <li><code>auto</code>:  Enables colored output only when the output is going to a terminal or TTY with support</li>
 <li><code>always</code>:  Enables colored output regardless of the detected environment</li>

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,8 +151,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
 
     // Initialize settings from all sources (env vars, pyproject.toml, CLI overrides)
-    Settings::init_with_cli(&working_dir, cli.globals.cli_overrides())
-        .context("Failed to load configuration")?;
+    Settings::init_with_cli(&working_dir, cli.globals.cli_overrides());
 
     let settings = Settings::get();
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,440 @@
+//! Unified configuration settings for prek.
+//!
+//! Settings are resolved from multiple sources with the following precedence (highest to lowest):
+//! 1. CLI flags (handled by clap, merged separately)
+//! 2. `pyproject.toml` `[tool.prek]` section
+//! 3. Environment variables (`PREK_*`)
+//! 4. Built-in defaults
+#![allow(clippy::result_large_err)]
+
+use std::path::{Path, PathBuf};
+use std::sync::{LazyLock, RwLock};
+
+use figment::providers::{Env, Serialized};
+use figment::{Figment, Profile, Provider, value::Map};
+use serde::{Deserialize, Serialize};
+
+/// Global settings instance, initialized lazily.
+///
+/// Call `Settings::init()` early in main to set the working directory,
+/// or it will default to the current directory.
+static SETTINGS: LazyLock<RwLock<Settings>> = LazyLock::new(|| RwLock::new(Settings::default()));
+
+/// Check if settings have been initialized
+static INITIALIZED: LazyLock<RwLock<bool>> = LazyLock::new(|| RwLock::new(false));
+
+/// Prek configuration settings.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+#[allow(clippy::struct_excessive_bools)]
+pub struct Settings {
+    /// Hook IDs to skip (equivalent to `PREK_SKIP`).
+    #[serde(default)]
+    pub skip: Vec<String>,
+
+    /// Override the prek data directory (equivalent to `PREK_HOME`).
+    pub home: Option<PathBuf>,
+
+    /// Control colored output: "auto", "always", or "never" (equivalent to `PREK_COLOR`).
+    pub color: Option<ColorChoice>,
+
+    /// Allow running without a `.pre-commit-config.yaml` (equivalent to `PREK_ALLOW_NO_CONFIG`).
+    #[serde(default)]
+    pub allow_no_config: bool,
+
+    /// Disable parallelism for installs and runs (equivalent to `PREK_NO_CONCURRENCY`).
+    #[serde(default)]
+    pub no_concurrency: bool,
+
+    /// Disable Rust-native built-in hooks (equivalent to `PREK_NO_FAST_PATH`).
+    #[serde(default)]
+    pub no_fast_path: bool,
+
+    /// Control how uv is installed (equivalent to `PREK_UV_SOURCE`).
+    pub uv_source: Option<String>,
+
+    /// Use system's trusted store instead of bundled roots (equivalent to `PREK_NATIVE_TLS`).
+    #[serde(default)]
+    pub native_tls: bool,
+
+    /// Container runtime to use: "auto", "docker", or "podman" (equivalent to `PREK_CONTAINER_RUNTIME`).
+    pub container_runtime: Option<ContainerRuntime>,
+}
+
+/// Color output choice.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize, clap::ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum ColorChoice {
+    /// Enables colored output only when the output is going to a terminal or TTY with support.
+    #[default]
+    Auto,
+    /// Enables colored output regardless of the detected environment.
+    Always,
+    /// Disables colored output.
+    Never,
+}
+
+impl From<ColorChoice> for anstream::ColorChoice {
+    fn from(value: ColorChoice) -> Self {
+        match value {
+            ColorChoice::Auto => Self::Auto,
+            ColorChoice::Always => Self::Always,
+            ColorChoice::Never => Self::Never,
+        }
+    }
+}
+
+impl std::fmt::Display for ColorChoice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Auto => write!(f, "auto"),
+            Self::Always => write!(f, "always"),
+            Self::Never => write!(f, "never"),
+        }
+    }
+}
+
+/// Container runtime choice.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize, clap::ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum ContainerRuntime {
+    /// Auto-detect available runtime.
+    #[default]
+    Auto,
+    /// Use Docker.
+    Docker,
+    /// Use Podman.
+    Podman,
+}
+
+impl std::fmt::Display for ContainerRuntime {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Auto => write!(f, "auto"),
+            Self::Docker => write!(f, "docker"),
+            Self::Podman => write!(f, "podman"),
+        }
+    }
+}
+
+/// Wrapper to extract `[tool.prek]` from pyproject.toml
+#[derive(Debug, Deserialize)]
+struct PyProjectToml {
+    tool: Option<PyProjectTool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PyProjectTool {
+    prek: Option<Settings>,
+}
+
+/// Custom provider that extracts `[tool.prek]` from a TOML file
+struct PyProjectProvider {
+    path: PathBuf,
+}
+
+impl PyProjectProvider {
+    fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+}
+
+impl Provider for PyProjectProvider {
+    fn metadata(&self) -> figment::Metadata {
+        figment::Metadata::named("pyproject.toml [tool.prek]")
+            .source(self.path.display().to_string())
+    }
+
+    fn data(&self) -> Result<Map<Profile, figment::value::Dict>, figment::Error> {
+        let Ok(content) = std::fs::read_to_string(&self.path) else {
+            return Ok(Map::new());
+        };
+
+        let pyproject: PyProjectToml = match toml::from_str(&content) {
+            Ok(p) => p,
+            Err(_) => return Ok(Map::new()),
+        };
+
+        match pyproject.tool.and_then(|t| t.prek) {
+            Some(settings) => Serialized::defaults(settings).data(),
+            None => Ok(Map::new()),
+        }
+    }
+}
+
+impl Settings {
+    /// Initialize settings from the given working directory.
+    ///
+    /// This should be called early in `main()` before any settings are accessed.
+    /// If not called, settings will use the current directory when first accessed.
+    pub fn init(working_dir: &Path) -> Result<(), figment::Error> {
+        let settings = Self::discover(working_dir)?;
+
+        let mut guard = SETTINGS.write().expect("settings lock poisoned");
+        *guard = settings;
+
+        let mut init_guard = INITIALIZED.write().expect("initialized lock poisoned");
+        *init_guard = true;
+
+        Ok(())
+    }
+
+    /// Initialize settings with CLI overrides.
+    ///
+    /// CLI flags take highest precedence over all other sources.
+    pub fn init_with_cli(
+        working_dir: &Path,
+        cli_overrides: CliOverrides,
+    ) -> Result<(), figment::Error> {
+        let figment = Self::build_figment(working_dir).merge(Serialized::defaults(cli_overrides));
+
+        let settings: Settings = figment.extract()?;
+
+        let mut guard = SETTINGS.write().expect("settings lock poisoned");
+        *guard = settings;
+
+        let mut init_guard = INITIALIZED.write().expect("initialized lock poisoned");
+        *init_guard = true;
+
+        Ok(())
+    }
+
+    /// Get the global settings instance.
+    ///
+    /// If settings haven't been initialized, this will initialize them
+    /// using the current directory.
+    pub fn get() -> Settings {
+        // Check if we need to initialize
+        {
+            let init_guard = INITIALIZED.read().expect("initialized lock poisoned");
+            if !*init_guard {
+                drop(init_guard);
+                // Try to initialize with current directory
+                let cwd = std::env::current_dir().unwrap_or_default();
+                let _ = Self::init(&cwd);
+            }
+        }
+
+        let guard = SETTINGS.read().expect("settings lock poisoned");
+        guard.clone()
+    }
+
+    /// Build the figment for the given working directory.
+    fn build_figment(working_dir: &Path) -> Figment {
+        let mut figment = Figment::new()
+            // Lowest precedence: built-in defaults
+            .merge(Serialized::defaults(Settings::default()))
+            // Next: environment variables
+            .merge(
+                Env::prefixed("PREK_")
+                    .map(|key| {
+                        // Convert PREK_FOO_BAR to foo-bar for serde
+                        key.as_str().to_lowercase().replace('_', "-").into()
+                    })
+                    .split(","), // Allow comma-separated lists for `skip`
+            );
+
+        // Walk up to find pyproject.toml
+        let mut current = Some(working_dir);
+        while let Some(dir) = current {
+            let pyproject_path = dir.join("pyproject.toml");
+            if pyproject_path.exists() {
+                // Higher precedence: pyproject.toml [tool.prek]
+                figment = figment.merge(PyProjectProvider::new(pyproject_path));
+                break;
+            }
+            current = dir.parent();
+        }
+
+        figment
+    }
+
+    /// Discover and resolve settings from the given directory.
+    fn discover(start_dir: &Path) -> Result<Self, figment::Error> {
+        Self::build_figment(start_dir).extract()
+    }
+
+    /// Check if a hook should be skipped.
+    pub fn should_skip(&self, hook_id: &str) -> bool {
+        self.skip.iter().any(|s| s == hook_id)
+    }
+
+    /// Get the resolved color choice.
+    pub fn resolved_color(&self) -> ColorChoice {
+        self.color.unwrap_or_default()
+    }
+
+    /// Get the resolved container runtime.
+    pub fn resolved_container_runtime(&self) -> ContainerRuntime {
+        self.container_runtime.unwrap_or_default()
+    }
+}
+
+/// CLI overrides that take highest precedence.
+///
+/// This struct contains only the fields that can be set via CLI flags.
+/// Fields are all optional - `None` means "use value from other sources".
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct CliOverrides {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<ColorChoice>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub no_concurrency: Option<bool>,
+    // Add other CLI-settable options here as needed
+}
+
+impl CliOverrides {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn color(mut self, color: Option<ColorChoice>) -> Self {
+        self.color = color;
+        self
+    }
+
+    #[must_use]
+    pub fn no_concurrency(mut self, value: bool) -> Self {
+        if value {
+            self.no_concurrency = Some(true);
+        }
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_default_settings() {
+        let settings = Settings::default();
+        assert!(settings.skip.is_empty());
+        assert!(settings.home.is_none());
+        assert!(settings.color.is_none());
+        assert!(!settings.allow_no_config);
+        assert!(!settings.no_concurrency);
+    }
+
+    #[test]
+    fn test_pyproject_loading() {
+        let dir = TempDir::new().unwrap();
+        let pyproject = dir.path().join("pyproject.toml");
+
+        let mut file = std::fs::File::create(&pyproject).unwrap();
+        write!(
+            file,
+            r#"
+[tool.prek]
+skip = ["black", "ruff"]
+no-concurrency = true
+color = "always"
+"#
+        )
+        .unwrap();
+
+        let settings = Settings::discover(dir.path()).unwrap();
+
+        assert_eq!(settings.skip, vec!["black", "ruff"]);
+        assert!(settings.no_concurrency);
+        assert_eq!(settings.color, Some(ColorChoice::Always));
+    }
+
+    #[test]
+    fn test_env_var_loading() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env("PREK_SKIP", "hook1,hook2");
+            jail.set_env("PREK_NO_CONCURRENCY", "true");
+            jail.set_env("PREK_COLOR", "never");
+
+            let settings = Settings::discover(jail.directory())?;
+
+            assert_eq!(settings.skip, vec!["hook1", "hook2"]);
+            assert!(settings.no_concurrency);
+            assert_eq!(settings.color, Some(ColorChoice::Never));
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_pyproject_overrides_env() {
+        figment::Jail::expect_with(|jail| {
+            // Set env var
+            jail.set_env("PREK_COLOR", "never");
+
+            // Create pyproject.toml with different value
+            jail.create_file(
+                "pyproject.toml",
+                r#"
+[tool.prek]
+color = "always"
+"#,
+            )?;
+
+            let settings = Settings::discover(jail.directory())?;
+
+            // pyproject.toml should win
+            assert_eq!(settings.color, Some(ColorChoice::Always));
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_cli_overrides_all() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env("PREK_COLOR", "never");
+            jail.create_file(
+                "pyproject.toml",
+                r#"
+[tool.prek]
+color = "auto"
+"#,
+            )?;
+
+            let figment = Settings::build_figment(jail.directory()).merge(Serialized::defaults(
+                CliOverrides {
+                    color: Some(ColorChoice::Always),
+                    ..Default::default()
+                },
+            ));
+
+            let settings: Settings = figment.extract()?;
+
+            // CLI should win
+            assert_eq!(settings.color, Some(ColorChoice::Always));
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_walks_up_directory_tree() {
+        figment::Jail::expect_with(|jail| {
+            // Create pyproject.toml in parent
+            jail.create_file(
+                "pyproject.toml",
+                r#"
+[tool.prek]
+skip = ["parent-hook"]
+"#,
+            )?;
+
+            // Create subdirectory
+            std::fs::create_dir_all(jail.directory().join("subdir/nested"))
+                .map_err(|e| e.to_string())?; // Convert io::Error to String, which impls Into<figment::Error>
+
+            let settings = Settings::discover(&jail.directory().join("subdir/nested"))?;
+
+            assert_eq!(settings.skip, vec!["parent-hook"]);
+
+            Ok(())
+        });
+    }
+}


### PR DESCRIPTION
Providing config from pyproject.toml as well as env vars and CLI flags

Allows configuration of what were previously env var only settings via pyproject.toml `[tool.prek]` (closes #1175)

- **Note** this does not let you put hook definitions in pyproject.toml, only the env var settings