### PR TITLE
Avoid pulling in unused tracing feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ prek-pty = { path = "crates/prek-pty", version = "0.2.19" }
 rustix = { version = "1.0.8", features = ["pty", "process", "fs", "termios"] }
 thiserror = { version = "2.0.11" }
 tokio = { version = "1.47.1", features = ["fs", "process", "rt", "sync", "macros", "net"] }
-tracing = { version = "0.1.40" }
+tracing = { version = "0.1.40", default-features = false, features = ["std"] }
 
 [package]
 name = "prek"


### PR DESCRIPTION
- **chore(tracing): configure out unused attributes feature**

…nope, this is in fact used (see `instrument` attributes), suspect probably not worth removing (would be worthwhile if it would avoid the large proc macro2 dep being built?)