### PR TITLE
Prevent `post-checkout` deadlock when cloning repos

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -7,6 +7,7 @@ use std::sync::LazyLock;
 
 use anyhow::Result;
 use path_clean::PathClean;
+use prek_consts::env_vars::EnvVars;
 use rustc_hash::FxHashSet;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing::{debug, instrument, warn};
@@ -374,11 +375,10 @@ async fn shallow_clone(rev: &str, path: &Path) -> Result<(), Error> {
 
     git_cmd("git checkout")?
         .current_dir(path)
-        .arg("-c")
-        .arg("core.hooksPath=/dev/null")
         .arg("checkout")
         .arg("FETCH_HEAD")
         .remove_git_env()
+        .env(EnvVars::PREK_INTERNAL__SKIP_POST_CHECKOUT, "1")
         .check(true)
         .output()
         .await?;
@@ -415,6 +415,7 @@ async fn full_clone(rev: &str, path: &Path) -> Result<(), Error> {
         .current_dir(path)
         .arg("checkout")
         .arg(rev)
+        .env(EnvVars::PREK_INTERNAL__SKIP_POST_CHECKOUT, "1")
         .remove_git_env()
         .check(true)
         .output()


### PR DESCRIPTION
I have a global `post-checkout` hook installed. I think what is happening is when I install hooks in my repository, `prek` then clones and checks out the hook repository. This checkout then triggers prek in the hook repository via the global post-checkout hook which then waits on the parent prek running in my repository to release (which it won't) and hangs indefinitely.

Also, I think it's veryyy rare anyone would want to run hooks here and for the most part, people don't want the install to error because the upstream hooks fail. Also, they (imo) needlessly slow this initialization anyways.

I confirmed locally this avoids the hanging.
___

Relevant logs from the issue,
```
$ cat prek.log 
2025-12-04T18:22:31.344962Z DEBUG prek: 0.2.19 (bdc40e36a 2025-11-26)
2025-12-04T18:22:31.345002Z DEBUG Args: ["prek", "run", "--verbose", "--log-file", "prek.log", "--refresh"]
2025-12-04T18:22:31.347216Z TRACE get_root: close time.busy=2.18ms time.idle=3.82µs
2025-12-04T18:22:31.347269Z DEBUG Git root: /home/jamison/code/onyx
2025-12-04T18:22:31.347287Z TRACE Executing `/usr/bin/git ls-files --unmerged`
2025-12-04T18:22:31.349930Z DEBUG Found workspace root at `/home/jamison/code/onyx`
2025-12-04T18:22:31.349992Z TRACE Include selectors: ``
2025-12-04T18:22:31.350006Z TRACE Skip selectors: ``
2025-12-04T18:22:31.350040Z DEBUG discover{root="/home/jamison/code/onyx" config=None refresh=true}: Performing fresh workspace discovery
2025-12-04T18:22:31.350096Z TRACE discover{root="/home/jamison/code/onyx" config=None refresh=true}:list_submodules{git_root="/home/jamison/code/onyx"}: close time.busy=6.32µs time.idle=1.45µs
2025-12-04T18:22:31.352610Z DEBUG Loading project configuration path=.pre-commit-config.yaml
2025-12-04T18:22:31.355411Z TRACE read_config{path="/home/jamison/code/onyx/.pre-commit-config.yaml"}: close time.busy=2.69ms time.idle=11.9µs
2025-12-04T18:22:31.364110Z TRACE discover{root="/home/jamison/code/onyx" config=None refresh=true}: close time.busy=14.1ms time.idle=4.47µs
2025-12-04T18:22:31.364208Z TRACE Executing `/usr/bin/git diff --exit-code --name-only -z /home/jamison/code/onyx/.pre-commit-config.yaml`
2025-12-04T18:22:31.368126Z TRACE Checking lock resource="store" path=/home/jamison/.cache/prek/.lock
2025-12-04T18:22:31.368171Z DEBUG Acquired lock resource="store"
2025-12-04T18:22:31.369430Z DEBUG Cloning repo target=/home/jamison/.cache/prek/scratch/.tmpl1tTJe repo=https://github.com/pre-commit/pre-commit-hooks@v4.6.0
2025-12-04T18:22:31.369496Z TRACE Executing `/usr/bin/git -c init.defaultObjectFormat= init --template= /home/jamison/.cache/prek/scratch/.tmpl1tTJe`
2025-12-04T18:22:31.370551Z DEBUG Cloning repo target=/home/jamison/.cache/prek/scratch/.tmpD4S3dZ repo=https://github.com/psf/black@25.1.0
2025-12-04T18:22:31.370570Z TRACE Executing `/usr/bin/git -c init.defaultObjectFormat= init --template= /home/jamison/.cache/prek/scratch/.tmpD4S3dZ`
2025-12-04T18:22:31.370970Z DEBUG Cloning repo target=/home/jamison/.cache/prek/scratch/.tmpq8h1tW repo=https://github.com/PyCQA/autoflake@v2.3.1
2025-12-04T18:22:31.370985Z TRACE Executing `/usr/bin/git -c init.defaultObjectFormat= init --template= /home/jamison/.cache/prek/scratch/.tmpq8h1tW`
2025-12-04T18:22:31.379100Z TRACE Executing `cd /home/jamison/.cache/prek/scratch/.tmpq8h1tW && /usr/bin/git remote add origin https://github.com/PyCQA/autoflake`
2025-12-04T18:22:31.379285Z TRACE Executing `cd /home/jamison/.cache/prek/scratch/.tmpl1tTJe && /usr/bin/git remote add origin https://github.com/pre-commit/pre-commit-hooks`
2025-12-04T18:22:31.379446Z TRACE Executing `cd /home/jamison/.cache/prek/scratch/.tmpD4S3dZ && /usr/bin/git remote add origin https://github.com/psf/black`
2025-12-04T18:22:31.381090Z TRACE Executing `cd /home/jamison/.cache/prek/scratch/.tmpq8h1tW && /usr/bin/git fetch origin v2.3.1 --depth=1`
2025-12-04T18:22:31.381237Z TRACE Executing `cd /home/jamison/.cache/prek/scratch/.tmpl1tTJe && /usr/bin/git fetch origin v4.6.0 --depth=1`
2025-12-04T18:22:31.381393Z TRACE Executing `cd /home/jamison/.cache/prek/scratch/.tmpD4S3dZ && /usr/bin/git fetch origin 25.1.0 --depth=1`
2025-12-04T18:22:32.799952Z TRACE Executing `cd /home/jamison/.cache/prek/scratch/.tmpl1tTJe && /usr/bin/git checkout FETCH_HEAD`
2025-12-04T18:22:32.823903Z TRACE Executing `cd /home/jamison/.cache/prek/scratch/.tmpq8h1tW && /usr/bin/git checkout FETCH_HEAD`
2025-12-04T18:22:33.185641Z TRACE Executing `cd /home/jamison/.cache/prek/scratch/.tmpD4S3dZ && /usr/bin/git checkout FETCH_HEAD`
```