### PR TITLE
Support apple's `container` for docker lang

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -221,7 +221,7 @@ Prek supports the following environment variables:
     - `auto` (default, auto-detect available runtime)
     - `docker`
     - `podman`
-    - `container`
+    - `container` (Apple's Container runtime on macOS, see [container](https://github.com/apple/container))
 
 Compatibility fallbacks:
 

--- a/docs/diff.md
+++ b/docs/diff.md
@@ -78,7 +78,7 @@ Gems specified in hook gemspec files and `additional_dependencies` will be insta
 
 ### Docker & Docker Image
 
-`prek` auto-detects the available container runtime on the system (Docker, Podman, or Container) and uses it to run container-based hooks. You can also explicitly specify the container runtime using the `PREK_CONTAINER_RUNTIME` environment variable.
+`prek` auto-detects the available container runtime on the system (Docker, Podman, or [Container](https://github.com/apple/container)) and uses it to run container-based hooks. You can also explicitly specify the container runtime using the [`PREK_CONTAINER_RUNTIME`](configuration.md#environment-variables) environment variable.
 
 ## Command line interface
 


### PR DESCRIPTION
Adding support for https://github.com/apple/container as a container runtime. As a newer project, it's not yet 100% docker-compatible so needed some special casing (missing `--volume`'s  `Z` option and `--init`)

Example:

```console
$ PREK_CONTAINER_RUNTIME=container cargo run -- try-repo https://github.com/gitleaks/gitleaks gitleaks-docker -a
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/prek try-repo 'https://github.com/gitleaks/gitleaks' gitleaks-docker -a`
Using config:
repos:
  - repo: https://github.com/gitleaks/gitleaks
    rev: b66ac75e4fa93d86d78fccd6e2f36d2c0698b2a2
    hooks:
      - id: gitleaks-docker
Detect hardcoded secrets.................................................Passed
```
