### PR TITLE
Enable Renovate's ":configMigration" preset

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,8 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
     'config:recommended',
+    // https://docs.renovatebot.com/presets-default/#configmigration
+    ':configMigration',
   ],
   schedule: [
     '* * 1,15 * *'


### PR DESCRIPTION
Found that the config needs to be migrated, while testing https://github.com/renovatebot/pre-commit-hooks

```
renovate-config-validator................................................Failed
- hook id: renovate-config-validator
- exit code: 1

  INFO: Validating .github/renovate.json5
   WARN: Config migration necessary
```