### PR TITLE
Update deprecated key in renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -66,7 +66,7 @@
     {
       groupName: 'pre-commit',
       matchManagers: ['pre-commit'],
-      matchPaths: ['.pre-commit-config.yaml']
+      matchFileNames: ['.pre-commit-config.yaml']
     },
     // Annotate GitHub Actions SHAs with a SemVer version.
     {


### PR DESCRIPTION
> matchPaths and matchFiles are now combined into matchFileNames, supporting exact match and glob-only. The "any string match" functionality of matchPaths is now removed

https://github.com/renovatebot/renovate/releases/tag/36.0.0

Supersedes #1396