### PR TITLE
Fix nested list indent rendering issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,7 +234,7 @@ Big thanks to @lmmx for driving this feature!
 ### Enhancements
 
 - Support`--cooldown-days` in `prek auto-update` ([#1172](https://github.com/j178/prek/pull/1172))
-  - Prefer tag creation timestamp in `--cooldown-days` ([#1221](https://github.com/j178/prek/pull/1221))
+    - Prefer tag creation timestamp in `--cooldown-days` ([#1221](https://github.com/j178/prek/pull/1221))
 - Use `cargo install` for packages in workspace ([#1207](https://github.com/j178/prek/pull/1207))
 
 ### Bug fixes
@@ -277,8 +277,8 @@ Want to show your project runs on prek? Add our README badge to your docs or rep
 ### Enhancements
 
 - Support Rust language ([#989](https://github.com/j178/prek/pull/989))
-  - Refactor Rust toolchain management ([#1198](https://github.com/j178/prek/pull/1198))
-  - Add support for finding packages in virtual workspaces ([#1180](https://github.com/j178/prek/pull/1180))
+    - Refactor Rust toolchain management ([#1198](https://github.com/j178/prek/pull/1198))
+    - Add support for finding packages in virtual workspaces ([#1180](https://github.com/j178/prek/pull/1180))
 - Add `prek cache size` command ([#1183](https://github.com/j178/prek/pull/1183))
 - Support orphan projects ([#1129](https://github.com/j178/prek/pull/1129))
 - Fallback to `manual` stage for hooks specified directly in command line ([#1185](https://github.com/j178/prek/pull/1185))

--- a/README.md
+++ b/README.md
@@ -299,9 +299,9 @@ prek self update
 - No hassle with your Python version or virtual environments, prek automatically installs the required Python version and creates a virtual environment for you.
 - Built-in support for [workspaces](https://prek.j178.dev/workspace/) (or monorepos), each subproject can have its own `.pre-commit-config.yaml` file.
 - [`prek run`](https://prek.j178.dev/cli/#prek-run) has some nifty improvements over `pre-commit run`, such as:
-  - `prek run --directory <dir>` runs hooks for files in the specified directory, no need to use `git ls-files -- <dir> | xargs pre-commit run --files` anymore.
-  - `prek run --last-commit` runs hooks for files changed in the last commit.
-  - `prek run [HOOK] [HOOK]` selects and runs multiple hooks.
+    - `prek run --directory <dir>` runs hooks for files in the specified directory, no need to use `git ls-files -- <dir> | xargs pre-commit run --files` anymore.
+    - `prek run --last-commit` runs hooks for files changed in the last commit.
+    - `prek run [HOOK] [HOOK]` selects and runs multiple hooks.
 - [`prek list`](https://prek.j178.dev/cli/#prek-list) command lists all available hooks, their ids, and descriptions, providing a better overview of the configured hooks.
 - [`prek auto-update`](https://prek.j178.dev/cli/#prek-auto-update) supports `--cooldown-days` to mitigate open source supply chain attacks.
 - prek provides shell completions for `prek run <hook_id>` command, making it easier to run specific hooks without remembering their ids.

--- a/docs/proposals/concurrency.md
+++ b/docs/proposals/concurrency.md
@@ -42,7 +42,7 @@ Execution is driven purely by priority numbers:
 The existing `require_serial` configuration key often causes confusion. In this design, its meaning is strictly scoped:
 
 * **`require_serial: true`**: Controls **invocation concurrency for that hook**. When running a hook against files, `prek` limits that hook to a single in-flight invocation at a time. This effectively disables running multiple batches of the *same hook* concurrently.
-  * `prek` will still try to pass all files in one invocation, but may split into multiple invocations if the OS command-line length limit would be exceeded.
+    * `prek` will still try to pass all files in one invocation, but may split into multiple invocations if the OS command-line length limit would be exceeded.
 * **It does NOT imply exclusive execution**. A hook with `require_serial: true` can still run in parallel with other hooks that share its `priority`.
 * If a hook *must* run alone (e.g., it modifies global state), it should be assigned a unique priority value that no other hook uses.
 


### PR DESCRIPTION
I noticed when reading the documentation that there are a couple bullet points not indented to the second level (in https://prek.j178.dev/#prek-provides-a-better-user-experience):

<img width="702" height="159" alt="image" src="https://github.com/user-attachments/assets/3bf8c09f-d57b-4905-9f05-d360c1f5ddf1" />

That's because `mkdocs` needs 4 spaces instead of 2.

I ran `mdformat` with the `mdformat-mkdocs` extension and found a couple more spots which are also fixed in this PR.

```shell
uv run --with mdformat --with mdformat-mkdocs mdformat --number **/*.md
```

There were more unrelated changes to this fix which I did not commit to keep the diff small.

NB: Thank you so much for creating `prek`! Love it!