### PR TITLE
Add mdformat pre-commit hook

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,8 +12,8 @@
 - Rust workspace under `crates/*`. The main CLI binary is `crates/prek` (`src/main.rs`).
 - `prek` is a Rust reimplementation of `pre-commit`: configuration parsing lives in `crates/prek/src/config.rs`, execution/dispatch is in `crates/prek/src/run.rs`, and integration tests exercise the CLI end-to-end under `crates/prek/tests/`.
 - User-facing output is centralized:
-  - Warnings go through `warn_user!` / `warn_user_once!` in `crates/prek/src/warnings.rs` (can be disabled via `-q` / `-qq`).
-  - Progress/output selection is via `Printer` in `crates/prek/src/printer.rs`.
+    - Warnings go through `warn_user!` / `warn_user_once!` in `crates/prek/src/warnings.rs` (can be disabled via `-q` / `-qq`).
+    - Progress/output selection is via `Printer` in `crates/prek/src/printer.rs`.
 - Cross-process coordination uses a store under `$PREK_HOME` (see `Store::from_settings` / `Store::lock_async` in `crates/prek/src/store.rs`).
 
 ## Developer workflows (preferred)
@@ -21,9 +21,9 @@
 - Lint/format like CI: `mise run lint` (runs `cargo fmt` + `cargo clippy --all-targets --all-features --workspace -- -D warnings`).
 - Run all tests: `mise run test` (workspace, all targets/features).
 - Snapshot-first test workflow (insta):
-  - Unit/bin tests with review UI: `mise run test-unit -- <filter>` or `mise run test-all-unit`.
-  - Integration tests with review UI: `mise run test-integration <test> [filter]` or `mise run test-all-integration`.
-  - Snapshots live under `crates/prek/src/snapshots/` and are used heavily by tests in `crates/prek/tests/`.
+    - Unit/bin tests with review UI: `mise run test-unit -- <filter>` or `mise run test-all-unit`.
+    - Integration tests with review UI: `mise run test-integration <test> [filter]` or `mise run test-all-integration`.
+    - Snapshots live under `crates/prek/src/snapshots/` and are used heavily by tests in `crates/prek/tests/`.
 
 ## Project-specific conventions
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,16 @@ repos:
     hooks:
       - id: typos
 
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 1.0.0
+    hooks:
+      - id: mdformat
+        language: python  # ensures that Renovate can update additional_dependencies
+        args: [--number, --compact-tables, --align-semantic-breaks-in-lists]
+        additional_dependencies:
+          - mdformat-mkdocs==5.1.3
+          - mdformat-simple-breaks==0.1.0
+
   - repo: local
     hooks:
       - id: cargo-fmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1155,6 +1155,7 @@ Then uninstall the old `prefligit` and install the new `prek` from scratch.
 - Set `GOROOT` when installing golang hook ([#381](https://github.com/j178/prefligit/pull/381))
 
 ### Other changes
+
 - Add devcontainer config ([#379](https://github.com/j178/prefligit/pull/379))
 - Bump rust toolchain to 1.89 ([#386](https://github.com/j178/prefligit/pull/386))
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,29 +6,29 @@ Thanks for your interest in improving **prek**! This guide walks through the dev
 
 1. **Install Rust with `rustup`** (recommended)
 
-   Install `rustup` from <https://rustup.rs> if you do not already have it. Then install the toolchain pinned in `rust-toolchain.toml` (currently Rust 1.90):
+    Install `rustup` from <https://rustup.rs> if you do not already have it. Then install the toolchain pinned in `rust-toolchain.toml` (currently Rust 1.90):
 
-   ```bash
-   rustup show
-   ```
+    ```bash
+    rustup show
+    ```
 
-   Finally, add the common developer components:
+    Finally, add the common developer components:
 
-   ```bash
-   rustup component add rustfmt clippy
-   ```
+    ```bash
+    rustup component add rustfmt clippy
+    ```
 
-1. **Install project helper tools**
+2. **Install project helper tools**
 
-   Install [`mise`](https://mise.jdx.dev/) to manage project-specific tools and tasks, then run `mise install` in the repository root to download the tool versions declared in `mise.toml` (for example `cargo-insta`, `cargo-nextest`, and the language toolchains used in integration tests).
+    Install [`mise`](https://mise.jdx.dev/) to manage project-specific tools and tasks, then run `mise install` in the repository root to download the tool versions declared in `mise.toml` (for example `cargo-insta`, `cargo-nextest`, and the language toolchains used in integration tests).
 
-1. (Optional) **Bootstrap git hooks**
+3. (Optional) **Bootstrap git hooks**
 
-   ```bash
-   prek install
-   ```
+    ```bash
+    prek install
+    ```
 
-   This installs a `pre-push` git hook that keeps formatting and linting checks aligned with CI before you push changes.
+    This installs a `pre-push` git hook that keeps formatting and linting checks aligned with CI before you push changes.
 
 ## 2. Writing tests with `insta` snapshot assertions
 
@@ -57,20 +57,20 @@ You can invoke the test suite directly with Cargo or use the convenience tasks d
 
 - To run and review a specific snapshot test:
 
-  ```bash
-  cargo test --package <package> --test <test> -- <test_name> -- --exact
-  cargo insta review
-  ```
+    ```bash
+    cargo test --package <package> --test <test> -- <test_name> -- --exact
+    cargo insta review
+    ```
 
 Where `<package>` is the crate name (for example, `prek`), `<test>` is the integration test file name (for example, `builtin_hooks`), and `<test_name>` is the specific test function name.
 
 - Run snapshot-aware tests with the review UI:
 
-  ```bash
-  cargo insta test --review [test arguments]
-  ```
+    ```bash
+    cargo insta test --review [test arguments]
+    ```
 
-  This command runs the selected tests, shows snapshot diffs, and lets you approve or reject updates interactively.
+    This command runs the selected tests, shows snapshot diffs, and lets you approve or reject updates interactively.
 
 ### Using mise tasks
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,14 @@
 </div>
 
 <!-- description:start -->
+
 [pre-commit](https://pre-commit.com/) is a framework to run hooks written in many languages, and it manages the
 language toolchain and dependencies for running the hooks.
 
 *prek* is a reimagined version of pre-commit, built in Rust.
 It is designed to be a faster, dependency-free and drop-in alternative for it,
 while also providing some additional long-requested features.
+
 <!-- description:end -->
 
 > [!NOTE]
@@ -28,6 +30,7 @@ while also providing some additional long-requested features.
 > Please note that some subcommands and languages are still missing for full drop‑in parity with `pre-commit`. Track the remaining gaps here: [TODO](https://prek.j178.dev/todo/).
 
 <!-- features:start -->
+
 ## Features
 
 - 🚀 A single binary with no dependencies, does not require Python or any other runtime.
@@ -37,6 +40,7 @@ while also providing some additional long-requested features.
 - 🐍 Integration with [`uv`](https://github.com/astral-sh/uv) for managing Python virtual environments and dependencies.
 - 🛠️ Improved toolchain installations for Python, Node.js, Go, Rust and Ruby, shared between hooks.
 - 📦 [Built-in](https://prek.j178.dev/builtin/) Rust-native implementation of some common hooks.
+
 <!-- features:end -->
 
 ## Table of contents
@@ -57,17 +61,21 @@ prek provides a standalone installer script to download and install the tool,
 On Linux and macOS:
 
 <!-- linux-standalone-install:start -->
+
 ```bash
 curl --proto '=https' --tlsv1.2 -LsSf https://github.com/j178/prek/releases/download/v0.2.30/prek-installer.sh | sh
 ```
+
 <!-- linux-standalone-install:end -->
 
 On Windows:
 
 <!-- windows-standalone-install:start -->
+
 ```powershell
 powershell -ExecutionPolicy ByPass -c "irm https://github.com/j178/prek/releases/download/v0.2.30/prek-installer.ps1 | iex"
 ```
+
 <!-- windows-standalone-install:end -->
 
 </details>
@@ -76,6 +84,7 @@ powershell -ExecutionPolicy ByPass -c "irm https://github.com/j178/prek/releases
 <summary>PyPI</summary>
 
 <!-- pypi-install:start -->
+
 prek is published as Python binary wheel to PyPI, you can install it using `pip`, `uv` (recommended), or `pipx`:
 
 ```bash
@@ -94,6 +103,7 @@ pip install prek
 # Using pipx
 pipx install prek
 ```
+
 <!-- pypi-install:end -->
 
 </details>
@@ -102,9 +112,11 @@ pipx install prek
 <summary>Homebrew</summary>
 
 <!-- homebrew-install:start -->
+
 ```bash
 brew install prek
 ```
+
 <!-- homebrew-install:end -->
 
 </details>
@@ -113,11 +125,13 @@ brew install prek
 <summary>mise</summary>
 
 <!-- mise-install:start -->
+
 To use prek with [mise](https://mise.jdx.dev) ([v2025.8.11](https://github.com/jdx/mise/releases/tag/v2025.8.11) or later):
 
 ```bash
 mise use prek
 ```
+
 <!-- mise-install:end -->
 
 </details>
@@ -126,11 +140,13 @@ mise use prek
 <summary>Cargo binstall</summary>
 
 <!-- cargo-binstall:start -->
+
 Install pre-compiled binaries from GitHub using [cargo-binstall](https://github.com/cargo-bins/cargo-binstall):
 
 ```bash
 cargo binstall prek
 ```
+
 <!-- cargo-binstall:end -->
 
 </details>
@@ -139,11 +155,13 @@ cargo binstall prek
 <summary>Cargo</summary>
 
 <!-- cargo-install:start -->
+
 Build from source using Cargo (Rust 1.89+ is required):
 
 ```bash
 cargo install --locked prek
 ```
+
 <!-- cargo-install:end -->
 
 </details>
@@ -152,6 +170,7 @@ cargo install --locked prek
 <summary>npmjs</summary>
 
 <!-- npmjs-install:start -->
+
 prek is published as a Node.js package, you can install it using `npm`, `pnpm`, or `npx`:
 
 ```bash
@@ -170,6 +189,7 @@ npm install -g @j178/prek
 # then use `prek` command
 prek --version
 ```
+
 <!-- npmjs-install:end -->
 
 </details>
@@ -178,6 +198,7 @@ prek --version
 <summary>Nix</summary>
 
 <!-- nix-install:start -->
+
 prek is available via [Nixpkgs](https://search.nixos.org/packages?channel=unstable&show=prek&query=prek).
 
 ```shell
@@ -191,6 +212,7 @@ nix-env -iA nixos.prek
 # Non-NixOS with flakes:
 nix profile install nixpkgs#prek
 ```
+
 <!-- nix-install:end -->
 
 </details>
@@ -199,11 +221,13 @@ nix profile install nixpkgs#prek
 <summary>Conda</summary>
 
 <!-- conda-forge-install:start -->
+
 prek is available as `prek` via [conda-forge](https://anaconda.org/conda-forge/prek).
 
 ```shell
 conda install conda-forge::prek
 ```
+
 <!-- conda-forge-install:end -->
 
 </details>
@@ -212,31 +236,39 @@ conda install conda-forge::prek
 <summary>Scoop (Windows)</summary>
 
 <!-- scoop-install:start -->
+
 prek is available via [Scoop](https://scoop.sh/#/apps?q=prek).
 
 ```powershell
 scoop install main/prek
 ```
+
 <!-- scoop-install:end -->
+
 </details>
 
 <details>
 <summary>MacPorts</summary>
 
 <!-- macports-install:start -->
+
 prek is available via [MacPorts](https://ports.macports.org/port/prek/).
 
 ```bash
 sudo port install prek
 ```
+
 <!-- macports-install:end -->
+
 </details>
 
 <details>
 <summary>GitHub Releases</summary>
 
 <!-- pre-built-binaries:start -->
+
 Pre-built binaries are available for download from the [GitHub releases](https://github.com/j178/prek/releases) page.
+
 <!-- pre-built-binaries:end -->
 
 </details>
@@ -245,6 +277,7 @@ Pre-built binaries are available for download from the [GitHub releases](https:/
 <summary>GitHub Actions</summary>
 
 <!-- github-actions:start -->
+
 prek can be used in GitHub Actions via the [j178/prek-action](https://github.com/j178/prek-action) repository.
 
 Example workflow:
@@ -264,15 +297,19 @@ jobs:
 This action installs prek and runs `prek run --all-files` on your repository.
 
 prek is also available via [`taiki-e/install-action`](https://github.com/taiki-e/install-action) for installing various tools.
+
 <!-- github-actions:end -->
+
 </details>
 
 <!-- self-update:start -->
+
 If installed via the standalone installer, prek can update itself to the latest version:
 
 ```bash
 prek self update
 ```
+
 <!-- self-update:end -->
 
 ## Quick start
@@ -281,6 +318,7 @@ prek self update
 - **I'm new to pre-commit-style tools:** learn the basics—creating a config, running hooks, and installing git hooks—in the [beginner quickstart walkthrough](https://prek.j178.dev/quickstart/#new-to-pre-commit-style-workflows).
 
 <!-- why:start -->
+
 ## Why prek?
 
 ### prek is faster

--- a/docs/builtin.md
+++ b/docs/builtin.md
@@ -25,6 +25,7 @@ repos:
 ```
 
 !!! note
+
     In this mode, `prek` will still clone the repository and create the environment (e.g., a Python venv) to ensure full compatibility and fallback capabilities. However, the actual hook execution bypasses the environment and runs the native Rust code.
 
 ### Supported Hooks

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -286,7 +286,7 @@ Allowed values:
 
 !!! note "prek-only"
 
-     This key is a `prek` extension. Upstream `pre-commit` uses `minimum_pre_commit_version`, which `prek` intentionally ignores.
+    This key is a `prek` extension. Upstream `pre-commit` uses `minimum_pre_commit_version`, which `prek` intentionally ignores.
 
 Require a minimum `prek` version for this config.
 
@@ -826,10 +826,15 @@ Require a minimum `prek` version for this specific hook.
 Prek supports the following environment variables:
 
 - `PREK_HOME` — Override the prek data directory (caches, toolchains, hook envs). Defaults to `~/.cache/prek` on macOS and Linux, and `%LOCALAPPDATA%\prek` on Windows.
+
 - `PREK_COLOR` — Control colored output: auto (default), always, or never.
+
 - `PREK_SKIP` — Comma-separated list of hook IDs to skip (e.g. black,ruff). See [Skipping Projects or Hooks](workspace.md#skipping-projects-or-hooks) for details.
+
 - `PREK_ALLOW_NO_CONFIG` — Allow running without a .pre-commit-config.yaml (useful for ad‑hoc runs).
+
 - `PREK_NO_CONCURRENCY` — Disable parallelism for installs and runs (set `PREK_NO_CONCURRENCY=1` to force concurrency to `1`).
+
 - `PREK_NO_FAST_PATH` — Disable Rust-native built-in hooks; always use the original hook implementation. See [Built-in Fast Hooks](builtin.md) for details.
 
 - `PREK_UV_SOURCE` — Control how uv (Python package installer) is installed. Options:

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,9 @@
 </div>
 
 {%
-  include-markdown "../README.md"
-  start="<!-- description:start -->"
-  end="<!-- description:end -->"
+include-markdown "../README.md"
+start="<!-- description:start -->"
+end="<!-- description:end -->"
 %}
 
 !!! note
@@ -17,15 +17,15 @@
     Please note that some subcommands and languages are still missing for full drop‑in parity with `pre-commit`. Track the remaining gaps here: [TODO](https://prek.j178.dev/todo/).
 
 {%
-  include-markdown "../README.md"
-  start="<!-- features:start -->"
-  end="<!-- features:end -->"
+include-markdown "../README.md"
+start="<!-- features:start -->"
+end="<!-- features:end -->"
 %}
 
 {%
-  include-markdown "../README.md"
-  start="<!-- why:start -->"
-  end="<!-- why:end -->"
+include-markdown "../README.md"
+start="<!-- why:start -->"
+end="<!-- why:end -->"
 %}
 
 ## Badges

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,17 +9,17 @@ The standalone installer automatically downloads and installs the correct binary
 ### Linux and macOS
 
 {%
-  include-markdown "../README.md"
-  start="<!-- linux-standalone-install:start -->"
-  end="<!-- linux-standalone-install:end -->"
+include-markdown "../README.md"
+start="<!-- linux-standalone-install:start -->"
+end="<!-- linux-standalone-install:end -->"
 %}
 
 ### Windows
 
 {%
-  include-markdown "../README.md"
-  start="<!-- windows-standalone-install:start -->"
-  end="<!-- windows-standalone-install:end -->"
+include-markdown "../README.md"
+start="<!-- windows-standalone-install:start -->"
+end="<!-- windows-standalone-install:end -->"
 %}
 
 ## Package Managers
@@ -27,97 +27,97 @@ The standalone installer automatically downloads and installs the correct binary
 ### PyPI
 
 {%
-  include-markdown "../README.md"
-  start="<!-- pypi-install:start -->"
-  end="<!-- pypi-install:end -->"
+include-markdown "../README.md"
+start="<!-- pypi-install:start -->"
+end="<!-- pypi-install:end -->"
 %}
 
 ### Homebrew (macOS/Linux)
 
 {%
-  include-markdown "../README.md"
-  start="<!-- homebrew-install:start -->"
-  end="<!-- homebrew-install:end -->"
+include-markdown "../README.md"
+start="<!-- homebrew-install:start -->"
+end="<!-- homebrew-install:end -->"
 %}
 
 ### mise
 
 {%
-  include-markdown "../README.md"
-  start="<!-- mise-install:start -->"
-  end="<!-- mise-install:end -->"
+include-markdown "../README.md"
+start="<!-- mise-install:start -->"
+end="<!-- mise-install:end -->"
 %}
 
 ### npmjs
 
 {%
-  include-markdown "../README.md"
-  start="<!-- npmjs-install:start -->"
-  end="<!-- npmjs-install:end -->"
+include-markdown "../README.md"
+start="<!-- npmjs-install:start -->"
+end="<!-- npmjs-install:end -->"
 %}
 
 ### Nix
 
 {%
-  include-markdown "../README.md"
-  start="<!-- nix-install:start -->"
-  end="<!-- nix-install:end -->"
+include-markdown "../README.md"
+start="<!-- nix-install:start -->"
+end="<!-- nix-install:end -->"
 %}
 
 ### Conda
 
 {%
-  include-markdown "../README.md"
-  start="<!-- conda-forge-install:start -->"
-  end="<!-- conda-forge-install:end -->"
+include-markdown "../README.md"
+start="<!-- conda-forge-install:start -->"
+end="<!-- conda-forge-install:end -->"
 %}
 
 ### Scoop (Windows)
 
 {%
-  include-markdown "../README.md"
-  start="<!-- scoop-install:start -->"
-  end="<!-- scoop-install:end -->"
+include-markdown "../README.md"
+start="<!-- scoop-install:start -->"
+end="<!-- scoop-install:end -->"
 %}
 
 ### MacPorts (macOS)
 
 {%
-  include-markdown "../README.md"
-  start="<!-- macports-install:start -->"
-  end="<!-- macports-install:end -->"
+include-markdown "../README.md"
+start="<!-- macports-install:start -->"
+end="<!-- macports-install:end -->"
 %}
 
 ### Install from Pre-Built Binaries
 
 {%
-  include-markdown "../README.md"
-  start="<!-- cargo-binstall:start -->"
-  end="<!-- cargo-binstall:end -->"
+include-markdown "../README.md"
+start="<!-- cargo-binstall:start -->"
+end="<!-- cargo-binstall:end -->"
 %}
 
 ## Build from Source
 
 {%
-  include-markdown "../README.md"
-  start="<!-- cargo-install:start -->"
-  end="<!-- cargo-install:end -->"
+include-markdown "../README.md"
+start="<!-- cargo-install:start -->"
+end="<!-- cargo-install:end -->"
 %}
 
 ## Download from GitHub Releases
 
 {%
-  include-markdown "../README.md"
-  start="<!-- pre-built-binaries:start -->"
-  end="<!-- pre-built-binaries:end -->"
+include-markdown "../README.md"
+start="<!-- pre-built-binaries:start -->"
+end="<!-- pre-built-binaries:end -->"
 %}
 
 ## Updating
 
 {%
-  include-markdown "../README.md"
-  start="<!-- self-update:start -->"
-  end="<!-- self-update:end -->"
+include-markdown "../README.md"
+start="<!-- self-update:start -->"
+end="<!-- self-update:end -->"
 %}
 
 For other installation methods, follow the same installation steps again.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -26,7 +26,7 @@ docker run --rm ghcr.io/j178/prek:v0.2.30 --version
 ## GitHub Actions
 
 {%
-  include-markdown "../README.md"
-  start="<!-- github-actions:start -->"
-  end="<!-- github-actions:end -->"
+include-markdown "../README.md"
+start="<!-- github-actions:start -->"
+end="<!-- github-actions:end -->"
 %}

--- a/docs/proposals/concurrency.md
+++ b/docs/proposals/concurrency.md
@@ -17,8 +17,8 @@ A new optional field `priority` is added to the hook configuration.
   priority: 10
 ```
 
-* **Type**: `u32`
-* **Default**: `None` (auto-populated by hook index)
+- **Type**: `u32`
+- **Default**: `None` (auto-populated by hook index)
 
 When `priority` is omitted, the scheduler assigns the hook a priority equal to its index in the configuration file, starting at `0`. This preserves the current sequential behavior by giving each hook a unique, increasing priority by default.
 
@@ -41,10 +41,10 @@ Execution is driven purely by priority numbers:
 
 The existing `require_serial` configuration key often causes confusion. In this design, its meaning is strictly scoped:
 
-* **`require_serial: true`**: Controls **invocation concurrency for that hook**. When running a hook against files, `prek` limits that hook to a single in-flight invocation at a time. This effectively disables running multiple batches of the *same hook* concurrently.
-    * `prek` will still try to pass all files in one invocation, but may split into multiple invocations if the OS command-line length limit would be exceeded.
-* **It does NOT imply exclusive execution**. A hook with `require_serial: true` can still run in parallel with other hooks that share its `priority`.
-* If a hook *must* run alone (e.g., it modifies global state), it should be assigned a unique priority value that no other hook uses.
+- **`require_serial: true`**: Controls **invocation concurrency for that hook**. When running a hook against files, `prek` limits that hook to a single in-flight invocation at a time. This effectively disables running multiple batches of the *same hook* concurrently.
+    - `prek` will still try to pass all files in one invocation, but may split into multiple invocations if the OS command-line length limit would be exceeded.
+- **It does NOT imply exclusive execution**. A hook with `require_serial: true` can still run in parallel with other hooks that share its `priority`.
+- If a hook *must* run alone (e.g., it modifies global state), it should be assigned a unique priority value that no other hook uses.
 
 ## Design Considerations
 
@@ -56,9 +56,9 @@ Positions are taken from the **fully flattened hook list for the current `.pre-c
 
 Example:
 
-* Hook at index `0` with no `priority` gets implicit priority `0`.
-* Hook at index `1` with `priority: 10` keeps priority `10`.
-* Hook at index `2` with no `priority` gets implicit priority `2`.
+- Hook at index `0` with no `priority` gets implicit priority `0`.
+- Hook at index `1` with `priority: 10` keeps priority `10`.
+- Hook at index `2` with no `priority` gets implicit priority `2`.
 
 This means a later hook with an implicit priority can run before an earlier hook that was assigned a larger explicit priority.
 
@@ -82,7 +82,7 @@ Example:
 
 If `fail_fast` is enabled:
 
-* If a hook fails, `prek` should wait for currently running hooks with the *current priority* to finish, but **abort** the execution of higher-priority groups.
+- If a hook fails, `prek` should wait for currently running hooks with the *current priority* to finish, but **abort** the execution of higher-priority groups.
 
 ### Example Configuration
 

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -113,6 +113,7 @@ repos:
 ```
 
 With this option:
+
 - Files in `src/backend/` are processed **only** by hooks in `src/backend/`
 - Files in `src/` (but not in `src/backend/`) are processed by hooks in `src/` and the workspace root
 - Files in the root (but not in subdirectories with configs) are processed by hooks in the root
@@ -315,7 +316,7 @@ prek run -c docs/.pre-commit-config.yaml
 ### Key Differences: Workspace vs Single Config
 
 | Feature | Workspace Mode | Single Config Mode |
-|---------|----------------|-------------------|
+| -- | -- | -- |
 | **Discovery** | Auto-discovers all `.pre-commit-config.yaml` files | Uses single specified config file |
 | **Working Directory** | Uses workspace root | Uses git repository root |
 | **File Scope** | All files in workspace | All files in git repo |


### PR DESCRIPTION
Follow-up to #1414 to add `mdformat` to the pre-commit config.

* I enabled `--number` to keep numbering of ordered lists in the source
* I enabled `--compact-tables` since the one existing table had the compact form
* I enabled `--align-semantic-breaks-in-lists` to align semantic line breaks in lists to the text as this was already done in existing lists
* The thematic break (horizontal line) has no config option but there is `mdformat-simple-breaks` which I've added (see https://github.com/csala/mdformat-simple-breaks#plugin-rationale)

There are also code formatters available, such as [`mdformat-beautysh`](https://github.com/hukkin/mdformat-beautysh) to format bash code blocks, and [`mdformat-config`](https://github.com/hukkin/mdformat-config) to format YAML code blocks. Those are the main ones being used in this documentation.

Let me know if you want those or if any of the above decisions are made should be changed.