### PR TITLE
Show accurate repo and hook details in `prek cache gc -v`

### DIFF
--- a/crates/prek/tests/cache.rs
+++ b/crates/prek/tests/cache.rs
@@ -60,8 +60,6 @@ fn cache_gc_verbose_shows_removed_entries() {
     Removed 1 repos:
     - https://github.com/pre-commit/pre-commit-hooks@v1.0.0
       path: [HOME]/repos/deadbeef
-      url: https://github.com/pre-commit/pre-commit-hooks
-      rev: v1.0.0
 
     Removed 1 hook envs:
     - hook-env-dead


### PR DESCRIPTION
```console
Would remove 3 repos, 3 hook envs, 2 tools, 1 cache entries (314.2MiB)

Would remove 3 repos:
- https://github.com/astral-sh/ruff-pre-commit@v0.9.1
  path: /Users/Jo/.cache/prek/repos/6971a9799d2dccce
- https://github.com/crate-ci/typos@v1.42.0
  path: /Users/Jo/.cache/prek/repos/1a1dc28c8d06fd41
- https://github.com/executablebooks/mdformat@1.0.0
  path: /Users/Jo/.cache/prek/repos/49bddecadbc9f103

Would remove 3 hook envs:
- golang env
  path: /Users/Jo/.cache/prek/hooks/golang-MsR59IpKYioJogJMNrxm
  language: golang (1.25.6)
  repo: https://github.com/rhysd/actionlint@v1.7.7
- python env
  path: /Users/Jo/.cache/prek/hooks/python-EPz6zVzkeZqbKdr0tq7c
  language: python (3.14.0)
  repo: https://github.com/python-jsonschema/check-jsonschema@0.31.0
- python env
  path: /Users/Jo/.cache/prek/hooks/python-Ep97uFBplyg6UlzeuLIh
  language: python (3.14.0)
  repo: https://github.com/executablebooks/mdformat@1.0.0
  deps: mdformat-mkdocs==5.1.3, mdformat-simple-breaks==0.1.0

Would remove 2 tools:
- go
  path: /Users/Jo/.cache/prek/tools/go
- uv
  path: /Users/Jo/.cache/prek/tools/uv

Would remove 1 cache entries:
- uv
  path: /Users/Jo/.cache/prek/cache/uv
```