### PR TITLE
Use `git ls-remote --tags` to list bun versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,8 +321,6 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
 
       - name: "Cargo test"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cargo llvm-cov nextest \
             --no-report \
@@ -412,8 +410,6 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
 
       - name: "Cargo test"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cargo nextest run \
             --workspace \
@@ -574,8 +570,6 @@ jobs:
 
       - name: "Cargo test"
         working-directory: ${{ env.PREK_WORKSPACE }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Remove msys64 from PATH for Rust compilation
           $env:PATH = ($env:PATH -split ';' | Where-Object { $_ -notmatch '\\msys64\\' }) -join ';'

--- a/crates/prek/src/cli/mod.rs
+++ b/crates/prek/src/cli/mod.rs
@@ -708,7 +708,7 @@ pub(crate) struct SelfUpdateArgs {
 
     /// A GitHub token for authentication.
     /// A token is not required but can be used to reduce the chance of encountering rate limits.
-    #[arg(long, env = "GITHUB_TOKEN")]
+    #[arg(long, env = EnvVars::GITHUB_TOKEN)]
     pub token: Option<String>,
 }
 

--- a/crates/prek/src/languages/golang/installer.rs
+++ b/crates/prek/src/languages/golang/installer.rs
@@ -181,7 +181,7 @@ impl GoInstaller {
             .output()
             .await?
             .stdout;
-        let output_str = String::from_utf8(output)?;
+        let output_str = str::from_utf8(&output)?;
         let versions: Vec<GoVersion> = output_str
             .lines()
             .filter_map(|line| {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -858,8 +858,6 @@ Prek supports the following environment variables:
     - `podman`
     - `container` (Apple's Container runtime on macOS, see [container](https://github.com/apple/container))
 
-- `GITHUB_TOKEN` — GitHub personal access token for API requests. Used when downloading Bun toolchains to avoid GitHub API rate limits (60 requests/hour unauthenticated vs 5,000/hour authenticated). This is already set automatically in GitHub Actions.
-
 Compatibility fallbacks:
 
 - `PRE_COMMIT_ALLOW_NO_CONFIG` — Fallback for `PREK_ALLOW_NO_CONFIG`.


### PR DESCRIPTION
`git ls-remote` is super lightweight and way faster than the GitHub Releases API, plus it doesn’t have a rate limit.