### PR TITLE
docs: fix HTML anchors, grammar, capitalization, and add missing tracking issues

### DIFF
--- a/crates/prek/src/cli/mod.rs
+++ b/crates/prek/src/cli/mod.rs
@@ -867,7 +867,7 @@ mod _gen {
                     let id = format!("{name_key}--{}", arg.get_id());
                     output.push_str(&format!("<dt id=\"{id}\">"));
                     output.push_str(&format!(
-                        "<a href=\"#{id}\"<code>{}</code></a>",
+                        "<a href=\"#{id}\"><code>{}</code></a>",
                         arg.get_value_names()
                             .unwrap()
                             .iter()

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -6,7 +6,7 @@ Caveats:
 
 - Benchmark performance may vary based on hardware, OS, network conditions, and other factors.
 - Benchmarks are not exhaustive; results may vary with different repositories and configurations.
-- Prek is under active development; performance may improve over time.
+- prek is under active development; performance may improve over time.
 
 Environment:
 

--- a/docs/builtin.md
+++ b/docs/builtin.md
@@ -1,6 +1,6 @@
 # Built-in Fast Hooks
 
-Prek includes fast, Rust-native implementations of popular hooks for speed and low overhead. These hooks are bundled directly into the `prek` binary, eliminating the need for external interpreters like Python for these specific checks.
+prek includes fast, Rust-native implementations of popular hooks for speed and low overhead. These hooks are bundled directly into the `prek` binary, eliminating the need for external interpreters like Python for these specific checks.
 
 Built-in hooks come into play in two ways:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,7 +39,7 @@ prek install [OPTIONS] [HOOK|PROJECT]...
 
 <h3 class="cli-reference">Arguments</h3>
 
-<dl class="cli-reference"><dt id="prek-install--includes"><a href="#prek-install--includes"<code>HOOK|PROJECT</code></a></dt><dd><p>Include the specified hooks or projects.</p>
+<dl class="cli-reference"><dt id="prek-install--includes"><a href="#prek-install--includes"><code>HOOK|PROJECT</code></a></dt><dd><p>Include the specified hooks or projects.</p>
 <p>Supports flexible selector syntax:</p>
 <ul>
 <li>
@@ -123,7 +123,7 @@ prek install-hooks [OPTIONS] [HOOK|PROJECT]...
 
 <h3 class="cli-reference">Arguments</h3>
 
-<dl class="cli-reference"><dt id="prek-install-hooks--includes"><a href="#prek-install-hooks--includes"<code>HOOK|PROJECT</code></a></dt><dd><p>Include the specified hooks or projects.</p>
+<dl class="cli-reference"><dt id="prek-install-hooks--includes"><a href="#prek-install-hooks--includes"><code>HOOK|PROJECT</code></a></dt><dd><p>Include the specified hooks or projects.</p>
 <p>Supports flexible selector syntax:</p>
 <ul>
 <li>
@@ -186,7 +186,7 @@ prek run [OPTIONS] [HOOK|PROJECT]...
 
 <h3 class="cli-reference">Arguments</h3>
 
-<dl class="cli-reference"><dt id="prek-run--includes"><a href="#prek-run--includes"<code>HOOK|PROJECT</code></a></dt><dd><p>Include the specified hooks or projects.</p>
+<dl class="cli-reference"><dt id="prek-run--includes"><a href="#prek-run--includes"><code>HOOK|PROJECT</code></a></dt><dd><p>Include the specified hooks or projects.</p>
 <p>Supports flexible selector syntax:</p>
 <ul>
 <li>
@@ -274,7 +274,7 @@ prek list [OPTIONS] [HOOK|PROJECT]...
 
 <h3 class="cli-reference">Arguments</h3>
 
-<dl class="cli-reference"><dt id="prek-list--includes"><a href="#prek-list--includes"<code>HOOK|PROJECT</code></a></dt><dd><p>Include the specified hooks or projects.</p>
+<dl class="cli-reference"><dt id="prek-list--includes"><a href="#prek-list--includes"><code>HOOK|PROJECT</code></a></dt><dd><p>Include the specified hooks or projects.</p>
 <p>Supports flexible selector syntax:</p>
 <ul>
 <li>
@@ -425,7 +425,7 @@ prek validate-config [OPTIONS] [CONFIG]...
 
 <h3 class="cli-reference">Arguments</h3>
 
-<dl class="cli-reference"><dt id="prek-validate-config--configs"><a href="#prek-validate-config--configs"<code>CONFIG</code></a></dt><dd><p>The path to the configuration file</p>
+<dl class="cli-reference"><dt id="prek-validate-config--configs"><a href="#prek-validate-config--configs"><code>CONFIG</code></a></dt><dd><p>The path to the configuration file</p>
 </dd></dl>
 
 <h3 class="cli-reference">Options</h3>
@@ -461,7 +461,7 @@ prek validate-manifest [OPTIONS] [MANIFEST]...
 
 <h3 class="cli-reference">Arguments</h3>
 
-<dl class="cli-reference"><dt id="prek-validate-manifest--manifests"><a href="#prek-validate-manifest--manifests"<code>MANIFEST</code></a></dt><dd><p>The path to the manifest file</p>
+<dl class="cli-reference"><dt id="prek-validate-manifest--manifests"><a href="#prek-validate-manifest--manifests"><code>MANIFEST</code></a></dt><dd><p>The path to the manifest file</p>
 </dd></dl>
 
 <h3 class="cli-reference">Options</h3>
@@ -710,7 +710,7 @@ prek init-template-dir [OPTIONS] <DIRECTORY>
 
 <h3 class="cli-reference">Arguments</h3>
 
-<dl class="cli-reference"><dt id="prek-init-template-dir--directory"><a href="#prek-init-template-dir--directory"<code>DIRECTORY</code></a></dt><dd><p>The directory in which to write the hook script</p>
+<dl class="cli-reference"><dt id="prek-init-template-dir--directory"><a href="#prek-init-template-dir--directory"><code>DIRECTORY</code></a></dt><dd><p>The directory in which to write the hook script</p>
 </dd></dl>
 
 <h3 class="cli-reference">Options</h3>
@@ -762,8 +762,8 @@ prek try-repo [OPTIONS] <REPO> [HOOK|PROJECT]...
 
 <h3 class="cli-reference">Arguments</h3>
 
-<dl class="cli-reference"><dt id="prek-try-repo--repo"><a href="#prek-try-repo--repo"<code>REPO</code></a></dt><dd><p>Repository to source hooks from</p>
-</dd><dt id="prek-try-repo--includes"><a href="#prek-try-repo--includes"<code>HOOK|PROJECT</code></a></dt><dd><p>Include the specified hooks or projects.</p>
+<dl class="cli-reference"><dt id="prek-try-repo--repo"><a href="#prek-try-repo--repo"><code>REPO</code></a></dt><dd><p>Repository to source hooks from</p>
+</dd><dt id="prek-try-repo--includes"><a href="#prek-try-repo--includes"><code>HOOK|PROJECT</code></a></dt><dd><p>Include the specified hooks or projects.</p>
 <p>Supports flexible selector syntax:</p>
 <ul>
 <li>
@@ -867,7 +867,7 @@ prek self update [OPTIONS] [TARGET_VERSION]
 
 <h3 class="cli-reference">Arguments</h3>
 
-<dl class="cli-reference"><dt id="prek-self-update--target_version"><a href="#prek-self-update--target_version"<code>TARGET_VERSION</code></a></dt><dd><p>Update to the specified version. If not provided, prek will update to the latest version</p>
+<dl class="cli-reference"><dt id="prek-self-update--target_version"><a href="#prek-self-update--target_version"><code>TARGET_VERSION</code></a></dt><dd><p>Update to the specified version. If not provided, prek will update to the latest version</p>
 </dd></dl>
 
 <h3 class="cli-reference">Options</h3>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,7 +102,7 @@ That schema tracks what `prek` accepts today, but `prek` also intentionally tole
 
 This section documents the keys `prek` supports in `.pre-commit-config.yaml` / `.pre-commit-config.yml`.
 
-### Prek-only options
+### prek-only options
 
 The following configuration entries are extensions implemented by `prek` and are not part of the documented `pre-commit` configuration surface.
 If you run them with upstream `pre-commit`, expect them to be ignored or to trigger an “unknown key” warning.
@@ -823,7 +823,7 @@ Require a minimum `prek` version for this specific hook.
 
 ## Environment variables
 
-Prek supports the following environment variables:
+prek supports the following environment variables:
 
 - `PREK_HOME` — Override the prek data directory (caches, toolchains, hook envs). If beginning with `~`, it is expanded to the user’s home directory. Defaults to `~/.cache/prek` on macOS and Linux, and `%LOCALAPPDATA%\prek` on Windows.
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -6,4 +6,4 @@ To enable verbose tracing output, use the `-vvv` flag when running prek:
 prek run -vvv
 ```
 
-Besides, every prek run it writes a log file to `~/.cache/prek/prek.log` by default. If you encounter issues, please include this log file when reporting bugs.
+Additionally, on every run prek writes a log file to `~/.cache/prek/prek.log` by default. If you encounter issues, please include this log file when reporting bugs.

--- a/docs/diff.md
+++ b/docs/diff.md
@@ -1,4 +1,4 @@
-# Difference from pre-commit
+# Differences from pre-commit
 
 ## General differences
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@
 
 !!! note
 
-    Although prek is pretty new, it’s already powering real‑world projects like [Apache Airflow](https://github.com/apache/airflow), and more projects are picking it up—see [Who is using prek?](#who-is-using-prek). If you’re looking for an alternative to `pre-commit`, please give it a try—we’d love your feedback!
+    Although prek is pretty new, it's already powering real‑world projects—see [Who is using prek?](#who-is-using-prek). If you're looking for an alternative to `pre-commit`, please give it a try—we'd love your feedback!
 
     Please note that some subcommands and languages are still missing for full drop‑in parity with `pre-commit`. Track the remaining gaps here: [TODO](https://prek.j178.dev/todo/).
 

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -127,13 +127,13 @@ Pre-release strings (for example `go1.22rc1`) are not supported yet.
 
 **Status in prek:** Not supported yet.
 
-Tracking: Not yet tracked
+Tracking: [#1445](https://github.com/j178/prek/issues/1445)
 
 ### julia
 
 **Status in prek:** Not supported yet.
 
-Tracking: Not yet tracked
+Tracking: [#1446](https://github.com/j178/prek/issues/1446)
 
 ### lua
 
@@ -169,7 +169,7 @@ Supported formats:
 
 **Status in prek:** Not supported yet.
 
-Tracking: Not yet tracked
+Tracking: [#1447](https://github.com/j178/prek/issues/1447)
 
 ### python
 

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -127,13 +127,13 @@ Pre-release strings (for example `go1.22rc1`) are not supported yet.
 
 **Status in prek:** Not supported yet.
 
-Tracking: —
+Tracking: Not yet tracked
 
 ### julia
 
 **Status in prek:** Not supported yet.
 
-Tracking: —
+Tracking: Not yet tracked
 
 ### lua
 
@@ -169,7 +169,7 @@ Supported formats:
 
 **Status in prek:** Not supported yet.
 
-Tracking: —
+Tracking: Not yet tracked
 
 ### python
 
@@ -347,6 +347,6 @@ Use `script` for simple repository scripts that only need file paths and no mana
 
 prek has experimental support in progress. pre-commit does not have a native `deno` language.
 
-Tracking: —
+Tracking: [#619](https://github.com/j178/prek/issues/619)
 
 If you want to help add support for the missing languages, check open issues or start a discussion in the repo.


### PR DESCRIPTION
Fixes broken HTML anchor tags in the CLI reference generator and regenerates the docs. Also standardizes on lowercase "prek" throughout, fixes minor grammar/title issues, syncs project mentions with README, and adds tracking issues for haskell/julia/perl language support.