### PR TITLE
Support refs to trees

### DIFF
--- a/crates/prek/src/git.rs
+++ b/crates/prek/src/git.rs
@@ -117,7 +117,7 @@ pub(crate) async fn get_changed_files(
     new: &str,
     root: &Path,
 ) -> Result<Vec<PathBuf>, Error> {
-    let mut build_cmd = |range: String| -> Result<Cmd, Error> {
+    let build_cmd = |range: String| -> Result<Cmd, Error> {
         let mut cmd = git_cmd("get changed files")?;
         cmd.arg("diff")
             .arg("--name-only")

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -2937,6 +2937,7 @@ fn expands_tilde_in_prek_home() -> Result<()> {
 fn run_with_tree_object_as_ref() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
+    context.configure_git_author();
 
     let cwd = context.work_dir();
     context.write_pre_commit_config(indoc::indoc! {r"


### PR DESCRIPTION
## Problem

Sometimes I want to run checks on a set of changes including my staged changes but not my unstaged changes. In pre-commit I do this by running:
```
$ pre-commit --from-ref=refs/remotes/origin/master --to-ref=$(git write-tree)
```
but in prek I get an error like:
```
$ prek --from-ref=refs/remotes/origin/master --to-ref=$(git write-tree)
error: Failed to collect files
  caused by: Command `get changed files` exited with an error:

[status]
exit status: 128

[stderr]
error: object 6824461bcaf59561411b9b4c1c66479a819ffb44 is a tree, not a commit
fatal: Invalid symmetric difference expression refs/remotes/origin/master...6824461bcaf59561411b9b4c1c66479a819ffb44
```

## Evaluation

This fails because I am passing in a ref to a tree instead of a ref to a commit. When passing in a commit/branch everything works as expected.

This happens because the `get_changed_files` uses `...` instead of `..`. `A...B` means "get all the differences in the A branch and the B branch when compared to their merge-base", `A..B` means "get all the differences between A and B". Importantly `...` requires commits because it compares to the merge base, `..` on the other hand compares any two references regardless of whether those references are commits or trees.

## Solution

Try to use `...` and fall back to `..`

This change feels safe because:
- it is [consistent with pre-commit](https://github.com/pre-commit/pre-commit/blob/main/pre_commit/git.py#L158)
- `get_changed_files` is only used in the case where `-to-ref` and `--from-ref` are used
- by default we use the same functionality as before. We just better handle the failure case
- no existing test fail

### Testing

I've added a new test that only passes with this code change and validated that no existing tests break because of this change.