### PR TITLE
fix(windows): keep VT enabled during progress

### DIFF
--- a/crates/prek/src/process.rs
+++ b/crates/prek/src/process.rs
@@ -37,6 +37,13 @@ use tracing::trace;
 
 use crate::git::GIT;
 
+#[cfg(windows)]
+fn reenable_vt() {
+    if *crate::run::USE_COLOR {
+        let _ = anstyle_query::windows::enable_ansi_colors();
+    }
+}
+
 /// An error from executing a Command
 #[derive(Debug, Error)]
 pub enum Error {
@@ -176,6 +183,12 @@ impl Cmd {
             summary: self.summary.clone(),
             cause,
         })?;
+
+        // Re-enable Windows VT mode in case subprocess corrupted console mode.
+        // Some tools disable ENABLE_VIRTUAL_TERMINAL_PROCESSING on exit.
+        #[cfg(windows)]
+        reenable_vt();
+
         self.maybe_check_output(&output)?;
         Ok(output)
     }
@@ -283,6 +296,8 @@ impl Cmd {
             summary: self.summary.clone(),
             cause,
         })?;
+        #[cfg(windows)]
+        reenable_vt();
         self.maybe_check_status(status)?;
         Ok(status)
     }


### PR DESCRIPTION
Some Windows hook installers (uv, pip, npm, cargo) disable `ENABLE_VIRTUAL_TERMINAL_PROCESSING` on exit, which causes indicatif's progress output to render as raw ANSI escape sequences during `prek install`.

This PR attempts two fixes:
1. Re-enable VT mode after subprocess `output()` and `status()` calls (148fe45df749eda56d8430cd9f067cfdc7002c13)
2. Run a background thread that periodically re-enables VT while progress bars are active (d31b4bdcccf57c1532ae933e9953c5b4b9d4898a)

Notably, the first alone did not fix the issue (see https://github.com/j178/prek/pull/1465#issuecomment-3812945380), but the second did.

Video of issue behavior: https://github.com/user-attachments/assets/10b75c59-f528-4a5e-95cd-c1987ee5de4a
Video of behavior after fix: https://github.com/user-attachments/assets/531000c8-32c7-4d98-a6a9-b1ab05e25582
(both courtesy of @chrisoro)

Fixes #1237