### PR TITLE
Require .pre-commit-config.yaml and log file in bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -32,7 +32,7 @@ body:
       description: |
         Please attach or paste the contents of your `.pre-commit-config.yaml` file if relevant.
     validations:
-      required: false
+      required: true
 
   - type: textarea
     attributes:
@@ -46,4 +46,4 @@ body:
         prek -vvv [your command]
         ```
     validations:
-      required: false
+      required: true


### PR DESCRIPTION
Make the attachment of configuration and log files mandatory in the bug report template.