### PR TITLE
Add GitHub artifact attestations to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,6 +277,10 @@ jobs:
     # "host" however must run to completion, no skipping allowed!
     if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') && (needs.custom-publish.result == 'skipped' || needs.custom-publish.result == 'success') }}
     runs-on: "ubuntu-latest"
+    permissions:
+      "attestations": "write"
+      "contents": "write"
+      "id-token": "write"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -295,6 +299,11 @@ jobs:
         run: |
           # Remove the granular manifests
           rm -f artifacts/*-dist-manifest.json
+      - name: Attest
+        uses: actions/attest-build-provenance@00014ed6ed5efc5b1ab7f7f34a39eb55d41aa4f8
+        with:
+          subject-path: |
+            artifacts/*
       - name: Create GitHub Release
         env:
           PRERELEASE_FLAG: "${{ fromJson(needs.host.outputs.val).announcement_is_prerelease && '--prerelease' || '' }}"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -17,6 +17,10 @@ dispatch-releases = true
 pr-run-mode = "skip"
 # Which phase dist should use to create the GitHub release
 github-release = "announce"
+# Whether to enable GitHub Attestations
+github-attestations = true
+# When to generate GitHub Attestations
+github-attestations-phase = "announce"
 # Whether to publish prereleases to package managers
 publish-prereleases = true
 # The installers to generate for each app
@@ -65,3 +69,4 @@ global = "ubuntu-latest"
 "actions/checkout" = "8e8c483db84b4bee98b60c0593521ed34d9990e8" # v6.0.1
 "actions/upload-artifact" = "b7c566a772e6b6bfb58ed0dc250532a479d7789f" # v6.0.0
 "actions/download-artifact" = "37930b1c2abaa49bbe596cd826c3c89aef350131" # v7.0.0
+"actions/attest-build-provenance" = "00014ed6ed5efc5b1ab7f7f34a39eb55d41aa4f8" # v3.1.0


### PR DESCRIPTION
Closes #1493

Adds [actions/attest-build-provenance](https://github.com/actions/attest-build-provenance) to the release workflow so consumers can verify artifacts were built by CI:

```bash
gh attestation verify <artifact> --repo j178/prek
```

GitHub already generates release attestations that verify file integrity (checksums), but build provenance additionally proves the artifacts were produced by the CI workflow rather than uploaded manually.