### PR TITLE
Don't check Python executable path in health check

### DIFF
--- a/crates/prek/src/languages/bun/version.rs
+++ b/crates/prek/src/languages/bun/version.rs
@@ -132,6 +132,7 @@ impl BunRequest {
             Self::MajorMinorPatch(major, minor, patch) => {
                 version.major == *major && version.minor == *minor && version.patch == *patch
             }
+            // FIXME: consider resolving symlinks and normalizing paths before comparison
             Self::Path(path) => toolchain.is_some_and(|toolchain_path| toolchain_path == path),
             Self::Range(req) => req.matches(version),
         }

--- a/crates/prek/src/languages/golang/version.rs
+++ b/crates/prek/src/languages/golang/version.rs
@@ -153,6 +153,7 @@ impl GoRequest {
             GoRequest::MajorMinorPatch(major, minor, patch) => {
                 version.0.major == *major && version.0.minor == *minor && version.0.patch == *patch
             }
+            // FIXME: consider resolving symlinks and normalizing paths before comparison
             GoRequest::Path(path) => toolchain.is_some_and(|t| t == path),
             GoRequest::Range(req, _) => req.matches(&version.0),
         }

--- a/crates/prek/src/languages/node/version.rs
+++ b/crates/prek/src/languages/node/version.rs
@@ -240,6 +240,7 @@ impl NodeRequest {
             NodeRequest::MajorMinorPatch(major, minor, patch) => {
                 version.major() == *major && version.minor() == *minor && version.patch() == *patch
             }
+            // FIXME: consider resolving symlinks and normalizing paths before comparison
             NodeRequest::Path(path) => toolchain.is_some_and(|t| t == path),
             NodeRequest::Range(req) => req.matches(version.version()),
             NodeRequest::Lts => version.lts.code_name().is_some(),

--- a/crates/prek/src/languages/python/python.rs
+++ b/crates/prek/src/languages/python/python.rs
@@ -74,8 +74,6 @@ async fn query_python_info(python: &Path) -> Result<PythonInfo, PythonInfoError>
     let info: QueryPythonInfo =
         serde_json::from_slice(&stdout).map_err(|err| PythonInfoError::Parse(err.to_string()))?;
     let python_exec = python_exec(&info.base_exec_prefix);
-    // Canonicalize to resolve symlinks for consistent comparison
-    let python_exec = fs::canonicalize(&python_exec).unwrap_or(python_exec);
 
     Ok(PythonInfo {
         version: info.version,
@@ -196,16 +194,6 @@ impl LanguageImpl for Python {
                 "Python version mismatch: expected {}, found {}",
                 info.language_version,
                 python_info.version
-            );
-        }
-
-        let expected_toolchain =
-            fs::canonicalize(&info.toolchain).unwrap_or_else(|_| info.toolchain.clone());
-        if python_info.python_exec != expected_toolchain {
-            anyhow::bail!(
-                "Python executable mismatch: expected {}, found {}",
-                expected_toolchain.display(),
-                python_info.python_exec.display()
             );
         }
 

--- a/crates/prek/src/languages/python/version.rs
+++ b/crates/prek/src/languages/python/version.rs
@@ -100,6 +100,7 @@ impl PythonRequest {
             PythonRequest::MajorMinorPatch(major, minor, patch) => {
                 version.major == *major && version.minor == *minor && version.patch == *patch
             }
+            // FIXME: consider resolving symlinks and normalizing paths before comparison
             PythonRequest::Path(path) => path == &install_info.toolchain,
             PythonRequest::Range(req, _) => req.matches(version),
         }

--- a/crates/prek/src/languages/ruby/version.rs
+++ b/crates/prek/src/languages/ruby/version.rs
@@ -99,6 +99,7 @@ impl RubyRequest {
             }
             Self::MajorMinor(maj, min) => version.major == *maj && version.minor == *min,
             Self::Major(maj) => version.major == *maj,
+            // FIXME: consider resolving symlinks and normalizing paths before comparison
             Self::Path(path) => toolchain.is_some_and(|t| t == path),
             Self::Range(req, _) => req.matches(version),
         }


### PR DESCRIPTION
It looked like `prek` was always re-installing my hooks.
Investigating with `prek install-hooks -vv` showed my a bunch of warnings:

> WARN Skipping unhealthy installed hook err=Python executable mismatch: expected /home/user/.local/share/uv/python/cpython-3.12-linux-x86_64-gnu/bin/python, found /home/user/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/bin/python path=/home/user/.cache/prek/hooks/python-WQV7m1JFnTc6mHEMUIFe

```/home/user/.local/share/uv/python/cpython-3.12-linux-x86_64-gnu```
is a symlink to
```/home/user/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu```
so these do actually match.

This PR fixes this by canonicalizing both paths before comparison to resolve symlinks and ensure consistent path matching regardless of how the Python toolchain is accessed.

- Canonicalize `python_exec` in `query_python_info` after constructing it
- Canonicalize `info.toolchain` in `check_health` before comparison
- Add integration test for symlinked toolchain scenario