### PR TITLE
Add GitHub artifact attestations to Docker workflow

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -159,3 +159,23 @@ jobs:
             "${annotations[@]}" \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf "${PREK_BASE_IMG}@sha256:%s " *)
+
+      - name: Export manifest digest
+        id: manifest-digest
+        env:
+          IMAGE: ${{ env.PREK_BASE_IMG }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          digest="$(
+            docker buildx imagetools inspect \
+              "${IMAGE}:${VERSION}" \
+              --format '{{json .Manifest}}' \
+            | jq -r '.digest'
+          )"
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@00014ed6ed5efc5b1ab7f7f34a39eb55d41aa4f8 # v3.1.0
+        with:
+          subject-name: ${{ env.PREK_BASE_IMG }}
+          subject-digest: ${{ steps.manifest-digest.outputs.digest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,9 @@ jobs:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
     permissions:
+      "attestations": "write"
       "contents": "read"
+      "id-token": "write"
       "packages": "write"
 
   # Build and package all the platform-agnostic(ish) things

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -52,7 +52,7 @@ local-artifacts-jobs = ["./build-binaries", "./build-docker"]
 publish-jobs = ["./publish", "homebrew"]
 # Post-announce jobs to run in CI
 post-announce-jobs = ["./publish-docs"]
-github-custom-job-permissions = { "publish-docs" = { contents = "read", pages = "write", id-token = "write" }, "build-docker" = { packages = "write", contents = "read" } }
+github-custom-job-permissions = { "publish-docs" = { contents = "read", pages = "write", id-token = "write" }, "build-docker" = { packages = "write", contents = "read", attestations = "write", id-token = "write" } }
 # A GitHub repo to push Homebrew formulas to
 tap = "j178/homebrew-tap"
 # Customize the Homebrew formula name


### PR DESCRIPTION
Adds [actions/attest-build-provenance](https://github.com/actions/attest-build-provenance) to the Docker build workflow so consumers can verify images were built by CI:

```bash
gh attestation verify oci://ghcr.io/j178/prek:latest --repo j178/prek
```

Similar to #1494 which added attestations for release artifacts.

Reference: [astral-sh/uv#8685](https://github.com/astral-sh/uv/pull/8685)