### PR TITLE
Use BTreeSet instead of FxHashSet to ensure sequential iteration

### DIFF
--- a/crates/prek/src/config.rs
+++ b/crates/prek/src/config.rs
@@ -203,6 +203,8 @@ impl HookType {
     Copy,
     PartialEq,
     Eq,
+    PartialOrd,
+    Ord,
     Default,
     Hash,
     Deserialize,

--- a/crates/prek/src/hook.rs
+++ b/crates/prek/src/hook.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 use std::ffi::OsStr;
 use std::fmt::{Display, Formatter};
 use std::ops::Deref;
@@ -344,7 +345,7 @@ impl HookBuilder {
 
         let stages = match options.stages {
             Some(stages) => {
-                let stages: FxHashSet<_> = stages.into_iter().collect();
+                let stages: BTreeSet<_> = stages.into_iter().collect();
                 if stages.is_empty() || stages.len() == Stage::value_variants().len() {
                     Stages::All
                 } else {
@@ -407,7 +408,7 @@ impl HookBuilder {
 #[derive(Debug, Clone)]
 pub(crate) enum Stages {
     All,
-    Some(FxHashSet<Stage>),
+    Some(BTreeSet<Stage>),
 }
 
 impl Stages {


### PR DESCRIPTION
```
failures:
---- list_verbose stdout ----
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Snapshot Summary ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Snapshot: list_verbose-2
Source: crates/prek/tests/list.rs:108
────────────────────────────────────────────────────────────────────────────────
program: prek
args:
  - list
  - "--verbose"
env:
  PREK_HOME: /home/buildozer/.local/share/prek/tests/.tmpjYY9WI/home
  PREK_INTERNAL__SORT_FILENAMES: "1"
────────────────────────────────────────────────────────────────────────────────
-old snapshot
+new results
────────────┬───────────────────────────────────────────────────────────────────
    6     6 │   Alias: fmt
    7     7 │   Name: Custom Code Formatter
    8     8 │   Description: Custom formatting tool with specific requirements
    9     9 │   Language: script
   10       │-  Stages: pre-commit, pre-push
         10 │+  Stages: pre-push, pre-commit
   11    11 │
   12    12 │
   13    13 │ ----- stderr -----
────────────┴───────────────────────────────────────────────────────────────────
```
