### PR TITLE
fix: hide progress bars in pseudo-TTY environments

### DIFF
--- a/crates/prek/src/printer.rs
+++ b/crates/prek/src/printer.rs
@@ -43,7 +43,13 @@ impl Printer {
         match self {
             Self::Silent => ProgressDrawTarget::hidden(),
             Self::Quiet => ProgressDrawTarget::hidden(),
-            Self::Default => ProgressDrawTarget::stderr(),
+            Self::Default => {
+                if crate::run::supports_progress() {
+                    ProgressDrawTarget::stderr()
+                } else {
+                    ProgressDrawTarget::hidden()
+                }
+            }
             // Confusingly, hide the progress bar when in verbose mode.
             // Otherwise, it gets interleaved with debug messages.
             Self::Verbose => ProgressDrawTarget::hidden(),


### PR DESCRIPTION
Fixes #1551

Progress bars now respect anstream's TTY detection instead of indicatif's independent check. This prevents garbled ANSI escape codes (`^[[2K`, `^[[1A`) in environments like Neovim/Fugitive which use pseudo-TTYs, but don't interpret cursor movement codes.