### PR TITLE
Do not make the child a session leader

### DIFF
--- a/crates/prek-consts/src/env_vars.rs
+++ b/crates/prek-consts/src/env_vars.rs
@@ -7,7 +7,6 @@ pub struct EnvVars;
 impl EnvVars {
     pub const PATH: &'static str = "PATH";
     pub const HOME: &'static str = "HOME";
-    pub const TERM: &'static str = "TERM";
     pub const CI: &'static str = "CI";
 
     // Git related

--- a/crates/prek/src/cli/list.rs
+++ b/crates/prek/src/cli/list.rs
@@ -107,7 +107,6 @@ pub(crate) async fn list(
                     writeln!(printer.stdout())?;
                 }
             } else {
-                // TODO: add project prefix to hook id
                 for hook in &filtered_hooks {
                     writeln!(printer.stdout(), "{}", hook.full_id())?;
                 }

--- a/crates/prek/src/process.rs
+++ b/crates/prek/src/process.rs
@@ -187,7 +187,6 @@ impl Cmd {
 
     #[cfg(not(windows))]
     pub async fn pty_output(&mut self) -> Result<Output, Error> {
-        use prek_consts::env_vars::EnvVars;
         use tokio::io::AsyncReadExt;
 
         // If color is not used, fallback to piped output.
@@ -206,16 +205,16 @@ impl Cmd {
         // (colors, progress bars, etc.). However, this is still a *pseudo*-terminal and it doesn't
         // necessarily provide a full/accurate terminal environment.
         //
-        // Some CLI programs probe terminal capabilities via terminfo/termcap based on `$TERM`, and
-        // a few are known to misbehave (including hanging) when those probes don't match the PTY
-        // implementation or when they expect a real TTY.
+        // Some libraries (for example Go's termenv) send OSC/CSI queries and wait for a response
+        // from the terminal. Our PTY doesn't emulate those responses, so they can block on a
+        // timeout if the program insists on probing capabilities.
         //
-        // Forcing `TERM=dumb` tells well-behaved programs to disable advanced terminal features and
-        // avoids capability negotiation that can deadlock under a fake PTY.
-        self.inner.env(EnvVars::TERM, "dumb");
-
-        let session_leader = pts.session_leader();
-        unsafe { self.inner.pre_exec(session_leader) };
+        // Previously, we tried to work around this by setting `TERM=dumb` in the environment,
+        // but that caused other issues (for example, some programs (e.g cargo), disable color entirely when they see `TERM=dumb`,
+        // even if the output is actually a terminal that supports color).
+        //
+        // We intentionally do not make the child a session leader/foreground process group here.
+        // When we did, termenv detected it as foreground and ran OSC probes, which then hung.
 
         let mut child = self.spawn()?;
 


### PR DESCRIPTION
Closes #1561
Previous fix: #1363

We run subcommands under a PTY so they behave like they do in an interactive terminal (colors, progress bars, etc.). However, this is still a *pseudo*-terminal and it doesn't necessarily provide a full/accurate terminal environment.

Some libraries (for example Go's termenv) send OSC/CSI queries and wait for a response from the terminal. Our PTY doesn't emulate those responses, so they can block on a timeout if the program insists on probing capabilities.

Previously, we tried to work around this by setting `TERM=dumb` in the environment, but that caused other issues (for example, some programs (e.g cargo), disable color entirely when they see `TERM=dumb`, even if the output is actually a terminal that supports color).

We intentionally do not make the child a session leader/foreground process group here. When we did, termenv detected it as foreground and ran OSC probes, which then hung.
