### PR TITLE
Make yaml-to-toml CONFIG argument optional

### DIFF
--- a/crates/prek/src/cli/mod.rs
+++ b/crates/prek/src/cli/mod.rs
@@ -734,9 +734,10 @@ pub(crate) enum UtilCommand {
 
 #[derive(Debug, Args)]
 pub(crate) struct YamlToTomlArgs {
-    /// The YAML configuration file to convert.
+    /// The YAML configuration file to convert. If omitted, discovers
+    /// `.pre-commit-config.yaml` or `.pre-commit-config.yml` in the current directory.
     #[arg(value_name = "CONFIG", value_hint = ValueHint::FilePath)]
-    pub(crate) input: PathBuf,
+    pub(crate) input: Option<PathBuf>,
 
     /// Path to write the generated prek.toml file.
     /// Defaults to `prek.toml` in the same directory as the input file.

--- a/crates/prek/src/cli/yaml_to_toml.rs
+++ b/crates/prek/src/cli/yaml_to_toml.rs
@@ -14,9 +14,9 @@ use crate::printer::Printer;
 
 /// Resolve the input config path, falling back to `.pre-commit-config.yaml` or
 /// `.pre-commit-config.yml` in the current directory.
-fn resolve_input(input: Option<&Path>) -> Result<PathBuf> {
+fn resolve_input(input: Option<PathBuf>) -> Result<PathBuf> {
     if let Some(path) = input {
-        return Ok(path.to_path_buf());
+        return Ok(path);
     }
 
     let yaml = Path::new(PRE_COMMIT_CONFIG_YAML);
@@ -40,7 +40,7 @@ fn resolve_input(input: Option<&Path>) -> Result<PathBuf> {
 }
 
 pub(crate) fn yaml_to_toml(
-    input: Option<&Path>,
+    input: Option<PathBuf>,
     output: Option<PathBuf>,
     force: bool,
     printer: Printer,
@@ -94,7 +94,8 @@ pub(crate) fn yaml_to_toml(
 
     writeln!(
         printer.stdout(),
-        "Written to `{}`",
+        "Converted `{}` → `{}`",
+        input.simplified_display().cyan(),
         output.simplified_display().cyan()
     )?;
 

--- a/crates/prek/src/cli/yaml_to_toml.rs
+++ b/crates/prek/src/cli/yaml_to_toml.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use owo_colors::OwoColorize;
-use prek_consts::PREK_TOML;
+use prek_consts::{PRE_COMMIT_CONFIG_YAML, PRE_COMMIT_CONFIG_YML, PREK_TOML};
 use toml_edit::{Array, ArrayOfTables, DocumentMut, InlineTable, Table, Value};
 
 use crate::cli::ExitStatus;
@@ -12,16 +12,45 @@ use crate::config;
 use crate::fs::Simplified;
 use crate::printer::Printer;
 
+/// Resolve the input config path, falling back to `.pre-commit-config.yaml` or
+/// `.pre-commit-config.yml` in the current directory.
+fn resolve_input(input: Option<&Path>) -> Result<PathBuf> {
+    if let Some(path) = input {
+        return Ok(path.to_path_buf());
+    }
+
+    let yaml = Path::new(PRE_COMMIT_CONFIG_YAML);
+    if yaml.is_file() {
+        return Ok(yaml.to_path_buf());
+    }
+
+    let yml = Path::new(PRE_COMMIT_CONFIG_YML);
+    if yml.is_file() {
+        return Ok(yml.to_path_buf());
+    }
+
+    anyhow::bail!(
+        "No `{}` or `{}` found in the current directory\n\n\
+         {} Provide a path explicitly: {}",
+        PRE_COMMIT_CONFIG_YAML.cyan(),
+        PRE_COMMIT_CONFIG_YML.cyan(),
+        "hint:".yellow().bold(),
+        "prek util yaml-to-toml <CONFIG>".cyan()
+    );
+}
+
 pub(crate) fn yaml_to_toml(
-    input: &Path,
+    input: Option<&Path>,
     output: Option<PathBuf>,
     force: bool,
     printer: Printer,
 ) -> Result<ExitStatus> {
-    // Validate the input file first.
-    let _ = config::load_config(input)?;
+    let input = resolve_input(input)?;
 
-    let content = fs_err::read_to_string(input)?;
+    // Validate the input file first.
+    let _ = config::load_config(&input)?;
+
+    let content = fs_err::read_to_string(&input)?;
     let value: serde_json::Value = serde_saphyr::from_str(&content)?;
 
     let output = output.unwrap_or_else(|| input.parent().unwrap_or(Path::new(".")).join(PREK_TOML));

--- a/crates/prek/src/main.rs
+++ b/crates/prek/src/main.rs
@@ -401,7 +401,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             UtilCommand::YamlToToml(args) => {
                 show_settings!(args);
 
-                cli::yaml_to_toml(args.input.as_deref(), args.output, args.force, printer)
+                cli::yaml_to_toml(args.input, args.output, args.force, printer)
             }
             UtilCommand::GenerateShellCompletion(args) => {
                 show_settings!(args);

--- a/crates/prek/src/main.rs
+++ b/crates/prek/src/main.rs
@@ -401,7 +401,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             UtilCommand::YamlToToml(args) => {
                 show_settings!(args);
 
-                cli::yaml_to_toml(&args.input, args.output, args.force, printer)
+                cli::yaml_to_toml(args.input.as_deref(), args.output, args.force, printer)
             }
             UtilCommand::GenerateShellCompletion(args) => {
                 show_settings!(args);

--- a/crates/prek/tests/yaml_to_toml.rs
+++ b/crates/prek/tests/yaml_to_toml.rs
@@ -68,14 +68,14 @@ fn yaml_to_toml_writes_default_output() -> anyhow::Result<()> {
         context
             .command()
             .args(["util", "yaml-to-toml", "config.yaml"]),
-        @r#"
+        @"
     success: true
     exit_code: 0
     ----- stdout -----
-    Written to `prek.toml`
+    Converted `config.yaml` → `prek.toml`
 
     ----- stderr -----
-    "#
+    "
     );
 
     insta::assert_snapshot!(context.read(PREK_TOML), @r#"
@@ -180,7 +180,7 @@ fn yaml_to_toml_force_overwrite() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    Written to `prek.toml`
+    Converted `config.yaml` → `prek.toml`
 
     ----- stderr -----
     "
@@ -265,14 +265,14 @@ fn yaml_to_toml_discovers_pre_commit_config_yaml() -> anyhow::Result<()> {
     cmd_snapshot!(
         context.filters(),
         context.command().args(["util", "yaml-to-toml"]),
-        @r#"
+        @"
     success: true
     exit_code: 0
     ----- stdout -----
-    Written to `prek.toml`
+    Converted `.pre-commit-config.yaml` → `prek.toml`
 
     ----- stderr -----
-    "#
+    "
     );
 
     context
@@ -295,14 +295,14 @@ fn yaml_to_toml_discovers_pre_commit_config_yml() -> anyhow::Result<()> {
     cmd_snapshot!(
         context.filters(),
         context.command().args(["util", "yaml-to-toml"]),
-        @r#"
+        @"
     success: true
     exit_code: 0
     ----- stdout -----
-    Written to `prek.toml`
+    Converted `.pre-commit-config.yml` → `prek.toml`
 
     ----- stderr -----
-    "#
+    "
     );
 
     context
@@ -343,14 +343,14 @@ fn yaml_to_toml_prefers_yaml_over_yml() -> anyhow::Result<()> {
     cmd_snapshot!(
         context.filters(),
         context.command().args(["util", "yaml-to-toml"]),
-        @r#"
+        @"
     success: true
     exit_code: 0
     ----- stdout -----
-    Written to `prek.toml`
+    Converted `.pre-commit-config.yaml` → `prek.toml`
 
     ----- stderr -----
-    "#
+    "
     );
 
     // The .yaml file contains trailing-whitespace, the .yml contains end-of-file-fixer.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -914,12 +914,12 @@ Convert a YAML configuration file to prek.toml
 <h3 class="cli-reference">Usage</h3>
 
 ```
-prek util yaml-to-toml [OPTIONS] <CONFIG>
+prek util yaml-to-toml [OPTIONS] [CONFIG]
 ```
 
 <h3 class="cli-reference">Arguments</h3>
 
-<dl class="cli-reference"><dt id="prek-util-yaml-to-toml--input"><a href="#prek-util-yaml-to-toml--input"><code>CONFIG</code></a></dt><dd><p>The YAML configuration file to convert</p>
+<dl class="cli-reference"><dt id="prek-util-yaml-to-toml--input"><a href="#prek-util-yaml-to-toml--input"><code>CONFIG</code></a></dt><dd><p>The YAML configuration file to convert. If omitted, discovers <code>.pre-commit-config.yaml</code> or <code>.pre-commit-config.yml</code> in the current directory</p>
 </dd></dl>
 
 <h3 class="cli-reference">Options</h3>


### PR DESCRIPTION
Now attempts to default to `.pre-commit-config.yaml` and `.pre-commit-config.yml` in PWD before erroring.

Feel free to close if you disagree, just ran into this when spinning up #1592, and figured it's worth fixing :)