### PR TITLE
Do not use EOL python version if no version was requested

### DIFF
--- a/crates/prek-consts/src/env_vars.rs
+++ b/crates/prek-consts/src/env_vars.rs
@@ -50,6 +50,7 @@ impl EnvVars {
     pub const UV_PYTHON_INSTALL_DIR: &'static str = "UV_PYTHON_INSTALL_DIR";
     pub const UV_MANAGED_PYTHON: &'static str = "UV_MANAGED_PYTHON";
     pub const UV_NO_MANAGED_PYTHON: &'static str = "UV_NO_MANAGED_PYTHON";
+    pub const UV_VENV_CLEAR: &'static str = "UV_VENV_CLEAR";
 
     // Node/Npm related
     pub const NPM_CONFIG_USERCONFIG: &'static str = "NPM_CONFIG_USERCONFIG";

--- a/crates/prek/src/languages/python/python.rs
+++ b/crates/prek/src/languages/python/python.rs
@@ -252,6 +252,8 @@ impl LanguageImpl for Python {
     }
 }
 
+const PYTHON_DEFAULT_VERSION_RANGE: &str = ">=3.10";
+
 fn to_uv_python_request(request: &LanguageRequest) -> Option<String> {
     match request {
         LanguageRequest::Any { .. } => None,
@@ -337,7 +339,8 @@ impl Python {
             .env_remove(EnvVars::UV_PYTHON)
             // `--managed_python` conflicts with `--python-preference`, ignore any user setting
             .env_remove(EnvVars::UV_MANAGED_PYTHON)
-            .env_remove(EnvVars::UV_NO_MANAGED_PYTHON);
+            .env_remove(EnvVars::UV_NO_MANAGED_PYTHON)
+            .env(EnvVars::UV_VENV_CLEAR, "1");
 
         if set_install_dir {
             cmd.env(
@@ -353,6 +356,8 @@ impl Python {
 
         if let Some(python) = to_uv_python_request(python_request) {
             cmd.arg("--python").arg(python);
+        } else {
+            cmd.arg("--python").arg(PYTHON_DEFAULT_VERSION_RANGE);
         }
 
         cmd


### PR DESCRIPTION
This PR makes sure no EOL python versions are used when creating a python venv without a specific requested version.
Otherwise uv chooses i.e. python 3.9 if it was downloaded via uv before.
I think this is only a workaround to uv not resolving a python version from the target `pyproject.toml`, but this should cover most cases where the target hook does not specify a `language_version` key since most projects support all versions that are not EOL. This change adds the `--python >=3.10` arg to the `uv venv` command to achieve that.

This is just a suggested work around. I can provide tests if the change is generally accepted.

fixes #1594