### PR TITLE
Add `#:schema` and `#:tombi` directives to generated prek.toml

### DIFF
--- a/crates/prek/src/cli/sample_config.rs
+++ b/crates/prek/src/cli/sample_config.rs
@@ -24,9 +24,10 @@ repos:
 "};
 
 static SAMPLE_CONFIG_TOML: &str = indoc::indoc! {r#"
-#:schema: https://www.schemastore.org/prek.json
 # Configuration file for `prek`, a git hook framework written in Rust.
 # See https://prek.j178.dev for more information.
+#:schema https://www.schemastore.org/prek.json
+#:tombi toml-version = "v1.1.0"
 
 [[repos]]
 repo = "builtin"

--- a/crates/prek/src/cli/yaml_to_toml.rs
+++ b/crates/prek/src/cli/yaml_to_toml.rs
@@ -78,6 +78,14 @@ fn json_to_toml(value: &serde_json::Value) -> Result<String> {
         .context("Expected a top-level mapping in the config file")?;
 
     let mut doc = DocumentMut::new();
+    doc.decor_mut().set_prefix(indoc::indoc! {r#"
+        # Configuration file for `prek`, a git hook framework written in Rust.
+        # See https://prek.j178.dev for more information.
+        #:schema https://www.schemastore.org/prek.json
+        #:tombi toml-version = "v1.1.0"
+
+        "#});
+
     for (key, value) in map {
         if key == "repos" {
             let repos = value.as_array().context("`repos` must be an array")?;

--- a/crates/prek/tests/sample_config.rs
+++ b/crates/prek/tests/sample_config.rs
@@ -111,9 +111,10 @@ fn sample_config_toml() {
     "#);
 
     insta::assert_snapshot!(context.read("prek.toml"), @r#"
-    #:schema: https://www.schemastore.org/prek.json
     # Configuration file for `prek`, a git hook framework written in Rust.
     # See https://prek.j178.dev for more information.
+    #:schema https://www.schemastore.org/prek.json
+    #:tombi toml-version = "v1.1.0"
 
     [[repos]]
     repo = "builtin"
@@ -133,9 +134,10 @@ fn sample_config_format() {
     success: true
     exit_code: 0
     ----- stdout -----
-    #:schema: https://www.schemastore.org/prek.json
     # Configuration file for `prek`, a git hook framework written in Rust.
     # See https://prek.j178.dev for more information.
+    #:schema https://www.schemastore.org/prek.json
+    #:tombi toml-version = "v1.1.0"
 
     [[repos]]
     repo = "builtin"
@@ -222,9 +224,10 @@ fn respect_format_if_filename_missing() {
     ");
 
     insta::assert_snapshot!(context.read("prek.toml"), @r#"
-    #:schema: https://www.schemastore.org/prek.json
     # Configuration file for `prek`, a git hook framework written in Rust.
     # See https://prek.j178.dev for more information.
+    #:schema https://www.schemastore.org/prek.json
+    #:tombi toml-version = "v1.1.0"
 
     [[repos]]
     repo = "builtin"

--- a/crates/prek/tests/yaml_to_toml.rs
+++ b/crates/prek/tests/yaml_to_toml.rs
@@ -79,6 +79,11 @@ fn yaml_to_toml_writes_default_output() -> anyhow::Result<()> {
     );
 
     insta::assert_snapshot!(context.read(PREK_TOML), @r#"
+    # Configuration file for `prek`, a git hook framework written in Rust.
+    # See https://prek.j178.dev for more information.
+    #:schema https://www.schemastore.org/prek.json
+    #:tombi toml-version = "v1.1.0"
+
     fail_fast = true
     default_install_hook_types = ["pre-push"]
     exclude = """


### PR DESCRIPTION
Fixes #1590