### PR TITLE
Add `prek util list-builtins` command

### DIFF
--- a/crates/prek/src/cli/list_builtins.rs
+++ b/crates/prek/src/cli/list_builtins.rs
@@ -16,22 +16,21 @@ struct SerializableBuiltinHook {
     description: Option<String>,
 }
 
+/// List all builtin hooks.
 pub(crate) fn list_builtins(
     output_format: ListOutputFormat,
     verbose: bool,
     printer: Printer,
 ) -> anyhow::Result<ExitStatus> {
-    let hooks: Vec<_> = BuiltinHooks::iter()
-        .filter_map(|variant| {
-            let id = variant.as_ref();
-            BuiltinHook::from_id(id).ok()
-        })
-        .collect();
+    let hooks = BuiltinHooks::iter().map(|variant| {
+        let id = variant.as_ref();
+        BuiltinHook::from_id(id).expect("All BuiltinHooks variants should be valid")
+    });
 
     match output_format {
         ListOutputFormat::Text => {
             if verbose {
-                for hook in &hooks {
+                for hook in hooks {
                     writeln!(printer.stdout(), "{}", hook.id.bold())?;
                     if let Some(description) = &hook.options.description {
                         writeln!(printer.stdout(), "  {description}")?;
@@ -39,14 +38,13 @@ pub(crate) fn list_builtins(
                     writeln!(printer.stdout())?;
                 }
             } else {
-                for hook in &hooks {
+                for hook in hooks {
                     writeln!(printer.stdout(), "{}", hook.id)?;
                 }
             }
         }
         ListOutputFormat::Json => {
             let serializable: Vec<_> = hooks
-                .into_iter()
                 .map(|h| SerializableBuiltinHook {
                     id: h.id,
                     name: h.name,

--- a/crates/prek/src/cli/mod.rs
+++ b/crates/prek/src/cli/mod.rs
@@ -216,8 +216,6 @@ pub(crate) enum Command {
     Run(Box<RunArgs>),
     /// List hooks configured in the current workspace.
     List(ListArgs),
-    /// List all built-in hooks bundled with prek.
-    ListBuiltins(ListBuiltinsArgs),
     /// Uninstall prek from git hooks.
     Uninstall(UninstallArgs),
     /// Validate configuration files (prek.toml or .pre-commit-config.yaml).
@@ -733,6 +731,8 @@ pub(crate) struct UtilNamespace {
 pub(crate) enum UtilCommand {
     /// Show file identification tags.
     Identify(IdentifyArgs),
+    /// List all built-in hooks bundled with prek.
+    ListBuiltins(ListBuiltinsArgs),
     /// Install hook script in a directory intended for use with `git config init.templateDir`.
     #[command(alias = "init-templatedir")]
     InitTemplateDir(InitTemplateDirArgs),

--- a/crates/prek/src/main.rs
+++ b/crates/prek/src/main.rs
@@ -301,11 +301,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             )
             .await
         }
-        Command::ListBuiltins(args) => {
-            show_settings!(args);
-
-            cli::list_builtins(args.output_format, cli.globals.verbose > 0, printer)
-        }
         Command::HookImpl(args) => {
             show_settings!(args);
 
@@ -388,6 +383,11 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 show_settings!(args);
 
                 cli::identify(&args.paths, args.output_format, printer)
+            }
+            UtilCommand::ListBuiltins(args) => {
+                show_settings!(args);
+
+                cli::list_builtins(args.output_format, cli.globals.verbose > 0, printer)
             }
             UtilCommand::InitTemplateDir(args) => {
                 show_settings!(args);

--- a/crates/prek/tests/common/mod.rs
+++ b/crates/prek/tests/common/mod.rs
@@ -225,12 +225,6 @@ impl TestContext {
         command
     }
 
-    pub fn list_builtins(&self) -> Command {
-        let mut command = self.command();
-        command.arg("list-builtins");
-        command
-    }
-
     pub fn auto_update(&self) -> Command {
         let mut cmd = self.command();
         cmd.arg("auto-update");

--- a/crates/prek/tests/list_builtins.rs
+++ b/crates/prek/tests/list_builtins.rs
@@ -6,7 +6,7 @@ mod common;
 fn list_builtins_basic() {
     let context = TestContext::new();
 
-    cmd_snapshot!(context.filters(), context.list_builtins(), @r"
+    cmd_snapshot!(context.filters(), context.command().arg("util").arg("list-builtins"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -35,7 +35,7 @@ fn list_builtins_basic() {
 fn list_builtins_verbose() {
     let context = TestContext::new();
 
-    cmd_snapshot!(context.filters(), context.list_builtins().arg("--verbose"), @r"
+    cmd_snapshot!(context.filters(), context.command().arg("util").arg("list-builtins").arg("--verbose"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -95,7 +95,7 @@ fn list_builtins_verbose() {
 fn list_builtins_json() {
     let context = TestContext::new();
 
-    cmd_snapshot!(context.filters(), context.list_builtins().arg("--output-format=json"), @r#"
+    cmd_snapshot!(context.filters(), context.command().arg("util").arg("list-builtins").arg("--output-format=json"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -2172,7 +2172,6 @@ fn selectors_completion() -> Result<()> {
     install-hooks	Create environments for all hooks used in the config file
     run	Run hooks
     list	List hooks configured in the current workspace
-    list-builtins	List all built-in hooks bundled with prek
     uninstall	Uninstall prek from git hooks
     validate-config	Validate configuration files (prek.toml or .pre-commit-config.yaml)
     validate-manifest	Validate `.pre-commit-hooks.yaml` files

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -16,7 +16,6 @@ prek [OPTIONS] [HOOK|PROJECT]... [COMMAND]
 <dt><a href="#prek-install-hooks"><code>prek install-hooks</code></a></dt><dd><p>Create environments for all hooks used in the config file</p></dd>
 <dt><a href="#prek-run"><code>prek run</code></a></dt><dd><p>Run hooks</p></dd>
 <dt><a href="#prek-list"><code>prek list</code></a></dt><dd><p>List hooks configured in the current workspace</p></dd>
-<dt><a href="#prek-list-builtins"><code>prek list-builtins</code></a></dt><dd><p>List all built-in hooks bundled with prek</p></dd>
 <dt><a href="#prek-uninstall"><code>prek uninstall</code></a></dt><dd><p>Uninstall prek from git hooks</p></dd>
 <dt><a href="#prek-validate-config"><code>prek validate-config</code></a></dt><dd><p>Validate configuration files (prek.toml or .pre-commit-config.yaml)</p></dd>
 <dt><a href="#prek-validate-manifest"><code>prek validate-manifest</code></a></dt><dd><p>Validate <code>.pre-commit-hooks.yaml</code> files</p></dd>
@@ -368,42 +367,6 @@ prek list [OPTIONS] [HOOK|PROJECT]...
 <p>Can be specified multiple times. Also accepts <code>PREK_SKIP</code> or <code>SKIP</code> environment variables (comma-delimited).</p>
 </dd><dt id="prek-list--verbose"><a href="#prek-list--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output</p>
 </dd><dt id="prek-list--version"><a href="#prek-list--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
-</dd></dl>
-
-## prek list-builtins
-
-List all built-in hooks bundled with prek
-
-<h3 class="cli-reference">Usage</h3>
-
-```
-prek list-builtins [OPTIONS]
-```
-
-<h3 class="cli-reference">Options</h3>
-
-<dl class="cli-reference"><dt id="prek-list-builtins--cd"><a href="#prek-list-builtins--cd"><code>--cd</code></a>, <code>-C</code> <i>dir</i></dt><dd><p>Change to directory before running</p>
-</dd><dt id="prek-list-builtins--color"><a href="#prek-list-builtins--color"><code>--color</code></a> <i>color</i></dt><dd><p>Whether to use color in output</p>
-<p>May also be set with the <code>PREK_COLOR</code> environment variable.</p><p>[default: auto]</p><p>Possible values:</p>
-<ul>
-<li><code>auto</code>:  Enables colored output only when the output is going to a terminal or TTY with support</li>
-<li><code>always</code>:  Enables colored output regardless of the detected environment</li>
-<li><code>never</code>:  Disables colored output</li>
-</ul></dd><dt id="prek-list-builtins--config"><a href="#prek-list-builtins--config"><code>--config</code></a>, <code>-c</code> <i>config</i></dt><dd><p>Path to alternate config file</p>
-</dd><dt id="prek-list-builtins--help"><a href="#prek-list-builtins--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Display the concise help for this command</p>
-</dd><dt id="prek-list-builtins--log-file"><a href="#prek-list-builtins--log-file"><code>--log-file</code></a> <i>log-file</i></dt><dd><p>Write trace logs to the specified file. If not specified, trace logs will be written to <code>$PREK_HOME/prek.log</code></p>
-</dd><dt id="prek-list-builtins--no-progress"><a href="#prek-list-builtins--no-progress"><code>--no-progress</code></a></dt><dd><p>Hide all progress outputs.</p>
-<p>For example, spinners or progress bars.</p>
-</dd><dt id="prek-list-builtins--output-format"><a href="#prek-list-builtins--output-format"><code>--output-format</code></a> <i>output-format</i></dt><dd><p>The output format</p>
-<p>[default: text]</p><p>Possible values:</p>
-<ul>
-<li><code>text</code></li>
-<li><code>json</code></li>
-</ul></dd><dt id="prek-list-builtins--quiet"><a href="#prek-list-builtins--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
-<p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which prek will write no output to stdout.</p>
-<p>May also be set with the <code>PREK_QUIET</code> environment variable.</p></dd><dt id="prek-list-builtins--refresh"><a href="#prek-list-builtins--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
-</dd><dt id="prek-list-builtins--verbose"><a href="#prek-list-builtins--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output</p>
-</dd><dt id="prek-list-builtins--version"><a href="#prek-list-builtins--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
 </dd></dl>
 
 ## prek uninstall
@@ -847,6 +810,7 @@ prek util [OPTIONS] <COMMAND>
 <h3 class="cli-reference">Commands</h3>
 
 <dl class="cli-reference"><dt><a href="#prek-util-identify"><code>prek util identify</code></a></dt><dd><p>Show file identification tags</p></dd>
+<dt><a href="#prek-util-list-builtins"><code>prek util list-builtins</code></a></dt><dd><p>List all built-in hooks bundled with prek</p></dd>
 <dt><a href="#prek-util-init-template-dir"><code>prek util init-template-dir</code></a></dt><dd><p>Install hook script in a directory intended for use with <code>git config init.templateDir</code></p></dd>
 <dt><a href="#prek-util-yaml-to-toml"><code>prek util yaml-to-toml</code></a></dt><dd><p>Convert a YAML configuration file to prek.toml</p></dd>
 </dl>
@@ -890,6 +854,42 @@ prek util identify [OPTIONS] [PATH]...
 <p>May also be set with the <code>PREK_QUIET</code> environment variable.</p></dd><dt id="prek-util-identify--refresh"><a href="#prek-util-identify--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
 </dd><dt id="prek-util-identify--verbose"><a href="#prek-util-identify--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output</p>
 </dd><dt id="prek-util-identify--version"><a href="#prek-util-identify--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
+</dd></dl>
+
+### prek util list-builtins
+
+List all built-in hooks bundled with prek
+
+<h3 class="cli-reference">Usage</h3>
+
+```
+prek util list-builtins [OPTIONS]
+```
+
+<h3 class="cli-reference">Options</h3>
+
+<dl class="cli-reference"><dt id="prek-util-list-builtins--cd"><a href="#prek-util-list-builtins--cd"><code>--cd</code></a>, <code>-C</code> <i>dir</i></dt><dd><p>Change to directory before running</p>
+</dd><dt id="prek-util-list-builtins--color"><a href="#prek-util-list-builtins--color"><code>--color</code></a> <i>color</i></dt><dd><p>Whether to use color in output</p>
+<p>May also be set with the <code>PREK_COLOR</code> environment variable.</p><p>[default: auto]</p><p>Possible values:</p>
+<ul>
+<li><code>auto</code>:  Enables colored output only when the output is going to a terminal or TTY with support</li>
+<li><code>always</code>:  Enables colored output regardless of the detected environment</li>
+<li><code>never</code>:  Disables colored output</li>
+</ul></dd><dt id="prek-util-list-builtins--config"><a href="#prek-util-list-builtins--config"><code>--config</code></a>, <code>-c</code> <i>config</i></dt><dd><p>Path to alternate config file</p>
+</dd><dt id="prek-util-list-builtins--help"><a href="#prek-util-list-builtins--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Display the concise help for this command</p>
+</dd><dt id="prek-util-list-builtins--log-file"><a href="#prek-util-list-builtins--log-file"><code>--log-file</code></a> <i>log-file</i></dt><dd><p>Write trace logs to the specified file. If not specified, trace logs will be written to <code>$PREK_HOME/prek.log</code></p>
+</dd><dt id="prek-util-list-builtins--no-progress"><a href="#prek-util-list-builtins--no-progress"><code>--no-progress</code></a></dt><dd><p>Hide all progress outputs.</p>
+<p>For example, spinners or progress bars.</p>
+</dd><dt id="prek-util-list-builtins--output-format"><a href="#prek-util-list-builtins--output-format"><code>--output-format</code></a> <i>output-format</i></dt><dd><p>The output format</p>
+<p>[default: text]</p><p>Possible values:</p>
+<ul>
+<li><code>text</code></li>
+<li><code>json</code></li>
+</ul></dd><dt id="prek-util-list-builtins--quiet"><a href="#prek-util-list-builtins--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
+<p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which prek will write no output to stdout.</p>
+<p>May also be set with the <code>PREK_QUIET</code> environment variable.</p></dd><dt id="prek-util-list-builtins--refresh"><a href="#prek-util-list-builtins--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
+</dd><dt id="prek-util-list-builtins--verbose"><a href="#prek-util-list-builtins--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output</p>
+</dd><dt id="prek-util-list-builtins--version"><a href="#prek-util-list-builtins--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
 </dd></dl>
 
 ### prek util init-template-dir


### PR DESCRIPTION
Fix misleading `prek list` help text and add `prek list-builtins` command

## Summary

`prek list` says "List available hooks" but actually lists hooks *configured in the current project*. This PR fixes the wording and adds a new `list-builtins` command so users can discover all built-in hooks from the CLI.

## Motivation

The `list` subcommand's help text reads:

```
$ prek list -h
List available hooks
```

This is misleading. `prek list` does not list hooks that are *available* to use — it lists hooks that are *currently configured* in the project's `.pre-commit-config.yaml`. "Available" implies a catalog of all possible hooks (especially builtins), when the actual behavior is scoped to the current config.

### How this causes confusion

1. User runs `prek list` in Project A, which has a **local** hook named `no-commit-to-main`
2. Output shows `.:no-commit-to-main` — reads like an "available" hook
3. User uses `id: no-commit-to-main` under `repo: builtin` in Project B
4. `prek run` fails: `unknown builtin hook id "no-commit-to-main"`

The user reasonably assumed `prek list` was showing hooks they could use anywhere, because the help text says "available."

## After this PR

```
$ prek -h
  list               List hooks configured in the current project
  list-builtins      List all built-in hooks bundled with prek
```

```
$ prek list-builtins
check-added-large-files
check-case-conflict
check-executables-have-shebangs
check-json
check-json5
check-merge-conflict
check-symlinks
check-toml
check-xml
check-yaml
detect-private-key
end-of-file-fixer
fix-byte-order-marker
mixed-line-ending
no-commit-to-branch
trailing-whitespace
```

Verbose mode shows descriptions:

```
$ prek list-builtins -v
check-added-large-files
  prevents giant files from being committed.

check-case-conflict
  checks for files that would conflict in case-insensitive filesystems
...
```

JSON output is also supported via `--output-format=json`.

## What changed

**`crates/prek/src/cli/mod.rs`**
- Fixed `List` doc comment from "List available hooks" to "List hooks configured in the current project"
- Added `ListBuiltins(ListBuiltinsArgs)` command variant with `--output-format` option

**`crates/prek/src/cli/list_builtins.rs`** (new)
- Iterates all `BuiltinHooks` variants via `strum::EnumIter` and outputs their ID, name, and description
- Supports text (default), verbose, and JSON output formats
- Works from any directory — no config file or git repo required

**`crates/prek/src/hooks/builtin_hooks/mod.rs`**
- Added `strum::EnumIter` derive to `BuiltinHooks` enum

**`crates/prek/src/main.rs`**
- Wired up `Command::ListBuiltins` dispatch

**`crates/prek/tests/list_builtins.rs`** (new)
- `list_builtins_basic`: verifies plain text output lists all 16 builtin hook IDs
- `list_builtins_verbose`: verifies verbose output includes descriptions
- `list_builtins_json`: verifies JSON output structure

**`docs/cli.md`**
- Auto-regenerated to include the new `list-builtins` command

Closes #1599