### PR TITLE
Preserve `additional_dependencies` order and use synthetic local repo for local hooks

### DIFF
--- a/crates/prek/src/cli/cache_gc.rs
+++ b/crates/prek/src/cli/cache_gc.rs
@@ -694,7 +694,7 @@ fn truncate_end(s: &str, max_chars: usize) -> String {
     out
 }
 
-fn split_repo_dependency(deps: &FxHashSet<String>) -> (Option<String>, Vec<String>) {
+fn split_repo_dependency(deps: &[String]) -> (Option<String>, Vec<String>) {
     // Best-effort: the remote repo dependency is typically `repo@rev`.
     // Prefer URL-like values to avoid accidentally treating PEP508 deps as repo identifiers.
     let mut repo_dep: Option<String> = None;
@@ -714,7 +714,6 @@ fn split_repo_dependency(deps: &FxHashSet<String>) -> (Option<String>, Vec<Strin
         }
     }
 
-    rest.sort_unstable();
     (repo_dep, rest)
 }
 
@@ -757,10 +756,11 @@ mod tests {
 
     #[test]
     fn split_repo_dependency_prefers_url_like_repo_at_rev() {
-        let mut deps = FxHashSet::default();
-        deps.insert("requests==2.32.0".to_string());
-        deps.insert("black==24.1.0".to_string());
-        deps.insert("https://github.com/pre-commit/pre-commit-hooks@v1.0.0".to_string());
+        let deps = vec![
+            "requests==2.32.0".to_string(),
+            "black==24.1.0".to_string(),
+            "https://github.com/pre-commit/pre-commit-hooks@v1.0.0".to_string(),
+        ];
 
         let (repo_dep, rest) = split_repo_dependency(&deps);
 
@@ -768,18 +768,16 @@ mod tests {
             repo_dep.as_deref(),
             Some("https://github.com/pre-commit/pre-commit-hooks@v1.0.0")
         );
-        assert_eq!(rest, vec!["black==24.1.0", "requests==2.32.0"]);
+        assert_eq!(rest, vec!["requests==2.32.0", "black==24.1.0"]);
     }
 
     #[test]
     fn split_repo_dependency_returns_none_when_no_repo_like_dep() {
-        let mut deps = FxHashSet::default();
-        deps.insert("requests==2.32.0".to_string());
-        deps.insert("black==24.1.0".to_string());
+        let deps = vec!["requests==2.32.0".to_string(), "black==24.1.0".to_string()];
 
         let (repo_dep, rest) = split_repo_dependency(&deps);
         assert!(repo_dep.is_none());
-        assert_eq!(rest, vec!["black==24.1.0", "requests==2.32.0"]);
+        assert_eq!(rest, vec!["requests==2.32.0", "black==24.1.0"]);
     }
 
     #[test]

--- a/crates/prek/src/languages/bun/bun.rs
+++ b/crates/prek/src/languages/bun/bun.rs
@@ -53,7 +53,7 @@ impl LanguageImpl for Bun {
 
         let mut info = InstallInfo::new(
             hook.language,
-            hook.env_key_dependencies().clone(),
+            hook.env_key_dependencies().to_vec(),
             &store.hooks_dir(),
         )?;
 

--- a/crates/prek/src/languages/docker.rs
+++ b/crates/prek/src/languages/docker.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 use std::collections::hash_map::DefaultHasher;
 use std::fs;
 use std::hash::{Hash, Hasher};
@@ -323,8 +322,7 @@ impl Docker {
 
         info.language.hash(&mut hasher);
         info.language_version.hash(&mut hasher);
-        let deps = info.dependencies.iter().collect::<BTreeSet<&String>>();
-        deps.hash(&mut hasher);
+        info.dependencies.hash(&mut hasher);
 
         let digest = hex::encode(hasher.finish().to_le_bytes());
         format!("prek-{digest}")
@@ -436,7 +434,7 @@ impl LanguageImpl for Docker {
 
         let mut info = InstallInfo::new(
             hook.language,
-            hook.env_key_dependencies().clone(),
+            hook.env_key_dependencies().to_vec(),
             &store.hooks_dir(),
         )?;
 

--- a/crates/prek/src/languages/golang/golang.rs
+++ b/crates/prek/src/languages/golang/golang.rs
@@ -45,7 +45,7 @@ impl LanguageImpl for Golang {
 
         let mut info = InstallInfo::new(
             hook.language,
-            hook.env_key_dependencies().clone(),
+            hook.env_key_dependencies().to_vec(),
             &store.hooks_dir(),
         )?;
         info.with_toolchain(go.bin().to_path_buf())

--- a/crates/prek/src/languages/haskell.rs
+++ b/crates/prek/src/languages/haskell.rs
@@ -33,7 +33,7 @@ impl LanguageImpl for Haskell {
 
         let mut info = InstallInfo::new(
             hook.language,
-            hook.env_key_dependencies().clone(),
+            hook.env_key_dependencies().to_vec(),
             &store.hooks_dir(),
         )?;
 

--- a/crates/prek/src/languages/julia.rs
+++ b/crates/prek/src/languages/julia.rs
@@ -26,7 +26,7 @@ impl LanguageImpl for Julia {
 
         let mut info = InstallInfo::new(
             hook.language,
-            hook.env_key_dependencies().clone(),
+            hook.env_key_dependencies().to_vec(),
             &store.hooks_dir(),
         )?;
 

--- a/crates/prek/src/languages/lua.rs
+++ b/crates/prek/src/languages/lua.rs
@@ -65,7 +65,7 @@ impl LanguageImpl for Lua {
 
         let mut info = InstallInfo::new(
             hook.language,
-            hook.env_key_dependencies().clone(),
+            hook.env_key_dependencies().to_vec(),
             &store.hooks_dir(),
         )?;
 

--- a/crates/prek/src/languages/node/node.rs
+++ b/crates/prek/src/languages/node/node.rs
@@ -54,7 +54,7 @@ impl LanguageImpl for Node {
 
         let mut info = InstallInfo::new(
             hook.language,
-            hook.env_key_dependencies().clone(),
+            hook.env_key_dependencies().to_vec(),
             &store.hooks_dir(),
         )?;
 

--- a/crates/prek/src/languages/node/version.rs
+++ b/crates/prek/src/languages/node/version.rs
@@ -257,7 +257,6 @@ mod tests {
     use super::{EXTRA_KEY_LTS, NodeRequest};
     use crate::config::Language;
     use crate::hook::InstallInfo;
-    use rustc_hash::FxHashSet;
     use std::path::PathBuf;
     use std::str::FromStr;
 
@@ -310,8 +309,7 @@ mod tests {
     #[test]
     fn test_node_request_satisfied_by() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let mut install_info =
-            InstallInfo::new(Language::Node, FxHashSet::default(), temp_dir.path())?;
+        let mut install_info = InstallInfo::new(Language::Node, Vec::new(), temp_dir.path())?;
         install_info
             .with_language_version(semver::Version::new(12, 18, 3))
             .with_toolchain(PathBuf::from("/usr/bin/node"))

--- a/crates/prek/src/languages/pygrep/pygrep.rs
+++ b/crates/prek/src/languages/pygrep/pygrep.rs
@@ -156,7 +156,7 @@ impl LanguageImpl for Pygrep {
 
         let mut info = InstallInfo::new(
             hook.language,
-            hook.env_key_dependencies().clone(),
+            hook.env_key_dependencies().to_vec(),
             &store.hooks_dir(),
         )?;
         info.with_toolchain(python);

--- a/crates/prek/src/languages/python/pep723.rs
+++ b/crates/prek/src/languages/python/pep723.rs
@@ -273,7 +273,7 @@ pub(crate) async fn extract_pep723_metadata(hook: &mut Hook) -> Result<()> {
     };
 
     if let Some(dependencies) = script.metadata.dependencies {
-        hook.additional_dependencies = dependencies.into_iter().collect();
+        hook.additional_dependencies = dependencies;
     }
     if let Some(language_request) = script.metadata.requires_python {
         if !hook.language_request.is_any() {

--- a/crates/prek/src/languages/python/version.rs
+++ b/crates/prek/src/languages/python/version.rs
@@ -137,7 +137,6 @@ fn split_wheel_tag_version(mut version: Vec<u64>) -> Vec<u64> {
 mod tests {
     use super::*;
     use crate::config::Language;
-    use rustc_hash::FxHashSet;
 
     #[test]
     fn test_parse_python_request() {
@@ -218,8 +217,7 @@ mod tests {
     #[test]
     fn test_satisfied_by() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let mut install_info =
-            InstallInfo::new(Language::Python, FxHashSet::default(), temp_dir.path())?;
+        let mut install_info = InstallInfo::new(Language::Python, Vec::new(), temp_dir.path())?;
         install_info
             .with_language_version(semver::Version::new(3, 12, 1))
             .with_toolchain(PathBuf::from("/usr/bin/python3.12"));

--- a/crates/prek/src/languages/ruby/gem.rs
+++ b/crates/prek/src/languages/ruby/gem.rs
@@ -3,7 +3,6 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use prek_consts::env_vars::EnvVars;
-use rustc_hash::FxHashSet;
 use tracing::debug;
 
 use crate::languages::ruby::installer::RubyResult;
@@ -84,7 +83,7 @@ pub(crate) async fn install_gems(
     ruby: &RubyResult,
     gem_home: &Path,
     repo_path: Option<&Path>,
-    additional_dependencies: &FxHashSet<String>,
+    additional_dependencies: &[String],
 ) -> Result<()> {
     let mut gem_files = Vec::new();
 

--- a/crates/prek/src/languages/ruby/ruby.rs
+++ b/crates/prek/src/languages/ruby/ruby.rs
@@ -47,7 +47,7 @@ impl LanguageImpl for Ruby {
         // 2. Create InstallInfo
         let mut info = InstallInfo::new(
             hook.language,
-            hook.env_key_dependencies().clone(),
+            hook.env_key_dependencies().to_vec(),
             &store.hooks_dir(),
         )?;
 

--- a/crates/prek/src/languages/ruby/version.rs
+++ b/crates/prek/src/languages/ruby/version.rs
@@ -120,7 +120,6 @@ impl RubyRequest {
 mod tests {
     use super::*;
     use crate::config::Language;
-    use rustc_hash::FxHashSet;
 
     #[test]
     fn test_parse_ruby_request() {
@@ -165,8 +164,7 @@ mod tests {
     #[test]
     fn test_version_matching() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let mut install_info =
-            InstallInfo::new(Language::Ruby, FxHashSet::default(), temp_dir.path())?;
+        let mut install_info = InstallInfo::new(Language::Ruby, Vec::new(), temp_dir.path())?;
         install_info
             .with_language_version(semver::Version::new(3, 3, 6))
             .with_toolchain(PathBuf::from("/usr/bin/ruby"));
@@ -189,8 +187,7 @@ mod tests {
         );
 
         let temp_dir = tempfile::tempdir()?;
-        let mut install_info =
-            InstallInfo::new(Language::Ruby, FxHashSet::default(), temp_dir.path())?;
+        let mut install_info = InstallInfo::new(Language::Ruby, Vec::new(), temp_dir.path())?;
         install_info
             .with_language_version(semver::Version::new(3, 1, 0))
             .with_toolchain(PathBuf::from("/usr/bin/ruby3.1"));

--- a/crates/prek/src/languages/rust/rust.rs
+++ b/crates/prek/src/languages/rust/rust.rs
@@ -346,7 +346,7 @@ impl LanguageImpl for Rust {
 
         let mut info = InstallInfo::new(
             hook.language,
-            hook.env_key_dependencies().clone(),
+            hook.env_key_dependencies().to_vec(),
             &store.hooks_dir(),
         )?;
         info.with_toolchain(rust.toolchain().to_path_buf())

--- a/crates/prek/src/languages/rust/version.rs
+++ b/crates/prek/src/languages/rust/version.rs
@@ -236,7 +236,6 @@ mod tests {
     use super::*;
     use crate::config::Language;
     use crate::hook::InstallInfo;
-    use rustc_hash::FxHashSet;
     use std::path::PathBuf;
     use std::str::FromStr;
 
@@ -313,8 +312,7 @@ mod tests {
         let toolchain_path = temp_dir.path().join("rust-toolchain");
         std::fs::write(&toolchain_path, b"")?;
 
-        let mut install_info =
-            InstallInfo::new(Language::Rust, FxHashSet::default(), temp_dir.path())?;
+        let mut install_info = InstallInfo::new(Language::Rust, Vec::new(), temp_dir.path())?;
         install_info
             .with_language_version(semver::Version::new(1, 71, 0))
             .with_toolchain(toolchain_path.clone());
@@ -340,8 +338,7 @@ mod tests {
     #[test]
     fn test_satisfied_by_channel() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let mut install_info =
-            InstallInfo::new(Language::Rust, FxHashSet::default(), temp_dir.path())?;
+        let mut install_info = InstallInfo::new(Language::Rust, Vec::new(), temp_dir.path())?;
         install_info
             .with_language_version(semver::Version::new(1, 75, 0))
             .with_toolchain(PathBuf::from("/some/path"))
@@ -358,8 +355,7 @@ mod tests {
     #[test]
     fn test_satisfied_by_any_with_stable_channel() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let mut install_info =
-            InstallInfo::new(Language::Rust, FxHashSet::default(), temp_dir.path())?;
+        let mut install_info = InstallInfo::new(Language::Rust, Vec::new(), temp_dir.path())?;
         install_info
             .with_language_version(semver::Version::new(1, 75, 0))
             .with_toolchain(PathBuf::from("/some/path"))
@@ -374,8 +370,7 @@ mod tests {
     #[test]
     fn test_satisfied_by_any_without_channel() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let mut install_info =
-            InstallInfo::new(Language::Rust, FxHashSet::default(), temp_dir.path())?;
+        let mut install_info = InstallInfo::new(Language::Rust, Vec::new(), temp_dir.path())?;
         install_info
             .with_language_version(semver::Version::new(1, 75, 0))
             .with_toolchain(PathBuf::from("/some/path"));

--- a/crates/prek/src/languages/swift.rs
+++ b/crates/prek/src/languages/swift.rs
@@ -94,7 +94,7 @@ impl LanguageImpl for Swift {
 
         let mut info = InstallInfo::new(
             hook.language,
-            hook.env_key_dependencies().clone(),
+            hook.env_key_dependencies().to_vec(),
             &store.hooks_dir(),
         )?;
 

--- a/crates/prek/src/store.rs
+++ b/crates/prek/src/store.rs
@@ -42,6 +42,8 @@ fn expand_tilde(path: PathBuf) -> PathBuf {
 }
 
 pub(crate) const REPO_MARKER: &str = ".prek-repo.json";
+const LOCAL_REPO_DIR: &str = "local-repo";
+const LOCAL_PYTHON_SETUP_PY: &str = "from setuptools import setup\n\n\nsetup(name='prek-placeholder-package', version='0.0.0', py_modules=[])\n";
 
 /// A store for managing repos.
 #[derive(Debug)]
@@ -187,6 +189,19 @@ impl Store {
 
     pub(crate) fn repos_dir(&self) -> PathBuf {
         self.path.join("repos")
+    }
+
+    /// Returns the synthetic local repository path for Python `repo: local` hooks.
+    pub(crate) fn local_repo_path(&self) -> Result<PathBuf, Error> {
+        let local_repo = self.path.join(LOCAL_REPO_DIR);
+        fs_err::create_dir_all(&local_repo)?;
+
+        let setup_py = local_repo.join("setup.py");
+        if !setup_py.try_exists()? {
+            fs_err::write(setup_py, LOCAL_PYTHON_SETUP_PY)?;
+        }
+
+        Ok(local_repo)
     }
 
     pub(crate) fn hooks_dir(&self) -> PathBuf {

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -2280,26 +2280,11 @@ fn selectors_completion() -> Result<()> {
     Ok(())
 }
 
-/// Test reusing hook environments only when dependencies are exactly same. (ignore order)
+/// Test reusing hook environments only when dependencies are exactly the same.
 #[test]
 fn reuse_env() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
-
-    let pkg_dir = context.work_dir().child("local_pkg");
-    pkg_dir.create_dir_all()?;
-    pkg_dir.child("setup.py").write_str(indoc::indoc! {r#"
-        from setuptools import setup
-
-        setup(
-            name="local-pkg",
-            version="0.1.0",
-            py_modules=["local_pkg"],
-        )
-    "#})?;
-    pkg_dir
-        .child("local_pkg.py")
-        .write_str("def hello():\n     print('hello')\n")?;
 
     context.write_pre_commit_config(indoc::indoc! {r#"
     repos:
@@ -2308,9 +2293,9 @@ fn reuse_env() -> Result<()> {
           - id: reuse-env
             name: reuse-env
             language: python
-            entry: python -c "import local_pkg; local_pkg.hello()"
+            entry: pyecho hello
             pass_filenames: false
-            additional_dependencies: ["./local_pkg"]
+            additional_dependencies: ["pyecho-cli"]
             verbose: true
     "#});
     context.git_add(".");


### PR DESCRIPTION
## Summary

- Replace `FxHashSet<String>` with `Vec<String>` for `additional_dependencies` throughout the codebase, preserving user-specified ordering and duplicates. This matches pre-commit semantics and fixes hooks that
pass non-dependency arguments (e.g., `--index-url <url>`) in `additional_dependencies`.
- For `repo: local` Python hooks with `additional_dependencies`, install from a synthetic placeholder repository (matching pre-commit's `pre-commit-placeholder-package`) instead of the project root. This prevents
 `.` from depending on user project contents.

Closes #1602
Closes #1603

## Notes

- Existing cached hook environments will be re-created on upgrade due to the `FxHashSet` → `Vec` serialization change. One-time cost, no user action needed in most cases.
- Users with existing cached `repo: local` Python hooks using `.` in `additional_dependencies` should run `prek clean` to pick up the new synthetic repo behavior.
- This fix is Python-specific for the synthetic local repo. Other languages with `repo: local` are not affected.