### PR TITLE
Add progress bar to `cache clean` and show removal summary

### DIFF
--- a/crates/prek/src/cli/cache_clean.rs
+++ b/crates/prek/src/cli/cache_clean.rs
@@ -7,6 +7,7 @@ use owo_colors::OwoColorize;
 use tracing::error;
 
 use crate::cli::ExitStatus;
+use crate::cli::cache_size::{DirStats, human_readable_bytes};
 use crate::printer::Printer;
 use crate::store::{CacheBucket, Store};
 
@@ -16,18 +17,81 @@ pub(crate) fn cache_clean(store: &Store, printer: Printer) -> Result<ExitStatus>
         return Ok(ExitStatus::Success);
     }
 
-    if let Err(e) = fix_permissions(store.cache_path(CacheBucket::Go)) {
+    if let Err(e) = fix_permissions(store.cache_path(CacheBucket::Go))
+        && e.kind() != io::ErrorKind::NotFound
+    {
         error!("Failed to fix permissions: {}", e);
     }
 
-    fs_err::remove_dir_all(store.path())?;
+    let stats = remove_dir_all_with_stats(store.path())?;
     writeln!(
         printer.stdout(),
         "Cleaned `{}`",
         store.path().display().cyan()
     )?;
+    if stats.file_count > 0 {
+        let (size, unit) = human_readable_bytes(stats.total_bytes);
+        writeln!(
+            printer.stdout(),
+            "Removed {} ({}{unit})",
+            file_label(stats.file_count),
+            format!("{size:.1}").cyan().bold(),
+        )?;
+    }
 
     Ok(ExitStatus::Success)
+}
+
+fn file_label(file_count: u64) -> String {
+    if file_count == 1 {
+        "1 file".to_string()
+    } else {
+        format!("{file_count} files")
+    }
+}
+
+/// Recursively removes a directory and all its contents, returning aggregate
+/// file count and byte totals. Returns an error if `path` is not a directory.
+fn remove_dir_all_with_stats(path: &Path) -> io::Result<DirStats> {
+    let metadata = fs_err::symlink_metadata(path)?;
+    if !metadata.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotADirectory,
+            format!("not a directory: {}", path.display()),
+        ));
+    }
+
+    let mut stats = DirStats::default();
+    for entry in fs_err::read_dir(path)? {
+        let entry = entry?;
+        let entry_path = entry.path();
+        let entry_stats = remove_entry_with_stats(&entry_path)?;
+        stats.file_count = stats.file_count.saturating_add(entry_stats.file_count);
+        stats.total_bytes = stats.total_bytes.saturating_add(entry_stats.total_bytes);
+    }
+
+    fs_err::remove_dir(path)?;
+    Ok(stats)
+}
+
+fn remove_entry_with_stats(path: &Path) -> io::Result<DirStats> {
+    let metadata = fs_err::symlink_metadata(path)?;
+    if metadata.is_dir() {
+        return remove_dir_all_with_stats(path);
+    }
+
+    remove_file_with_stats(path, &metadata)
+}
+
+fn remove_file_with_stats(path: &Path, metadata: &std::fs::Metadata) -> io::Result<DirStats> {
+    let mut stats = DirStats::default();
+    if metadata.is_file() || metadata.file_type().is_symlink() {
+        stats.file_count = 1;
+        stats.total_bytes = metadata.len();
+    }
+
+    fs_err::remove_file(path)?;
+    Ok(stats)
 }
 
 /// Add write permission to GOMODCACHE directory recursively.
@@ -65,4 +129,75 @@ pub fn fix_permissions<P: AsRef<Path>>(path: P) -> io::Result<()> {
 pub fn fix_permissions<P: AsRef<Path>>(_path: P) -> io::Result<()> {
     // On Windows, permissions are handled differently and this function does nothing.
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DirStats, file_label, remove_dir_all_with_stats};
+    use assert_fs::fixture::TempDir;
+
+    #[test]
+    fn file_label_uses_singular_and_plural() {
+        assert_eq!(file_label(0), "0 files");
+        assert_eq!(file_label(1), "1 file");
+        assert_eq!(file_label(2), "2 files");
+    }
+
+    #[test]
+    fn remove_dir_all_with_stats_counts_and_removes_tree() {
+        let temp = TempDir::new().expect("create temp dir");
+        let cache_root = temp.path().join("cache");
+        fs_err::create_dir_all(cache_root.join("nested/deep")).expect("create nested dirs");
+        fs_err::write(cache_root.join("root.txt"), b"hello").expect("write root file");
+        fs_err::write(cache_root.join("nested/data.txt"), b"abc").expect("write nested file");
+        fs_err::write(cache_root.join("nested/deep/end.bin"), b"zz").expect("write deep file");
+
+        let stats = remove_dir_all_with_stats(&cache_root).expect("remove dir with stats");
+        assert_eq!(stats.file_count, 3);
+        assert_eq!(stats.total_bytes, 10);
+        assert!(!cache_root.exists());
+    }
+
+    #[test]
+    fn remove_dir_all_with_stats_empty_directory() {
+        let temp = TempDir::new().expect("create temp dir");
+        let cache_root = temp.path().join("cache");
+        fs_err::create_dir_all(&cache_root).expect("create cache dir");
+
+        let stats = remove_dir_all_with_stats(&cache_root).expect("remove empty dir with stats");
+        assert_eq!(stats, DirStats::default());
+        assert!(!cache_root.exists());
+    }
+
+    #[test]
+    fn remove_dir_all_with_stats_rejects_non_directory() {
+        let temp = TempDir::new().expect("create temp dir");
+        let file_path = temp.path().join("not-a-dir.txt");
+        fs_err::write(&file_path, b"important data").expect("write file");
+
+        let err = remove_dir_all_with_stats(&file_path).expect_err("should reject non-directory");
+        assert_eq!(err.kind(), std::io::ErrorKind::NotADirectory);
+        assert!(file_path.exists(), "file must not be deleted");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remove_dir_all_with_stats_counts_symlink_entries() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().expect("create temp dir");
+        let cache_root = temp.path().join("cache");
+        fs_err::create_dir_all(&cache_root).expect("create cache dir");
+
+        let link_path = cache_root.join("link-to-missing");
+        symlink("missing-target", &link_path).expect("create symlink");
+        let expected_len = fs_err::symlink_metadata(&link_path)
+            .expect("symlink metadata")
+            .len();
+
+        let stats = remove_dir_all_with_stats(&cache_root).expect("remove dir with symlink");
+        assert_eq!(stats.file_count, 1);
+        assert_eq!(stats.total_bytes, expected_len);
+        assert!(!cache_root.exists());
+    }
 }

--- a/crates/prek/src/cli/cache_gc.rs
+++ b/crates/prek/src/cli/cache_gc.rs
@@ -292,9 +292,9 @@ pub(crate) async fn cache_gc(
     } else {
         writeln!(
             printer.stdout(),
-            "{verb} {} ({}{removed_unit})",
+            "{verb} {} ({})",
             removed.joined(),
-            format!("{removed_bytes:.1}").cyan().bold(),
+            format!("{removed_bytes:.1} {removed_unit}").cyan().bold(),
         )?;
 
         if verbose {

--- a/crates/prek/src/cli/cache_gc.rs
+++ b/crates/prek/src/cli/cache_gc.rs
@@ -294,7 +294,7 @@ pub(crate) async fn cache_gc(
             printer.stdout(),
             "{verb} {} ({})",
             removed.joined(),
-            format!("{removed_bytes:.1} {removed_unit}").cyan().bold(),
+            format!("{removed_bytes:.1}{removed_unit}").cyan().bold(),
         )?;
 
         if verbose {

--- a/crates/prek/src/cli/cache_size.rs
+++ b/crates/prek/src/cli/cache_size.rs
@@ -7,6 +7,7 @@ use crate::cli::ExitStatus;
 use crate::printer::Printer;
 use crate::store::Store;
 
+/// Aggregate statistics for files within a directory tree.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct DirStats {
     pub(crate) file_count: u64,

--- a/crates/prek/src/cli/cache_size.rs
+++ b/crates/prek/src/cli/cache_size.rs
@@ -7,6 +7,12 @@ use crate::cli::ExitStatus;
 use crate::printer::Printer;
 use crate::store::Store;
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DirStats {
+    pub(crate) file_count: u64,
+    pub(crate) total_bytes: u64,
+}
+
 /// Display the total size of the cache.
 pub(crate) fn cache_size(
     store: &Store,
@@ -14,7 +20,7 @@ pub(crate) fn cache_size(
     printer: Printer,
 ) -> Result<ExitStatus> {
     // Walk the entire cache root
-    let total_bytes = dir_size_bytes(store.path());
+    let total_bytes = dir_stats(store.path())?.total_bytes;
     if human_readable {
         let (bytes, unit) = human_readable_bytes(total_bytes);
         writeln!(printer.stdout_important(), "{bytes:.1}{unit}")?;
@@ -36,23 +42,88 @@ pub(crate) fn cache_size(
 )]
 pub(crate) fn human_readable_bytes(bytes: u64) -> (f32, &'static str) {
     const UNITS: [&str; 7] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"];
+    if bytes == 0 {
+        return (0.0, UNITS[0]);
+    }
+
     let bytes_f32 = bytes as f32;
     let i = ((bytes_f32.log2() / 10.0) as usize).min(UNITS.len() - 1);
     (bytes_f32 / 1024_f32.powi(i as i32), UNITS[i])
 }
 
-pub(crate) fn dir_size_bytes(path: &Path) -> u64 {
+pub(crate) fn dir_stats(path: &Path) -> Result<DirStats> {
     if !path.exists() {
-        return 0;
+        return Ok(DirStats::default());
     }
 
     walkdir::WalkDir::new(path)
         .follow_links(false)
         .into_iter()
-        .filter_map(Result::ok)
-        .filter_map(|entry| match entry.metadata() {
-            Ok(metadata) if metadata.is_file() => Some(metadata.len()),
-            _ => None,
+        .try_fold(DirStats::default(), |mut stats, entry| {
+            let entry = entry?;
+            let metadata = entry.metadata()?;
+            if metadata.is_file() {
+                stats.file_count = stats.file_count.saturating_add(1);
+                stats.total_bytes = stats.total_bytes.saturating_add(metadata.len());
+            }
+            Ok(stats)
         })
-        .sum()
+}
+
+pub(crate) fn dir_size_bytes(path: &Path) -> u64 {
+    dir_stats(path)
+        .map(|stats| stats.total_bytes)
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DirStats, dir_stats, human_readable_bytes};
+    use assert_fs::fixture::TempDir;
+
+    #[test]
+    fn human_readable_bytes_handles_zero() {
+        let (value, unit) = human_readable_bytes(0);
+        assert!(value.abs() < f32::EPSILON);
+        assert_eq!(unit, "B");
+    }
+
+    #[test]
+    fn dir_stats_missing_directory() {
+        let temp = TempDir::new().expect("create temp dir");
+        let missing = temp.path().join("missing");
+
+        assert_eq!(
+            dir_stats(&missing).expect("missing dir stats"),
+            DirStats::default()
+        );
+    }
+
+    #[test]
+    fn dir_stats_empty_directory() {
+        let temp = TempDir::new().expect("create temp dir");
+
+        assert_eq!(
+            dir_stats(temp.path()).expect("empty dir stats"),
+            DirStats::default()
+        );
+    }
+
+    #[test]
+    fn dir_stats_nested_files() {
+        let temp = TempDir::new().expect("create temp dir");
+        let nested = temp.path().join("nested/deep");
+        fs_err::create_dir_all(&nested).expect("create nested dirs");
+        fs_err::write(temp.path().join("root.txt"), b"hello").expect("write root file");
+        fs_err::write(temp.path().join("nested/data.txt"), b"abc").expect("write nested file");
+        fs_err::write(temp.path().join("nested/deep/end.bin"), b"zz").expect("write deep file");
+
+        assert_eq!(
+            dir_stats(temp.path()).expect("nested dir stats"),
+            DirStats {
+                file_count: 3,
+                total_bytes: 10,
+            }
+        );
+    }
 }

--- a/crates/prek/src/cli/cache_size.rs
+++ b/crates/prek/src/cli/cache_size.rs
@@ -24,7 +24,7 @@ pub(crate) fn cache_size(
     let total_bytes = dir_stats(store.path())?.total_bytes;
     if human_readable {
         let (bytes, unit) = human_readable_bytes(total_bytes);
-        writeln!(printer.stdout_important(), "{bytes:.1}{unit}")?;
+        writeln!(printer.stdout_important(), "{bytes:.1} {unit}")?;
     } else {
         writeln!(printer.stdout_important(), "{total_bytes}")?;
     }

--- a/crates/prek/src/cli/cache_size.rs
+++ b/crates/prek/src/cli/cache_size.rs
@@ -7,13 +7,6 @@ use crate::cli::ExitStatus;
 use crate::printer::Printer;
 use crate::store::Store;
 
-/// Aggregate statistics for files within a directory tree.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct DirStats {
-    pub(crate) file_count: u64,
-    pub(crate) total_bytes: u64,
-}
-
 /// Display the total size of the cache.
 pub(crate) fn cache_size(
     store: &Store,
@@ -21,10 +14,10 @@ pub(crate) fn cache_size(
     printer: Printer,
 ) -> Result<ExitStatus> {
     // Walk the entire cache root
-    let total_bytes = dir_stats(store.path())?.total_bytes;
+    let total_bytes = dir_size_bytes(store.path());
     if human_readable {
         let (bytes, unit) = human_readable_bytes(total_bytes);
-        writeln!(printer.stdout_important(), "{bytes:.1} {unit}")?;
+        writeln!(printer.stdout_important(), "{bytes:.1}{unit}")?;
     } else {
         writeln!(printer.stdout_important(), "{total_bytes}")?;
     }
@@ -43,43 +36,31 @@ pub(crate) fn cache_size(
 )]
 pub(crate) fn human_readable_bytes(bytes: u64) -> (f32, &'static str) {
     const UNITS: [&str; 7] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"];
-    if bytes == 0 {
-        return (0.0, UNITS[0]);
-    }
 
     let bytes_f32 = bytes as f32;
     let i = ((bytes_f32.log2() / 10.0) as usize).min(UNITS.len() - 1);
     (bytes_f32 / 1024_f32.powi(i as i32), UNITS[i])
 }
 
-pub(crate) fn dir_stats(path: &Path) -> Result<DirStats> {
+pub(crate) fn dir_size_bytes(path: &Path) -> u64 {
     if !path.exists() {
-        return Ok(DirStats::default());
+        return 0;
     }
 
     walkdir::WalkDir::new(path)
         .follow_links(false)
         .into_iter()
-        .try_fold(DirStats::default(), |mut stats, entry| {
-            let entry = entry?;
-            let metadata = entry.metadata()?;
-            if metadata.is_file() {
-                stats.file_count = stats.file_count.saturating_add(1);
-                stats.total_bytes = stats.total_bytes.saturating_add(metadata.len());
-            }
-            Ok(stats)
+        .filter_map(Result::ok)
+        .filter_map(|entry| match entry.metadata() {
+            Ok(metadata) if metadata.is_file() => Some(metadata.len()),
+            _ => None,
         })
-}
-
-pub(crate) fn dir_size_bytes(path: &Path) -> u64 {
-    dir_stats(path)
-        .map(|stats| stats.total_bytes)
-        .unwrap_or_default()
+        .sum()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{DirStats, dir_stats, human_readable_bytes};
+    use super::{dir_size_bytes, human_readable_bytes};
     use assert_fs::fixture::TempDir;
 
     #[test]
@@ -90,41 +71,35 @@ mod tests {
     }
 
     #[test]
-    fn dir_stats_missing_directory() {
-        let temp = TempDir::new().expect("create temp dir");
+    fn dir_stats_missing_directory() -> anyhow::Result<()> {
+        let temp = TempDir::new()?;
         let missing = temp.path().join("missing");
 
-        assert_eq!(
-            dir_stats(&missing).expect("missing dir stats"),
-            DirStats::default()
-        );
+        assert_eq!(dir_size_bytes(&missing), 0);
+
+        Ok(())
     }
 
     #[test]
-    fn dir_stats_empty_directory() {
-        let temp = TempDir::new().expect("create temp dir");
+    fn dir_stats_empty_directory() -> anyhow::Result<()> {
+        let temp = TempDir::new()?;
 
-        assert_eq!(
-            dir_stats(temp.path()).expect("empty dir stats"),
-            DirStats::default()
-        );
+        assert_eq!(dir_size_bytes(temp.path()), 0);
+
+        Ok(())
     }
 
     #[test]
-    fn dir_stats_nested_files() {
-        let temp = TempDir::new().expect("create temp dir");
+    fn dir_stats_nested_files() -> anyhow::Result<()> {
+        let temp = TempDir::new()?;
         let nested = temp.path().join("nested/deep");
-        fs_err::create_dir_all(&nested).expect("create nested dirs");
-        fs_err::write(temp.path().join("root.txt"), b"hello").expect("write root file");
-        fs_err::write(temp.path().join("nested/data.txt"), b"abc").expect("write nested file");
-        fs_err::write(temp.path().join("nested/deep/end.bin"), b"zz").expect("write deep file");
+        fs_err::create_dir_all(&nested)?;
+        fs_err::write(temp.path().join("root.txt"), b"hello")?;
+        fs_err::write(temp.path().join("nested/data.txt"), b"abc")?;
+        fs_err::write(temp.path().join("nested/deep/end.bin"), b"zz")?;
 
-        assert_eq!(
-            dir_stats(temp.path()).expect("nested dir stats"),
-            DirStats {
-                file_count: 3,
-                total_bytes: 10,
-            }
-        );
+        assert_eq!(dir_size_bytes(temp.path()), 10);
+
+        Ok(())
     }
 }

--- a/crates/prek/src/cli/reporter.rs
+++ b/crates/prek/src/cli/reporter.rs
@@ -278,3 +278,31 @@ impl AutoUpdateReporter {
         self.reporter.on_complete();
     }
 }
+
+#[derive(Debug)]
+pub(crate) struct CleaningReporter {
+    bar: ProgressBar,
+}
+
+impl CleaningReporter {
+    pub(crate) fn new(printer: Printer, max: usize) -> Self {
+        let bar = ProgressBar::with_draw_target(Some(max as u64), printer.target());
+        bar.set_style(
+            ProgressStyle::with_template("{prefix} [{bar:20}] {percent}%")
+                .unwrap()
+                .progress_chars("=> "),
+        );
+        bar.set_prefix(format!("{}", "Cleaning".bold().cyan()));
+        Self { bar }
+    }
+}
+
+impl CleaningReporter {
+    pub(crate) fn on_clean(&self) {
+        self.bar.inc(1);
+    }
+
+    pub(crate) fn on_complete(&self) {
+        self.bar.finish_and_clear();
+    }
+}

--- a/crates/prek/tests/cache.rs
+++ b/crates/prek/tests/cache.rs
@@ -104,16 +104,20 @@ fn cache_gc_verbose_shows_removed_entries() {
 
 #[test]
 fn cache_clean() -> anyhow::Result<()> {
-    let context = TestContext::new();
+    let context = TestContext::new().with_filtered_cache_clean_summary();
 
     let home = context.work_dir().child("home");
     home.create_dir_all()?;
+    home.child("cache/nested").create_dir_all()?;
+    home.child("cache/data.bin").write_str("hello")?;
+    home.child("cache/nested/data.bin").write_str("world!")?;
 
     cmd_snapshot!(context.filters(), context.command().arg("cache").arg("clean").env("PREK_HOME", &*home), @r"
     success: true
     exit_code: 0
     ----- stdout -----
     Cleaned `[TEMP_DIR]/home`
+    Removed [N] file(s) ([SIZE])
 
     ----- stderr -----
     ");
@@ -122,11 +126,14 @@ fn cache_clean() -> anyhow::Result<()> {
 
     // Test `prek clean` works for backward compatibility
     home.create_dir_all()?;
+    home.child("cache").create_dir_all()?;
+    home.child("cache/one.txt").write_str("abc")?;
     cmd_snapshot!(context.filters(), context.command().arg("clean").env("PREK_HOME", &*home), @r"
     success: true
     exit_code: 0
     ----- stdout -----
     Cleaned `[TEMP_DIR]/home`
+    Removed [N] file(s) ([SIZE])
 
     ----- stderr -----
     ");

--- a/crates/prek/tests/cache.rs
+++ b/crates/prek/tests/cache.rs
@@ -112,14 +112,13 @@ fn cache_clean() -> anyhow::Result<()> {
     home.child("cache/data.bin").write_str("hello")?;
     home.child("cache/nested/data.bin").write_str("world!")?;
 
-    cmd_snapshot!(context.filters(), context.command().arg("cache").arg("clean").env("PREK_HOME", &*home), @r"
+    cmd_snapshot!(context.filters(), context.command().arg("cache").arg("clean").env("PREK_HOME", &*home), @"
     success: true
     exit_code: 0
     ----- stdout -----
-    Cleaning [TEMP_DIR]/home
-    Removed [N] file(s) ([SIZE])
 
     ----- stderr -----
+    Removed [N] file(s) ([SIZE])
     ");
 
     home.assert(predicates::path::missing());
@@ -128,14 +127,13 @@ fn cache_clean() -> anyhow::Result<()> {
     home.create_dir_all()?;
     home.child("cache").create_dir_all()?;
     home.child("cache/one.txt").write_str("abc")?;
-    cmd_snapshot!(context.filters(), context.command().arg("clean").env("PREK_HOME", &*home), @r"
+    cmd_snapshot!(context.filters(), context.command().arg("clean").env("PREK_HOME", &*home), @"
     success: true
     exit_code: 0
     ----- stdout -----
-    Cleaning [TEMP_DIR]/home
-    Removed [N] file(s) ([SIZE])
 
     ----- stderr -----
+    Removed [N] file(s) ([SIZE])
     ");
 
     home.assert(predicates::path::missing());

--- a/crates/prek/tests/cache.rs
+++ b/crates/prek/tests/cache.rs
@@ -116,7 +116,7 @@ fn cache_clean() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    Cleaned `[TEMP_DIR]/home`
+    Cleaning [TEMP_DIR]/home
     Removed [N] file(s) ([SIZE])
 
     ----- stderr -----
@@ -132,7 +132,7 @@ fn cache_clean() -> anyhow::Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    Cleaned `[TEMP_DIR]/home`
+    Cleaning [TEMP_DIR]/home
     Removed [N] file(s) ([SIZE])
 
     ----- stderr -----

--- a/crates/prek/tests/common/mod.rs
+++ b/crates/prek/tests/common/mod.rs
@@ -390,6 +390,16 @@ impl TestContext {
         ));
         self
     }
+
+    /// Add extra filtering for `cache clean` summary output.
+    #[must_use]
+    pub fn with_filtered_cache_clean_summary(mut self) -> Self {
+        self.filters.push((
+            r"(?m)^Removed \d+ files? \([^)]+\)\n".to_string(),
+            "Removed [N] file(s) ([SIZE])\n".to_string(),
+        ));
+        self
+    }
 }
 
 #[doc(hidden)] // Macro and test context only, don't use directly.

--- a/crates/prek/tests/common/mod.rs
+++ b/crates/prek/tests/common/mod.rs
@@ -385,7 +385,7 @@ impl TestContext {
             .push((r"(?m)^\d+\n".to_string(), "[SIZE]\n".to_string()));
         // Filter human-readable sizes (e.g., "384.2 KiB")
         self.filters.push((
-            r"(?m)^\d+(\.\d+)? [KMGT]i?B\n".to_string(),
+            r"(?m)^\d+(\.\d+)? ([KMGTPE]i)?B\n".to_string(),
             "[SIZE]\n".to_string(),
         ));
         self
@@ -405,7 +405,7 @@ impl TestContext {
 #[doc(hidden)] // Macro and test context only, don't use directly.
 pub const INSTA_FILTERS: &[(&str, &str)] = &[
     // File sizes
-    (r"(\s|\()(\d+\.)?\d+([KM]i)?B", "$1[SIZE]"),
+    (r"(\s|\()(\d+\.)?\d+\s?([KMGTPE]i)?B", "$1[SIZE]"),
     // Rewrite Windows output to Unix output
     (r"\\([\w\d]|\.\.|\.)", "/$1"),
     // The exact message is host language dependent


### PR DESCRIPTION
## Summary

- Print `Cleaning <path>` before deletion starts for immediate feedback
- Print `Removed N files (X.X MiB)` after completion
- Extract shared `DirStats` struct from `cache_size` for reuse
- Fix `human_readable_bytes(0)` returning NaN
- Silence spurious `fix_permissions` error when Go cache doesn't exist
- Standardize output formatting across cache commands (consistent spacing, styling, remove backticks)