### PR TITLE
Add `homeassistant-powercalc` to the list of users of prek

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ prek is pretty new, but it is already being used or recommend by some projects a
 - [cocoindex-io/cocoindex](https://github.com/cocoindex-io/cocoindex/pull/1564)
 - [cachix/devenv](https://github.com/cachix/devenv/pull/2304)
 - [copper-project/copper-rs](https://github.com/copper-project/copper-rs/pull/783)
+- [bramstroker/homeassistant-powercalc](https://github.com/bramstroker/homeassistant-powercalc/pull/3978)
 
 <!-- --8<-- [end: why] -->
 


### PR DESCRIPTION
Thanks for creating the tooling it's awesome.
Implemented in my project Powercalc, which is one of the most popular custom integration for Home Assistant.
Would be nice to list it in the reference list.