### PR TITLE
Respect `core.sharedRepository` for hook permissions

### DIFF
--- a/crates/prek/src/cli/install.rs
+++ b/crates/prek/src/cli/install.rs
@@ -46,7 +46,9 @@ pub(crate) async fn install(
         );
     }
 
-    let shared_repo = git::is_shared_repository().await.unwrap_or(false);
+    let hook_mode = git::get_shared_repository_file_mode(0o755)
+        .await
+        .unwrap_or(0o755);
 
     let project = match Project::discover(config.as_deref(), &CWD) {
         Ok(project) => Some(project),
@@ -83,7 +85,7 @@ pub(crate) async fn install(
             &hooks_path,
             overwrite,
             allow_missing_config,
-            shared_repo,
+            hook_mode,
             quiet,
             verbose,
             no_progress,
@@ -178,7 +180,7 @@ fn install_hook_script(
     hooks_path: &Path,
     overwrite: bool,
     skip_on_missing_config: bool,
-    shared_repo: bool,
+    hook_mode: u32,
     quiet: u8,
     verbose: u8,
     no_progress: bool,
@@ -310,15 +312,13 @@ fn install_hook_script(
         use std::os::unix::fs::PermissionsExt;
 
         let mut perms = hook_path.metadata()?.permissions();
-        // Use group-writable permissions for shared repositories
-        let mode = if shared_repo { 0o775 } else { 0o755 };
-        perms.set_mode(mode);
+        perms.set_mode(hook_mode);
         fs_err::set_permissions(&hook_path, perms)?;
     }
 
     // Unused on non-Unix platforms
     #[cfg(not(unix))]
-    let _ = shared_repo;
+    let _ = hook_mode;
 
     writeln!(printer.stdout(), "{hint}")?;
 

--- a/crates/prek/src/git.rs
+++ b/crates/prek/src/git.rs
@@ -498,9 +498,56 @@ pub(crate) async fn has_hooks_path_set() -> Result<bool> {
     }
 }
 
-/// Check if the repository is configured for shared access.
-/// Returns true if `core.sharedRepository` is set to a value that enables group permissions.
-pub(crate) async fn is_shared_repository() -> Result<bool> {
+/// Compute the file mode for a newly created file based on `core.sharedRepository`.
+///
+/// This mirrors the relevant parts of Git's `git_config_perm` in `setup.c`
+/// and `calc_shared_perm` in `path.c`.
+fn shared_repository_file_mode(value: &str, mode: u32) -> Option<u32> {
+    const PERM_GROUP: u32 = 0o660;
+    const PERM_EVERYBODY: u32 = 0o664;
+
+    fn apply(mode: u32, mut tweak: u32, replace: bool) -> u32 {
+        // From Git's `calc_shared_perm`: if the original file is not
+        // user-writable, do not introduce any write bits via the shared
+        // repository permission tweak.
+        if mode & 0o200 == 0 {
+            tweak &= !0o222;
+        }
+        // Also from `calc_shared_perm`: for executable files, mirror read bits
+        // into execute bits so an explicit mode like 0640 becomes 0750 when
+        // applied to a 0755 file.
+        if mode & 0o100 != 0 {
+            tweak |= (tweak & 0o444) >> 2;
+        }
+        // Named values like `group` and `all` add permissions on top of the
+        // existing mode, while octal values replace the low permission bits.
+        if replace {
+            (mode & !0o777) | tweak
+        } else {
+            mode | tweak
+        }
+    }
+
+    let value = value.trim().to_ascii_lowercase();
+    let (tweak, replace) = match value.as_str() {
+        "" | "umask" | "false" | "no" | "off" | "0" => return None,
+        "group" | "true" | "yes" | "on" | "1" => (PERM_GROUP, false),
+        "all" | "world" | "everybody" | "2" => (PERM_EVERYBODY, false),
+        // Parsed like Git's `git_config_perm`, which also accepts explicit
+        // octal modes such as `0640`.
+        _ => (u32::from_str_radix(&value, 8).ok()?, true),
+    };
+
+    // `git_config_perm` rejects explicit modes that do not grant user read/write.
+    if replace && tweak & 0o600 != 0o600 {
+        return None;
+    }
+
+    Some(apply(mode, tweak, replace))
+}
+
+/// Resolve the file mode implied by `core.sharedRepository` for a newly created file.
+pub(crate) async fn get_shared_repository_file_mode(mode: u32) -> Result<u32> {
     let output = git_cmd("get shared repository config")?
         .arg("config")
         .arg("--get")
@@ -509,15 +556,10 @@ pub(crate) async fn is_shared_repository() -> Result<bool> {
         .output()
         .await?;
     if output.status.success() {
-        let val = String::from_utf8_lossy(&output.stdout);
-        let trimmed = val.trim().to_lowercase();
-        // git accepts: "group", "true", "1", "all", "world", "everybody", or octal modes
-        Ok(matches!(
-            trimmed.as_str(),
-            "group" | "true" | "1" | "all" | "world" | "everybody"
-        ) || trimmed.starts_with('0'))
+        let value = str::from_utf8(&output.stdout)?;
+        Ok(shared_repository_file_mode(value, mode).unwrap_or(mode))
     } else {
-        Ok(false)
+        Ok(mode)
     }
 }
 
@@ -673,4 +715,36 @@ pub(crate) fn list_submodules(git_root: &Path) -> Result<Vec<PathBuf>, Error> {
         .filter_map(|line| line.split_whitespace().nth(1))
         .map(|submodule| git_root.join(submodule))
         .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::shared_repository_file_mode;
+
+    #[test]
+    fn shared_repository_group_mode_matches_git_behavior() {
+        for value in ["group", "true", "yes", "on", "1"] {
+            assert_eq!(shared_repository_file_mode(value, 0o755), Some(0o775));
+        }
+    }
+
+    #[test]
+    fn shared_repository_everybody_mode_matches_git_behavior() {
+        for value in ["all", "world", "everybody", "2"] {
+            assert_eq!(shared_repository_file_mode(value, 0o755), Some(0o775));
+        }
+    }
+
+    #[test]
+    fn shared_repository_octal_mode_matches_git_behavior() {
+        assert_eq!(shared_repository_file_mode("0640", 0o644), Some(0o640));
+        assert_eq!(shared_repository_file_mode("0640", 0o755), Some(0o750));
+    }
+
+    #[test]
+    fn shared_repository_umask_or_invalid_values_do_not_override_mode() {
+        for value in ["", "umask", "false", "no", "off", "0", "invalid", "0400"] {
+            assert_eq!(shared_repository_file_mode(value, 0o755), None);
+        }
+    }
 }

--- a/crates/prek/tests/install.rs
+++ b/crates/prek/tests/install.rs
@@ -433,6 +433,31 @@ fn install_uses_group_permissions_for_shared_repository() {
     );
 }
 
+/// Hook permissions should respect explicit octal `core.sharedRepository` values.
+#[test]
+#[cfg(unix)]
+fn install_uses_explicit_shared_repository_mode() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let context = TestContext::new();
+    context.init_project();
+
+    git_cmd(context.work_dir())
+        .args(["config", "core.sharedRepository", "0640"])
+        .assert()
+        .success();
+
+    context.install().assert().success();
+
+    let hook_path = context.work_dir().join(".git/hooks/pre-commit");
+    let metadata = std::fs::metadata(&hook_path).unwrap();
+    let mode = metadata.permissions().mode() & 0o777;
+    assert_eq!(
+        mode, 0o750,
+        "Hook should respect explicit shared mode (0o750), got {mode:o}"
+    );
+}
+
 /// Run `prek install --install-hooks` to install the git hook and create prek hook environments.
 #[test]
 fn install_with_hooks() -> anyhow::Result<()> {


### PR DESCRIPTION
I use git repos with multiple users, but encounter problems like:
```
--- devenv:git-hooks:install stderr:
0000.00: error: failed to open file `.git/hooks/pre-commit`: Permission denied (os error 13)
```

So I adapted this tool to respect the `core.sharedRepository` config.

When `core.sharedRepository` is set to `group` (or similar), hook files are now
created with `0o775` instead of `0o755`, allowing multiple users to update them.