### PR TITLE
Update configuration.md with TOML 1.1 notes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -168,10 +168,10 @@ You may want to use the longer form if your editor/IDE complains about it.
 
     ```toml
     default_language_version.python = "3.12"
-    
+
     [[repos]]
     repo = "local"
-    
+
     [[repos.hooks]]
     id = "ruff"
     name = "ruff"


### PR DESCRIPTION
TOML 1.1 is not yet universally available. This hit me on Visual Studio Code using [Even Better TOML](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml). While this issue does not affect `prek` directly, users may encounter errors on their IDE/editor and wonder what is going on.
