### PR TITLE
Align stage defaulting behavior with pre-commit

### DIFF
--- a/crates/prek/src/config.rs
+++ b/crates/prek/src/config.rs
@@ -266,14 +266,17 @@ impl Stage {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) enum Stages {
-    #[default]
     All,
     Some(BTreeSet<Stage>),
 }
 
 impl Stages {
+    pub(crate) fn is_empty(&self) -> bool {
+        matches!(self, Self::Some(stages) if stages.is_empty())
+    }
+
     pub(crate) fn contains(&self, stage: Stage) -> bool {
         match self {
             Self::All => true,
@@ -294,8 +297,12 @@ impl Display for Stages {
         match self {
             Self::All => write!(f, "all"),
             Self::Some(stages) => {
-                let stages_str = stages.iter().map(ToString::to_string).join(", ");
-                write!(f, "{stages_str}")
+                if stages.is_empty() {
+                    write!(f, "none")
+                } else {
+                    let stages_str = stages.iter().map(ToString::to_string).join(", ");
+                    write!(f, "{stages_str}")
+                }
             }
         }
     }
@@ -304,7 +311,7 @@ impl Display for Stages {
 impl From<Vec<Stage>> for Stages {
     fn from(value: Vec<Stage>) -> Self {
         let stages: BTreeSet<_> = value.into_iter().collect();
-        if stages.is_empty() || stages.len() == Stage::value_variants().len() {
+        if stages.len() == Stage::value_variants().len() {
             Self::All
         } else {
             Self::Some(stages)
@@ -1237,16 +1244,31 @@ mod tests {
     );
 
     #[test]
-    fn stages_deserialize_empty_as_all() {
+    fn stages_deserialize_empty_as_empty() {
         #[derive(Debug, Deserialize)]
         struct Wrapper {
             stages: Stages,
         }
 
         let parsed: Wrapper = serde_saphyr::from_str("stages: []\n").expect("stages should parse");
-        assert_eq!(parsed.stages, Stages::default());
-        assert!(parsed.stages.contains(Stage::Manual));
-        assert!(parsed.stages.contains(Stage::PreCommit));
+        assert_eq!(parsed.stages, Stages::Some(BTreeSet::new()));
+        assert!(!parsed.stages.contains(Stage::Manual));
+        assert!(!parsed.stages.contains(Stage::PreCommit));
+    }
+
+    #[test]
+    fn config_default_stages_deserialize_empty_as_empty() {
+        let parsed: Config =
+            serde_saphyr::from_str("repos: []\ndefault_stages: []\n").expect("config should parse");
+
+        assert_eq!(parsed.default_stages, Some(Stages::Some(BTreeSet::new())));
+    }
+
+    #[test]
+    fn config_default_stages_omitted_keeps_none() {
+        let parsed: Config = serde_saphyr::from_str("repos: []\n").expect("config should parse");
+
+        assert_eq!(parsed.default_stages, None);
     }
 
     #[test]

--- a/crates/prek/src/hook.rs
+++ b/crates/prek/src/hook.rs
@@ -84,8 +84,8 @@ impl HookSpec {
                 .and_then(|v| v.get(&language).cloned());
         }
 
-        if self.options.stages.is_none() {
-            self.options.stages.clone_from(&config.default_stages);
+        if self.options.stages.as_ref().is_none_or(Stages::is_empty) {
+            self.options.stages = Some(config.default_stages.clone().unwrap_or(Stages::All));
         }
     }
 }
@@ -327,7 +327,7 @@ impl HookBuilder {
         let pass_filenames = options.pass_filenames.unwrap_or(PassFilenames::All);
         let require_serial = options.require_serial.unwrap_or(false);
         let verbose = options.verbose.unwrap_or(false);
-        let stages = options.stages.unwrap_or_default();
+        let stages = options.stages.unwrap_or(Stages::All);
         let additional_dependencies = options
             .additional_dependencies
             .unwrap_or_default()
@@ -838,7 +838,7 @@ mod tests {
     use prek_identify::tags;
     use rustc_hash::FxHashMap;
 
-    use crate::config::{HookOptions, Language, PassFilenames, RemoteHook};
+    use crate::config::{Config, HookOptions, Language, PassFilenames, RemoteHook, Stage, Stages};
     use crate::hook::HookSpec;
     use crate::languages::version::LanguageRequest;
     use crate::workspace::Project;
@@ -997,6 +997,150 @@ mod tests {
         }
         "#);
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn hook_builder_empty_hook_stages_inherit_default_stages() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let config_path = temp.path().join(PRE_COMMIT_CONFIG_YAML);
+        fs_err::write(&config_path, "repos: []\ndefault_stages: [manual]\n")?;
+
+        let project = Arc::new(Project::from_config_file(
+            Cow::Borrowed(&config_path),
+            None,
+        )?);
+        let repo = Arc::new(Repo::Local { hooks: vec![] });
+
+        let hook_spec = HookSpec {
+            id: "test-hook".to_string(),
+            name: "test-hook".to_string(),
+            entry: "python3 -c 'print(1)'".to_string(),
+            language: Language::Python,
+            priority: None,
+            options: HookOptions {
+                stages: Some(Stages::Some(std::collections::BTreeSet::new())),
+                ..Default::default()
+            },
+        };
+
+        let hook = HookBuilder::new(project, repo, hook_spec, 0)
+            .build()
+            .await?;
+
+        assert_eq!(
+            hook.stages,
+            Stages::Some([Stage::Manual].into_iter().collect())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn hook_spec_apply_project_defaults_sets_explicit_all_when_default_stages_missing() {
+        let config: Config = serde_saphyr::from_str("repos: []\n").expect("config should parse");
+
+        let mut hook_spec = HookSpec {
+            id: "test-hook".to_string(),
+            name: "test-hook".to_string(),
+            entry: "python3 -c 'print(1)'".to_string(),
+            language: Language::Python,
+            priority: None,
+            options: HookOptions::default(),
+        };
+
+        hook_spec.apply_project_defaults(&config);
+
+        assert_eq!(hook_spec.options.stages, Some(Stages::All));
+    }
+
+    #[tokio::test]
+    async fn hook_builder_preserves_explicit_empty_default_stages() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let config_path = temp.path().join(PRE_COMMIT_CONFIG_YAML);
+        fs_err::write(&config_path, "repos: []\ndefault_stages: []\n")?;
+
+        let project = Arc::new(Project::from_config_file(
+            Cow::Borrowed(&config_path),
+            None,
+        )?);
+        let repo = Arc::new(Repo::Local { hooks: vec![] });
+
+        let hook_spec = HookSpec {
+            id: "test-hook".to_string(),
+            name: "test-hook".to_string(),
+            entry: "python3 -c 'print(1)'".to_string(),
+            language: Language::Python,
+            priority: None,
+            options: HookOptions::default(),
+        };
+
+        let hook = HookBuilder::new(project, repo, hook_spec, 0)
+            .build()
+            .await?;
+
+        assert_eq!(hook.stages, Stages::Some(std::collections::BTreeSet::new()));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn hook_builder_defaults_to_all_when_stages_and_default_stages_missing() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let config_path = temp.path().join(PRE_COMMIT_CONFIG_YAML);
+        fs_err::write(&config_path, "repos: []\n")?;
+
+        let project = Arc::new(Project::from_config_file(
+            Cow::Borrowed(&config_path),
+            None,
+        )?);
+        let repo = Arc::new(Repo::Local { hooks: vec![] });
+
+        let hook_spec = HookSpec {
+            id: "test-hook".to_string(),
+            name: "test-hook".to_string(),
+            entry: "python3 -c 'print(1)'".to_string(),
+            language: Language::Python,
+            priority: None,
+            options: HookOptions::default(),
+        };
+
+        let hook = HookBuilder::new(project, repo, hook_spec, 0)
+            .build()
+            .await?;
+
+        assert_eq!(hook.stages, Stages::All);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn hook_builder_empty_hook_stages_default_to_all_when_default_stages_missing()
+    -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let config_path = temp.path().join(PRE_COMMIT_CONFIG_YAML);
+        fs_err::write(&config_path, "repos: []\n")?;
+
+        let project = Arc::new(Project::from_config_file(
+            Cow::Borrowed(&config_path),
+            None,
+        )?);
+        let repo = Arc::new(Repo::Local { hooks: vec![] });
+
+        let hook_spec = HookSpec {
+            id: "test-hook".to_string(),
+            name: "test-hook".to_string(),
+            entry: "python3 -c 'print(1)'".to_string(),
+            language: Language::Python,
+            priority: None,
+            options: HookOptions {
+                stages: Some(Stages::Some(std::collections::BTreeSet::new())),
+                ..Default::default()
+            },
+        };
+
+        let hook = HookBuilder::new(project, repo, hook_spec, 0)
+            .build()
+            .await?;
+
+        assert_eq!(hook.stages, Stages::All);
         Ok(())
     }
 


### PR DESCRIPTION
I noticed this difference in behavior while looking into #1785.

This change fixes `stage` defaulting to match pre-commit, especially around explicit empty stage lists.

The key edge case is `default_stages: []`:

in pre-commit, omitted `default_stages` means all stages
explicit `default_stages: []` means no stages.

Before:

explicit empty stage configuration could be treated like the default-all case
omitted and explicitly empty values were not distinguished correctly in effective behavior

After:

omitted `default_stages` still behaves as all stages
explicit `default_stages: []` now stays empty