### PR TITLE
docs: fix incorrect type reference in ArchiveExtension::from_path

### DIFF
--- a/crates/prek/src/archive.rs
+++ b/crates/prek/src/archive.rs
@@ -61,7 +61,7 @@ pub enum ArchiveExtension {
 }
 
 impl ArchiveExtension {
-    /// Extract the [`SourceDistExtension`] from a path.
+    /// Extract the [`ArchiveExtension`] from a path.
     pub fn from_path(path: impl AsRef<Path>) -> Result<Self, Error> {
         /// Returns true if the path is a tar file (e.g., `.tar.gz`).
         fn is_tar(path: &Path) -> bool {


### PR DESCRIPTION
Corrected the doc comment for `ArchiveExtension::from_path` which incorrectly  referenced `SourceDistExtension`. 

The method returns `ArchiveExtension`, not `SourceDistExtension`.
