### PR TITLE
fix: show tag names in `auto-update --freeze` output

### DIFF
--- a/crates/prek/src/cli/auto_update.rs
+++ b/crates/prek/src/cli/auto_update.rs
@@ -33,6 +33,15 @@ struct Revision {
     frozen: Option<String>,
 }
 
+impl Revision {
+    fn display_rev(&self) -> String {
+        match &self.frozen {
+            Some(rev) => format!("{rev}@{}", self.rev),
+            None => self.rev.clone(),
+        }
+    }
+}
+
 pub(crate) async fn auto_update(
     store: &Store,
     config: Option<PathBuf>,
@@ -54,6 +63,9 @@ pub(crate) async fn auto_update(
     // TODO: support selectors?
     let selectors = Selectors::default();
     let workspace = Workspace::discover(store, workspace_root, config, Some(&selectors), true)?;
+
+    // Parse `# frozen: <rev>` comments from config files to display old revs
+    let frozen_revs = parse_frozen_comments(&workspace);
 
     // Collect repos and deduplicate by RemoteRepo
     #[allow(clippy::mutable_key_type)]
@@ -129,12 +141,16 @@ pub(crate) async fn auto_update(
                 let is_changed = remote_repo.rev != new_rev.rev;
 
                 if is_changed {
+                    let old = Revision {
+                        rev: remote_repo.rev.clone(),
+                        frozen: frozen_revs.get(&remote_repo.rev).cloned(),
+                    };
                     writeln!(
                         printer.stdout(),
                         "[{}] updating {} -> {}",
                         remote_repo.repo.as_str().cyan(),
-                        remote_repo.rev,
-                        new_rev.rev
+                        old.display_rev(),
+                        new_rev.display_rev()
                     )?;
                 } else {
                     writeln!(
@@ -473,6 +489,25 @@ async fn get_best_candidate_tag(repo: &Path, rev: &str, current_rev: &str) -> Re
         .next()
         .map(ToString::to_string)
         .with_context(|| format!("No tags found for revision {rev}"))
+}
+
+/// Parse `# frozen: <rev>` comments from config files, returning a map from SHA to rev name.
+fn parse_frozen_comments(workspace: &Workspace) -> FxHashMap<String, String> {
+    let rev_re = regex!(r#"^\s*rev\b\s*[:=]\s*['"]?([a-f0-9]{40})['"]?\s*#\s*frozen:\s*(\S+)"#);
+    let mut map = FxHashMap::default();
+
+    for project in workspace.projects() {
+        let Ok(content) = fs_err::read_to_string(project.config_file()) else {
+            continue;
+        };
+        for line in content.lines() {
+            if let Some(caps) = rev_re.captures(line) {
+                map.insert(caps[1].to_string(), caps[2].to_string());
+            }
+        }
+    }
+
+    map
 }
 
 async fn write_new_config(path: &Path, revisions: &[Option<Revision>]) -> Result<()> {

--- a/crates/prek/tests/auto_update.rs
+++ b/crates/prek/tests/auto_update.rs
@@ -511,14 +511,14 @@ fn auto_update_freeze() -> Result<()> {
     let filters = context
         .filters()
         .into_iter()
-        .chain([(r" [a-f0-9]{40}", r" [COMMIT_SHA]")])
+        .chain([(r"[a-f0-9]{40}", r"[COMMIT_SHA]")])
         .collect::<Vec<_>>();
 
     cmd_snapshot!(filters.clone(), context.auto_update().arg("--freeze").arg("--cooldown-days").arg("0"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
-    [[HOME]/test-repos/freeze-repo] updating v1.0.0 -> [COMMIT_SHA]
+    [[HOME]/test-repos/freeze-repo] updating v1.0.0 -> v1.1.0@[COMMIT_SHA]
 
     ----- stderr -----
     ");
@@ -706,7 +706,7 @@ fn auto_update_with_existing_frozen_comment() -> Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    [[HOME]/test-repos/frozen-repo] updating [COMMIT_SHA] -> v1.2.0
+    [[HOME]/test-repos/frozen-repo] updating v1.0.0@[COMMIT_SHA] -> v1.2.0
 
     ----- stderr -----
     "#);
@@ -1312,7 +1312,7 @@ fn auto_update_freeze_toml() -> Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    [[HOME]/test-repos/freeze-repo] updating v1.0.0 -> [COMMIT_SHA]
+    [[HOME]/test-repos/freeze-repo] updating v1.0.0 -> v1.1.0@[COMMIT_SHA]
 
     ----- stderr -----
     ");
@@ -1545,7 +1545,7 @@ fn auto_update_freeze_toml_with_comment() -> Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    [[HOME]/test-repos/freeze-repo] updating v1.0.0 -> [COMMIT_SHA]
+    [[HOME]/test-repos/freeze-repo] updating v1.0.0 -> v1.1.0@[COMMIT_SHA]
 
     ----- stderr -----
     ");


### PR DESCRIPTION
### Summary

- Display `rev@sha` instead of raw commit SHA in `auto-update --freeze` console output
- Add `display_rev()` helper to `Revision` that formats as `rev@sha` when frozen, plain rev otherwise
- Parse `# frozen:` comments from config files to also show the tag on the "from" side of already-frozen repos
- Adjust test snapshot SHA filter to match SHAs after `@`

Closes #1854