### PR TITLE
Remove unnecessary rust version in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for your interest in improving **prek**! This guide walks through the dev
 
 1. **Install Rust with `rustup`** (recommended)
 
-    Install `rustup` from <https://rustup.rs> if you do not already have it. Then install the toolchain pinned in `rust-toolchain.toml` (currently Rust 1.90):
+    Install `rustup` from <https://rustup.rs> if you do not already have it. Then install the toolchain pinned in `rust-toolchain.toml`:
 
     ```bash
     rustup show


### PR DESCRIPTION
The current Rust version listed in the `CONTRIBUTING.md` file is incorrect.
According to `rust-toolchain.md` the version is pinned to `1.94`
- #1751 

Removing the listed version in `CONTRIBUTING.md` completely prevents using the wrong rust version.
I guess one can expect a developer to be able to look up the pinned version in `rust-toolchain.md` directly.
