### PR TITLE
Clean stale patch files in `cache gc`

### DIFF
--- a/crates/prek/src/cli/cache_gc.rs
+++ b/crates/prek/src/cli/cache_gc.rs
@@ -2,6 +2,7 @@ use std::fmt::Write;
 use std::fmt::{Display, Formatter};
 use std::ops::AddAssign;
 use std::path::Path;
+use std::time::{Duration, SystemTime};
 
 use anyhow::Result;
 use owo_colors::OwoColorize;
@@ -23,6 +24,7 @@ enum RemovalKind {
     HookEnvs,
     Tools,
     CacheEntries,
+    PatchFiles,
 }
 
 impl RemovalKind {
@@ -33,6 +35,7 @@ impl RemovalKind {
                 RemovalKind::HookEnvs => "hook envs",
                 RemovalKind::Tools => "tools",
                 RemovalKind::CacheEntries => "cache entries",
+                RemovalKind::PatchFiles => "patch files",
             }
         } else {
             match self {
@@ -40,10 +43,13 @@ impl RemovalKind {
                 RemovalKind::HookEnvs => "hook env",
                 RemovalKind::Tools => "tool",
                 RemovalKind::CacheEntries => "cache entry",
+                RemovalKind::PatchFiles => "patch file",
             }
         }
     }
 }
+
+const STALE_PATCH_RETENTION: Duration = Duration::from_secs(30 * 24 * 60 * 60);
 
 #[derive(Debug, Clone)]
 struct RemovalItem {
@@ -272,16 +278,15 @@ pub(crate) async fn cache_gc(
     if !dry_run {
         let _ = fs_err::remove_dir_all(store.scratch_path());
     }
-    // NOTE: Do not clear `patches/` here. It can contain user-important temporary patches.
-    // A future enhancement could implement a safer cleanup strategy (e.g. GC patches older
-    // than a configurable age, or only remove patches known to be orphaned).
-    // let _ = fs_err::remove_dir_all(store.patches_dir())?;
+    // Keep recent recovery patches, but clear out stale ones that are unlikely to be useful.
+    let removed_patches = sweep_stale_patch_files(&store.patches_dir(), dry_run, verbose)?;
 
     let mut removed = RemovalSummary::default();
     removed += &removed_repos;
     removed += &removed_hooks;
     removed += &removed_tools;
     removed += &removed_cache;
+    removed += &removed_patches;
 
     let removed_total_bytes = removed.total_bytes();
     let (removed_bytes, removed_unit) = human_readable_bytes(removed_total_bytes);
@@ -302,6 +307,7 @@ pub(crate) async fn cache_gc(
             print_removed_details(printer, verb, &removed_hooks)?;
             print_removed_details(printer, verb, &removed_tools)?;
             print_removed_details(printer, verb, &removed_cache)?;
+            print_removed_details(printer, verb, &removed_patches)?;
         }
     }
 
@@ -601,6 +607,82 @@ fn sweep_dir_by_name(
                 if let Some(item) = item {
                     removal.items.push(item);
                 }
+            }
+        }
+    }
+
+    Ok(removal)
+}
+
+fn sweep_stale_patch_files(root: &Path, dry_run: bool, collect_names: bool) -> Result<Removal> {
+    let mut removal = Removal::new(RemovalKind::PatchFiles);
+    let entries = match fs_err::read_dir(root) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(Removal::new(RemovalKind::PatchFiles));
+        }
+        Err(err) => return Err(err.into()),
+    };
+
+    let cutoff = SystemTime::now()
+        .checked_sub(STALE_PATCH_RETENTION)
+        .unwrap_or(SystemTime::UNIX_EPOCH);
+
+    for entry in entries {
+        let Ok(entry) = entry else {
+            continue;
+        };
+
+        if !entry.file_type().is_ok_and(|file_type| file_type.is_file()) {
+            continue;
+        }
+
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if name.starts_with('.') || path.extension().and_then(|ext| ext.to_str()) != Some("patch") {
+            continue;
+        }
+
+        let metadata = match entry.metadata() {
+            Ok(metadata) => metadata,
+            Err(err) => {
+                warn!(%err, path = %path.display(), "Failed to read patch metadata");
+                continue;
+            }
+        };
+        let modified = match metadata.modified() {
+            Ok(modified) => modified,
+            Err(err) => {
+                warn!(%err, path = %path.display(), "Failed to read patch modified time");
+                continue;
+            }
+        };
+        if modified > cutoff {
+            continue;
+        }
+
+        let entry_bytes = metadata.len();
+        let item = collect_names
+            .then(|| RemovalItem::new(name.to_string(), path.to_string_lossy().to_string()));
+
+        if dry_run {
+            removal.count += 1;
+            removal.bytes = removal.bytes.saturating_add(entry_bytes);
+            if let Some(item) = item {
+                removal.items.push(item);
+            }
+            continue;
+        }
+
+        if let Err(err) = fs_err::remove_file(&path) {
+            warn!(%err, path = %path.display(), "Failed to remove old patch file");
+        } else {
+            removal.count += 1;
+            removal.bytes = removal.bytes.saturating_add(entry_bytes);
+            if let Some(item) = item {
+                removal.items.push(item);
             }
         }
     }

--- a/crates/prek/tests/cache.rs
+++ b/crates/prek/tests/cache.rs
@@ -3,6 +3,7 @@ use assert_fs::fixture::{ChildPath, PathChild, PathCreateDir};
 use assert_fs::prelude::FileWriteStr;
 use prek_consts::PRE_COMMIT_CONFIG_YAML;
 use serde_json::json;
+use std::time::{Duration, SystemTime};
 
 use crate::common::{TestContext, cmd_snapshot};
 
@@ -561,6 +562,64 @@ fn cache_gc_keeps_local_hook_env() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[test]
+fn cache_gc_removes_stale_patch_files() -> anyhow::Result<()> {
+    let context = TestContext::new();
+
+    context.write_pre_commit_config("repos: []\n");
+
+    let home = context.home_dir();
+    let config_path = context.work_dir().child(PRE_COMMIT_CONFIG_YAML);
+    write_config_tracking_file(home, &[config_path.path()])?;
+
+    let old_patch = home.child("patches/old.patch");
+    let recent_patch = home.child("patches/recent.patch");
+
+    write_patch_file(
+        &old_patch,
+        "old patch\n",
+        SystemTime::now() - Duration::from_secs(60 * 24 * 60 * 60),
+    )?;
+    write_patch_file(
+        &recent_patch,
+        "recent patch\n",
+        SystemTime::now() - Duration::from_secs(24 * 60 * 60),
+    )?;
+
+    cmd_snapshot!(context.filters(), context.command().args(["cache", "gc", "-v", "--dry-run"]), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Would remove 1 patch file ([SIZE])
+
+    Would remove 1 patch file:
+    - old.patch
+      path: [HOME]/patches/old.patch
+
+    ----- stderr -----
+    ");
+    old_patch.assert(predicates::path::is_file());
+    recent_patch.assert(predicates::path::is_file());
+
+    cmd_snapshot!(context.filters(), context.command().args(["cache", "gc", "-v"]), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Removed 1 patch file ([SIZE])
+
+    Removed 1 patch file:
+    - old.patch
+      path: [HOME]/patches/old.patch
+
+    ----- stderr -----
+    ");
+
+    old_patch.assert(predicates::path::missing());
+    recent_patch.assert(predicates::path::is_file());
+
+    Ok(())
+}
+
 fn write_config_tracking_file(
     home: &ChildPath,
     configs: &[&std::path::Path],
@@ -571,6 +630,17 @@ fn write_config_tracking_file(
         .collect();
     let content = serde_json::to_string_pretty(&configs)?;
     home.child("config-tracking.json").write_str(&content)?;
+    Ok(())
+}
+
+fn write_patch_file(path: &ChildPath, content: &str, modified: SystemTime) -> anyhow::Result<()> {
+    let parent = path.path().parent().expect("patch file has parent");
+    fs_err::create_dir_all(parent)?;
+    fs_err::write(path.path(), content)?;
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(path.path())?
+        .set_modified(modified)?;
     Ok(())
 }
 
@@ -681,7 +751,7 @@ fn cache_gc_drops_missing_tracked_config() -> anyhow::Result<()> {
     let tracked: Vec<String> = serde_json::from_str(&content)?;
     assert!(tracked.is_empty());
 
-    // Scratch and patches are always cleared when GC runs.
+    // Scratch is always cleared. Patch directories remain unless they contain stale patch files.
     home.child("scratch").assert(predicates::path::missing());
     home.child("patches").assert(predicates::path::is_dir());
 


### PR DESCRIPTION
Clean stale `*.patch` files during `prek cache gc`

Closes #1635
