### PR TITLE
Restore git index from saved tree on stash conflict rollback

### DIFF
--- a/crates/prek/src/cli/run/keeper.rs
+++ b/crates/prek/src/cli/run/keeper.rs
@@ -19,6 +19,7 @@ static RESTORE_WORKTREE: Mutex<Option<WorkTreeKeeper>> = Mutex::new(None);
 struct IntentToAddKeeper(Vec<PathBuf>);
 struct WorkingTreeKeeper {
     root: PathBuf,
+    tree: String,
     patch: Option<PathBuf>,
 }
 
@@ -99,7 +100,7 @@ impl WorkingTreeKeeper {
             .arg("--exit-code")
             .arg("--no-color")
             .arg("--no-ext-diff")
-            .arg(tree)
+            .arg(&tree)
             .arg("--")
             .arg(root)
             .check(false)
@@ -111,6 +112,7 @@ impl WorkingTreeKeeper {
             // No non-staged changes
             Ok(Self {
                 root: root.to_path_buf(),
+                tree,
                 patch: None,
             })
         } else if output.status.code() == Some(1) {
@@ -119,6 +121,7 @@ impl WorkingTreeKeeper {
                 // probably git auto crlf behavior quirks
                 Ok(Self {
                     root: root.to_path_buf(),
+                    tree,
                     patch: None,
                 })
             } else {
@@ -146,10 +149,11 @@ impl WorkingTreeKeeper {
 
                 // Clean the working tree
                 debug!("Cleaning working tree");
-                Self::checkout_working_tree(root)?;
+                Self::checkout_working_tree(root, None)?;
 
                 Ok(Self {
                     root: root.to_path_buf(),
+                    tree,
                     patch: Some(patch_path),
                 })
             }
@@ -158,16 +162,24 @@ impl WorkingTreeKeeper {
         }
     }
 
-    fn checkout_working_tree(root: &Path) -> Result<()> {
-        let output = Command::new(GIT.as_ref()?)
-            .arg("-c")
-            .arg("submodule.recurse=0")
-            .arg("checkout")
-            .arg("--")
+    /// Check out the working tree to match the index (when `tree` is `None`)
+    /// or to match a specific tree object (when `tree` is `Some`).
+    ///
+    /// When a tree-ish is provided, `git checkout <tree> -- <root>` resets both
+    /// the index entries and the working tree files for paths under `root` to
+    /// match the tree. This is used during rollback to guarantee the index is
+    /// restored to its pre-hook state.
+    fn checkout_working_tree(root: &Path, tree: Option<&str>) -> Result<()> {
+        let mut cmd = Command::new(GIT.as_ref()?);
+        cmd.arg("-c").arg("submodule.recurse=0").arg("checkout");
+        if let Some(tree) = tree {
+            cmd.arg(tree);
+        }
+        cmd.arg("--")
             .arg(root)
             // prevent recursive post-checkout hooks
-            .env(EnvVars::PREK_INTERNAL__SKIP_POST_CHECKOUT, "1")
-            .output()?;
+            .env(EnvVars::PREK_INTERNAL__SKIP_POST_CHECKOUT, "1");
+        let output = cmd.output()?;
         if output.status.success() {
             Ok(())
         } else {
@@ -203,8 +215,12 @@ impl WorkingTreeKeeper {
                 "Stashed changes conflicted with changes made by hook, rolling back the hook changes".red().bold()
             );
 
-            // Discard any changes made by hooks, and try applying the patch again.
-            Self::checkout_working_tree(&self.root)?;
+            // Discard any changes made by hooks and restore the index to its
+            // pre-hook state by checking out the saved tree.  Using the tree
+            // (rather than a bare `git checkout -- <root>`) guarantees both
+            // the index and working tree are reset to their original state,
+            // even if hooks or git internals modified index entries.
+            Self::checkout_working_tree(&self.root, Some(&self.tree))?;
             Self::git_apply(patch)?;
         }
 

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -1421,6 +1421,77 @@ fn staged_files_only() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn stash_conflict_rollback_restores_index_from_saved_tree() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    let cwd = context.work_dir();
+    cwd.child("corrupt-index.py").write_str(indoc::indoc! {r#"
+        import pathlib
+        import subprocess
+
+        empty = subprocess.check_output(
+            ["git", "hash-object", "-w", "--stdin"],
+            input=b"",
+        ).decode().strip()
+        subprocess.check_call([
+            "git",
+            "update-index",
+            "--cacheinfo",
+            "100644",
+            empty,
+            "new-file.txt",
+        ])
+        pathlib.Path("new-file.txt").write_text("hook content\n")
+    "#})?;
+    context.write_pre_commit_config(indoc::indoc! {r"
+        repos:
+          - repo: local
+            hooks:
+              - id: corrupt-index
+                name: corrupt-index
+                language: system
+                entry: python3 corrupt-index.py
+                pass_filenames: false
+                always_run: true
+    "});
+    cwd.child("README.md").write_str("initial\n")?;
+    context.git_add(".");
+    context.git_commit("Initial commit");
+
+    cwd.child("new-file.txt").write_str("staged content\n")?;
+    context.git_add("new-file.txt");
+    cwd.child("new-file.txt").write_str("unstaged content\n")?;
+
+    let filters: Vec<_> = context
+        .filters()
+        .into_iter()
+        .chain([(r"/\d+-\d+.patch", "/[TIME]-[PID].patch")])
+        .collect();
+
+    cmd_snapshot!(filters, context.run(), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    corrupt-index............................................................Failed
+    - hook id: corrupt-index
+    - files were modified by this hook
+
+    ----- stderr -----
+    Unstaged changes detected, stashing unstaged changes to `[HOME]/patches/[TIME]-[PID].patch`
+    Stashed changes conflicted with changes made by hook, rolling back the hook changes
+    Restored working tree changes from `[HOME]/patches/[TIME]-[PID].patch`
+    ");
+
+    let output = git_cmd(cwd).arg("show").arg(":new-file.txt").output()?;
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(String::from_utf8(output.stdout)?, "staged content\n");
+    assert_eq!(context.read("new-file.txt"), "unstaged content\n");
+
+    Ok(())
+}
+
 #[cfg(unix)]
 #[test]
 fn restore_on_interrupt() -> Result<()> {


### PR DESCRIPTION
## Summary

Fixes #1889 — when auto-fixing hooks (e.g. `end-of-file-fixer`, `trailing-whitespace`) modify staged files and there are unstaged changes elsewhere, prek's stash/restore mechanism can leave the git index in a corrupted state. This causes newly added files to be silently committed as empty blobs.

### Root cause

In `WorkingTreeKeeper::restore()`, when a stash conflict is detected, the rollback calls `git checkout -- <root>` (without a tree-ish). This checks out from the **current index**, which may have drifted from its pre-hook state. If the index was modified during the hook run (e.g. by git internals or hook interactions), the rollback produces incorrect file content.

### Fix

- Save the tree SHA from `git write-tree` (captured in `clean()` before hooks run) in the `WorkingTreeKeeper` struct.
- During conflict rollback in `restore()`, use `git checkout <saved_tree> -- <root>` instead of `git checkout -- <root>`.
- `git checkout <tree> -- <root>` resets **both** the index entries and working tree files to match the saved tree, guaranteeing they return to their exact pre-hook state regardless of what happened during the hook run.

The initial working tree clean in `clean()` continues to use `git checkout -- <root>` (no tree-ish), since the tree was just created from the current index and the two are identical at that point.

### Reproduction scenario

1. Stage files with `git add api/` (leaving other files unstaged)
2. Some staged files have trailing whitespace or missing final newlines
3. `git commit` triggers prek → hooks fix the files → stash conflict → rollback
4. Index is left corrupted: newly added files have empty content in the index
5. Subsequent `git add` + `git commit` commits the empty files

### Changes

Single file changed: `crates/prek/src/cli/run/keeper.rs`

- Added `tree: String` field to `WorkingTreeKeeper` to persist the pre-hook tree SHA
- Changed `checkout_working_tree()` to accept an optional `tree` parameter
- Rollback path now passes the saved tree to `checkout_working_tree()`

Made with [Cursor](https://cursor.com)