### PR TITLE
Improve merge conflict marker detection

### DIFF
--- a/crates/prek/src/hooks/pre_commit_hooks/check_merge_conflict.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_merge_conflict.rs
@@ -66,7 +66,6 @@ async fn check_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)>
     let mut line = Vec::new();
     let mut line_number = 1;
     let mut in_conflict = false;
-    let mut separator_line_number = None;
 
     let mut report_conflict = |line_number: usize, pattern: &str| {
         output.extend(conflict_message(filename, line_number, pattern));
@@ -77,7 +76,6 @@ async fn check_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)>
         if line.starts_with(START_PATTERN) {
             report_conflict(line_number, "<<<<<<< ");
             in_conflict = true;
-            separator_line_number = None;
         } else if in_conflict && line.starts_with(ANCESTOR_PATTERN) {
             report_conflict(line_number, "||||||| ");
         } else if in_conflict
@@ -85,11 +83,8 @@ async fn check_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)>
                 .iter()
                 .any(|pattern| line.starts_with(pattern))
         {
-            separator_line_number = Some(line_number);
+            report_conflict(line_number, "=======");
         } else if line.starts_with(END_PATTERN) {
-            if let Some(separator_line_number) = separator_line_number.take() {
-                report_conflict(separator_line_number, "=======");
-            }
             report_conflict(line_number, ">>>>>>> ");
             in_conflict = false;
         }
@@ -100,6 +95,7 @@ async fn check_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)>
 
     Ok((code, output))
 }
+
 fn conflict_message(filename: &Path, line_number: usize, pattern: &str) -> Vec<u8> {
     format!(
         "{}:{line_number}: Merge conflict string {pattern:?} found\n",
@@ -230,7 +226,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_separator_not_reported_without_conflict_end() -> Result<()> {
+    async fn test_separator_reported_without_conflict_end() -> Result<()> {
         let dir = tempdir()?;
         let content = b"Before conflict\n<<<<<<< HEAD\nOur changes\n=======\n";
         let file_path = create_test_file(&dir, "partial_conflict.txt", content).await?;
@@ -238,7 +234,7 @@ mod tests {
         assert_eq!(code, 1);
         let output_str = String::from_utf8_lossy(&output);
         assert!(output_str.contains("<<<<<<< "));
-        assert!(!output_str.contains("======="));
+        assert!(output_str.contains("======="));
         Ok(())
     }
 

--- a/crates/prek/src/hooks/pre_commit_hooks/check_merge_conflict.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_merge_conflict.rs
@@ -9,13 +9,10 @@ use crate::hook::Hook;
 use crate::hooks::run_concurrent_file_checks;
 use crate::run::CONCURRENCY;
 
-const CONFLICT_PATTERNS: &[&[u8]] = &[
-    b"<<<<<<< ",
-    b"======= ",
-    b"=======\r\n",
-    b"=======\n",
-    b">>>>>>> ",
-];
+const START_PATTERN: &[u8] = b"<<<<<<< ";
+const ANCESTOR_PATTERN: &[u8] = b"||||||| ";
+const END_PATTERN: &[u8] = b">>>>>>> ";
+const SEPARATOR_PATTERNS: &[&[u8]] = &[b"======= ", b"=======\r\n", b"=======\n"];
 
 #[derive(Parser)]
 #[command(disable_help_subcommand = true)]
@@ -68,29 +65,33 @@ async fn check_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)>
     let mut output = Vec::new();
     let mut line = Vec::new();
     let mut line_number = 1;
+    let mut in_conflict = false;
+    let mut separator_line_number = None;
+
+    let mut report_conflict = |line_number: usize, pattern: &str| {
+        output.extend(conflict_message(filename, line_number, pattern));
+        code = 1;
+    };
 
     while reader.read_until(b'\n', &mut line).await? != 0 {
-        // Check all patterns
-        for pattern in CONFLICT_PATTERNS {
-            if line.starts_with(pattern) {
-                // Don't trim the pattern - display it as-is (minus any line endings)
-                let pattern_display = if pattern.ends_with(b"\r\n") {
-                    &pattern[..pattern.len() - 2]
-                } else if pattern.ends_with(b"\n") {
-                    &pattern[..pattern.len() - 1]
-                } else {
-                    pattern
-                };
-                let pattern_str = str::from_utf8(pattern_display)
-                    .expect("conflict pattern should be valid UTF-8");
-                let error_message = format!(
-                    "{}:{line_number}: Merge conflict string {pattern_str:?} found\n",
-                    filename.display(),
-                );
-                output.extend(error_message.into_bytes());
-                code = 1;
-                break; // Only report one pattern per line
+        if line.starts_with(START_PATTERN) {
+            report_conflict(line_number, "<<<<<<< ");
+            in_conflict = true;
+            separator_line_number = None;
+        } else if in_conflict && line.starts_with(ANCESTOR_PATTERN) {
+            report_conflict(line_number, "||||||| ");
+        } else if in_conflict
+            && SEPARATOR_PATTERNS
+                .iter()
+                .any(|pattern| line.starts_with(pattern))
+        {
+            separator_line_number = Some(line_number);
+        } else if line.starts_with(END_PATTERN) {
+            if let Some(separator_line_number) = separator_line_number.take() {
+                report_conflict(separator_line_number, "=======");
             }
+            report_conflict(line_number, ">>>>>>> ");
+            in_conflict = false;
         }
 
         line.clear();
@@ -98,6 +99,13 @@ async fn check_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)>
     }
 
     Ok((code, output))
+}
+fn conflict_message(filename: &Path, line_number: usize, pattern: &str) -> Vec<u8> {
+    format!(
+        "{}:{line_number}: Merge conflict string {pattern:?} found\n",
+        filename.display(),
+    )
+    .into_bytes()
 }
 
 #[cfg(test)]
@@ -142,19 +150,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_conflict_marker_middle() -> Result<()> {
-        let dir = tempdir()?;
-        let content = b"Some content\n======= \nConflicting line\n";
-        let file_path = create_test_file(&dir, "conflict.txt", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
-        let output_str = String::from_utf8_lossy(&output);
-        assert!(output_str.contains("======= "));
-        Ok(())
-    }
-
-    #[tokio::test]
     async fn test_conflict_marker_end() -> Result<()> {
         let dir = tempdir()?;
         let content = b"Some content\n>>>>>>> branch\nMore content\n";
@@ -184,6 +179,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_diff3_conflict_block() -> Result<()> {
+        let dir = tempdir()?;
+        let content = b"Before conflict\n<<<<<<< HEAD\nOur changes\n||||||| base\nCommon ancestor\n=======\nTheir changes\n>>>>>>> branch\nAfter conflict\n";
+        let file_path = create_test_file(&dir, "conflict.txt", content).await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 1);
+        assert!(!output.is_empty());
+        let output_str = String::from_utf8_lossy(&output);
+        assert!(output_str.contains("<<<<<<< "));
+        assert!(output_str.contains("||||||| "));
+        assert!(output_str.contains("======="));
+        assert!(output_str.contains(">>>>>>> "));
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_conflict_marker_not_at_start() -> Result<()> {
         let dir = tempdir()?;
         let content = b"Some content <<<<<<< HEAD\n";
@@ -198,7 +209,7 @@ mod tests {
     #[tokio::test]
     async fn test_conflict_marker_crlf() -> Result<()> {
         let dir = tempdir()?;
-        let content = b"Some content\r\n=======\r\nConflicting line\r\n";
+        let content = b"Some content\r\n<<<<<<< HEAD\r\nConflicting line\r\n=======\r\nOther line\r\n>>>>>>> branch\r\n";
         let file_path = create_test_file(&dir, "conflict_crlf.txt", content).await?;
         let (code, output) = check_file(Path::new(""), &file_path).await?;
         assert_eq!(code, 1);
@@ -209,11 +220,47 @@ mod tests {
     #[tokio::test]
     async fn test_conflict_marker_lf() -> Result<()> {
         let dir = tempdir()?;
-        let content = b"Some content\n=======\nConflicting line\n";
+        let content =
+            b"Some content\n<<<<<<< HEAD\nConflicting line\n=======\nOther line\n>>>>>>> branch\n";
         let file_path = create_test_file(&dir, "conflict_lf.txt", content).await?;
         let (code, output) = check_file(Path::new(""), &file_path).await?;
         assert_eq!(code, 1);
         assert!(!output.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_separator_not_reported_without_conflict_end() -> Result<()> {
+        let dir = tempdir()?;
+        let content = b"Before conflict\n<<<<<<< HEAD\nOur changes\n=======\n";
+        let file_path = create_test_file(&dir, "partial_conflict.txt", content).await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 1);
+        let output_str = String::from_utf8_lossy(&output);
+        assert!(output_str.contains("<<<<<<< "));
+        assert!(!output_str.contains("======="));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_ancestor_not_reported_without_conflict_start() -> Result<()> {
+        let dir = tempdir()?;
+        let content = b"Before conflict\n||||||| base\n";
+        let file_path = create_test_file(&dir, "partial_conflict.txt", content).await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 0);
+        assert!(output.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_rst_heading_is_not_treated_as_conflict() -> Result<()> {
+        let dir = tempdir()?;
+        let content = b"Depends\n=======\n";
+        let file_path = create_test_file(&dir, "doc.rst", content).await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 0);
+        assert!(output.is_empty());
         Ok(())
     }
 

--- a/crates/prek/tests/builtin_hooks.rs
+++ b/crates/prek/tests/builtin_hooks.rs
@@ -1907,6 +1907,14 @@ fn check_merge_conflict_hook() -> Result<()> {
         Conflicting line
     "})?;
 
+    cwd.child("partial_separator_conflict.txt")
+        .write_str(indoc::indoc! {r"
+        Some content
+        <<<<<<< HEAD
+        Conflicting line
+        =======
+    "})?;
+
     context.git_add(".");
 
     // First run: hooks should fail due to conflict markers
@@ -1918,10 +1926,12 @@ fn check_merge_conflict_hook() -> Result<()> {
     - hook id: check-merge-conflict
     - exit code: 1
 
-      partial_conflict.txt:2: Merge conflict string "<<<<<<< " found
+      partial_separator_conflict.txt:2: Merge conflict string "<<<<<<< " found
+      partial_separator_conflict.txt:4: Merge conflict string "=======" found
       conflict.txt:2: Merge conflict string "<<<<<<< " found
       conflict.txt:4: Merge conflict string "=======" found
       conflict.txt:6: Merge conflict string ">>>>>>> " found
+      partial_conflict.txt:2: Merge conflict string "<<<<<<< " found
 
     ----- stderr -----
     "#);
@@ -1934,6 +1944,9 @@ fn check_merge_conflict_hook() -> Result<()> {
     "})?;
 
     cwd.child("partial_conflict.txt")
+        .write_str("Some content\nResolved line\n")?;
+
+    cwd.child("partial_separator_conflict.txt")
         .write_str("Some content\nResolved line\n")?;
 
     context.git_add(".");

--- a/crates/prek/tests/builtin_hooks.rs
+++ b/crates/prek/tests/builtin_hooks.rs
@@ -1952,6 +1952,86 @@ fn check_merge_conflict_hook() -> Result<()> {
 }
 
 #[test]
+fn check_merge_conflict_ignores_rst_headings() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    context.write_pre_commit_config(indoc::indoc! {r"
+        repos:
+          - repo: builtin
+            hooks:
+              - id: check-merge-conflict
+                args: ['--assume-in-merge']
+    "});
+
+    let cwd = context.work_dir();
+    cwd.child("doc.rst").write_str(indoc::indoc! {r"
+        Depends
+        =======
+    "})?;
+
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    check for merge conflicts................................................Passed
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn check_merge_conflict_diff3_hook() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    context.write_pre_commit_config(indoc::indoc! {r"
+        repos:
+          - repo: builtin
+            hooks:
+              - id: check-merge-conflict
+                args: ['--assume-in-merge']
+    "});
+
+    let cwd = context.work_dir();
+    cwd.child("diff3.txt").write_str(indoc::indoc! {r"
+        Before conflict
+        <<<<<<< HEAD
+        Our changes
+        ||||||| base
+        Common ancestor
+        =======
+        Their changes
+        >>>>>>> branch
+        After conflict
+    "})?;
+
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    check for merge conflicts................................................Failed
+    - hook id: check-merge-conflict
+    - exit code: 1
+
+      diff3.txt:2: Merge conflict string "<<<<<<< " found
+      diff3.txt:4: Merge conflict string "||||||| " found
+      diff3.txt:6: Merge conflict string "=======" found
+      diff3.txt:8: Merge conflict string ">>>>>>> " found
+
+    ----- stderr -----
+    "#);
+
+    Ok(())
+}
+
+#[test]
 fn check_merge_conflict_without_assume_flag() -> Result<()> {
     let context = TestContext::new();
     context.init_project();

--- a/docs/builtin.md
+++ b/docs/builtin.md
@@ -455,7 +455,7 @@ Checks for merge conflict markers.
 - By default, this hook exits successfully when not in a merge/rebase state.
 - Detects conflict markers only when they appear at the start of a line.
 - Detects standard conflict blocks (`<<<<<<<`, `=======`, `>>>>>>>`) and diff3 ancestor markers (`|||||||`).
-- `=======` is only reported when it appears inside a conflict block, which avoids false positives for content such as reStructuredText headings.
+- `=======` is only reported after a preceding `<<<<<<<`, which avoids false positives for content such as reStructuredText headings.
 
 ---
 

--- a/docs/builtin.md
+++ b/docs/builtin.md
@@ -443,7 +443,7 @@ Detects files staged as regular files whose `HEAD` version is a symlink, which u
 
 #### `check-merge-conflict`
 
-Checks for merge conflict strings.
+Checks for merge conflict markers.
 
 **Supported arguments** (compatible with `pre-commit-hooks`):
 
@@ -453,7 +453,9 @@ Checks for merge conflict strings.
 **Caveats**
 
 - By default, this hook exits successfully when not in a merge/rebase state.
-- Detects common conflict markers only when they appear at the start of a line.
+- Detects conflict markers only when they appear at the start of a line.
+- Detects standard conflict blocks (`<<<<<<<`, `=======`, `>>>>>>>`) and diff3 ancestor markers (`|||||||`).
+- `=======` is only reported when it appears inside a conflict block, which avoids false positives for content such as reStructuredText headings.
 
 ---
 


### PR DESCRIPTION
## Summary

- make `check-merge-conflict` detect conflict blocks contextually instead of flagging any bare `=======`
- add support for diff3 ancestor markers (`|||||||`)

Closes #1924 
Closes #1523 