### PR TITLE
Hide up-to-date output in non-verbose mode

### DIFF
--- a/crates/prek/src/cli/auto_update.rs
+++ b/crates/prek/src/cli/auto_update.rs
@@ -187,7 +187,7 @@ enum DisplayEventKind {
     Update { current: Revision, next: Revision },
     FrozenUpdate { current: String, next: String },
     FrozenRemove { current: String },
-    UpToDate,
+    UpToDate { current: Revision },
     Failure { error: String },
 }
 
@@ -222,6 +222,7 @@ pub(crate) async fn auto_update(
     store: &Store,
     config: Option<PathBuf>,
     filter_repos: Vec<String>,
+    verbose: bool,
     bleeding_edge: bool,
     freeze: bool,
     jobs: usize,
@@ -272,7 +273,8 @@ pub(crate) async fn auto_update(
     // Group results by project config file
     #[expect(clippy::mutable_key_type)]
     let mut project_updates: ProjectUpdates<'_> = FxHashMap::default();
-    let apply_result = apply_repo_updates(outcomes, dry_run, printer, &mut project_updates)?;
+    let apply_result =
+        apply_repo_updates(outcomes, verbose, dry_run, printer, &mut project_updates)?;
 
     if !dry_run {
         for (project, revisions) in project_updates {
@@ -443,7 +445,11 @@ fn format_display_event(kind: &DisplayEventKind, dry_run: bool) -> String {
             format!("{} frozen comment", remove_verb(dry_run)).yellow(),
             current.cyan()
         ),
-        DisplayEventKind::UpToDate => "already up to date".dimmed().to_string(),
+        DisplayEventKind::UpToDate { current } => format!(
+            "{} {}",
+            "already up to date at".dimmed(),
+            format_revision(&current.rev, current.frozen.as_deref())
+        ),
         DisplayEventKind::Failure { error } => {
             format!("{} {error}", "update failed:".red())
         }
@@ -540,6 +546,7 @@ fn write_display_events(
 #[expect(clippy::mutable_key_type)]
 fn apply_repo_updates<'a>(
     updates: Vec<RepoUpdate<'a>>,
+    verbose: bool,
     dry_run: bool,
     printer: Printer,
     project_updates: &mut ProjectUpdates<'a>,
@@ -639,7 +646,7 @@ fn apply_repo_updates<'a>(
                     }
                 }
 
-                if !is_changed && !has_frozen_notice {
+                if verbose && !is_changed && !has_frozen_notice {
                     for usage in &update.target.usages {
                         display_events.push(DisplayEvent {
                             stream: DisplayStream::Stdout,
@@ -647,7 +654,12 @@ fn apply_repo_updates<'a>(
                             repo: update.target.repo,
                             remote_index: usage.remote_index,
                             line_number: usage.rev_line_number,
-                            kind: DisplayEventKind::UpToDate,
+                            kind: DisplayEventKind::UpToDate {
+                                current: Revision {
+                                    rev: update.target.current_rev.to_string(),
+                                    frozen: usage.current_frozen.clone(),
+                                },
+                            },
                         });
                     }
                 }

--- a/crates/prek/src/main.rs
+++ b/crates/prek/src/main.rs
@@ -376,6 +376,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 &store,
                 cli.globals.config,
                 args.repo,
+                cli.globals.verbose > 0,
                 args.bleeding_edge,
                 args.freeze,
                 args.jobs,

--- a/crates/prek/tests/auto_update.rs
+++ b/crates/prek/tests/auto_update.rs
@@ -176,8 +176,6 @@ fn auto_update_already_up_to_date() -> Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    [HOME]/test-repos/up-to-date-repo
-      already up to date
 
     ----- stderr -----
     ");
@@ -194,6 +192,38 @@ fn auto_update_already_up_to_date() -> Result<()> {
             ");
         }
     );
+
+    Ok(())
+}
+
+#[test]
+fn auto_update_already_up_to_date_verbose() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    let repo_path = create_local_git_repo(&context, "up-to-date-repo-verbose", &["v1.0.0"])?;
+
+    context.write_pre_commit_config(&indoc::formatdoc! {r"
+        repos:
+          - repo: {}
+            rev: v1.0.0
+            hooks:
+              - id: test-hook
+    ", repo_path});
+
+    context.git_add(".");
+
+    let filters = context.filters();
+
+    cmd_snapshot!(filters, context.auto_update().arg("-v").arg("--cooldown-days").arg("0"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [HOME]/test-repos/up-to-date-repo-verbose
+      already up to date at `v1.0.0`
+
+    ----- stderr -----
+    ");
 
     Ok(())
 }
@@ -231,7 +261,7 @@ fn auto_update_does_not_rewrite_config_when_up_to_date() -> Result<()> {
         .assert()
         .success();
     let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
-    assert!(stdout.contains("already up to date"));
+    assert!(stdout.is_empty());
 
     let after_secs = std::fs::metadata(config_path.path())?
         .modified()?
@@ -276,9 +306,6 @@ fn auto_update_multiple_repos_mixed() -> Result<()> {
     ----- stdout -----
     [HOME]/test-repos/repo1
       line 3: updating rev `v1.0.0` -> `v1.1.0`
-
-    [HOME]/test-repos/repo2
-      already up to date
 
     ----- stderr -----
     [HOME]/test-repos/repo1
@@ -417,9 +444,6 @@ fn auto_update_specific_repos() -> Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    [HOME]/test-repos/repo1
-      already up to date
-
     [HOME]/test-repos/repo2
       updating rev `v2.0.0` -> `v2.1.0`
 
@@ -1545,9 +1569,6 @@ fn auto_update_workspace() -> Result<()> {
     project-b/.pre-commit-config.yaml
       [HOME]/test-repos/workspace-repo2
         updating rev `v1.0.0` -> `v1.5.0`
-
-      [HOME]/test-repos/workspace-repo3
-        already up to date
 
     ----- stderr -----
     ");


### PR DESCRIPTION
## Summary
- hide `auto-update`'s `already up to date` output unless verbose mode is enabled
- include the current rev in verbose `already up to date` messages
