### PR TITLE
Support Android npm launcher

### DIFF
--- a/npm/bin/prek.js
+++ b/npm/bin/prek.js
@@ -99,6 +99,18 @@ function currentLibc() {
   return isMusl() ? "musl" : "glibc";
 }
 
+function matchesLibc(spec, libc) {
+  if (!spec.libc) {
+    return true;
+  }
+  if (process.platform === "android") {
+    // Android uses Bionic, so currentLibc() returns null. The static musl
+    // binary is the compatible package for Termux.
+    return spec.libc === "musl";
+  }
+  return spec.libc === libc;
+}
+
 function pickPlatformPackage() {
   const libc = currentLibc();
   debug(
@@ -113,7 +125,7 @@ function pickPlatformPackage() {
     if (!spec.cpu.includes(process.arch)) {
       return false;
     }
-    if (spec.libc && spec.libc !== libc) {
+    if (!matchesLibc(spec, libc)) {
       return false;
     }
     if (!matchesArmVersion(spec)) {

--- a/scripts/build-npm-packages.py
+++ b/scripts/build-npm-packages.py
@@ -70,7 +70,13 @@ class PlatformSpec:
             "cpu": self.cpu,
             "files": [self.binary_name, "README.md", "LICENSE"],
         }
-        if self.libc is not None:
+        # Only emit package-level libc for Linux-only specs. npm checks this
+        # field before installing optional dependencies and only detects libc
+        # when os == "linux"; Android's libc value is undefined. If the shared
+        # Linux/Android arm64 musl package declared "libc": ["musl"], npm would
+        # reject it on Termux before bin/prek.js can select the static musl
+        # binary. Keep libc in platforms.json for the launcher's matching.
+        if self.libc is not None and self.os == ["linux"]:
             package_json["libc"] = [self.libc]
         return package_json
 
@@ -108,11 +114,13 @@ PLATFORMS = (
         libc="glibc",
     ),
     PlatformSpec(
+        # Android/Termux reports process.platform as "android", but the
+        # statically linked aarch64 Linux musl binary runs there.
         rust_target="aarch64-unknown-linux-musl",
         package_name="@j178/prek-linux-arm64-musl",
         archive_file="prek-aarch64-unknown-linux-musl.tar.gz",
         binary_name="prek",
-        os=["linux"],
+        os=["linux", "android"],
         cpu=["arm64"],
         libc="musl",
     ),


### PR DESCRIPTION
Allow the existing `@j178/prek-linux-arm64-musl` package to cover Android/Termux, and omit package-level `libc` metadata for that shared package so npm can install it before the launcher selects the static musl binary.

Closes #1977