### PR TITLE
Use dedicated Android npm package

### DIFF
--- a/npm/bin/prek.js
+++ b/npm/bin/prek.js
@@ -99,18 +99,6 @@ function currentLibc() {
   return isMusl() ? "musl" : "glibc";
 }
 
-function matchesLibc(spec, libc) {
-  if (!spec.libc) {
-    return true;
-  }
-  if (process.platform === "android") {
-    // Android uses Bionic, so currentLibc() returns null. The static musl
-    // binary is the compatible package for Termux.
-    return spec.libc === "musl";
-  }
-  return spec.libc === libc;
-}
-
 function pickPlatformPackage() {
   const libc = currentLibc();
   debug(
@@ -125,7 +113,7 @@ function pickPlatformPackage() {
     if (!spec.cpu.includes(process.arch)) {
       return false;
     }
-    if (!matchesLibc(spec, libc)) {
+    if (spec.libc && spec.libc !== libc) {
       return false;
     }
     if (!matchesArmVersion(spec)) {

--- a/scripts/build-npm-packages.py
+++ b/scripts/build-npm-packages.py
@@ -70,13 +70,7 @@ class PlatformSpec:
             "cpu": self.cpu,
             "files": [self.binary_name, "README.md", "LICENSE"],
         }
-        # Only emit package-level libc for Linux-only specs. npm checks this
-        # field before installing optional dependencies and only detects libc
-        # when os == "linux"; Android's libc value is undefined. If the shared
-        # Linux/Android arm64 musl package declared "libc": ["musl"], npm would
-        # reject it on Termux before bin/prek.js can select the static musl
-        # binary. Keep libc in platforms.json for the launcher's matching.
-        if self.libc is not None and self.os == ["linux"]:
+        if self.libc is not None:
             package_json["libc"] = [self.libc]
         return package_json
 
@@ -114,15 +108,25 @@ PLATFORMS = (
         libc="glibc",
     ),
     PlatformSpec(
-        # Android/Termux reports process.platform as "android", but the
-        # statically linked aarch64 Linux musl binary runs there.
         rust_target="aarch64-unknown-linux-musl",
         package_name="@j178/prek-linux-arm64-musl",
         archive_file="prek-aarch64-unknown-linux-musl.tar.gz",
         binary_name="prek",
-        os=["linux", "android"],
+        os=["linux"],
         cpu=["arm64"],
         libc="musl",
+    ),
+    PlatformSpec(
+        # Android/Termux reports process.platform as "android" and uses
+        # Bionic, not glibc or musl. Reuse the static Linux musl artifact via a
+        # dedicated package with no package-level libc restriction so npm can
+        # install it on Android.
+        rust_target="aarch64-unknown-linux-musl",
+        package_name="@j178/prek-android-arm64",
+        archive_file="prek-aarch64-unknown-linux-musl.tar.gz",
+        binary_name="prek",
+        os=["android"],
+        cpu=["arm64"],
     ),
     PlatformSpec(
         rust_target="armv7-unknown-linux-gnueabihf",


### PR DESCRIPTION
Revert the shared Linux/Android musl package handling from 7f44e09982ce8aa6b51ee14d639e7b211e521704.

Add a dedicated `@j178/prek-android-arm64` platform spec that reuses the `aarch64-unknown-linux-musl` artifact without package-level libc metadata, so npm can install it on Android/Termux.

Follow-up to #1977