### PR TITLE
Add `auto-update --exclude-repo <repo>` to skip repos

### DIFF
--- a/crates/prek/src/cli/auto_update/mod.rs
+++ b/crates/prek/src/cli/auto_update/mod.rs
@@ -213,6 +213,7 @@ pub(crate) async fn auto_update(
     store: &Store,
     config: Option<PathBuf>,
     filter_repos: Vec<String>,
+    exclude_repos: Vec<String>,
     verbose: bool,
     bleeding_edge: bool,
     freeze: bool,
@@ -231,7 +232,8 @@ pub(crate) async fn auto_update(
 
     let repo_sources = collect_repo_sources(&workspace)?;
     let sources = repo_sources.iter().filter(|repo_source| {
-        filter_repos.is_empty() || filter_repos.iter().any(|repo| repo == repo_source.repo)
+        (filter_repos.is_empty() || filter_repos.iter().any(|repo| repo == repo_source.repo))
+            && !exclude_repos.iter().any(|repo| repo == repo_source.repo)
     });
     let outcomes: Vec<RepoUpdate<'_>> = futures::stream::iter(sources)
         .map(async |repo_source| {

--- a/crates/prek/src/cli/mod.rs
+++ b/crates/prek/src/cli/mod.rs
@@ -710,8 +710,11 @@ pub(crate) struct AutoUpdateArgs {
     #[arg(long)]
     pub(crate) freeze: bool,
     /// Only update this repository. This option may be specified multiple times.
-    #[arg(long)]
+    #[arg(long, value_name = "REPO", conflicts_with = "exclude_repo")]
     pub(crate) repo: Vec<String>,
+    /// Do not update this repository. This option may be specified multiple times.
+    #[arg(long, value_name = "REPO")]
+    pub(crate) exclude_repo: Vec<String>,
     /// Do not write changes to the config file, only display what would be changed.
     #[arg(long)]
     pub(crate) dry_run: bool,

--- a/crates/prek/src/main.rs
+++ b/crates/prek/src/main.rs
@@ -376,6 +376,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 &store,
                 cli.globals.config,
                 args.repo,
+                args.exclude_repo,
                 cli.globals.verbose > 0,
                 args.bleeding_edge,
                 args.freeze,

--- a/crates/prek/tests/auto_update.rs
+++ b/crates/prek/tests/auto_update.rs
@@ -471,6 +471,64 @@ fn auto_update_specific_repos() -> Result<()> {
 }
 
 #[test]
+fn auto_update_exclude_repo_skips_fetching_repo() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    let repo_path = create_local_git_repo(&context, "included-repo", &["v1.0.0", "v1.1.0"])?;
+    let missing_repo_path = context
+        .home_dir()
+        .child("test-repos/missing-repo")
+        .to_string_lossy()
+        .to_string();
+
+    context.write_pre_commit_config(&indoc::formatdoc! {r"
+        repos:
+          - repo: {}
+            rev: v1.0.0
+            hooks:
+              - id: test-hook
+          - repo: {}
+            rev: v9.9.9
+            hooks:
+              - id: another-hook
+    ", repo_path, missing_repo_path});
+
+    context.git_add(".");
+
+    let filters = context.filters();
+
+    cmd_snapshot!(filters.clone(), context.auto_update().arg("--exclude-repo").arg(&missing_repo_path).arg("--cooldown-days").arg("0"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [HOME]/test-repos/included-repo
+      updating rev `v1.0.0` -> `v1.1.0`
+
+    ----- stderr -----
+    ");
+
+    insta::with_settings!(
+        { filters => filters.clone() },
+        {
+            assert_snapshot!(context.read(PRE_COMMIT_CONFIG_YAML), @"
+            repos:
+              - repo: [HOME]/test-repos/included-repo
+                rev: v1.1.0
+                hooks:
+                  - id: test-hook
+              - repo: [HOME]/test-repos/missing-repo
+                rev: v9.9.9
+                hooks:
+                  - id: another-hook
+            ");
+        }
+    );
+
+    Ok(())
+}
+
+#[test]
 fn auto_update_bleeding_edge() -> Result<()> {
     let context = TestContext::new();
     context.init_project();

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -563,6 +563,7 @@ prek auto-update [OPTIONS]
 </dd><dt id="prek-auto-update--cooldown-days"><a href="#prek-auto-update--cooldown-days"><code>--cooldown-days</code></a> <i>days</i></dt><dd><p>Minimum release age (in days) required for a version to be eligible.</p>
 <p>The age is computed from the tag creation timestamp for annotated tags, or from the tagged commit timestamp for lightweight tags. A value of <code>0</code> disables this check.</p>
 <p>[default: 0]</p></dd><dt id="prek-auto-update--dry-run"><a href="#prek-auto-update--dry-run"><code>--dry-run</code></a></dt><dd><p>Do not write changes to the config file, only display what would be changed</p>
+</dd><dt id="prek-auto-update--exclude-repo"><a href="#prek-auto-update--exclude-repo"><code>--exclude-repo</code></a> <i>repo</i></dt><dd><p>Do not update this repository. This option may be specified multiple times</p>
 </dd><dt id="prek-auto-update--freeze"><a href="#prek-auto-update--freeze"><code>--freeze</code></a></dt><dd><p>Store &quot;frozen&quot; hashes in <code>rev</code> instead of tag names</p>
 </dd><dt id="prek-auto-update--help"><a href="#prek-auto-update--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Display the concise help for this command</p>
 </dd><dt id="prek-auto-update--jobs"><a href="#prek-auto-update--jobs"><code>--jobs</code></a>, <code>-j</code> <i>jobs</i></dt><dd><p>Number of threads to use</p>


### PR DESCRIPTION
Adds `prek auto-update --exclude-repo <repo>` as an opt-out repository filter.

The new flag can be repeated and is applied before repository fetches are scheduled, so skipped repositories are not cloned or evaluated.

Closes #1972