### PR TITLE
Add `auto-update --exit-code` to exit with non-zero on updates

### DIFF
--- a/crates/prek/src/cli/auto_update/mod.rs
+++ b/crates/prek/src/cli/auto_update/mod.rs
@@ -324,7 +324,7 @@ pub(crate) async fn auto_update(
     freeze: bool,
     jobs: usize,
     dry_run: bool,
-    check: bool,
+    exit_code: bool,
     cooldown_days: u8,
     printer: Printer,
 ) -> Result<ExitStatus> {
@@ -380,7 +380,7 @@ pub(crate) async fn auto_update(
         }
     }
 
-    if apply_result.failure || (check && apply_result.has_updates) {
+    if apply_result.failure || (exit_code && apply_result.has_updates) {
         return Ok(ExitStatus::Failure);
     }
     Ok(ExitStatus::Success)

--- a/crates/prek/src/cli/mod.rs
+++ b/crates/prek/src/cli/mod.rs
@@ -745,7 +745,10 @@ pub(crate) struct AutoUpdateArgs {
     /// Do not write changes to the config file, only display what would be changed.
     #[arg(long)]
     pub(crate) dry_run: bool,
-    /// Alias of `--dry-run` that exits with status 1 if updates would be made.
+    /// Exit with status 1 if updates are available.
+    #[arg(long)]
+    pub(crate) exit_code: bool,
+    /// Alias of `--dry-run --exit-code`.
     #[arg(long)]
     pub(crate) check: bool,
     /// Number of threads to use.

--- a/crates/prek/src/main.rs
+++ b/crates/prek/src/main.rs
@@ -386,7 +386,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.freeze,
                 args.jobs,
                 args.dry_run || args.check,
-                args.check,
+                args.exit_code || args.check,
                 args.cooldown_days,
                 printer,
             )

--- a/crates/prek/tests/auto_update.rs
+++ b/crates/prek/tests/auto_update.rs
@@ -2075,6 +2075,148 @@ fn auto_update_check() -> Result<()> {
 }
 
 #[test]
+fn auto_update_dry_run_exit_code() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    let repo_path = create_local_git_repo(
+        &context,
+        "dry-run-exit-code-test-repo",
+        &["v1.0.0", "v1.1.0", "v2.0.0"],
+    )?;
+
+    context.write_pre_commit_config(&indoc::formatdoc! {r"
+        repos:
+          - repo: {}
+            rev: v1.0.0
+            hooks:
+              - id: test-hook
+    ", repo_path});
+    context.git_add(".");
+
+    let filters = context.filters();
+
+    cmd_snapshot!(filters.clone(), context.auto_update().arg("--dry-run").arg("--exit-code").arg("--cooldown-days").arg("0"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    [HOME]/test-repos/dry-run-exit-code-test-repo
+      would update rev `v1.0.0` -> `v2.0.0`
+
+    ----- stderr -----
+    ");
+
+    insta::with_settings!(
+        { filters => filters.clone() },
+        {
+            assert_snapshot!(context.read(PRE_COMMIT_CONFIG_YAML), @"
+            repos:
+              - repo: [HOME]/test-repos/dry-run-exit-code-test-repo
+                rev: v1.0.0
+                hooks:
+                  - id: test-hook
+            ");
+        }
+    );
+
+    Ok(())
+}
+
+#[test]
+fn auto_update_exit_code_updates_config() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    let repo_path = create_local_git_repo(
+        &context,
+        "exit-code-test-repo",
+        &["v1.0.0", "v1.1.0", "v2.0.0"],
+    )?;
+
+    context.write_pre_commit_config(&indoc::formatdoc! {r"
+        repos:
+          - repo: {}
+            rev: v1.0.0
+            hooks:
+              - id: test-hook
+    ", repo_path});
+    context.git_add(".");
+
+    let filters = context.filters();
+
+    cmd_snapshot!(filters.clone(), context.auto_update().arg("--exit-code").arg("--cooldown-days").arg("0"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    [HOME]/test-repos/exit-code-test-repo
+      updating rev `v1.0.0` -> `v2.0.0`
+
+    ----- stderr -----
+    ");
+
+    insta::with_settings!(
+        { filters => filters.clone() },
+        {
+            assert_snapshot!(context.read(PRE_COMMIT_CONFIG_YAML), @"
+            repos:
+              - repo: [HOME]/test-repos/exit-code-test-repo
+                rev: v2.0.0
+                hooks:
+                  - id: test-hook
+            ");
+        }
+    );
+
+    Ok(())
+}
+
+#[test]
+fn auto_update_exit_code_succeeds_when_up_to_date() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    let repo_path = create_local_git_repo(
+        &context,
+        "exit-code-up-to-date-test-repo",
+        &["v1.0.0", "v2.0.0"],
+    )?;
+
+    context.write_pre_commit_config(&indoc::formatdoc! {r"
+        repos:
+          - repo: {}
+            rev: v2.0.0
+            hooks:
+              - id: test-hook
+    ", repo_path});
+    context.git_add(".");
+
+    let filters = context.filters();
+
+    cmd_snapshot!(filters.clone(), context.auto_update().arg("--exit-code").arg("--cooldown-days").arg("0"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+
+    insta::with_settings!(
+        { filters => filters.clone() },
+        {
+            assert_snapshot!(context.read(PRE_COMMIT_CONFIG_YAML), @"
+            repos:
+              - repo: [HOME]/test-repos/exit-code-up-to-date-test-repo
+                rev: v2.0.0
+                hooks:
+                  - id: test-hook
+            ");
+        }
+    );
+
+    Ok(())
+}
+
+#[test]
 fn quoting_float_like_version_number() -> Result<()> {
     let context = TestContext::new();
     context.init_project();

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -552,7 +552,7 @@ prek auto-update [OPTIONS]
 
 <dl class="cli-reference"><dt id="prek-auto-update--bleeding-edge"><a href="#prek-auto-update--bleeding-edge"><code>--bleeding-edge</code></a></dt><dd><p>Update to the bleeding edge of the default branch instead of the latest tagged version</p>
 </dd><dt id="prek-auto-update--cd"><a href="#prek-auto-update--cd"><code>--cd</code></a>, <code>-C</code> <i>dir</i></dt><dd><p>Change to directory before running</p>
-</dd><dt id="prek-auto-update--check"><a href="#prek-auto-update--check"><code>--check</code></a></dt><dd><p>Alias of <code>--dry-run</code> that exits with status 1 if updates would be made</p>
+</dd><dt id="prek-auto-update--check"><a href="#prek-auto-update--check"><code>--check</code></a></dt><dd><p>Alias of <code>--dry-run --exit-code</code></p>
 </dd><dt id="prek-auto-update--color"><a href="#prek-auto-update--color"><code>--color</code></a> <i>color</i></dt><dd><p>Whether to use color in output</p>
 <p>May also be set with the <code>PREK_COLOR</code> environment variable.</p><p>[default: auto]</p><p>Possible values:</p>
 <ul>
@@ -566,6 +566,7 @@ prek auto-update [OPTIONS]
 </dd><dt id="prek-auto-update--exclude-repo"><a href="#prek-auto-update--exclude-repo"><code>--exclude-repo</code></a> <i>repo</i></dt><dd><p>Do not update this repository. This option may be specified multiple times</p>
 </dd><dt id="prek-auto-update--exclude-tag"><a href="#prek-auto-update--exclude-tag"><code>--exclude-tag</code></a> <i>pattern</i></dt><dd><p>Ignore tags matching this glob pattern. This option may be specified multiple times.</p>
 <p>For example, use <code>--exclude-tag nightly</code> to skip a moving tag, or <code>--exclude-tag '*-{alpha,beta,rc}*'</code> to skip common prerelease tags.</p>
+</dd><dt id="prek-auto-update--exit-code"><a href="#prek-auto-update--exit-code"><code>--exit-code</code></a></dt><dd><p>Exit with status 1 if updates are available</p>
 </dd><dt id="prek-auto-update--freeze"><a href="#prek-auto-update--freeze"><code>--freeze</code></a></dt><dd><p>Store &quot;frozen&quot; hashes in <code>rev</code> instead of tag names</p>
 </dd><dt id="prek-auto-update--help"><a href="#prek-auto-update--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Display the concise help for this command</p>
 </dd><dt id="prek-auto-update--include-tag"><a href="#prek-auto-update--include-tag"><code>--include-tag</code></a> <i>pattern</i></dt><dd><p>Only consider tags matching this glob pattern. This option may be specified multiple times.</p>

--- a/docs/diff.md
+++ b/docs/diff.md
@@ -54,7 +54,7 @@ For a compatibility-focused command mapping, see [Compatibility with pre-commit]
 - `prek auto-update` updates all projects in the workspace to their latest revisions.
 - `prek auto-update` checks updates for the same repository only once, speeding up the process in workspace mode.
 - `prek auto-update` supports `--dry-run` to preview the updates without applying them.
-- `prek auto-update` supports `--check` to exit non-zero when updates are available or frozen-reference mismatches are found, without rewriting the config.
+- `prek auto-update` supports `--exit-code` to exit non-zero when updates are available, and `--check` as an alias for `--dry-run --exit-code`.
 - `prek auto-update` validates pinned SHA revisions against fetched upstream refs, including impostor-commit detection, and keeps stale `# frozen:` comments in sync when it can.
 - `prek auto-update` supports the `--cooldown-days` option to skip releases newer than the specified number of days (based on the tag creation timestamp for annotated tags, or the tagged commit timestamp for lightweight tags).
 - `prek auto-update` supports `--exclude-repo` to skip selected repositories while updating everything else.


### PR DESCRIPTION
## Summary

- add `prek auto-update --exit-code` to return status 1 when updates are available
- keep `--check` as an alias for `--dry-run --exit-code`

Closes #2001