### PR TITLE
Preserve non-UTF8 filenames from git

### DIFF
--- a/crates/prek-identify/src/lib.rs
+++ b/crates/prek-identify/src/lib.rs
@@ -18,13 +18,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-use std::borrow::Cow;
 use std::io::{BufRead, Read};
 use std::ops::BitOrAssign;
 use std::path::Path;
 
 #[cfg(feature = "serde")]
 use serde::de::{Error as DeError, SeqAccess, Visitor};
+#[cfg(any(feature = "serde", feature = "schemars"))]
+use std::borrow::Cow;
 
 pub mod tags;
 
@@ -300,19 +301,17 @@ pub fn tags_from_path(path: &Path) -> Result<TagSet, Error> {
 
 fn tags_from_filename(filename: &Path) -> TagSet {
     let ext = filename.extension().and_then(|ext| ext.to_str());
-    let filename = filename
+    let mut result = filename
         .file_name()
         .and_then(|name| name.to_str())
-        .expect("Invalid filename");
-
-    let mut result = tags::NAMES
-        .get(filename)
-        .or_else(|| {
-            // Allow e.g. "Dockerfile.xenial" to match "Dockerfile".
-            filename
-                .split('.')
-                .next()
-                .and_then(|name| tags::NAMES.get(name))
+        .and_then(|filename| {
+            tags::NAMES.get(filename).or_else(|| {
+                // Allow e.g. "Dockerfile.xenial" to match "Dockerfile".
+                filename
+                    .split('.')
+                    .next()
+                    .and_then(|name| tags::NAMES.get(name))
+            })
         })
         .copied()
         .unwrap_or_default();
@@ -595,6 +594,17 @@ mod tests {
 
         let tags = super::tags_from_filename(Path::new("Tiltfile.dev"));
         assert_tagset(&tags, &["text", "tiltfile"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn tags_from_non_utf8_filename_uses_utf8_extension_when_available() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt as _;
+
+        let tags = super::tags_from_filename(Path::new(OsStr::from_bytes(b"bad-\xff.py")));
+
+        assert_tagset(&tags, &["python", "text"]);
     }
 
     #[test]

--- a/crates/prek/src/cli/auto_update/mod.rs
+++ b/crates/prek/src/cli/auto_update/mod.rs
@@ -187,19 +187,19 @@ impl TagFilters {
     /// Repo-specific include filters override global include filters for that repo.
     fn is_included(&self, repo: &str, tag: &str) -> bool {
         if let Some(repo_include) = self.repo_include.get(repo) {
-            return repo_include.is_empty() || repo_include.is_match(tag);
+            return repo_include.is_empty() || repo_include.is_match(Path::new(tag));
         }
 
-        self.global_include.is_empty() || self.global_include.is_match(tag)
+        self.global_include.is_empty() || self.global_include.is_match(Path::new(tag))
     }
 
     /// Returns whether a tag matches any global or repo-specific exclude filter.
     fn is_excluded(&self, repo: &str, tag: &str) -> bool {
-        self.global_exclude.is_match(tag)
+        self.global_exclude.is_match(Path::new(tag))
             || self
                 .repo_exclude
                 .get(repo)
-                .is_some_and(|set| set.is_match(tag))
+                .is_some_and(|set| set.is_match(Path::new(tag)))
     }
 }
 

--- a/crates/prek/src/cli/run/filter.rs
+++ b/crates/prek/src/cli/run/filter.rs
@@ -27,9 +27,6 @@ impl<'a> FilenameFilter<'a> {
     }
 
     pub(crate) fn filter(&self, filename: &Path) -> bool {
-        let Some(filename) = filename.to_str() else {
-            return false;
-        };
         if let Some(pattern) = &self.include {
             if !pattern.is_match(filename) {
                 return false;
@@ -399,6 +396,10 @@ mod tests {
         FilePattern::Glob(GlobPatterns::new(vec![pattern.to_string()]).unwrap())
     }
 
+    fn regex_pattern(pattern: &str) -> FilePattern {
+        FilePattern::regex(pattern).unwrap()
+    }
+
     #[test]
     fn filename_filter_supports_glob_include_and_exclude() {
         let include = glob_pattern("src/**/*.rs");
@@ -408,5 +409,48 @@ mod tests {
         assert!(filter.filter(Path::new("src/lib/main.rs")));
         assert!(!filter.filter(Path::new("src/lib/ignored.rs")));
         assert!(!filter.filter(Path::new("tests/main.rs")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn filename_filter_allows_non_utf8_paths_without_patterns() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt as _;
+
+        let path = Path::new(OsStr::from_bytes(b"bad-\xff.py"));
+        let filter = FilenameFilter::new(None, None);
+
+        assert!(filter.filter(path));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn filename_filter_matches_non_utf8_paths_with_glob_patterns() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt as _;
+
+        let include = glob_pattern("**/*.py");
+        let exclude = glob_pattern("**/*.py");
+        let path = Path::new(OsStr::from_bytes(b"bad-\xff.py"));
+        let filter = FilenameFilter::new(Some(&include), None);
+
+        assert!(filter.filter(path));
+
+        let filter = FilenameFilter::new(None, Some(&exclude));
+
+        assert!(!filter.filter(path));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn filename_filter_skips_non_utf8_paths_with_regex_include() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt as _;
+
+        let include = regex_pattern(r".*\.py$");
+        let path = Path::new(OsStr::from_bytes(b"bad-\xff.py"));
+        let filter = FilenameFilter::new(Some(&include), None);
+
+        assert!(!filter.filter(path));
     }
 }

--- a/crates/prek/src/config.rs
+++ b/crates/prek/src/config.rs
@@ -40,8 +40,8 @@ impl GlobPatterns {
         self.patterns.is_empty()
     }
 
-    pub(crate) fn is_match(&self, value: &str) -> bool {
-        self.set.is_match(Path::new(value))
+    pub(crate) fn is_match(&self, path: &Path) -> bool {
+        self.set.is_match(path)
     }
 }
 
@@ -182,19 +182,22 @@ pub(crate) enum FilePattern {
 }
 
 impl FilePattern {
-    pub(crate) fn new_glob(patterns: Vec<String>) -> Result<Self, globset::Error> {
+    pub(crate) fn glob(patterns: Vec<String>) -> Result<Self, globset::Error> {
         Ok(Self::Glob(GlobPatterns::new(patterns)?))
     }
 
-    pub(crate) fn new_regex(pattern: &str) -> Result<Self, fancy_regex::Error> {
+    pub(crate) fn regex(pattern: &str) -> Result<Self, fancy_regex::Error> {
         Ok(Self::Regex(Regex::new(pattern)?))
     }
 
-    pub(crate) fn is_match(&self, str: &str) -> bool {
+    pub(crate) fn is_match(&self, path: &Path) -> bool {
         match self {
             FilePattern::Never => false,
-            FilePattern::Regex(regex) => regex.is_match(str).unwrap_or(false),
-            FilePattern::Glob(globs) => globs.is_match(str),
+            // Regex patterns are text matchers; globs can match OS paths directly.
+            FilePattern::Regex(regex) => path
+                .to_str()
+                .is_some_and(|path| regex.is_match(path).unwrap_or(false)),
+            FilePattern::Glob(globs) => globs.is_match(path),
         }
     }
 }
@@ -1460,9 +1463,9 @@ mod tests {
             matches!(parsed.files, FilePattern::Regex(_)),
             "expected regex pattern"
         );
-        assert!(parsed.files.is_match("src/main.rs"));
-        assert!(!parsed.files.is_match("other/main.rs"));
-        assert!(parsed.exclude.is_match("target/debug/app"));
+        assert!(parsed.files.is_match(Path::new("src/main.rs")));
+        assert!(!parsed.files.is_match(Path::new("other/main.rs")));
+        assert!(parsed.exclude.is_match(Path::new("target/debug/app")));
 
         let glob_yaml = indoc::indoc! {r"
             files:
@@ -1476,10 +1479,10 @@ mod tests {
             matches!(parsed.files, FilePattern::Glob(_)),
             "expected glob pattern"
         );
-        assert!(parsed.files.is_match("src/lib/main.rs"));
-        assert!(!parsed.files.is_match("src/lib/main.py"));
-        assert!(parsed.exclude.is_match("target/debug/app"));
-        assert!(!parsed.exclude.is_match("src/lib/main.rs"));
+        assert!(parsed.files.is_match(Path::new("src/lib/main.rs")));
+        assert!(!parsed.files.is_match(Path::new("src/lib/main.py")));
+        assert!(parsed.exclude.is_match(Path::new("target/debug/app")));
+        assert!(!parsed.exclude.is_match(Path::new("src/lib/main.rs")));
 
         let glob_list_yaml = indoc::indoc! {r"
             files:
@@ -1493,11 +1496,11 @@ mod tests {
         "};
         let parsed: Wrapper =
             serde_saphyr::from_str(glob_list_yaml).expect("glob list patterns should parse");
-        assert!(parsed.files.is_match("src/lib/main.rs"));
-        assert!(parsed.files.is_match("crates/foo/src/lib.rs"));
-        assert!(!parsed.files.is_match("tests/main.rs"));
-        assert!(parsed.exclude.is_match("target/debug/app"));
-        assert!(parsed.exclude.is_match("dist/app"));
+        assert!(parsed.files.is_match(Path::new("src/lib/main.rs")));
+        assert!(parsed.files.is_match(Path::new("crates/foo/src/lib.rs")));
+        assert!(!parsed.files.is_match(Path::new("tests/main.rs")));
+        assert!(parsed.exclude.is_match(Path::new("target/debug/app")));
+        assert!(parsed.exclude.is_match(Path::new("dist/app")));
     }
 
     #[test]
@@ -1512,24 +1515,24 @@ mod tests {
             pattern.to_string(),
             "glob: [src/**/*.rs, crates/**/src/**/*.rs]"
         );
-        assert!(pattern.is_match("src/main.rs"));
-        assert!(pattern.is_match("crates/foo/src/lib.rs"));
-        assert!(!pattern.is_match("tests/main.rs"));
+        assert!(pattern.is_match(Path::new("src/main.rs")));
+        assert!(pattern.is_match(Path::new("crates/foo/src/lib.rs")));
+        assert!(!pattern.is_match(Path::new("tests/main.rs")));
     }
 
     #[test]
     fn file_pattern_never_matches() {
         let pattern = FilePattern::Never;
-        assert!(!pattern.is_match(""));
-        assert!(!pattern.is_match("foo.txt"));
-        assert!(!pattern.is_match("nested/path.rs"));
+        assert!(!pattern.is_match(Path::new("")));
+        assert!(!pattern.is_match(Path::new("foo.txt")));
+        assert!(!pattern.is_match(Path::new("nested/path.rs")));
     }
 
     #[test]
     fn empty_glob_list_matches_nothing() {
         let pattern = serde_saphyr::from_str::<FilePattern>("glob: []").unwrap();
-        assert!(!pattern.is_match("any/file.rs"));
-        assert!(!pattern.is_match(""));
+        assert!(!pattern.is_match(Path::new("any/file.rs")));
+        assert!(!pattern.is_match(Path::new("")));
     }
 
     #[test]

--- a/crates/prek/src/git.rs
+++ b/crates/prek/src/git.rs
@@ -86,8 +86,22 @@ pub(crate) fn git_cmd(summary: &str) -> Result<Cmd, Error> {
 fn zsplit(s: &[u8]) -> Result<Vec<PathBuf>, Utf8Error> {
     s.split(|&b| b == b'\0')
         .filter(|slice| !slice.is_empty())
-        .map(|slice| str::from_utf8(slice).map(PathBuf::from))
+        .map(path_from_git_bytes)
         .collect()
+}
+
+#[cfg(unix)]
+#[expect(clippy::unnecessary_wraps)]
+fn path_from_git_bytes(bytes: &[u8]) -> Result<PathBuf, Utf8Error> {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt as _;
+
+    Ok(PathBuf::from(OsStr::from_bytes(bytes)))
+}
+
+#[cfg(not(unix))]
+fn path_from_git_bytes(bytes: &[u8]) -> Result<PathBuf, Utf8Error> {
+    str::from_utf8(bytes).map(PathBuf::from)
 }
 
 pub(crate) async fn intent_to_add_files(root: &Path) -> Result<Vec<PathBuf>, Error> {
@@ -859,6 +873,20 @@ pub(crate) fn list_submodules(git_root: &Path) -> Result<Vec<PathBuf>, Error> {
 #[cfg(test)]
 mod tests {
     use super::shared_repository_file_mode;
+    #[cfg(unix)]
+    use super::zsplit;
+
+    #[cfg(unix)]
+    #[test]
+    fn zsplit_preserves_non_utf8_paths() {
+        use std::os::unix::ffi::OsStrExt as _;
+
+        let paths = zsplit(b"normal.py\0bad-\xff.py\0").unwrap();
+
+        assert_eq!(paths.len(), 2);
+        assert_eq!(paths[0].as_os_str().as_bytes(), b"normal.py");
+        assert_eq!(paths[1].as_os_str().as_bytes(), b"bad-\xff.py");
+    }
 
     #[test]
     fn shared_repository_group_mode_matches_git_behavior() {

--- a/crates/prek/src/hooks/builtin_hooks/mod.rs
+++ b/crates/prek/src/hooks/builtin_hooks/mod.rs
@@ -164,7 +164,7 @@ impl BuiltinHook {
                         "checks for filenames which cannot be created on Windows.".to_string(),
                     ),
                     files: Some(
-                        FilePattern::new_regex(
+                        FilePattern::regex(
                             check_illegal_windows_names::ILLEGAL_WINDOWS_PATTERN,
                         )
                         .expect("builtin files regex must be valid"),

--- a/crates/prek/src/hooks/meta_hooks.rs
+++ b/crates/prek/src/hooks/meta_hooks.rs
@@ -53,8 +53,7 @@ impl MetaHook {
     pub(crate) fn from_id(id: &str) -> Result<Self, ()> {
         let hook_id = MetaHooks::from_str(id).map_err(|_| ())?;
         let config_file_glob =
-            FilePattern::new_glob(CONFIG_FILENAMES.iter().map(ToString::to_string).collect())
-                .unwrap();
+            FilePattern::glob(CONFIG_FILENAMES.iter().map(ToString::to_string).collect()).unwrap();
 
         Ok(match hook_id {
             MetaHooks::CheckHooksApply => MetaHook {
@@ -146,17 +145,13 @@ fn excludes_any(
     }
 
     files.iter().any(|f| {
-        let Some(f) = f.as_ref().to_str() else {
-            return false; // Skip files that cannot be converted to a string
-        };
-
         if let Some(pattern) = &include {
-            if !pattern.is_match(f) {
+            if !pattern.is_match(f.as_ref()) {
                 return false;
             }
         }
         if let Some(pattern) = &exclude {
-            if !pattern.is_match(f) {
+            if !pattern.is_match(f.as_ref()) {
                 return false;
             }
         }
@@ -271,7 +266,7 @@ mod tests {
     use prek_consts::{PRE_COMMIT_CONFIG_YAML, PRE_COMMIT_CONFIG_YML, PREK_TOML};
 
     fn regex_pattern(pattern: &str) -> FilePattern {
-        FilePattern::new_regex(pattern).unwrap()
+        FilePattern::regex(pattern).unwrap()
     }
 
     #[test]
@@ -299,15 +294,15 @@ mod tests {
     fn meta_hook_patterns_cover_config_files() {
         let apply = MetaHook::from_id("check-hooks-apply").expect("known meta hook");
         let apply_files = apply.options.files.as_ref().expect("files should be set");
-        assert!(apply_files.is_match(PRE_COMMIT_CONFIG_YAML));
-        assert!(apply_files.is_match(PRE_COMMIT_CONFIG_YML));
-        assert!(apply_files.is_match(PREK_TOML));
+        assert!(apply_files.is_match(Path::new(PRE_COMMIT_CONFIG_YAML)));
+        assert!(apply_files.is_match(Path::new(PRE_COMMIT_CONFIG_YML)));
+        assert!(apply_files.is_match(Path::new(PREK_TOML)));
 
         let useless = MetaHook::from_id("check-useless-excludes").expect("known meta hook");
         let useless_files = useless.options.files.as_ref().expect("files should be set");
-        assert!(useless_files.is_match(PRE_COMMIT_CONFIG_YAML));
-        assert!(useless_files.is_match(PRE_COMMIT_CONFIG_YML));
-        assert!(useless_files.is_match(PREK_TOML));
+        assert!(useless_files.is_match(Path::new(PRE_COMMIT_CONFIG_YAML)));
+        assert!(useless_files.is_match(Path::new(PRE_COMMIT_CONFIG_YML)));
+        assert!(useless_files.is_match(Path::new(PREK_TOML)));
 
         let identity = MetaHook::from_id("identity").expect("known meta hook");
         assert!(identity.options.files.is_none());


### PR DESCRIPTION
Preserve raw Git path bytes on Unix so non-UTF8 filenames no longer abort file collection.

Glob filters now match paths directly; regex filters remain UTF-8-only.

Closes #1701 
Closes #649 