### PR TITLE
Generate CI language tests matrix

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,8 +1,4 @@
 [profile.ci-core]
-# Exclude heavy language-specific integration tests from the main CI runs.
-# Keep this as a deny-list so new language test modules run in ci-core until
-# they are deliberately moved to the language-test matrix.
-default-filter = "not binary_id(prek::languages) or (binary_id(prek::languages) and not (test(bun::) or test(dart::) or test(deno::) or test(docker::) or test(docker_image::) or test(dotnet::) or test(golang::) or test(haskell::) or test(julia::) or test(lua::) or test(node::) or test(python::) or test(ruby::) or test(rust::) or test(swift::)))"
 status-level = "skip"
 final-status-level = "slow"
 failure-output = "immediate"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,6 +320,8 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: "Cargo test"
+        env:
+          CI_CORE_FILTER: ${{ needs.plan.outputs.ci-core-filter }}
         run: |
           cargo llvm-cov nextest \
             --lcov \
@@ -328,7 +330,7 @@ jobs:
             --cargo-profile fast-build \
             --profile ci-core \
             --features schemars \
-            -E '${{ needs.plan.outputs.ci-core-filter }}'
+            -E "${CI_CORE_FILTER}"
 
       - name: "Upload coverage reports to Codecov"
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
@@ -389,6 +391,8 @@ jobs:
       - name: "Cargo test"
         working-directory: ${{ env.PREK_WORKSPACE }}
         shell: pwsh
+        env:
+          CI_CORE_FILTER: ${{ needs.plan.outputs.ci-core-filter }}
         run: |
           # Remove msys64 from PATH for Rust compilation
           $env:PATH = ($env:PATH -split ';' | Where-Object { $_ -notmatch '\\msys64\\' }) -join ';'
@@ -400,7 +404,7 @@ jobs:
             --cargo-profile fast-build `
             --features schemars `
             --profile ci-core `
-            -E '${{ needs.plan.outputs.ci-core-filter }}'
+            -E $env:CI_CORE_FILTER
 
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
     outputs:
       test-code: ${{ !contains(github.event.pull_request.labels.*.name, 'test:skip') && (steps.changed.outputs.any_code_changed == 'true' || github.ref == 'refs/heads/master') }}
       save-rust-cache: ${{ github.ref == 'refs/heads/master' || steps.changed.outputs.cache_changed == 'true' }}
+      language-test-matrix: ${{ steps.nextest.outputs.language-test-matrix }}
+      ci-core-filter: ${{ steps.nextest.outputs.ci-core-filter }}
       # Run benchmarks if Rust code or benchmark-related files changed
       run-bench: ${{ !contains(github.event.pull_request.labels.*.name, 'test:skip') && (steps.changed.outputs.rust_code_changed == 'true' || steps.changed.outputs.bench_related_changed == 'true' || github.ref == 'refs/heads/master') }}
     steps:
@@ -102,6 +104,12 @@ jobs:
             echo "rust_code_changed=${RUST_CODE_CHANGED}"
             echo "bench_related_changed=${BENCH_RELATED_CHANGED}"
           } >> "${GITHUB_OUTPUT}"
+
+      - name: "Generate nextest filters"
+        id: nextest
+        shell: bash
+        run: |
+          python3 scripts/generate_ci_matrix.py --group-size 4 --github-output >> "${GITHUB_OUTPUT}"
 
   lint:
     name: "lint"
@@ -319,7 +327,8 @@ jobs:
             --workspace \
             --cargo-profile fast-build \
             --profile ci-core \
-            --features schemars
+            --features schemars \
+            -E '${{ needs.plan.outputs.ci-core-filter }}'
 
       - name: "Upload coverage reports to Codecov"
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
@@ -390,7 +399,8 @@ jobs:
             --workspace `
             --cargo-profile fast-build `
             --features schemars `
-            --profile ci-core
+            --profile ci-core `
+            -E '${{ needs.plan.outputs.ci-core-filter }}'
 
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
@@ -408,62 +418,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      matrix:
-        # Keep platform constraints encoded directly in grouped rows:
-        # Docker only runs on Ubuntu, Swift skips Windows, and Haskell skips macOS.
-        include:
-          - os: ubuntu-latest
-            group: 1
-            languages: bun dart deno
-            filter: test(bun::) or test(dart::) or test(deno::)
-          - os: ubuntu-latest
-            group: 2
-            languages: docker dotnet golang
-            filter: test(docker::) or test(docker_image::) or test(dotnet::) or test(golang::)
-          - os: ubuntu-latest
-            group: 3
-            languages: haskell julia lua
-            filter: test(haskell::) or test(julia::) or test(lua::)
-          - os: ubuntu-latest
-            group: 4
-            languages: node python ruby
-            filter: test(node::) or test(python::) or test(ruby::)
-          - os: ubuntu-latest
-            group: 5
-            languages: rust swift
-            filter: test(rust::) or test(swift::)
-          - os: macos-latest
-            group: 1
-            languages: bun dart deno
-            filter: test(bun::) or test(dart::) or test(deno::)
-          - os: macos-latest
-            group: 2
-            languages: dotnet golang julia
-            filter: test(dotnet::) or test(golang::) or test(julia::)
-          - os: macos-latest
-            group: 3
-            languages: lua node python
-            filter: test(lua::) or test(node::) or test(python::)
-          - os: macos-latest
-            group: 4
-            languages: ruby rust swift
-            filter: test(ruby::) or test(rust::) or test(swift::)
-          - os: windows-latest
-            group: 1
-            languages: bun dart deno
-            filter: test(bun::) or test(dart::) or test(deno::)
-          - os: windows-latest
-            group: 2
-            languages: dotnet golang haskell
-            filter: test(dotnet::) or test(golang::) or test(haskell::)
-          - os: windows-latest
-            group: 3
-            languages: julia lua node
-            filter: test(julia::) or test(lua::) or test(node::)
-          - os: windows-latest
-            group: 4
-            languages: python ruby rust
-            filter: test(python::) or test(ruby::) or test(rust::)
+      matrix: ${{ fromJSON(needs.plan.outputs.language-test-matrix) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/scripts/generate_ci_matrix.py
+++ b/scripts/generate_ci_matrix.py
@@ -1,0 +1,126 @@
+# /// script
+# requires-python = ">=3.11"
+# ///
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+
+LANGUAGE_FILTERS = {
+    "bun": "test(bun::)",
+    "dart": "test(dart::)",
+    "deno": "test(deno::)",
+    "docker": "test(docker::) or test(docker_image::)",
+    "dotnet": "test(dotnet::)",
+    "golang": "test(golang::)",
+    "haskell": "test(haskell::)",
+    "julia": "test(julia::)",
+    "lua": "test(lua::)",
+    "node": "test(node::)",
+    "python": "test(python::)",
+    "ruby": "test(ruby::)",
+    "rust": "test(rust::)",
+    "swift": "test(swift::)",
+}
+
+LANGUAGES = tuple(LANGUAGE_FILTERS)
+
+
+@dataclass(frozen=True)
+class Platform:
+    os: str
+    unsupported_languages: frozenset[str]
+
+    def languages(self) -> list[str]:
+        return [
+            language
+            for language in LANGUAGES
+            if language not in self.unsupported_languages
+        ]
+
+
+PLATFORMS = (
+    # Docker only runs on Ubuntu, Swift skips Windows, and Haskell skips macOS.
+    Platform("ubuntu-latest", frozenset()),
+    Platform("macos-latest", frozenset({"docker", "haskell"})),
+    Platform("windows-latest", frozenset({"docker", "swift"})),
+)
+
+
+def chunks(items: list[str], size: int) -> list[list[str]]:
+    return [items[index : index + size] for index in range(0, len(items), size)]
+
+
+def language_filter(languages: list[str]) -> str:
+    return " or ".join(LANGUAGE_FILTERS[language] for language in languages)
+
+
+def ci_core_filter() -> str:
+    # Exclude heavy language-specific integration tests from the main CI runs.
+    excluded_languages = language_filter(list(LANGUAGES))
+
+    # Keep this as a deny-list so new language test modules run in ci-core until
+    # they are deliberately added to LANGUAGE_FILTERS and the language-test matrix.
+    return (
+        "not binary_id(prek::languages) or "
+        f"(binary_id(prek::languages) and not ({excluded_languages}))"
+    )
+
+
+def generate_language_test_matrix(group_size: int) -> dict[str, list[dict[str, str | int]]]:
+    include = []
+    for platform in PLATFORMS:
+        for group, languages in enumerate(chunks(platform.languages(), group_size), start=1):
+            include.append(
+                {
+                    "os": platform.os,
+                    "group": group,
+                    "languages": " ".join(languages),
+                    "filter": language_filter(languages),
+                }
+            )
+
+    return {"include": include}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate GitHub Actions matrices for CI jobs.",
+    )
+    parser.add_argument(
+        "--group-size",
+        type=int,
+        default=4,
+        help="maximum number of languages per language-test job",
+    )
+    parser.add_argument(
+        "--github-output",
+        action="store_true",
+        help="emit values in GitHub Actions output format",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.group_size < 1:
+        msg = "--group-size must be greater than zero"
+        raise SystemExit(msg)
+
+    language_test_matrix = json.dumps(
+        generate_language_test_matrix(args.group_size),
+        separators=(",", ":"),
+    )
+    core_filter = ci_core_filter()
+
+    if args.github_output:
+        print(f"language-test-matrix={language_test_matrix}")
+        print(f"ci-core-filter={core_filter}")
+    else:
+        print(language_test_matrix)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Generate the language-test matrix and core nextest filter from a Python script so the grouping size and language deny-list stay in one place.