### PR TITLE
Add global auto-update cooldown
    config

### DIFF
--- a/crates/prek-consts/src/env_vars.rs
+++ b/crates/prek-consts/src/env_vars.rs
@@ -35,6 +35,7 @@ impl EnvVars {
 
     // PREK internal environment variables
     pub const PREK_INTERNAL__TEST_DIR: &'static str = "PREK_INTERNAL__TEST_DIR";
+    pub const PREK_INTERNAL__USER_CONFIG_PATH: &'static str = "PREK_INTERNAL__USER_CONFIG_PATH";
     pub const PREK_INTERNAL__SORT_FILENAMES: &'static str = "PREK_INTERNAL__SORT_FILENAMES";
     pub const PREK_INTERNAL__SKIP_POST_CHECKOUT: &'static str = "PREK_INTERNAL__SKIP_POST_CHECKOUT";
     pub const PREK_INTERNAL__RUN_ORIGINAL_PRE_COMMIT: &'static str =

--- a/crates/prek/src/cli/mod.rs
+++ b/crates/prek/src/cli/mod.rs
@@ -757,7 +757,7 @@ pub(crate) struct AutoUpdateArgs {
     /// Minimum release age (in days) required for a version to be eligible.
     ///
     /// The age is computed from the tag creation timestamp for annotated tags, or from the tagged commit timestamp for lightweight tags.
-    /// Defaults to `auto-update.cooldown-days` in the global config, or `0` when unset.
+    /// Defaults to `auto_update.cooldown_days` in the global config, or `0` when unset.
     /// A value of `0` disables this check.
     #[arg(long, value_name = "DAYS", conflicts_with = "bleeding_edge")]
     pub(crate) cooldown_days: Option<u8>,

--- a/crates/prek/src/cli/mod.rs
+++ b/crates/prek/src/cli/mod.rs
@@ -757,14 +757,10 @@ pub(crate) struct AutoUpdateArgs {
     /// Minimum release age (in days) required for a version to be eligible.
     ///
     /// The age is computed from the tag creation timestamp for annotated tags, or from the tagged commit timestamp for lightweight tags.
+    /// Defaults to `auto-update.cooldown-days` in the global config, or `0` when unset.
     /// A value of `0` disables this check.
-    #[arg(
-        long,
-        value_name = "DAYS",
-        default_value_t = 0,
-        conflicts_with = "bleeding_edge"
-    )]
-    pub(crate) cooldown_days: u8,
+    #[arg(long, value_name = "DAYS", conflicts_with = "bleeding_edge")]
+    pub(crate) cooldown_days: Option<u8>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/prek/src/main.rs
+++ b/crates/prek/src/main.rs
@@ -26,6 +26,7 @@ use crate::cli::{
 use crate::cli::{SelfCommand, SelfNamespace, SelfUpdateArgs};
 use crate::printer::Printer;
 use crate::run::USE_COLOR;
+use crate::settings::{AutoUpdateSettings, FilesystemOptions};
 use crate::store::Store;
 
 mod archive;
@@ -49,6 +50,7 @@ mod resource_limit;
 mod run;
 #[cfg(feature = "schemars")]
 mod schema;
+mod settings;
 mod store;
 mod version;
 mod warnings;
@@ -373,6 +375,10 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
         }
         Command::SampleConfig(args) => cli::sample_config(args.file.into(), args.format, printer),
         Command::AutoUpdate(args) => {
+            let filesystem = FilesystemOptions::user()?;
+            let settings = AutoUpdateSettings::resolve(&args, filesystem);
+            show_settings!(settings);
+
             cli::auto_update(
                 &store,
                 cli.globals.config,
@@ -388,7 +394,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.jobs,
                 args.dry_run || args.check,
                 args.exit_code || args.check,
-                args.cooldown_days,
+                settings.cooldown_days,
                 printer,
             )
             .await

--- a/crates/prek/src/main.rs
+++ b/crates/prek/src/main.rs
@@ -376,7 +376,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
         Command::SampleConfig(args) => cli::sample_config(args.file.into(), args.format, printer),
         Command::AutoUpdate(args) => {
             let filesystem = FilesystemOptions::user()?;
-            let settings = AutoUpdateSettings::resolve(&args, filesystem);
+            let settings = AutoUpdateSettings::resolve(&args, filesystem.as_ref());
             show_settings!(settings);
 
             cli::auto_update(

--- a/crates/prek/src/settings.rs
+++ b/crates/prek/src/settings.rs
@@ -73,14 +73,14 @@ impl Deref for FilesystemOptions {
 
 /// Options as represented in the global `prek.toml` file.
 #[derive(Debug, Clone, Default, Deserialize)]
-#[serde(default, deny_unknown_fields, rename_all = "snake_case")]
+#[serde(default, rename_all = "snake_case")]
 pub(crate) struct Options {
     auto_update: Option<AutoUpdateOptions>,
 }
 
 /// Options for the `auto-update` command.
 #[derive(Debug, Clone, Default, Deserialize)]
-#[serde(default, deny_unknown_fields, rename_all = "snake_case")]
+#[serde(default, rename_all = "snake_case")]
 struct AutoUpdateOptions {
     cooldown_days: Option<u8>,
 }
@@ -92,14 +92,14 @@ pub(crate) struct AutoUpdateSettings {
 }
 
 impl AutoUpdateSettings {
-    pub(crate) fn resolve(args: &AutoUpdateArgs, filesystem: Option<FilesystemOptions>) -> Self {
+    pub(crate) fn resolve(args: &AutoUpdateArgs, filesystem: Option<&FilesystemOptions>) -> Self {
         Self {
             cooldown_days: args
                 .cooldown_days
                 .or_else(|| {
                     filesystem
-                        .and_then(|fs| fs.auto_update.clone())
-                        .and_then(|fs| fs.cooldown_days)
+                        .and_then(|fs| fs.auto_update.as_ref())
+                        .and_then(|au| au.cooldown_days)
                 })
                 .unwrap_or_default(),
         }

--- a/crates/prek/src/settings.rs
+++ b/crates/prek/src/settings.rs
@@ -4,11 +4,16 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use etcetera::BaseStrategy;
+use prek_consts::env_vars::EnvVars;
 use serde::Deserialize;
 
 use crate::cli::AutoUpdateArgs;
 
 fn user_config_path() -> Option<PathBuf> {
+    if let Some(path) = EnvVars::var_os(EnvVars::PREK_INTERNAL__USER_CONFIG_PATH) {
+        return Some(PathBuf::from(path));
+    }
+
     etcetera::choose_base_strategy()
         .ok()
         .map(|strategy| strategy.config_dir().join("prek").join("prek.toml"))

--- a/crates/prek/src/settings.rs
+++ b/crates/prek/src/settings.rs
@@ -1,0 +1,107 @@
+use std::io::ErrorKind;
+use std::ops::Deref;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use etcetera::BaseStrategy;
+use serde::Deserialize;
+
+use crate::cli::AutoUpdateArgs;
+
+fn user_config_path() -> Option<PathBuf> {
+    etcetera::choose_base_strategy()
+        .ok()
+        .map(|strategy| strategy.config_dir().join("prek").join("prek.toml"))
+}
+
+/// Options loaded from a user-level `prek.toml` file.
+#[derive(Debug, Clone)]
+pub(crate) struct FilesystemOptions(Options);
+
+impl FilesystemOptions {
+    /// Load user-level options from the platform config directory.
+    pub(crate) fn user() -> Result<Option<Self>> {
+        let Some(path) = user_config_path() else {
+            tracing::trace!(
+                "Skipping global config lookup because no platform config directory was found"
+            );
+            return Ok(None);
+        };
+
+        tracing::trace!(path = %path.display(), "Searching for global config");
+        Self::from_file(&path)
+    }
+
+    fn from_file(path: &Path) -> Result<Option<Self>> {
+        let content = match fs_err::read_to_string(path) {
+            Ok(content) => {
+                tracing::debug!(path = %path.display(), "Read global config");
+                content
+            }
+            Err(err)
+                if matches!(
+                    err.kind(),
+                    ErrorKind::NotFound | ErrorKind::NotADirectory | ErrorKind::PermissionDenied
+                ) =>
+            {
+                tracing::trace!(
+                    path = %path.display(),
+                    "Global config not found or inaccessible, skipping"
+                );
+                return Ok(None);
+            }
+            Err(err) => {
+                return Err(err)
+                    .with_context(|| format!("Failed to read global config `{}`", path.display()));
+            }
+        };
+
+        toml::from_str(&content)
+            .map(Self)
+            .map(Some)
+            .with_context(|| format!("Failed to parse global config `{}`", path.display()))
+    }
+}
+
+impl Deref for FilesystemOptions {
+    type Target = Options;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Options as represented in the global `prek.toml` file.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
+pub(crate) struct Options {
+    auto_update: Option<AutoUpdateOptions>,
+}
+
+/// Options for the `auto-update` command.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
+struct AutoUpdateOptions {
+    cooldown_days: Option<u8>,
+}
+
+/// Resolved settings for the `auto-update` command.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct AutoUpdateSettings {
+    pub(crate) cooldown_days: u8,
+}
+
+impl AutoUpdateSettings {
+    pub(crate) fn resolve(args: &AutoUpdateArgs, filesystem: Option<FilesystemOptions>) -> Self {
+        Self {
+            cooldown_days: args
+                .cooldown_days
+                .or_else(|| {
+                    filesystem
+                        .and_then(|fs| fs.auto_update.clone())
+                        .and_then(|fs| fs.cooldown_days)
+                })
+                .unwrap_or_default(),
+        }
+    }
+}

--- a/crates/prek/src/settings.rs
+++ b/crates/prek/src/settings.rs
@@ -73,14 +73,14 @@ impl Deref for FilesystemOptions {
 
 /// Options as represented in the global `prek.toml` file.
 #[derive(Debug, Clone, Default, Deserialize)]
-#[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
+#[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 pub(crate) struct Options {
     auto_update: Option<AutoUpdateOptions>,
 }
 
 /// Options for the `auto-update` command.
 #[derive(Debug, Clone, Default, Deserialize)]
-#[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
+#[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 struct AutoUpdateOptions {
     cooldown_days: Option<u8>,
 }

--- a/crates/prek/tests/common/mod.rs
+++ b/crates/prek/tests/common/mod.rs
@@ -150,7 +150,6 @@ impl TestContext {
     }
 
     pub fn command(&self) -> Command {
-        let config_home = self.home_dir.child("config");
         let mut cmd = if EnvVars::is_set(EnvVars::PREK_INTERNAL__RUN_ORIGINAL_PRE_COMMIT) {
             // Run the original pre-commit to check compatibility.
             let mut cmd = Command::new("pre-commit");
@@ -170,11 +169,10 @@ impl TestContext {
             cmd
         };
 
-        cmd.env("HOME", &**self.home_dir())
-            .env("USERPROFILE", &**self.home_dir())
-            .env("XDG_CONFIG_HOME", config_home.path())
-            .env("APPDATA", config_home.path())
-            .env("LOCALAPPDATA", &**self.home_dir());
+        cmd.env(
+            EnvVars::PREK_INTERNAL__USER_CONFIG_PATH,
+            self.user_config_path().path(),
+        );
 
         // Disable git autocrlf to avoid line ending issues in tests.
         cmd.env("GIT_CONFIG_COUNT", "1")
@@ -184,15 +182,21 @@ impl TestContext {
         cmd
     }
 
-    pub fn write_global_config(&self, content: &str) {
+    fn user_config_path(&self) -> ChildPath {
+        self.home_dir
+            .child("config")
+            .child("prek")
+            .child("prek.toml")
+    }
+
+    pub fn write_user_config(&self, content: &str) {
         let config_dir = self.home_dir.child("config").child("prek");
         config_dir
             .create_dir_all()
-            .expect("Failed to create global config directory");
-        config_dir
-            .child("prek.toml")
+            .expect("Failed to create user config directory");
+        self.user_config_path()
             .write_str(content)
-            .expect("Failed to write global config");
+            .expect("Failed to write user config");
     }
 
     pub fn run(&self) -> Command {

--- a/crates/prek/tests/common/mod.rs
+++ b/crates/prek/tests/common/mod.rs
@@ -150,6 +150,7 @@ impl TestContext {
     }
 
     pub fn command(&self) -> Command {
+        let config_home = self.home_dir.child("config");
         let mut cmd = if EnvVars::is_set(EnvVars::PREK_INTERNAL__RUN_ORIGINAL_PRE_COMMIT) {
             // Run the original pre-commit to check compatibility.
             let mut cmd = Command::new("pre-commit");
@@ -169,12 +170,29 @@ impl TestContext {
             cmd
         };
 
+        cmd.env("HOME", &**self.home_dir())
+            .env("USERPROFILE", &**self.home_dir())
+            .env("XDG_CONFIG_HOME", config_home.path())
+            .env("APPDATA", config_home.path())
+            .env("LOCALAPPDATA", &**self.home_dir());
+
         // Disable git autocrlf to avoid line ending issues in tests.
         cmd.env("GIT_CONFIG_COUNT", "1")
             .env("GIT_CONFIG_KEY_0", "core.autocrlf")
             .env("GIT_CONFIG_VALUE_0", "false");
 
         cmd
+    }
+
+    pub fn write_global_config(&self, content: &str) {
+        let config_dir = self.home_dir.child("config").child("prek");
+        config_dir
+            .create_dir_all()
+            .expect("Failed to create global config directory");
+        config_dir
+            .child("prek.toml")
+            .write_str(content)
+            .expect("Failed to write global config");
     }
 
     pub fn run(&self) -> Command {

--- a/crates/prek/tests/global_config.rs
+++ b/crates/prek/tests/global_config.rs
@@ -36,8 +36,8 @@ fn global_config_missing_file_uses_defaults() {
 fn global_config_applies_cooldown_days() {
     let context = TestContext::new();
     context.write_global_config(indoc::indoc! {r"
-        [auto-update]
-        cooldown-days = 3
+        [auto_update]
+        cooldown_days = 3
     "});
 
     cmd_snapshot!(context.filters(), context.auto_update().arg("--show-settings"), @"
@@ -70,8 +70,8 @@ fn global_config_applies_cooldown_days() {
 fn global_config_cli_args_override_file() {
     let context = TestContext::new();
     context.write_global_config(indoc::indoc! {r"
-        [auto-update]
-        cooldown-days = 3
+        [auto_update]
+        cooldown_days = 3
     "});
 
     cmd_snapshot!(
@@ -111,8 +111,8 @@ fn global_config_cli_args_override_file() {
 fn global_config_invalid_file_reports_parse_error() {
     let context = TestContext::new();
     context.write_global_config(indoc::indoc! {r#"
-        [auto-update]
-        cooldown-days = "soon"
+        [auto_update]
+        cooldown_days = "soon"
     "#});
 
     cmd_snapshot!(context.filters(), context.auto_update().arg("--show-settings"), @r#"
@@ -138,7 +138,7 @@ fn global_config_invalid_file_reports_parse_error() {
     error: Failed to parse global config `[HOME]/config/prek/prek.toml`
       caused by: TOML parse error at line 2, column 17
       |
-    2 | cooldown-days = "soon"
+    2 | cooldown_days = "soon"
       |                 ^^^^^^
     invalid type: string "soon", expected u8
     "#);

--- a/crates/prek/tests/global_config.rs
+++ b/crates/prek/tests/global_config.rs
@@ -108,6 +108,43 @@ fn global_config_cli_args_override_file() {
 }
 
 #[test]
+fn global_config_ignores_unknown_options() {
+    let context = TestContext::new();
+    context.write_global_config(indoc::indoc! {r#"
+        future_option = true
+
+        [auto_update]
+        cooldown_days = 3
+        future_option = "ignored"
+    "#});
+
+    cmd_snapshot!(context.filters(), context.auto_update().arg("--show-settings"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    GlobalArgs {
+        config: None,
+        cd: None,
+        color: Auto,
+        refresh: false,
+        help: (),
+        no_progress: false,
+        quiet: 0,
+        verbose: 0,
+        log_file: None,
+        no_log_file: false,
+        version: (),
+        show_settings: true,
+    }
+    AutoUpdateSettings {
+        cooldown_days: 3,
+    }
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn global_config_invalid_file_reports_parse_error() {
     let context = TestContext::new();
     context.write_global_config(indoc::indoc! {r#"

--- a/crates/prek/tests/global_config.rs
+++ b/crates/prek/tests/global_config.rs
@@ -1,0 +1,145 @@
+use crate::common::{TestContext, cmd_snapshot};
+
+mod common;
+
+#[test]
+fn global_config_missing_file_uses_defaults() {
+    let context = TestContext::new();
+
+    cmd_snapshot!(context.filters(), context.auto_update().arg("--show-settings"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    GlobalArgs {
+        config: None,
+        cd: None,
+        color: Auto,
+        refresh: false,
+        help: (),
+        no_progress: false,
+        quiet: 0,
+        verbose: 0,
+        log_file: None,
+        no_log_file: false,
+        version: (),
+        show_settings: true,
+    }
+    AutoUpdateSettings {
+        cooldown_days: 0,
+    }
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn global_config_applies_cooldown_days() {
+    let context = TestContext::new();
+    context.write_global_config(indoc::indoc! {r"
+        [auto-update]
+        cooldown-days = 3
+    "});
+
+    cmd_snapshot!(context.filters(), context.auto_update().arg("--show-settings"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    GlobalArgs {
+        config: None,
+        cd: None,
+        color: Auto,
+        refresh: false,
+        help: (),
+        no_progress: false,
+        quiet: 0,
+        verbose: 0,
+        log_file: None,
+        no_log_file: false,
+        version: (),
+        show_settings: true,
+    }
+    AutoUpdateSettings {
+        cooldown_days: 3,
+    }
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn global_config_cli_args_override_file() {
+    let context = TestContext::new();
+    context.write_global_config(indoc::indoc! {r"
+        [auto-update]
+        cooldown-days = 3
+    "});
+
+    cmd_snapshot!(
+        context.filters(),
+        context
+            .auto_update()
+            .arg("--show-settings")
+            .arg("--cooldown-days")
+            .arg("0"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    GlobalArgs {
+        config: None,
+        cd: None,
+        color: Auto,
+        refresh: false,
+        help: (),
+        no_progress: false,
+        quiet: 0,
+        verbose: 0,
+        log_file: None,
+        no_log_file: false,
+        version: (),
+        show_settings: true,
+    }
+    AutoUpdateSettings {
+        cooldown_days: 0,
+    }
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn global_config_invalid_file_reports_parse_error() {
+    let context = TestContext::new();
+    context.write_global_config(indoc::indoc! {r#"
+        [auto-update]
+        cooldown-days = "soon"
+    "#});
+
+    cmd_snapshot!(context.filters(), context.auto_update().arg("--show-settings"), @r#"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+    GlobalArgs {
+        config: None,
+        cd: None,
+        color: Auto,
+        refresh: false,
+        help: (),
+        no_progress: false,
+        quiet: 0,
+        verbose: 0,
+        log_file: None,
+        no_log_file: false,
+        version: (),
+        show_settings: true,
+    }
+
+    ----- stderr -----
+    error: Failed to parse global config `[HOME]/config/prek/prek.toml`
+      caused by: TOML parse error at line 2, column 17
+      |
+    2 | cooldown-days = "soon"
+      |                 ^^^^^^
+    invalid type: string "soon", expected u8
+    "#);
+}

--- a/crates/prek/tests/global_config.rs
+++ b/crates/prek/tests/global_config.rs
@@ -35,7 +35,7 @@ fn global_config_missing_file_uses_defaults() {
 #[test]
 fn global_config_applies_cooldown_days() {
     let context = TestContext::new();
-    context.write_global_config(indoc::indoc! {r"
+    context.write_user_config(indoc::indoc! {r"
         [auto_update]
         cooldown_days = 3
     "});
@@ -69,7 +69,7 @@ fn global_config_applies_cooldown_days() {
 #[test]
 fn global_config_cli_args_override_file() {
     let context = TestContext::new();
-    context.write_global_config(indoc::indoc! {r"
+    context.write_user_config(indoc::indoc! {r"
         [auto_update]
         cooldown_days = 3
     "});
@@ -110,7 +110,7 @@ fn global_config_cli_args_override_file() {
 #[test]
 fn global_config_ignores_unknown_options() {
     let context = TestContext::new();
-    context.write_global_config(indoc::indoc! {r#"
+    context.write_user_config(indoc::indoc! {r#"
         future_option = true
 
         [auto_update]
@@ -147,7 +147,7 @@ fn global_config_ignores_unknown_options() {
 #[test]
 fn global_config_invalid_file_reports_parse_error() {
     let context = TestContext::new();
-    context.write_global_config(indoc::indoc! {r#"
+    context.write_user_config(indoc::indoc! {r#"
         [auto_update]
         cooldown_days = "soon"
     "#});

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,24 @@ Both formats are first-class and will be supported long-term. They describe the 
           - id: trailing-whitespace
     ```
 
+## Global configuration
+
+`prek` also reads an optional user-level global config from the platform config directory:
+
+- Linux and macOS: `~/.config/prek/prek.toml` (or `$XDG_CONFIG_HOME/prek/prek.toml` when `XDG_CONFIG_HOME` is set)
+- Windows: `%APPDATA%\prek\prek.toml`
+
+This file is for user-level `prek` settings, not hook definitions. Project hooks still live in the project config files described below.
+
+The first supported global setting is the default cooldown for `prek auto-update`:
+
+```toml
+[auto-update]
+cooldown-days = 7
+```
+
+`prek auto-update --cooldown-days <DAYS>` overrides this value for a single command invocation.
+
 ## Pre-commit compatibility
 
 `prek` is **fully compatible** with [`pre-commit`](https://pre-commit.com/) YAML configs, so your existing `.pre-commit-config.yaml` files work unchanged.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,8 +36,8 @@ This file is for user-level `prek` settings, not hook definitions. Project hooks
 The first supported global setting is the default cooldown for `prek auto-update`:
 
 ```toml
-[auto-update]
-cooldown-days = 7
+[auto_update]
+cooldown_days = 7
 ```
 
 `prek auto-update --cooldown-days <DAYS>` overrides this value for a single command invocation.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -561,8 +561,8 @@ prek auto-update [OPTIONS]
 <li><code>never</code>:  Disables colored output</li>
 </ul></dd><dt id="prek-auto-update--config"><a href="#prek-auto-update--config"><code>--config</code></a>, <code>-c</code> <i>config</i></dt><dd><p>Path to alternate config file</p>
 </dd><dt id="prek-auto-update--cooldown-days"><a href="#prek-auto-update--cooldown-days"><code>--cooldown-days</code></a> <i>days</i></dt><dd><p>Minimum release age (in days) required for a version to be eligible.</p>
-<p>The age is computed from the tag creation timestamp for annotated tags, or from the tagged commit timestamp for lightweight tags. A value of <code>0</code> disables this check.</p>
-<p>[default: 0]</p></dd><dt id="prek-auto-update--dry-run"><a href="#prek-auto-update--dry-run"><code>--dry-run</code></a></dt><dd><p>Do not write changes to the config file, only display what would be changed</p>
+<p>The age is computed from the tag creation timestamp for annotated tags, or from the tagged commit timestamp for lightweight tags. Defaults to <code>auto-update.cooldown-days</code> in the global config, or <code>0</code> when unset. A value of <code>0</code> disables this check.</p>
+</dd><dt id="prek-auto-update--dry-run"><a href="#prek-auto-update--dry-run"><code>--dry-run</code></a></dt><dd><p>Do not write changes to the config file, only display what would be changed</p>
 </dd><dt id="prek-auto-update--exclude-repo"><a href="#prek-auto-update--exclude-repo"><code>--exclude-repo</code></a> <i>repo</i></dt><dd><p>Do not update this repository. This option may be specified multiple times</p>
 </dd><dt id="prek-auto-update--exclude-tag"><a href="#prek-auto-update--exclude-tag"><code>--exclude-tag</code></a> <i>pattern</i></dt><dd><p>Ignore tags matching this glob pattern. This option may be specified multiple times.</p>
 <p>For example, use <code>--exclude-tag nightly</code> to skip a moving tag, or <code>--exclude-tag '*-{alpha,beta,rc}*'</code> to skip common prerelease tags.</p>

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -561,7 +561,7 @@ prek auto-update [OPTIONS]
 <li><code>never</code>:  Disables colored output</li>
 </ul></dd><dt id="prek-auto-update--config"><a href="#prek-auto-update--config"><code>--config</code></a>, <code>-c</code> <i>config</i></dt><dd><p>Path to alternate config file</p>
 </dd><dt id="prek-auto-update--cooldown-days"><a href="#prek-auto-update--cooldown-days"><code>--cooldown-days</code></a> <i>days</i></dt><dd><p>Minimum release age (in days) required for a version to be eligible.</p>
-<p>The age is computed from the tag creation timestamp for annotated tags, or from the tagged commit timestamp for lightweight tags. Defaults to <code>auto-update.cooldown-days</code> in the global config, or <code>0</code> when unset. A value of <code>0</code> disables this check.</p>
+<p>The age is computed from the tag creation timestamp for annotated tags, or from the tagged commit timestamp for lightweight tags. Defaults to <code>auto_update.cooldown_days</code> in the global config, or <code>0</code> when unset. A value of <code>0</code> disables this check.</p>
 </dd><dt id="prek-auto-update--dry-run"><a href="#prek-auto-update--dry-run"><code>--dry-run</code></a></dt><dd><p>Do not write changes to the config file, only display what would be changed</p>
 </dd><dt id="prek-auto-update--exclude-repo"><a href="#prek-auto-update--exclude-repo"><code>--exclude-repo</code></a> <i>repo</i></dt><dd><p>Do not update this repository. This option may be specified multiple times</p>
 </dd><dt id="prek-auto-update--exclude-tag"><a href="#prek-auto-update--exclude-tag"><code>--exclude-tag</code></a> <i>pattern</i></dt><dd><p>Ignore tags matching this glob pattern. This option may be specified multiple times.</p>

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -2,6 +2,30 @@
 
 This page documents the configuration keys that `prek` understands.
 
+## Global config file
+
+`prek` reads an optional user-level global config from:
+
+- Linux and macOS: `~/.config/prek/prek.toml` (or `$XDG_CONFIG_HOME/prek/prek.toml` when `XDG_CONFIG_HOME` is set)
+- Windows: `%APPDATA%\prek\prek.toml`
+
+This file stores user-level `prek` settings and does not define project hooks.
+
+### `auto-update.cooldown-days`
+
+Default cooldown for `prek auto-update`.
+
+- Type: integer days
+- Default: `0`
+- CLI override: `prek auto-update --cooldown-days <DAYS>`
+
+```toml
+[auto-update]
+cooldown-days = 7
+```
+
+The age is computed from the tag creation timestamp for annotated tags, or from the tagged commit timestamp for lightweight tags. A value of `0` disables the cooldown check.
+
 ## Top-level keys
 
 ### `repos` (required)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -11,7 +11,7 @@ This page documents the configuration keys that `prek` understands.
 
 This file stores user-level `prek` settings and does not define project hooks.
 
-### `auto-update.cooldown-days`
+### `auto_update.cooldown_days`
 
 Default cooldown for `prek auto-update`.
 
@@ -20,8 +20,8 @@ Default cooldown for `prek auto-update`.
 - CLI override: `prek auto-update --cooldown-days <DAYS>`
 
 ```toml
-[auto-update]
-cooldown-days = 7
+[auto_update]
+cooldown_days = 7
 ```
 
 The age is computed from the tag creation timestamp for annotated tags, or from the tagged commit timestamp for lightweight tags. A value of `0` disables the cooldown check.


### PR DESCRIPTION
Adds a user-level global `prek.toml` and wires `auto-update.cooldown-days` into `prek auto-update`

Closes #2032
Related #58 