### PR TITLE
Pass commit message file to workspace hooks

### DIFF
--- a/crates/prek/src/cli/run/filter.rs
+++ b/crates/prek/src/cli/run/filter.rs
@@ -225,10 +225,15 @@ impl CollectOptions {
     }
 }
 
-/// Get all filenames to run hooks on.
-/// Returns a list of file paths relative to the workspace root.
-#[instrument(level = "trace", skip_all)]
-pub(crate) async fn collect_files(root: &Path, opts: CollectOptions) -> Result<Vec<PathBuf>> {
+pub(crate) enum RunInput {
+    /// File paths relative to the workspace root.
+    Files(Vec<PathBuf>),
+    /// Absolute path to the Git message file passed by `commit-msg` and `prepare-commit-msg`.
+    MessageFile(PathBuf),
+}
+
+/// Get hook input for the selected stage.
+pub(crate) async fn collect_run_input(root: &Path, opts: CollectOptions) -> Result<RunInput> {
     let CollectOptions {
         hook_stage,
         from_ref,
@@ -239,6 +244,47 @@ pub(crate) async fn collect_files(root: &Path, opts: CollectOptions) -> Result<V
         commit_msg_filename,
     } = opts;
 
+    if matches!(hook_stage, Stage::PrepareCommitMsg | Stage::CommitMsg) {
+        let path = commit_msg_filename.expect("commit_msg_filename should be set");
+        return Ok(RunInput::MessageFile(GIT_ROOT.as_ref()?.join(path)));
+    }
+
+    collect_workspace_files(
+        root,
+        hook_stage,
+        from_ref,
+        to_ref,
+        all_files,
+        files,
+        directories,
+    )
+    .await
+    .map(RunInput::Files)
+}
+
+/// Get workspace filenames to run hooks on.
+/// Returns a list of file paths relative to the workspace root.
+pub(crate) async fn collect_files(root: &Path, opts: CollectOptions) -> Result<Vec<PathBuf>> {
+    match collect_run_input(root, opts).await? {
+        RunInput::Files(files) => Ok(files),
+        // This compatibility API can only return workspace-relative files.
+        // Git message files are hook arguments, not workspace files, and are
+        // handled through `RunInput` by the main runner.
+        RunInput::MessageFile(_) => Ok(vec![]),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+#[instrument(level = "trace", skip_all)]
+async fn collect_workspace_files(
+    root: &Path,
+    hook_stage: Stage,
+    from_ref: Option<String>,
+    to_ref: Option<String>,
+    all_files: bool,
+    files: Vec<String>,
+    directories: Vec<String>,
+) -> Result<Vec<PathBuf>> {
     let git_root = GIT_ROOT.as_ref()?;
 
     // The workspace root relative to the git root.
@@ -259,7 +305,6 @@ pub(crate) async fn collect_files(root: &Path, opts: CollectOptions) -> Result<V
         all_files,
         files,
         directories,
-        commit_msg_filename,
     )
     .await?;
 
@@ -300,16 +345,9 @@ async fn collect_files_from_args(
     all_files: bool,
     files: Vec<String>,
     directories: Vec<String>,
-    commit_msg_filename: Option<String>,
 ) -> Result<Vec<PathBuf>> {
     if !hook_stage.operate_on_files() {
         return Ok(vec![]);
-    }
-
-    if hook_stage == Stage::PrepareCommitMsg || hook_stage == Stage::CommitMsg {
-        let path = commit_msg_filename.expect("commit_msg_filename should be set");
-        let path = adjust_relative_path(&path, git_root)?;
-        return Ok(vec![path]);
     }
 
     if let (Some(from_ref), Some(to_ref)) = (from_ref, to_ref) {

--- a/crates/prek/src/cli/run/mod.rs
+++ b/crates/prek/src/cli/run/mod.rs
@@ -1,4 +1,4 @@
-pub(crate) use filter::{CollectOptions, FileFilter, collect_files};
+pub(crate) use filter::{CollectOptions, FileFilter, RunInput, collect_files, collect_run_input};
 pub(crate) use run::{install_hooks, run};
 pub(crate) use selector::{SelectorSource, Selectors};
 

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write as _;
 use std::io::Write as _;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::{Arc, LazyLock};
 
@@ -19,7 +19,7 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::cli::reporter::{HookInitReporter, HookInstallReporter, HookRunReporter};
 use crate::cli::run::keeper::WorkTreeKeeper;
-use crate::cli::run::{CollectOptions, FileFilter, Selectors, collect_files};
+use crate::cli::run::{CollectOptions, FileFilter, RunInput, Selectors, collect_run_input};
 use crate::cli::{ExitStatus, RunExtraArgs};
 use crate::config::{Language, PassFilenames, Stage};
 use crate::fs::CWD;
@@ -29,7 +29,7 @@ use crate::printer::Printer;
 use crate::run::{CONCURRENCY, USE_COLOR};
 use crate::store::Store;
 use crate::workspace::{Project, Workspace};
-use crate::{git, warn_user};
+use crate::{fs, git, warn_user};
 
 #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 pub(crate) async fn run(
@@ -177,7 +177,7 @@ pub(crate) async fn run(
 
     set_env_vars(from_ref.as_ref(), to_ref.as_ref(), &extra_args);
 
-    let filenames = collect_files(
+    let input = collect_run_input(
         workspace.root(),
         CollectOptions {
             hook_stage,
@@ -203,7 +203,7 @@ pub(crate) async fn run(
     run_hooks(
         &workspace,
         &installed_hooks,
-        filenames,
+        input,
         store,
         show_diff_on_failure,
         fail_fast,
@@ -570,12 +570,55 @@ impl StatusPrinter {
     }
 }
 
+enum ProjectHookInput<'a> {
+    Files(FileFilter<'a>),
+    MessageFile(PathBuf),
+}
+
+impl<'a> ProjectHookInput<'a> {
+    fn new(
+        input: &'a RunInput,
+        project: &Project,
+        consumed_files: Option<&mut FxHashSet<&'a Path>>,
+    ) -> Result<Self> {
+        match input {
+            RunInput::Files(files) => Ok(Self::Files(FileFilter::for_project(
+                files.iter(),
+                project,
+                consumed_files,
+            ))),
+            RunInput::MessageFile(path) => Ok(Self::MessageFile(fs::normalize_path(
+                fs::relative_to(path, project.path())?,
+            ))),
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Self::Files(filter) => filter.len(),
+            Self::MessageFile(_) => 1,
+        }
+    }
+
+    fn for_hook(&self, hook: &Hook) -> Vec<&Path> {
+        match self {
+            Self::Files(filter) => filter.for_hook(hook),
+            Self::MessageFile(path) => {
+                // `commit-msg` and `prepare-commit-msg` receive Git's message file, which is not
+                // a workspace file. The `files`/`exclude`/`types` filters are workspace-file
+                // selectors, so they do not apply to this hook argument.
+                vec![path.as_path()]
+            }
+        }
+    }
+}
+
 /// Run all hooks.
 #[allow(clippy::fn_params_excessive_bools)]
 async fn run_hooks(
     workspace: &Workspace,
     hooks: &[InstalledHook],
-    filenames: Vec<PathBuf>,
+    input: RunInput,
     store: &Store,
     show_diff_on_failure: bool,
     fail_fast: Option<bool>,
@@ -609,14 +652,14 @@ async fn run_hooks(
     let mut consumed_files = FxHashSet::default();
 
     'outer: for project in workspace.all_projects() {
-        let filter = FileFilter::for_project(filenames.iter(), project, Some(&mut consumed_files));
+        let project_input = ProjectHookInput::new(&input, project, Some(&mut consumed_files))?;
 
         let Some(mut hooks) = project_to_hooks.remove(project) else {
             continue;
         };
         trace!(
             "Files for project `{project}` after filtered: {}",
-            filter.len()
+            project_input.len()
         );
 
         // Sort hooks by priority (lower number means higher priority).
@@ -641,7 +684,7 @@ async fn run_hooks(
         for group_range in PriorityGroupRanges::new(&hooks) {
             let group_hooks = hooks[group_range].to_vec();
             let mut group_results =
-                run_priority_group(group_hooks, &filter, store, dry_run, &reporter).await?;
+                run_priority_group(group_hooks, &project_input, store, dry_run, &reporter).await?;
 
             // Print results in a stable order (same order as config within the project).
             group_results.sort_unstable_by_key(|a| a.hook.idx);
@@ -769,7 +812,7 @@ impl Iterator for PriorityGroupRanges<'_> {
 
 async fn run_priority_group(
     group_hooks: Vec<InstalledHook>,
-    filter: &FileFilter<'_>,
+    input: &ProjectHookInput<'_>,
     store: &Store,
     dry_run: bool,
     reporter: &HookRunReporter,
@@ -784,7 +827,7 @@ async fn run_priority_group(
     let mut results = futures::stream::iter(
         group_hooks
             .into_iter()
-            .map(|hook| run_hook(hook, filter, store, dry_run, reporter)),
+            .map(|hook| run_hook(hook, input, store, dry_run, reporter)),
     )
     .buffer_unordered(*CONCURRENCY);
 
@@ -1000,12 +1043,12 @@ impl RunResult {
 
 async fn run_hook(
     hook: InstalledHook,
-    filter: &FileFilter<'_>,
+    input: &ProjectHookInput<'_>,
     store: &Store,
     dry_run: bool,
     reporter: &HookRunReporter,
 ) -> Result<RunResult> {
-    let mut filenames = filter.for_hook(&hook);
+    let mut filenames = input.for_hook(&hook);
     trace!(
         "Files for hook `{}` after filtered: {}",
         hook.id,

--- a/crates/prek/tests/hook_impl.rs
+++ b/crates/prek/tests/hook_impl.rs
@@ -571,6 +571,81 @@ fn workspace_hook_impl_root() -> anyhow::Result<()> {
 }
 
 #[test]
+fn workspace_commit_msg_hook_receives_message_file_for_each_project() -> anyhow::Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    let config = indoc! {r#"
+    default_install_hook_types:
+      - commit-msg
+    repos:
+      - repo: local
+        hooks:
+        - id: commit-msg-args
+          name: Commit Msg Args
+          language: python
+          entry: python -c 'import os, pathlib, sys; print("cwd:", os.getcwd()); print("args:", sys.argv[1:]); assert len(sys.argv) == 2; assert pathlib.Path(sys.argv[1]).is_file()'
+          stages: [commit-msg]
+          always_run: true
+          verbose: true
+    "#};
+
+    context.setup_workspace(&["template"], config)?;
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.install(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    prek installed at `.git/hooks/commit-msg`
+
+    ----- stderr -----
+    ");
+
+    let mut commit = git_cmd(context.work_dir());
+    commit
+        .env(EnvVars::PREK_HOME, &**context.home_dir())
+        .arg("commit")
+        .arg("-m")
+        .arg("feat: initial");
+
+    let filters = context
+        .filters()
+        .into_iter()
+        .chain([("[a-f0-9]{7}", "abc1234")])
+        .collect::<Vec<_>>();
+
+    cmd_snapshot!(filters, commit, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [master (root-commit) abc1234] feat: initial
+     2 files changed, 24 insertions(+)
+     create mode 100644 .pre-commit-config.yaml
+     create mode 100644 template/.pre-commit-config.yaml
+
+    ----- stderr -----
+    Running hooks for `template`:
+    Commit Msg Args..........................................................Passed
+    - hook id: commit-msg-args
+    - duration: [TIME]
+
+      cwd: [TEMP_DIR]/template
+      args: ['../.git/COMMIT_EDITMSG']
+
+    Running hooks for `.`:
+    Commit Msg Args..........................................................Passed
+    - hook id: commit-msg-args
+    - duration: [TIME]
+
+      cwd: [TEMP_DIR]/
+      args: ['.git/COMMIT_EDITMSG']
+    ");
+
+    Ok(())
+}
+
+#[test]
 fn workspace_hook_impl_subdirectory() -> anyhow::Result<()> {
     let context = TestContext::new();
     let cwd = context.work_dir();


### PR DESCRIPTION
Workspace `commit-msg` and `prepare-commit-msg` hooks now receive the Git message file as hook input for every matching project instead of losing it during workspace file filtering.

This keeps normal workspace file ownership in `FileFilter`, while message-stage hook input is resolved once and converted to a project-relative argument at run time.

Fixes #1194, Fixes #2042