### PR TITLE
Add project auto-update cooldown config

### DIFF
--- a/crates/prek/src/cli/auto_update/mod.rs
+++ b/crates/prek/src/cli/auto_update/mod.rs
@@ -15,6 +15,7 @@ use crate::config::GlobPatterns;
 use crate::fs::CWD;
 use crate::printer::Printer;
 use crate::run::CONCURRENCY;
+use crate::settings::FilesystemOptions;
 use crate::store::Store;
 use crate::workspace::{Project, Workspace};
 
@@ -54,6 +55,8 @@ struct RepoTarget<'a> {
     repo: &'a str,
     /// The currently configured `rev` for this target.
     current_rev: &'a str,
+    /// The resolved cooldown window to apply when selecting an update for this target.
+    cooldown_days: u8,
     /// The sorted hook ids that must still exist after updating this target.
     required_hook_ids: Vec<&'a str>,
     /// Every config usage that shares this exact `repo + rev + hook set`.
@@ -325,19 +328,21 @@ pub(crate) async fn auto_update(
     jobs: usize,
     dry_run: bool,
     exit_code: bool,
-    cooldown_days: u8,
+    cooldown_days: Option<u8>,
+    filesystem: Option<FilesystemOptions>,
     printer: Printer,
 ) -> Result<ExitStatus> {
-    let tag_filters =
-        TagFilters::new(include_tag, exclude_tag, repo_include_tag, repo_exclude_tag)?;
     let workspace_root = Workspace::find_root(config.as_deref(), &CWD)?;
     // TODO: support selectors?
     let selectors = Selectors::default();
     let workspace = Workspace::discover(store, workspace_root, config, Some(&selectors), true)?;
+
+    let tag_filters =
+        TagFilters::new(include_tag, exclude_tag, repo_include_tag, repo_exclude_tag)?;
     let jobs = if jobs == 0 { *CONCURRENCY } else { jobs };
     let reporter = AutoUpdateReporter::new(printer);
 
-    let repo_sources = collect_repo_sources(&workspace)?;
+    let repo_sources = collect_repo_sources(&workspace, cooldown_days, filesystem.as_ref())?;
     let sources = repo_sources.iter().filter(|repo_source| {
         (filter_repos.is_empty() || filter_repos.iter().any(|repo| repo == repo_source.repo))
             && !exclude_repos.iter().any(|repo| repo == repo_source.repo)
@@ -345,14 +350,8 @@ pub(crate) async fn auto_update(
     let outcomes: Vec<RepoUpdate<'_>> = futures::stream::iter(sources)
         .map(async |repo_source| {
             let progress = reporter.on_update_start(repo_source.repo);
-            let result = evaluate_repo_source(
-                repo_source,
-                bleeding_edge,
-                freeze,
-                cooldown_days,
-                &tag_filters,
-            )
-            .await;
+            let result =
+                evaluate_repo_source(repo_source, bleeding_edge, freeze, &tag_filters).await;
             reporter.on_update_complete(progress);
             result
         })

--- a/crates/prek/src/cli/auto_update/source.rs
+++ b/crates/prek/src/cli/auto_update/source.rs
@@ -16,14 +16,32 @@ use crate::cli::auto_update::{
 };
 use crate::config::{Repo, looks_like_sha};
 use crate::fs::Simplified;
+use crate::settings::{AutoUpdateSettings, FilesystemOptions};
 use crate::workspace::Workspace;
 
+type RepoTargetKey<'a> = (&'a str, Vec<&'a str>, u8);
+type RepoTargetsByKey<'a> = FxHashMap<RepoTargetKey<'a>, RepoTarget<'a>>;
+type RepoSourcesByRepo<'a> = FxHashMap<&'a str, RepoTargetsByKey<'a>>;
+
 /// Collects the configured remote repos grouped by fetch source, revision, and hook set.
-pub(super) fn collect_repo_sources(workspace: &Workspace) -> Result<Vec<RepoSource<'_>>> {
-    let mut repo_sources: FxHashMap<&str, FxHashMap<(&str, Vec<&str>), RepoTarget<'_>>> =
-        FxHashMap::default();
+pub(super) fn collect_repo_sources<'a>(
+    workspace: &'a Workspace,
+    cli_cooldown_days: Option<u8>,
+    filesystem: Option<&FilesystemOptions>,
+) -> Result<Vec<RepoSource<'a>>> {
+    let mut repo_sources: RepoSourcesByRepo<'a> = FxHashMap::default();
 
     for project in workspace.projects() {
+        let settings = AutoUpdateSettings::resolve(
+            cli_cooldown_days,
+            filesystem,
+            project
+                .config()
+                .auto_update
+                .as_ref()
+                .and_then(|options| options.cooldown_days),
+        );
+        let cooldown_days = settings.cooldown_days;
         let remote_count = project
             .config()
             .repos
@@ -64,10 +82,15 @@ pub(super) fn collect_repo_sources(workspace: &Workspace) -> Result<Vec<RepoSour
             let target = repo_sources
                 .entry(remote_repo.repo.as_str())
                 .or_default()
-                .entry((remote_repo.rev.as_str(), required_hook_ids.clone()))
+                .entry((
+                    remote_repo.rev.as_str(),
+                    required_hook_ids.clone(),
+                    cooldown_days,
+                ))
                 .or_insert_with(|| RepoTarget {
                     repo: remote_repo.repo.as_str(),
                     current_rev: remote_repo.rev.as_str(),
+                    cooldown_days,
                     required_hook_ids,
                     usages: Vec::new(),
                 });
@@ -90,6 +113,7 @@ pub(super) fn collect_repo_sources(workspace: &Workspace) -> Result<Vec<RepoSour
             targets.sort_by(|a, b| {
                 a.current_rev
                     .cmp(b.current_rev)
+                    .then_with(|| a.cooldown_days.cmp(&b.cooldown_days))
                     .then_with(|| a.required_hook_ids.cmp(&b.required_hook_ids))
             });
             RepoSource { repo, targets }
@@ -167,7 +191,6 @@ pub(super) async fn evaluate_repo_source<'a>(
     repo_source: &'a RepoSource<'a>,
     bleeding_edge: bool,
     freeze: bool,
-    cooldown_days: u8,
     tag_filters: &TagFilters,
 ) -> Result<Vec<RepoUpdate<'a>>> {
     let tmp_dir = tempfile::tempdir()?;
@@ -214,7 +237,6 @@ pub(super) async fn evaluate_repo_source<'a>(
             target,
             bleeding_edge,
             freeze,
-            cooldown_days,
             &tag_timestamps,
             &update_tag_timestamps,
         )
@@ -232,7 +254,6 @@ async fn evaluate_repo_target<'a>(
     target: &'a RepoTarget<'a>,
     bleeding_edge: bool,
     freeze: bool,
-    cooldown_days: u8,
     tag_timestamps: &[TagTimestamp],
     update_tag_timestamps: &[TagTimestamp],
 ) -> Result<ResolvedRepoUpdate<'a>> {
@@ -252,7 +273,7 @@ async fn evaluate_repo_target<'a>(
         repo_path,
         target.current_rev,
         bleeding_edge,
-        cooldown_days,
+        target.cooldown_days,
         update_tag_timestamps,
     )
     .await?;

--- a/crates/prek/src/cli/mod.rs
+++ b/crates/prek/src/cli/mod.rs
@@ -757,7 +757,7 @@ pub(crate) struct AutoUpdateArgs {
     /// Minimum release age (in days) required for a version to be eligible.
     ///
     /// The age is computed from the tag creation timestamp for annotated tags, or from the tagged commit timestamp for lightweight tags.
-    /// Defaults to `auto_update.cooldown_days` in the global config, or `0` when unset.
+    /// Defaults to `auto_update.cooldown_days` in the project or global config, or `0` when unset.
     /// A value of `0` disables this check.
     #[arg(long, value_name = "DAYS", conflicts_with = "bleeding_edge")]
     pub(crate) cooldown_days: Option<u8>,

--- a/crates/prek/src/cli/mod.rs
+++ b/crates/prek/src/cli/mod.rs
@@ -758,7 +758,7 @@ pub(crate) struct AutoUpdateArgs {
     ///
     /// The age is computed from the tag creation timestamp for annotated tags, or from the tagged commit timestamp for lightweight tags.
     /// Defaults to `auto_update.cooldown_days` in the project or global config, or `0` when unset.
-    /// A value of `0` disables this check.
+    /// Valid values are `0` through `255`; `0` disables this check.
     #[arg(long, value_name = "DAYS", conflicts_with = "bleeding_edge")]
     pub(crate) cooldown_days: Option<u8>,
 }

--- a/crates/prek/src/config.rs
+++ b/crates/prek/src/config.rs
@@ -1117,6 +1117,14 @@ where
     })
 }
 
+/// Controls how `prek auto-update` selects eligible releases.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub(crate) struct AutoUpdateOptions {
+    pub(crate) cooldown_days: Option<u8>,
+}
+
 // TODO: warn sensible regex
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -1129,6 +1137,8 @@ where
     schemars(extend("x-tombi-toml-version" = "v1.1.0")),
 )]
 pub(crate) struct Config {
+    /// Default settings for `prek auto-update` in this project.
+    pub auto_update: Option<AutoUpdateOptions>,
     pub repos: Vec<Repo>,
     /// A list of `--hook-types` which will be used by default when running `prek install`.
     /// Default is `[pre-commit]`.

--- a/crates/prek/src/hook.rs
+++ b/crates/prek/src/hook.rs
@@ -921,6 +921,7 @@ mod tests {
                 relative_path: "",
                 idx: 0,
                 config: Config {
+                    auto_update: None,
                     repos: [],
                     default_install_hook_types: None,
                     default_language_version: Some(

--- a/crates/prek/src/main.rs
+++ b/crates/prek/src/main.rs
@@ -26,7 +26,7 @@ use crate::cli::{
 use crate::cli::{SelfCommand, SelfNamespace, SelfUpdateArgs};
 use crate::printer::Printer;
 use crate::run::USE_COLOR;
-use crate::settings::{AutoUpdateSettings, FilesystemOptions};
+use crate::settings::FilesystemOptions;
 use crate::store::Store;
 
 mod archive;
@@ -376,8 +376,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
         Command::SampleConfig(args) => cli::sample_config(args.file.into(), args.format, printer),
         Command::AutoUpdate(args) => {
             let filesystem = FilesystemOptions::user()?;
-            let settings = AutoUpdateSettings::resolve(&args, filesystem.as_ref());
-            show_settings!(settings);
+            show_settings!(args);
 
             cli::auto_update(
                 &store,
@@ -394,7 +393,8 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.jobs,
                 args.dry_run || args.check,
                 args.exit_code || args.check,
-                settings.cooldown_days,
+                args.cooldown_days,
+                filesystem,
                 printer,
             )
             .await

--- a/crates/prek/src/settings.rs
+++ b/crates/prek/src/settings.rs
@@ -7,8 +7,6 @@ use etcetera::BaseStrategy;
 use prek_consts::env_vars::EnvVars;
 use serde::Deserialize;
 
-use crate::cli::AutoUpdateArgs;
-
 fn user_config_path() -> Option<PathBuf> {
     if let Some(path) = EnvVars::var_os(EnvVars::PREK_INTERNAL__USER_CONFIG_PATH) {
         return Some(PathBuf::from(path));
@@ -97,14 +95,18 @@ pub(crate) struct AutoUpdateSettings {
 }
 
 impl AutoUpdateSettings {
-    pub(crate) fn resolve(args: &AutoUpdateArgs, filesystem: Option<&FilesystemOptions>) -> Self {
+    pub(crate) fn resolve(
+        cli_cooldown_days: Option<u8>,
+        filesystem: Option<&FilesystemOptions>,
+        project_cooldown_days: Option<u8>,
+    ) -> Self {
         Self {
-            cooldown_days: args
-                .cooldown_days
+            cooldown_days: cli_cooldown_days
+                .or(project_cooldown_days)
                 .or_else(|| {
                     filesystem
                         .and_then(|fs| fs.auto_update.as_ref())
-                        .and_then(|au| au.cooldown_days)
+                        .and_then(|options| options.cooldown_days)
                 })
                 .unwrap_or_default(),
         }

--- a/crates/prek/src/snapshots/prek__config__tests__language_version.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__language_version.snap
@@ -4,6 +4,7 @@ expression: result
 ---
 Ok(
     Config {
+        auto_update: None,
         repos: [
             Local(
                 LocalRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__meta_hooks-5.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__meta_hooks-5.snap
@@ -3,6 +3,7 @@ source: crates/prek/src/config.rs
 expression: result
 ---
 Config {
+    auto_update: None,
     repos: [
         Meta(
             MetaRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__numeric_rev_is_parsed_as_string.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__numeric_rev_is_parsed_as_string.snap
@@ -3,6 +3,7 @@ source: crates/prek/src/config.rs
 expression: config
 ---
 Config {
+    auto_update: None,
     repos: [
         Remote(
             RemoteRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__parse_hooks-3.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__parse_hooks-3.snap
@@ -3,6 +3,7 @@ source: crates/prek/src/config.rs
 expression: result
 ---
 Config {
+    auto_update: None,
     repos: [
         Local(
             LocalRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__parse_repos-3.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__parse_repos-3.snap
@@ -3,6 +3,7 @@ source: crates/prek/src/config.rs
 expression: result
 ---
 Config {
+    auto_update: None,
     repos: [
         Local(
             LocalRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__parse_repos-4.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__parse_repos-4.snap
@@ -3,6 +3,7 @@ source: crates/prek/src/config.rs
 expression: result
 ---
 Config {
+    auto_update: None,
     repos: [
         Remote(
             RemoteRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__parse_repos-6.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__parse_repos-6.snap
@@ -3,6 +3,7 @@ source: crates/prek/src/config.rs
 expression: result
 ---
 Config {
+    auto_update: None,
     repos: [
         Remote(
             RemoteRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__parse_repos.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__parse_repos.snap
@@ -3,6 +3,7 @@ source: crates/prek/src/config.rs
 expression: result
 ---
 Config {
+    auto_update: None,
     repos: [
         Local(
             LocalRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__read_config_with_merge_keys.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__read_config_with_merge_keys.snap
@@ -3,6 +3,7 @@ source: crates/prek/src/config.rs
 expression: config
 ---
 Config {
+    auto_update: None,
     repos: [
         Local(
             LocalRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__read_config_with_nested_merge_keys.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__read_config_with_nested_merge_keys.snap
@@ -3,6 +3,7 @@ source: crates/prek/src/config.rs
 expression: config
 ---
 Config {
+    auto_update: None,
     repos: [
         Local(
             LocalRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__read_toml_config.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__read_toml_config.snap
@@ -3,6 +3,7 @@ source: crates/prek/src/config.rs
 expression: config
 ---
 Config {
+    auto_update: None,
     repos: [
         Local(
             LocalRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__read_yaml_config.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__read_yaml_config.snap
@@ -3,6 +3,7 @@ source: crates/prek/src/config.rs
 expression: config
 ---
 Config {
+    auto_update: None,
     repos: [
         Remote(
             RemoteRepo {

--- a/crates/prek/tests/auto_update.rs
+++ b/crates/prek/tests/auto_update.rs
@@ -1902,6 +1902,111 @@ fn auto_update_workspace() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn auto_update_workspace_same_repo_uses_project_cooldown() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+    context.write_user_config(indoc::indoc! {r"
+        [auto_update]
+        cooldown_days = 1
+    "});
+
+    let repo_path =
+        create_local_git_repo(&context, "workspace-cooldown-repo", &["v1.0.0", "v1.1.0"])?;
+    git_cmd(&repo_path)
+        .arg("commit")
+        .arg("-m")
+        .arg("Release v2.0.0")
+        .arg("--allow-empty")
+        .assert()
+        .success();
+    git_cmd(&repo_path)
+        .arg("tag")
+        .arg("v2.0.0")
+        .arg("-m")
+        .arg("v2.0.0")
+        .assert()
+        .success();
+
+    context.setup_workspace(
+        &["project-a", "project-b"],
+        "repos: []", // Minimal valid config for root
+    )?;
+
+    context
+        .work_dir()
+        .child("project-a/.pre-commit-config.yaml")
+        .write_str(&indoc::formatdoc! {r"
+        auto_update:
+          cooldown_days: 0
+        repos:
+          - repo: {}
+            rev: v1.0.0
+            hooks:
+              - id: test-hook
+    ", repo_path})?;
+
+    context
+        .work_dir()
+        .child("project-b/.pre-commit-config.yaml")
+        .write_str(&indoc::formatdoc! {r"
+        repos:
+          - repo: {}
+            rev: v1.0.0
+            hooks:
+              - id: test-hook
+    ", repo_path})?;
+
+    context.git_add(".");
+
+    let filters = context.filters();
+
+    cmd_snapshot!(filters.clone(), context.auto_update(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    project-a/.pre-commit-config.yaml
+      [HOME]/test-repos/workspace-cooldown-repo
+        updating rev `v1.0.0` -> `v2.0.0`
+
+    project-b/.pre-commit-config.yaml
+      [HOME]/test-repos/workspace-cooldown-repo
+        updating rev `v1.0.0` -> `v1.1.0`
+
+    ----- stderr -----
+    ");
+
+    insta::with_settings!(
+        { filters => filters.clone() },
+        {
+            assert_snapshot!(context.read("project-a/.pre-commit-config.yaml"), @"
+            auto_update:
+              cooldown_days: 0
+            repos:
+              - repo: [HOME]/test-repos/workspace-cooldown-repo
+                rev: v2.0.0
+                hooks:
+                  - id: test-hook
+            ");
+        }
+    );
+
+    insta::with_settings!(
+        { filters => filters.clone() },
+        {
+            assert_snapshot!(context.read("project-b/.pre-commit-config.yaml"), @"
+            repos:
+              - repo: [HOME]/test-repos/workspace-cooldown-repo
+                rev: v1.1.0
+                hooks:
+                  - id: test-hook
+            ");
+        }
+    );
+
+    Ok(())
+}
+
 // When multiple tags point to the same object, prek prefers a tag that:
 // - contains a dot (e.g., a SemVer-like tag), and
 // - is most similar to the current revision, as measured by Levenshtein distance.

--- a/crates/prek/tests/global_config.rs
+++ b/crates/prek/tests/global_config.rs
@@ -3,105 +3,15 @@ use crate::common::{TestContext, cmd_snapshot};
 mod common;
 
 #[test]
-fn global_config_missing_file_uses_defaults() {
+fn global_config_missing_file_is_optional() {
     let context = TestContext::new();
+    context.init_project();
+    context.write_pre_commit_config("repos: []");
 
-    cmd_snapshot!(context.filters(), context.auto_update().arg("--show-settings"), @"
+    cmd_snapshot!(context.filters(), context.auto_update(), @"
     success: true
     exit_code: 0
     ----- stdout -----
-    GlobalArgs {
-        config: None,
-        cd: None,
-        color: Auto,
-        refresh: false,
-        help: (),
-        no_progress: false,
-        quiet: 0,
-        verbose: 0,
-        log_file: None,
-        no_log_file: false,
-        version: (),
-        show_settings: true,
-    }
-    AutoUpdateSettings {
-        cooldown_days: 0,
-    }
-
-    ----- stderr -----
-    ");
-}
-
-#[test]
-fn global_config_applies_cooldown_days() {
-    let context = TestContext::new();
-    context.write_user_config(indoc::indoc! {r"
-        [auto_update]
-        cooldown_days = 3
-    "});
-
-    cmd_snapshot!(context.filters(), context.auto_update().arg("--show-settings"), @"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    GlobalArgs {
-        config: None,
-        cd: None,
-        color: Auto,
-        refresh: false,
-        help: (),
-        no_progress: false,
-        quiet: 0,
-        verbose: 0,
-        log_file: None,
-        no_log_file: false,
-        version: (),
-        show_settings: true,
-    }
-    AutoUpdateSettings {
-        cooldown_days: 3,
-    }
-
-    ----- stderr -----
-    ");
-}
-
-#[test]
-fn global_config_cli_args_override_file() {
-    let context = TestContext::new();
-    context.write_user_config(indoc::indoc! {r"
-        [auto_update]
-        cooldown_days = 3
-    "});
-
-    cmd_snapshot!(
-        context.filters(),
-        context
-            .auto_update()
-            .arg("--show-settings")
-            .arg("--cooldown-days")
-            .arg("0"),
-        @"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    GlobalArgs {
-        config: None,
-        cd: None,
-        color: Auto,
-        refresh: false,
-        help: (),
-        no_progress: false,
-        quiet: 0,
-        verbose: 0,
-        log_file: None,
-        no_log_file: false,
-        version: (),
-        show_settings: true,
-    }
-    AutoUpdateSettings {
-        cooldown_days: 0,
-    }
 
     ----- stderr -----
     ");
@@ -110,6 +20,8 @@ fn global_config_cli_args_override_file() {
 #[test]
 fn global_config_ignores_unknown_options() {
     let context = TestContext::new();
+    context.init_project();
+    context.write_pre_commit_config("repos: []");
     context.write_user_config(indoc::indoc! {r#"
         future_option = true
 
@@ -118,27 +30,10 @@ fn global_config_ignores_unknown_options() {
         future_option = "ignored"
     "#});
 
-    cmd_snapshot!(context.filters(), context.auto_update().arg("--show-settings"), @"
+    cmd_snapshot!(context.filters(), context.auto_update(), @"
     success: true
     exit_code: 0
     ----- stdout -----
-    GlobalArgs {
-        config: None,
-        cd: None,
-        color: Auto,
-        refresh: false,
-        help: (),
-        no_progress: false,
-        quiet: 0,
-        verbose: 0,
-        log_file: None,
-        no_log_file: false,
-        version: (),
-        show_settings: true,
-    }
-    AutoUpdateSettings {
-        cooldown_days: 3,
-    }
 
     ----- stderr -----
     ");
@@ -147,29 +42,17 @@ fn global_config_ignores_unknown_options() {
 #[test]
 fn global_config_invalid_file_reports_parse_error() {
     let context = TestContext::new();
+    context.init_project();
+    context.write_pre_commit_config("repos: []");
     context.write_user_config(indoc::indoc! {r#"
         [auto_update]
         cooldown_days = "soon"
     "#});
 
-    cmd_snapshot!(context.filters(), context.auto_update().arg("--show-settings"), @r#"
+    cmd_snapshot!(context.filters(), context.auto_update(), @r#"
     success: false
     exit_code: 2
     ----- stdout -----
-    GlobalArgs {
-        config: None,
-        cd: None,
-        color: Auto,
-        refresh: false,
-        help: (),
-        no_progress: false,
-        quiet: 0,
-        verbose: 0,
-        log_file: None,
-        no_log_file: false,
-        version: (),
-        show_settings: true,
-    }
 
     ----- stderr -----
     error: Failed to parse global config `[HOME]/config/prek/prek.toml`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,6 +57,7 @@ Project config can also define the same setting, scoped to that project:
     ```
 
 `prek auto-update --cooldown-days <DAYS>` overrides both project and global config for a single command invocation.
+The cooldown value must be between `0` and `255` days, inclusive; `0` disables the cooldown check.
 
 In workspace mode, project-level `auto_update` settings are not inherited by nested projects. The setting only affects the project config file that defines it; sub-projects use their own `auto_update` setting, then the user-level global config, then the default.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,7 +40,23 @@ The first supported global setting is the default cooldown for `prek auto-update
 cooldown_days = 7
 ```
 
-`prek auto-update --cooldown-days <DAYS>` overrides this value for a single command invocation.
+Project config can also define the same setting, scoped to that project:
+
+=== "prek.toml"
+
+    ```toml
+    [auto_update]
+    cooldown_days = 7
+    ```
+
+=== ".pre-commit-config.yaml"
+
+    ```yaml
+    auto_update:
+      cooldown_days: 7
+    ```
+
+`prek auto-update --cooldown-days <DAYS>` overrides both project and global config for a single command invocation.
 
 ## Pre-commit compatibility
 
@@ -58,6 +74,7 @@ These entries are implemented by `prek` and are not part of the documented upstr
 They work in both YAML and TOML, but they only matter for compatibility if you share a YAML config with upstream `pre-commit`.
 
 - Top-level:
+    - [`auto_update.cooldown_days`](reference/configuration.md#auto_updatecooldown_days)
     - [`minimum_prek_version`](reference/configuration.md#prek-only-minimum-prek-version-config)
     - [`orphan`](reference/configuration.md#prek-only-orphan)
 - Repo type:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,6 +58,8 @@ Project config can also define the same setting, scoped to that project:
 
 `prek auto-update --cooldown-days <DAYS>` overrides both project and global config for a single command invocation.
 
+In workspace mode, project-level `auto_update` settings are not inherited by nested projects. The setting only affects the project config file that defines it; sub-projects use their own `auto_update` setting, then the user-level global config, then the default.
+
 ## Pre-commit compatibility
 
 `prek` is **fully compatible** with [`pre-commit`](https://pre-commit.com/) YAML configs, so your existing `.pre-commit-config.yaml` files work unchanged.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -561,7 +561,7 @@ prek auto-update [OPTIONS]
 <li><code>never</code>:  Disables colored output</li>
 </ul></dd><dt id="prek-auto-update--config"><a href="#prek-auto-update--config"><code>--config</code></a>, <code>-c</code> <i>config</i></dt><dd><p>Path to alternate config file</p>
 </dd><dt id="prek-auto-update--cooldown-days"><a href="#prek-auto-update--cooldown-days"><code>--cooldown-days</code></a> <i>days</i></dt><dd><p>Minimum release age (in days) required for a version to be eligible.</p>
-<p>The age is computed from the tag creation timestamp for annotated tags, or from the tagged commit timestamp for lightweight tags. Defaults to <code>auto_update.cooldown_days</code> in the global config, or <code>0</code> when unset. A value of <code>0</code> disables this check.</p>
+<p>The age is computed from the tag creation timestamp for annotated tags, or from the tagged commit timestamp for lightweight tags. Defaults to <code>auto_update.cooldown_days</code> in the project or global config, or <code>0</code> when unset. A value of <code>0</code> disables this check.</p>
 </dd><dt id="prek-auto-update--dry-run"><a href="#prek-auto-update--dry-run"><code>--dry-run</code></a></dt><dd><p>Do not write changes to the config file, only display what would be changed</p>
 </dd><dt id="prek-auto-update--exclude-repo"><a href="#prek-auto-update--exclude-repo"><code>--exclude-repo</code></a> <i>repo</i></dt><dd><p>Do not update this repository. This option may be specified multiple times</p>
 </dd><dt id="prek-auto-update--exclude-tag"><a href="#prek-auto-update--exclude-tag"><code>--exclude-tag</code></a> <i>pattern</i></dt><dd><p>Ignore tags matching this glob pattern. This option may be specified multiple times.</p>

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -561,7 +561,7 @@ prek auto-update [OPTIONS]
 <li><code>never</code>:  Disables colored output</li>
 </ul></dd><dt id="prek-auto-update--config"><a href="#prek-auto-update--config"><code>--config</code></a>, <code>-c</code> <i>config</i></dt><dd><p>Path to alternate config file</p>
 </dd><dt id="prek-auto-update--cooldown-days"><a href="#prek-auto-update--cooldown-days"><code>--cooldown-days</code></a> <i>days</i></dt><dd><p>Minimum release age (in days) required for a version to be eligible.</p>
-<p>The age is computed from the tag creation timestamp for annotated tags, or from the tagged commit timestamp for lightweight tags. Defaults to <code>auto_update.cooldown_days</code> in the project or global config, or <code>0</code> when unset. A value of <code>0</code> disables this check.</p>
+<p>The age is computed from the tag creation timestamp for annotated tags, or from the tagged commit timestamp for lightweight tags. Defaults to <code>auto_update.cooldown_days</code> in the project or global config, or <code>0</code> when unset. Valid values are <code>0</code> through <code>255</code>; <code>0</code> disables this check.</p>
 </dd><dt id="prek-auto-update--dry-run"><a href="#prek-auto-update--dry-run"><code>--dry-run</code></a></dt><dd><p>Do not write changes to the config file, only display what would be changed</p>
 </dd><dt id="prek-auto-update--exclude-repo"><a href="#prek-auto-update--exclude-repo"><code>--exclude-repo</code></a> <i>repo</i></dt><dd><p>Do not update this repository. This option may be specified multiple times</p>
 </dd><dt id="prek-auto-update--exclude-tag"><a href="#prek-auto-update--exclude-tag"><code>--exclude-tag</code></a> <i>pattern</i></dt><dd><p>Ignore tags matching this glob pattern. This option may be specified multiple times.</p>

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -11,7 +11,7 @@ This page documents the configuration keys that `prek` understands.
 
 This file stores user-level `prek` settings and does not define project hooks.
 
-### `auto_update.cooldown_days`
+### Global `auto_update.cooldown_days`
 
 Default cooldown for `prek auto-update`.
 
@@ -26,7 +26,38 @@ cooldown_days = 7
 
 The age is computed from the tag creation timestamp for annotated tags, or from the tagged commit timestamp for lightweight tags. A value of `0` disables the cooldown check.
 
+Project configs can also set `auto_update.cooldown_days`. The effective precedence is:
+
+1. `prek auto-update --cooldown-days <DAYS>`
+2. project config
+3. user-level global config
+4. default `0`
+
 ## Top-level keys
+
+### `auto_update.cooldown_days`
+
+Project default cooldown for `prek auto-update`.
+
+- Type: integer days
+- Default: inherited from the user-level global config, or `0`
+- CLI override: `prek auto-update --cooldown-days <DAYS>`
+
+=== "prek.toml"
+
+    ```toml
+    [auto_update]
+    cooldown_days = 7
+    ```
+
+=== ".pre-commit-config.yaml"
+
+    ```yaml
+    auto_update:
+      cooldown_days: 7
+    ```
+
+In workspace mode, this setting is scoped to the project config file that defines it. If two projects use the same repo URL with different cooldown settings, `prek auto-update` fetches the repo once but evaluates each project with its own cooldown.
 
 ### `repos` (required)
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -57,7 +57,7 @@ Project default cooldown for `prek auto-update`.
       cooldown_days: 7
     ```
 
-In workspace mode, this setting is scoped to the project config file that defines it. If two projects use the same repo URL with different cooldown settings, `prek auto-update` fetches the repo once but evaluates each project with its own cooldown.
+In workspace mode, this setting is scoped to the project config file that defines it. It applies only to that project and is not inherited by nested projects. Sub-projects use their own `auto_update` setting, then the user-level global config, then the default. If two projects use the same repo URL with different cooldown settings, `prek auto-update` fetches the repo once but evaluates each project with its own cooldown.
 
 ### `repos` (required)
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -15,7 +15,7 @@ This file stores user-level `prek` settings and does not define project hooks.
 
 Default cooldown for `prek auto-update`.
 
-- Type: integer days
+- Type: integer days, `0` to `255`
 - Default: `0`
 - CLI override: `prek auto-update --cooldown-days <DAYS>`
 
@@ -39,7 +39,7 @@ Project configs can also set `auto_update.cooldown_days`. The effective preceden
 
 Project default cooldown for `prek auto-update`.
 
-- Type: integer days
+- Type: integer days, `0` to `255`
 - Default: inherited from the user-level global config, or `0`
 - CLI override: `prek auto-update --cooldown-days <DAYS>`
 

--- a/prek.schema.json
+++ b/prek.schema.json
@@ -5,6 +5,10 @@
   "description": "The configuration file for prek, a git hook manager written in Rust.",
   "type": "object",
   "properties": {
+    "auto_update": {
+      "description": "Default settings for `prek auto-update` in this project.",
+      "$ref": "#/definitions/AutoUpdateOptions"
+    },
     "repos": {
       "type": "array",
       "items": {
@@ -129,6 +133,17 @@
   "additionalProperties": true,
   "x-tombi-toml-version": "v1.1.0",
   "definitions": {
+    "AutoUpdateOptions": {
+      "description": "Controls how `prek auto-update` selects eligible releases.",
+      "type": "object",
+      "properties": {
+        "cooldown_days": {
+          "type": "integer",
+          "maximum": 255,
+          "minimum": 0
+        }
+      }
+    },
     "Repo": {
       "description": "A repository of hooks, which can be remote, local, meta, or builtin.",
       "type": "object",


### PR DESCRIPTION
## Summary

Add project-level `auto_update.cooldown_days` support for `prek.toml` and `.pre-commit-config.yaml`.

Closes #1765 