### PR TITLE
Respect hook filters for message files

### DIFF
--- a/crates/prek/src/cli/run/filter.rs
+++ b/crates/prek/src/cli/run/filter.rs
@@ -143,14 +143,13 @@ pub(crate) fn cached_tags<'a>(
         .as_ref()
 }
 
-pub(crate) struct FileFilter<'a> {
+pub(crate) struct ProjectFiles<'a> {
     files: Vec<ProjectFile<'a>>,
 }
 
-impl<'a> FileFilter<'a> {
-    /// Create a `FileFilter` for a project by filtering the input filenames with the project's relative path and include/exclude patterns.
+impl<'a> ProjectFiles<'a> {
+    /// Create project-owned files after applying the project's relative path and include/exclude patterns.
     /// `filenames` are paths relative to the workspace root.
-    #[instrument(level = "trace", skip_all, fields(project = %project))]
     pub(crate) fn for_project<I>(
         filenames: I,
         project: &Project,

--- a/crates/prek/src/cli/run/filter.rs
+++ b/crates/prek/src/cli/run/filter.rs
@@ -1,3 +1,4 @@
+use std::cell::OnceCell;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -25,7 +26,7 @@ impl<'a> FilenameFilter<'a> {
         Self { include, exclude }
     }
 
-    pub(crate) fn filter(&self, filename: &Path) -> bool {
+    pub(crate) fn matches(&self, filename: &Path) -> bool {
         if let Some(pattern) = &self.include {
             if !pattern.is_match(filename) {
                 return false;
@@ -60,7 +61,7 @@ impl<'a> FileTagFilter<'a> {
         }
     }
 
-    pub(crate) fn filter(&self, file_types: &TagSet) -> bool {
+    pub(crate) fn matches(&self, file_types: &TagSet) -> bool {
         if self.all.is_some_and(|s| !s.is_subset(file_types)) {
             return false;
         }
@@ -77,9 +78,73 @@ impl<'a> FileTagFilter<'a> {
     }
 }
 
+pub(crate) struct HookFileFilter<'a> {
+    filename: FilenameFilter<'a>,
+    tags: FileTagFilter<'a>,
+}
+
+impl<'a> HookFileFilter<'a> {
+    pub(crate) fn new(hook: &'a Hook) -> Self {
+        Self {
+            filename: FilenameFilter::new(hook.files.as_ref(), hook.exclude.as_ref()),
+            tags: FileTagFilter::new(
+                Some(&hook.types),
+                Some(&hook.types_or),
+                Some(&hook.exclude_types),
+            ),
+        }
+    }
+
+    pub(crate) fn matches_filename(&self, filename: &Path) -> bool {
+        self.filename.matches(filename)
+    }
+
+    pub(crate) fn matches_tags(&self, tags: Option<&TagSet>) -> bool {
+        tags.is_some_and(|tags| self.tags.matches(tags))
+    }
+
+    fn matches_project_file(&self, file: &ProjectFile<'_>) -> bool {
+        self.matches_filename(file.hook_path) && self.matches_tags(file.tags())
+    }
+}
+
+struct ProjectFile<'a> {
+    workspace_path: &'a Path,
+    hook_path: &'a Path,
+    tags: OnceCell<Option<TagSet>>,
+}
+
+impl<'a> ProjectFile<'a> {
+    fn new(workspace_path: &'a Path, hook_path: &'a Path) -> Self {
+        Self {
+            workspace_path,
+            hook_path,
+            tags: OnceCell::new(),
+        }
+    }
+
+    fn tags(&self) -> Option<&TagSet> {
+        cached_tags(&self.tags, self.workspace_path)
+    }
+}
+
+pub(crate) fn cached_tags<'a>(
+    cache: &'a OnceCell<Option<TagSet>>,
+    path: &Path,
+) -> Option<&'a TagSet> {
+    cache
+        .get_or_init(|| match tags_from_path(path) {
+            Ok(tags) => Some(tags),
+            Err(err) => {
+                error!(filename = ?path.display(), error = %err, "Failed to get tags");
+                None
+            }
+        })
+        .as_ref()
+}
+
 pub(crate) struct FileFilter<'a> {
-    filenames: Vec<&'a Path>,
-    filename_prefix: PathBuf,
+    files: Vec<ProjectFile<'a>>,
 }
 
 impl<'a> FileFilter<'a> {
@@ -94,7 +159,7 @@ impl<'a> FileFilter<'a> {
     where
         I: Iterator<Item = &'a PathBuf> + Send,
     {
-        let filter = FilenameFilter::new(
+        let filename_filter = FilenameFilter::new(
             project.config().files.as_ref(),
             project.config().exclude.as_ref(),
         );
@@ -106,7 +171,7 @@ impl<'a> FileFilter<'a> {
         // *before* applying the project's include/exclude patterns. This ensures that even
         // files excluded by this project are still considered "owned" by it and hidden
         // from parent projects.
-        let filenames = filenames
+        let files = filenames
             .map(PathBuf::as_path)
             // Collect files that are inside the hook project directory.
             .filter(|filename| filename.starts_with(relative_path))
@@ -122,22 +187,23 @@ impl<'a> FileFilter<'a> {
                 }
             })
             // Strip the project-relative prefix before applying project-level include/exclude patterns.
-            .filter(|filename| {
+            .filter_map(|filename| {
                 let relative = filename
                     .strip_prefix(relative_path)
                     .expect("Filename should start with project relative path");
-                filter.filter(relative)
+                if filename_filter.matches(relative) {
+                    Some(ProjectFile::new(filename, relative))
+                } else {
+                    None
+                }
             })
             .collect::<Vec<_>>();
 
-        Self {
-            filenames,
-            filename_prefix: relative_path.to_path_buf(),
-        }
+        Self { files }
     }
 
     pub(crate) fn len(&self) -> usize {
-        self.filenames.len()
+        self.files.len()
     }
 
     /// Filter filenames by type tags for a specific hook.
@@ -147,18 +213,17 @@ impl<'a> FileFilter<'a> {
         types_or: Option<&TagSet>,
         exclude_types: Option<&TagSet>,
     ) -> Vec<&Path> {
-        let filter = FileTagFilter::new(types, types_or, exclude_types);
+        let tag_filter = FileTagFilter::new(types, types_or, exclude_types);
         let filenames: Vec<_> = self
-            .filenames
+            .files
             .iter()
-            .filter(|filename| match tags_from_path(filename) {
-                Ok(tags) => filter.filter(&tags),
-                Err(err) => {
-                    error!(filename = ?filename.display(), error = %err, "Failed to get tags");
-                    false
+            .filter_map(|file| {
+                if tag_filter.matches(file.tags()?) {
+                    Some(file.workspace_path)
+                } else {
+                    None
                 }
             })
-            .copied()
             .collect();
 
         filenames
@@ -167,41 +232,17 @@ impl<'a> FileFilter<'a> {
     /// Filter filenames by file patterns and tags for a specific hook.
     #[instrument(level = "trace", skip_all, fields(hook = ?hook.id))]
     pub(crate) fn for_hook(&self, hook: &Hook) -> Vec<&Path> {
-        // Filter by hook `files` and `exclude` patterns.
-        let filter = FilenameFilter::new(hook.files.as_ref(), hook.exclude.as_ref());
-
-        let filenames = self.filenames.iter().filter(|filename| {
-            // Strip the project-relative prefix before applying hook-level include/exclude patterns.
-            if let Ok(relative) = filename.strip_prefix(&self.filename_prefix) {
-                filter.filter(relative)
-            } else {
-                false
-            }
-        });
-
-        // Filter by hook `types`, `types_or` and `exclude_types`.
-        let filter = FileTagFilter::new(
-            Some(&hook.types),
-            Some(&hook.types_or),
-            Some(&hook.exclude_types),
-        );
-        let filenames = filenames.filter(|filename| match tags_from_path(filename) {
-            Ok(tags) => filter.filter(&tags),
-            Err(err) => {
-                error!(filename = ?filename.display(), error = %err, "Failed to get tags");
-                false
-            }
-        });
-
-        // Strip the prefix to get relative paths.
-        let filenames: Vec<_> = filenames
-            .map(|p| {
-                p.strip_prefix(&self.filename_prefix)
-                    .expect("Filename should start with project relative path")
+        let hook_filter = HookFileFilter::new(hook);
+        self.files
+            .iter()
+            .filter_map(|file| {
+                if hook_filter.matches_project_file(file) {
+                    Some(file.hook_path)
+                } else {
+                    None
+                }
             })
-            .collect();
-
-        filenames
+            .collect()
     }
 }
 
@@ -443,9 +484,9 @@ mod tests {
         let exclude = glob_pattern("src/**/ignored.rs");
         let filter = FilenameFilter::new(Some(&include), Some(&exclude));
 
-        assert!(filter.filter(Path::new("src/lib/main.rs")));
-        assert!(!filter.filter(Path::new("src/lib/ignored.rs")));
-        assert!(!filter.filter(Path::new("tests/main.rs")));
+        assert!(filter.matches(Path::new("src/lib/main.rs")));
+        assert!(!filter.matches(Path::new("src/lib/ignored.rs")));
+        assert!(!filter.matches(Path::new("tests/main.rs")));
     }
 
     #[cfg(unix)]
@@ -457,7 +498,7 @@ mod tests {
         let path = Path::new(OsStr::from_bytes(b"bad-\xff.py"));
         let filter = FilenameFilter::new(None, None);
 
-        assert!(filter.filter(path));
+        assert!(filter.matches(path));
     }
 
     #[cfg(unix)]
@@ -471,11 +512,11 @@ mod tests {
         let path = Path::new(OsStr::from_bytes(b"bad-\xff.py"));
         let filter = FilenameFilter::new(Some(&include), None);
 
-        assert!(filter.filter(path));
+        assert!(filter.matches(path));
 
         let filter = FilenameFilter::new(None, Some(&exclude));
 
-        assert!(!filter.filter(path));
+        assert!(!filter.matches(path));
     }
 
     #[cfg(unix)]
@@ -488,6 +529,6 @@ mod tests {
         let path = Path::new(OsStr::from_bytes(b"bad-\xff.py"));
         let filter = FilenameFilter::new(Some(&include), None);
 
-        assert!(!filter.filter(path));
+        assert!(!filter.matches(path));
     }
 }

--- a/crates/prek/src/cli/run/filter.rs
+++ b/crates/prek/src/cli/run/filter.rs
@@ -1,4 +1,3 @@
-use std::cell::OnceCell;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -6,7 +5,7 @@ use itertools::{Either, Itertools};
 use path_clean::PathClean;
 use prek_consts::env_vars::EnvVars;
 use prek_identify::{TagSet, tags_from_path};
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::{debug, error, instrument};
 
 use crate::config::{FilePattern, Stage};
@@ -103,15 +102,14 @@ impl<'a> HookFileFilter<'a> {
         tags.is_some_and(|tags| self.tags.matches(tags))
     }
 
-    fn matches_project_file(&self, file: &ProjectFile<'_>) -> bool {
-        self.matches_filename(file.hook_path) && self.matches_tags(file.tags())
+    fn matches_project_file(&self, file: &ProjectFile<'_>, tag_cache: &mut FileTagCache) -> bool {
+        self.matches_filename(file.hook_path) && self.matches_tags(file.tags(tag_cache))
     }
 }
 
 struct ProjectFile<'a> {
     workspace_path: &'a Path,
     hook_path: &'a Path,
-    tags: OnceCell<Option<TagSet>>,
 }
 
 impl<'a> ProjectFile<'a> {
@@ -119,28 +117,33 @@ impl<'a> ProjectFile<'a> {
         Self {
             workspace_path,
             hook_path,
-            tags: OnceCell::new(),
         }
     }
 
-    fn tags(&self) -> Option<&TagSet> {
-        cached_tags(&self.tags, self.workspace_path)
+    fn tags<'cache>(&self, tag_cache: &'cache mut FileTagCache) -> Option<&'cache TagSet> {
+        tag_cache.tags(self.workspace_path)
     }
 }
 
-pub(crate) fn cached_tags<'a>(
-    cache: &'a OnceCell<Option<TagSet>>,
-    path: &Path,
-) -> Option<&'a TagSet> {
-    cache
-        .get_or_init(|| match tags_from_path(path) {
-            Ok(tags) => Some(tags),
-            Err(err) => {
-                error!(filename = ?path.display(), error = %err, "Failed to get tags");
-                None
-            }
-        })
-        .as_ref()
+#[derive(Default)]
+pub(crate) struct FileTagCache {
+    tags_by_path: FxHashMap<PathBuf, Option<TagSet>>,
+}
+
+impl FileTagCache {
+    pub(crate) fn tags(&mut self, path: &Path) -> Option<&TagSet> {
+        if !self.tags_by_path.contains_key(path) {
+            let tags = match tags_from_path(path) {
+                Ok(tags) => Some(tags),
+                Err(err) => {
+                    error!(filename = ?path.display(), error = %err, "Failed to get tags");
+                    None
+                }
+            };
+            self.tags_by_path.insert(path.to_path_buf(), tags);
+        }
+        self.tags_by_path.get(path).and_then(Option::as_ref)
+    }
 }
 
 pub(crate) struct ProjectFiles<'a> {
@@ -211,37 +214,31 @@ impl<'a> ProjectFiles<'a> {
         types: Option<&TagSet>,
         types_or: Option<&TagSet>,
         exclude_types: Option<&TagSet>,
+        tag_cache: &mut FileTagCache,
     ) -> Vec<&Path> {
         let tag_filter = FileTagFilter::new(types, types_or, exclude_types);
-        let filenames: Vec<_> = self
-            .files
-            .iter()
-            .filter_map(|file| {
-                if tag_filter.matches(file.tags()?) {
-                    Some(file.workspace_path)
-                } else {
-                    None
+        let mut filenames = Vec::new();
+        for file in &self.files {
+            if let Some(tags) = file.tags(tag_cache) {
+                if tag_filter.matches(tags) {
+                    filenames.push(file.workspace_path);
                 }
-            })
-            .collect();
-
+            }
+        }
         filenames
     }
 
     /// Filter filenames by file patterns and tags for a specific hook.
     #[instrument(level = "trace", skip_all, fields(hook = ?hook.id))]
-    pub(crate) fn for_hook(&self, hook: &Hook) -> Vec<&Path> {
+    pub(crate) fn for_hook(&self, hook: &Hook, tag_cache: &mut FileTagCache) -> Vec<&Path> {
         let hook_filter = HookFileFilter::new(hook);
-        self.files
-            .iter()
-            .filter_map(|file| {
-                if hook_filter.matches_project_file(file) {
-                    Some(file.hook_path)
-                } else {
-                    None
-                }
-            })
-            .collect()
+        let mut filenames = Vec::new();
+        for file in &self.files {
+            if hook_filter.matches_project_file(file, tag_cache) {
+                filenames.push(file.hook_path);
+            }
+        }
+        filenames
     }
 }
 

--- a/crates/prek/src/cli/run/mod.rs
+++ b/crates/prek/src/cli/run/mod.rs
@@ -1,4 +1,4 @@
-pub(crate) use filter::{CollectOptions, FileFilter, RunInput, collect_files, collect_run_input};
+pub(crate) use filter::{CollectOptions, ProjectFiles, RunInput, collect_files, collect_run_input};
 pub(crate) use run::{install_hooks, run};
 pub(crate) use selector::{SelectorSource, Selectors};
 

--- a/crates/prek/src/cli/run/mod.rs
+++ b/crates/prek/src/cli/run/mod.rs
@@ -1,4 +1,6 @@
-pub(crate) use filter::{CollectOptions, ProjectFiles, RunInput, collect_files, collect_run_input};
+pub(crate) use filter::{
+    CollectOptions, FileTagCache, ProjectFiles, RunInput, collect_files, collect_run_input,
+};
 pub(crate) use run::{install_hooks, run};
 pub(crate) use selector::{SelectorSource, Selectors};
 

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -1,3 +1,4 @@
+use std::cell::OnceCell;
 use std::fmt::Write as _;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
@@ -6,11 +7,11 @@ use std::sync::{Arc, LazyLock};
 
 use anyhow::{Context, Result};
 use futures::stream::{FuturesUnordered, StreamExt};
-use mea::once::OnceCell;
 use mea::semaphore::Semaphore;
 use owo_colors::OwoColorize;
 use prek_consts::env_vars::EnvVars;
 use prek_consts::{PRE_COMMIT_CONFIG_YAML, PREK_TOML};
+use prek_identify::TagSet;
 use rand::SeedableRng;
 use rand::prelude::{SliceRandom, StdRng};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -18,6 +19,7 @@ use tracing::{debug, trace, warn};
 use unicode_width::UnicodeWidthStr;
 
 use crate::cli::reporter::{HookInitReporter, HookInstallReporter, HookRunReporter};
+use crate::cli::run::filter::{HookFileFilter, cached_tags};
 use crate::cli::run::keeper::WorkTreeKeeper;
 use crate::cli::run::{CollectOptions, FileFilter, RunInput, Selectors, collect_run_input};
 use crate::cli::{ExitStatus, RunExtraArgs};
@@ -266,14 +268,14 @@ fn set_env_vars(from_ref: Option<&String>, to_ref: Option<&String>, args: &RunEx
 #[derive(Debug)]
 struct LazyInstallInfo {
     info: Arc<InstallInfo>,
-    health: OnceCell<bool>,
+    health: mea::once::OnceCell<bool>,
 }
 
 impl LazyInstallInfo {
     fn new(info: Arc<InstallInfo>) -> Self {
         Self {
             info,
-            health: OnceCell::new(),
+            health: mea::once::OnceCell::new(),
         }
     }
 
@@ -572,7 +574,11 @@ impl StatusPrinter {
 
 enum ProjectHookInput<'a> {
     Files(FileFilter<'a>),
-    MessageFile(PathBuf),
+    MessageFile {
+        absolute_path: &'a Path,
+        hook_arg: PathBuf,
+        tags: OnceCell<Option<TagSet>>,
+    },
 }
 
 impl<'a> ProjectHookInput<'a> {
@@ -587,27 +593,40 @@ impl<'a> ProjectHookInput<'a> {
                 project,
                 consumed_files,
             ))),
-            RunInput::MessageFile(path) => Ok(Self::MessageFile(fs::normalize_path(
-                fs::relative_to(path, project.path())?,
-            ))),
+            RunInput::MessageFile(path) => Ok(Self::MessageFile {
+                absolute_path: path,
+                hook_arg: fs::normalize_path(fs::relative_to(path, project.path())?),
+                tags: OnceCell::new(),
+            }),
         }
     }
 
     fn len(&self) -> usize {
         match self {
             Self::Files(filter) => filter.len(),
-            Self::MessageFile(_) => 1,
+            Self::MessageFile { .. } => 1,
         }
     }
 
     fn for_hook(&self, hook: &Hook) -> Vec<&Path> {
         match self {
             Self::Files(filter) => filter.for_hook(hook),
-            Self::MessageFile(path) => {
-                // `commit-msg` and `prepare-commit-msg` receive Git's message file, which is not
-                // a workspace file. The `files`/`exclude`/`types` filters are workspace-file
-                // selectors, so they do not apply to this hook argument.
-                vec![path.as_path()]
+            Self::MessageFile {
+                absolute_path,
+                hook_arg,
+                tags,
+            } => {
+                // `commit-msg` and `prepare-commit-msg` receive Git's special message file,
+                // which can live outside a project root, so it bypasses project ownership
+                // filtering. Hook-level `files`/`exclude`/`types` filters still apply.
+                let hook_filter = HookFileFilter::new(hook);
+                if hook_filter.matches_filename(hook_arg)
+                    && hook_filter.matches_tags(cached_tags(tags, absolute_path))
+                {
+                    vec![hook_arg.as_path()]
+                } else {
+                    vec![]
+                }
             }
         }
     }

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -1,4 +1,3 @@
-use std::cell::OnceCell;
 use std::fmt::Write as _;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
@@ -11,7 +10,6 @@ use mea::semaphore::Semaphore;
 use owo_colors::OwoColorize;
 use prek_consts::env_vars::EnvVars;
 use prek_consts::{PRE_COMMIT_CONFIG_YAML, PREK_TOML};
-use prek_identify::TagSet;
 use rand::SeedableRng;
 use rand::prelude::{SliceRandom, StdRng};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -19,9 +17,11 @@ use tracing::{debug, trace, warn};
 use unicode_width::UnicodeWidthStr;
 
 use crate::cli::reporter::{HookInitReporter, HookInstallReporter, HookRunReporter};
-use crate::cli::run::filter::{HookFileFilter, cached_tags};
+use crate::cli::run::filter::HookFileFilter;
 use crate::cli::run::keeper::WorkTreeKeeper;
-use crate::cli::run::{CollectOptions, ProjectFiles, RunInput, Selectors, collect_run_input};
+use crate::cli::run::{
+    CollectOptions, FileTagCache, ProjectFiles, RunInput, Selectors, collect_run_input,
+};
 use crate::cli::{ExitStatus, RunExtraArgs};
 use crate::config::{Language, PassFilenames, Stage};
 use crate::fs::CWD;
@@ -577,7 +577,6 @@ enum ProjectHookInput<'a> {
     MessageFile {
         absolute_path: &'a Path,
         hook_arg: PathBuf,
-        tags: OnceCell<Option<TagSet>>,
     },
 }
 
@@ -596,7 +595,6 @@ impl<'a> ProjectHookInput<'a> {
             RunInput::MessageFile(path) => Ok(Self::MessageFile {
                 absolute_path: path,
                 hook_arg: fs::normalize_path(fs::relative_to(path, project.path())?),
-                tags: OnceCell::new(),
             }),
         }
     }
@@ -608,20 +606,19 @@ impl<'a> ProjectHookInput<'a> {
         }
     }
 
-    fn for_hook(&self, hook: &Hook) -> Vec<&Path> {
+    fn for_hook(&self, hook: &Hook, tag_cache: &mut FileTagCache) -> Vec<&Path> {
         match self {
-            Self::Files(project_files) => project_files.for_hook(hook),
+            Self::Files(project_files) => project_files.for_hook(hook, tag_cache),
             Self::MessageFile {
                 absolute_path,
                 hook_arg,
-                tags,
             } => {
                 // `commit-msg` and `prepare-commit-msg` receive Git's special message file,
                 // which can live outside a project root, so it bypasses project ownership
                 // filtering. Hook-level `files`/`exclude`/`types` filters still apply.
                 let hook_filter = HookFileFilter::new(hook);
                 if hook_filter.matches_filename(hook_arg)
-                    && hook_filter.matches_tags(cached_tags(tags, absolute_path))
+                    && hook_filter.matches_tags(tag_cache.tags(absolute_path))
                 {
                     vec![hook_arg.as_path()]
                 } else {
@@ -669,6 +666,7 @@ async fn run_hooks(
 
     // Track files that have been consumed by orphan projects.
     let mut consumed_files = FxHashSet::default();
+    let mut tag_cache = FileTagCache::default();
 
     'outer: for project in workspace.all_projects() {
         let project_input = ProjectHookInput::new(&input, project, Some(&mut consumed_files))?;
@@ -702,8 +700,15 @@ async fn run_hooks(
 
         for group_range in PriorityGroupRanges::new(&hooks) {
             let group_hooks = hooks[group_range].to_vec();
-            let mut group_results =
-                run_priority_group(group_hooks, &project_input, store, dry_run, &reporter).await?;
+            let mut group_results = run_priority_group(
+                group_hooks,
+                &project_input,
+                &mut tag_cache,
+                store,
+                dry_run,
+                &reporter,
+            )
+            .await?;
 
             // Print results in a stable order (same order as config within the project).
             group_results.sort_unstable_by_key(|a| a.hook.idx);
@@ -832,6 +837,7 @@ impl Iterator for PriorityGroupRanges<'_> {
 async fn run_priority_group(
     group_hooks: Vec<InstalledHook>,
     input: &ProjectHookInput<'_>,
+    tag_cache: &mut FileTagCache,
     store: &Store,
     dry_run: bool,
     reporter: &HookRunReporter,
@@ -843,12 +849,17 @@ async fn run_priority_group(
         group_hooks.iter().map(|h| &h.id).collect::<Vec<_>>()
     );
 
-    let mut results = futures::stream::iter(
-        group_hooks
-            .into_iter()
-            .map(|hook| run_hook(hook, input, store, dry_run, reporter)),
-    )
-    .buffer_unordered(*CONCURRENCY);
+    let mut results = futures::stream::iter(group_hooks)
+        .map(|hook| {
+            let filenames = input.for_hook(&hook, tag_cache);
+            trace!(
+                "Files for hook `{}` after filtered: {}",
+                hook.id,
+                filenames.len()
+            );
+            run_hook(hook, filenames, store, dry_run, reporter)
+        })
+        .buffer_unordered(*CONCURRENCY);
 
     let mut group_results = Vec::new();
     while let Some(result) = results.next().await {
@@ -1062,18 +1073,11 @@ impl RunResult {
 
 async fn run_hook(
     hook: InstalledHook,
-    input: &ProjectHookInput<'_>,
+    mut filenames: Vec<&Path>,
     store: &Store,
     dry_run: bool,
     reporter: &HookRunReporter,
 ) -> Result<RunResult> {
-    let mut filenames = input.for_hook(&hook);
-    trace!(
-        "Files for hook `{}` after filtered: {}",
-        hook.id,
-        filenames.len()
-    );
-
     if filenames.is_empty() && !hook.always_run {
         return Ok(RunResult::from_status(hook, RunStatus::NoFiles));
     }

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -21,7 +21,7 @@ use unicode_width::UnicodeWidthStr;
 use crate::cli::reporter::{HookInitReporter, HookInstallReporter, HookRunReporter};
 use crate::cli::run::filter::{HookFileFilter, cached_tags};
 use crate::cli::run::keeper::WorkTreeKeeper;
-use crate::cli::run::{CollectOptions, FileFilter, RunInput, Selectors, collect_run_input};
+use crate::cli::run::{CollectOptions, ProjectFiles, RunInput, Selectors, collect_run_input};
 use crate::cli::{ExitStatus, RunExtraArgs};
 use crate::config::{Language, PassFilenames, Stage};
 use crate::fs::CWD;
@@ -573,7 +573,7 @@ impl StatusPrinter {
 }
 
 enum ProjectHookInput<'a> {
-    Files(FileFilter<'a>),
+    Files(ProjectFiles<'a>),
     MessageFile {
         absolute_path: &'a Path,
         hook_arg: PathBuf,
@@ -588,7 +588,7 @@ impl<'a> ProjectHookInput<'a> {
         consumed_files: Option<&mut FxHashSet<&'a Path>>,
     ) -> Result<Self> {
         match input {
-            RunInput::Files(files) => Ok(Self::Files(FileFilter::for_project(
+            RunInput::Files(files) => Ok(Self::Files(ProjectFiles::for_project(
                 files.iter(),
                 project,
                 consumed_files,
@@ -603,14 +603,14 @@ impl<'a> ProjectHookInput<'a> {
 
     fn len(&self) -> usize {
         match self {
-            Self::Files(filter) => filter.len(),
+            Self::Files(project_files) => project_files.len(),
             Self::MessageFile { .. } => 1,
         }
     }
 
     fn for_hook(&self, hook: &Hook) -> Vec<&Path> {
         match self {
-            Self::Files(filter) => filter.for_hook(hook),
+            Self::Files(project_files) => project_files.for_hook(hook),
             Self::MessageFile {
                 absolute_path,
                 hook_arg,

--- a/crates/prek/src/hooks/meta_hooks.rs
+++ b/crates/prek/src/hooks/meta_hooks.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use prek_consts::CONFIG_FILENAMES;
 
 use crate::cli::reporter::HookRunReporter;
-use crate::cli::run::{CollectOptions, FileFilter, collect_files};
+use crate::cli::run::{CollectOptions, ProjectFiles, collect_files};
 use crate::config::{self, FilePattern, HookOptions, Language, MetaHook};
 use crate::hook::Hook;
 use crate::store::Store;
@@ -106,7 +106,7 @@ pub(crate) async fn check_hooks_apply(
         let path = relative_path.join(filename);
         let mut project = Project::from_config_file(path.into(), None)?;
         project.with_relative_path(relative_path.to_path_buf());
-        let filter = FileFilter::for_project(input.iter(), &project, None);
+        let project_files = ProjectFiles::for_project(input.iter(), &project, None);
 
         let project_hooks = project
             .init_hooks(store, None)
@@ -118,7 +118,7 @@ pub(crate) async fn check_hooks_apply(
                 continue;
             }
 
-            let filenames = filter.for_hook(&project_hook);
+            let filenames = project_files.for_hook(&project_hook);
 
             if filenames.is_empty() {
                 code = 1;
@@ -168,7 +168,7 @@ pub(crate) async fn check_useless_excludes(
     // `collect_files` returns paths relative to the hook's project root.
     // The meta hook itself runs from the workspace root, so we build both:
     // - `input_project`: for matching `files`/`exclude` patterns (project-relative)
-    // - `input_workspace`: for `FileFilter` (workspace-relative)
+    // - `input_workspace`: for `ProjectFiles` (workspace-relative)
     let input_project = collect_files(hook.work_dir(), CollectOptions::all_files()).await?;
     let input_workspace: Vec<_> = input_project
         .iter()
@@ -197,7 +197,7 @@ pub(crate) async fn check_useless_excludes(
             )?;
         }
 
-        let filter = FileFilter::for_project(input_workspace.iter(), &project, None);
+        let project_files = ProjectFiles::for_project(input_workspace.iter(), &project, None);
 
         for repo in &config.repos {
             let hooks_iter: Box<dyn Iterator<Item = (&String, &HookOptions)>> = match repo {
@@ -208,7 +208,7 @@ pub(crate) async fn check_useless_excludes(
             };
 
             for (hook_id, opts) in hooks_iter {
-                let filtered_files = filter.by_type(
+                let filtered_files = project_files.by_type(
                     opts.types.as_ref(),
                     opts.types_or.as_ref(),
                     opts.exclude_types.as_ref(),

--- a/crates/prek/src/hooks/meta_hooks.rs
+++ b/crates/prek/src/hooks/meta_hooks.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use prek_consts::CONFIG_FILENAMES;
 
 use crate::cli::reporter::HookRunReporter;
-use crate::cli::run::{CollectOptions, ProjectFiles, collect_files};
+use crate::cli::run::{CollectOptions, FileTagCache, ProjectFiles, collect_files};
 use crate::config::{self, FilePattern, HookOptions, Language, MetaHook};
 use crate::hook::Hook;
 use crate::store::Store;
@@ -101,6 +101,7 @@ pub(crate) async fn check_hooks_apply(
 
     let mut code = 0;
     let mut output = Vec::new();
+    let mut tag_cache = FileTagCache::default();
 
     for filename in filenames {
         let path = relative_path.join(filename);
@@ -118,7 +119,7 @@ pub(crate) async fn check_hooks_apply(
                 continue;
             }
 
-            let filenames = project_files.for_hook(&project_hook);
+            let filenames = project_files.for_hook(&project_hook, &mut tag_cache);
 
             if filenames.is_empty() {
                 code = 1;
@@ -177,6 +178,7 @@ pub(crate) async fn check_useless_excludes(
 
     let mut code = 0;
     let mut output = Vec::new();
+    let mut tag_cache = FileTagCache::default();
 
     for filename in filenames {
         let path = relative_path.join(filename);
@@ -212,6 +214,7 @@ pub(crate) async fn check_useless_excludes(
                     opts.types.as_ref(),
                     opts.types_or.as_ref(),
                     opts.exclude_types.as_ref(),
+                    &mut tag_cache,
                 );
 
                 // `filtered_files` is workspace-relative (it includes the project prefix).

--- a/crates/prek/tests/hook_impl.rs
+++ b/crates/prek/tests/hook_impl.rs
@@ -646,6 +646,56 @@ fn workspace_commit_msg_hook_receives_message_file_for_each_project() -> anyhow:
 }
 
 #[test]
+fn commit_msg_builtin_hook_respects_message_file_filters() {
+    let context = TestContext::new();
+    context.init_project();
+
+    context.write_pre_commit_config(indoc! {r"
+    default_install_hook_types:
+      - commit-msg
+    repos:
+      - repo: builtin
+        hooks:
+        - id: check-json
+    "});
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.install(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    prek installed at `.git/hooks/commit-msg`
+
+    ----- stderr -----
+    ");
+
+    let mut commit = git_cmd(context.work_dir());
+    commit
+        .env(EnvVars::PREK_HOME, &**context.home_dir())
+        .arg("commit")
+        .arg("-m")
+        .arg("dummy");
+
+    let filters = context
+        .filters()
+        .into_iter()
+        .chain([("[a-f0-9]{7}", "abc1234")])
+        .collect::<Vec<_>>();
+
+    cmd_snapshot!(filters, commit, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [master (root-commit) abc1234] dummy
+     1 file changed, 6 insertions(+)
+     create mode 100644 .pre-commit-config.yaml
+
+    ----- stderr -----
+    check json...........................................(no files to check)Skipped
+    ");
+}
+
+#[test]
 fn workspace_hook_impl_subdirectory() -> anyhow::Result<()> {
     let context = TestContext::new();
     let cwd = context.work_dir();

--- a/scripts/hyperfine-run-benchmarks.sh
+++ b/scripts/hyperfine-run-benchmarks.sh
@@ -66,7 +66,7 @@ close_section() {
 # Hyperfine's JSON has results[0] = reference and results[1] = current.
 # A ratio > 1 means current is slower (regression), < 1 means faster (improvement).
 check_variance() {
-  local cmd="$1"
+  local label="$1"
   local num_results
   num_results=$(jq '.results | length' "$OUT_JSON")
 
@@ -83,10 +83,10 @@ check_variance() {
   if (( $(echo "${pct#-} > 10" | bc -l) )); then
     if (( $(echo "$ratio < 1" | bc -l) )); then
       improvement_count=$((improvement_count + 1))
-      write_line "✅  Performance improvement for \`$cmd\`: ${pct#-}% faster"
+      write_line "✅  Performance improvement for \`$label\`: ${pct#-}% faster"
     else
       regression_count=$((regression_count + 1))
-      write_line "⚠️  Warning: Performance regression for \`$cmd\`: ${pct}% slower"
+      write_line "⚠️  Warning: Performance regression for \`$label\`: ${pct}% slower"
     fi
   fi
 }
@@ -97,8 +97,7 @@ benchmark() {
   local runs="${3:-30}"
   local setup="${4:-}"
   local prepare="${5:-}"
-  local check_change="${6:-false}"
-  local label_suffix="${7:-}"
+  local label_suffix="${6:-}"
   local label="prek $cmd"
   local -a hyperfine_args=(-i -N -w "$warmup" -r "$runs" --export-markdown "$OUT_MD" --export-json "$OUT_JSON")
 
@@ -122,9 +121,7 @@ benchmark() {
   fi
   cat "$OUT_MD" >> "$REPORT_BODY"
   write_blank_line
-  if [ "$check_change" = "true" ]; then
-    check_variance "$cmd"
-  fi
+  check_variance "$label"
 }
 
 create_meta_workspace() {
@@ -188,7 +185,6 @@ for cmd in "${CMDS[@]}"; do
   else
     benchmark "$cmd" 3 50
   fi
-  check_variance "$cmd"
 done
 
 # Benchmark builtin hooks in test directory
@@ -196,12 +192,12 @@ cd "$TARGET_WORKSPACE"
 
 # Cold vs warm benchmarks before polluting cache
 write_section "Cold vs Warm Runs" "Comparing first run (cold) vs subsequent runs (warm cache):"
-benchmark "run --all-files" 0 10 "rm -rf ~/.cache/prek" "git checkout -- ." false "(cold - no cache)"
-benchmark "run --all-files" 3 20 "" "git checkout -- ." false "(warm - with cache)"
+benchmark "run --all-files" 0 10 "rm -rf ~/.cache/prek" "git checkout -- ." "(cold - no cache)"
+benchmark "run --all-files" 3 20 "" "git checkout -- ." "(warm - with cache)"
 
 # Full benchmark suite with cache warmed up
 write_section "Full Hook Suite" "Running the builtin hook suite on the benchmark workspace:"
-benchmark "run --all-files" 3 50 "" "git checkout -- ." true "(full builtin hook suite)"
+benchmark "run --all-files" 3 50 "" "git checkout -- ." "(full builtin hook suite)"
 
 # Individual hook performance
 write_section "Individual Hook Performance" "Benchmarking each hook individually on the test repo:"
@@ -223,19 +219,19 @@ done
 
 # Installation performance
 write_section "Installation Performance" "Benchmarking hook installation (fast path hooks skip Python setup):"
-benchmark "install-hooks" 1 5 "rm -rf ~/.cache/prek/hooks ~/.cache/prek/repos" "" false "(cold - no cache)"
-benchmark "install-hooks" 1 5 "" "" false "(warm - with cache)"
+benchmark "install-hooks" 1 5 "rm -rf ~/.cache/prek/hooks ~/.cache/prek/repos" "" "(cold - no cache)"
+benchmark "install-hooks" 1 5 "" "" "(warm - with cache)"
 
 # File filtering/scoping performance
 write_section "File Filtering/Scoping Performance" "Testing different file selection modes:"
 
 git add -A
-benchmark "run" 3 20 "" "sh -c 'git checkout -- . && git add -A'" false "(staged files only)"
-benchmark "run --files '*.json'" 3 20 "" "" false "(specific file type)"
+benchmark "run" 3 20 "" "sh -c 'git checkout -- . && git add -A'" "(staged files only)"
+benchmark "run --files '*.json'" 3 20 "" "" "(specific file type)"
 
 # Workspace discovery & initialization
 write_section "Workspace Discovery & Initialization" "Benchmarking hook discovery and initialization overhead:"
-benchmark "run --dry-run --all-files" 3 20 "" "" false "(measures init overhead)"
+benchmark "run --dry-run --all-files" 3 20 "" "" "(measures init overhead)"
 
 # Meta hooks performance
 write_section "Meta Hooks Performance" "Benchmarking meta hooks separately:"


### PR DESCRIPTION
Fixes #2048

Commit-message hooks receive Git's message file outside normal workspace ownership filtering, but hook-level `files`, `exclude`, and `types` filters still decide whether a hook should run on that argument.

This keeps the message-file path available for `commit-msg` and `prepare-commit-msg` hooks while preventing file-oriented hooks such as `check-json` from parsing `.git/COMMIT_EDITMSG` when their filters do not match.