### PR TITLE
Expand tilde in `--config`, `--cd`, `--log-file` and `--git-dir`

### DIFF
--- a/crates/prek/src/cli/mod.rs
+++ b/crates/prek/src/cli/mod.rs
@@ -3,13 +3,14 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use clap::builder::styling::{AnsiColor, Effects};
-use clap::builder::{ArgPredicate, Styles};
+use clap::builder::{ArgPredicate, PathBufValueParser, Styles, TypedValueParser};
 use clap::{ArgAction, Args, Parser, Subcommand, ValueHint};
 use clap_complete::engine::ArgValueCompleter;
 use prek_consts::env_vars::EnvVars;
 use serde::{Deserialize, Serialize};
 
 use crate::config::{HookType, Language, Stage};
+use crate::fs::expand_tilde;
 
 mod auto_update;
 mod cache_clean;
@@ -155,7 +156,12 @@ pub(crate) struct Cli {
 #[allow(clippy::struct_excessive_bools)]
 pub(crate) struct GlobalArgs {
     /// Path to alternate config file.
-    #[arg(global = true, short, long)]
+    #[arg(
+        global = true,
+        short,
+        long,
+        value_parser = PathBufValueParser::new().map(expand_tilde),
+    )]
     pub(crate) config: Option<PathBuf>,
 
     /// Change to directory before running.
@@ -165,6 +171,7 @@ pub(crate) struct GlobalArgs {
         long,
         value_name = "DIR",
         value_hint = ValueHint::DirPath,
+        value_parser = PathBufValueParser::new().map(expand_tilde),
     )]
     pub(crate) cd: Option<PathBuf>,
 
@@ -205,7 +212,13 @@ pub(crate) struct GlobalArgs {
 
     /// Write trace logs to the specified file.
     /// If not specified, trace logs will be written to `$PREK_HOME/prek.log`.
-    #[arg(global = true, long, value_name = "LOG_FILE", value_hint = ValueHint::FilePath)]
+    #[arg(
+        global = true,
+        long,
+        value_name = "LOG_FILE",
+        value_hint = ValueHint::FilePath,
+        value_parser = PathBufValueParser::new().map(expand_tilde),
+    )]
     pub(crate) log_file: Option<PathBuf>,
 
     /// Do not write trace logs to a log file.
@@ -346,7 +359,12 @@ pub(crate) struct InstallArgs {
     /// refuses to install shims while `core.hooksPath` is configured outside the repo.
     /// It only writes shims to `<GIT_DIR>/hooks`; Git will keep using
     /// `core.hooksPath` until that config changes.
-    #[arg(long, value_name = "GIT_DIR", value_hint = ValueHint::DirPath)]
+    #[arg(
+        long,
+        value_name = "GIT_DIR",
+        value_hint = ValueHint::DirPath,
+        value_parser = PathBufValueParser::new().map(expand_tilde),
+    )]
     pub(crate) git_dir: Option<PathBuf>,
 }
 
@@ -411,7 +429,12 @@ pub(crate) struct UninstallArgs {
     /// refuses to modify shims while `core.hooksPath` is configured outside the repo.
     /// It only removes shims from `<GIT_DIR>/hooks`; Git may still use the configured
     /// `core.hooksPath` until that config changes.
-    #[arg(long, value_name = "GIT_DIR", value_hint = ValueHint::DirPath)]
+    #[arg(
+        long,
+        value_name = "GIT_DIR",
+        value_hint = ValueHint::DirPath,
+        value_parser = PathBufValueParser::new().map(expand_tilde),
+    )]
     pub(crate) git_dir: Option<PathBuf>,
 }
 

--- a/crates/prek/src/fs.rs
+++ b/crates/prek/src/fs.rs
@@ -53,6 +53,16 @@ static LOCK_WARNING_PATHS: LazyLock<Mutex<FxHashSet<PathBuf>>> = LazyLock::new(D
 static FORCE_CROSS_PROCESS_LOCK_WARNING_FOR: LazyLock<Mutex<FxHashSet<PathBuf>>> =
     LazyLock::new(Default::default);
 
+/// Expand a path starting with `~` to the user's home directory.
+pub(crate) fn expand_tilde(path: PathBuf) -> PathBuf {
+    if let Ok(stripped) = path.strip_prefix("~") {
+        if let Some(home) = std::env::home_dir() {
+            return home.join(stripped);
+        }
+    }
+    path
+}
+
 /// A file lock that is automatically released when dropped.
 #[derive(Debug)]
 pub struct LockedFile {

--- a/crates/prek/src/store.rs
+++ b/crates/prek/src/store.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 use tracing::{debug, warn};
 
 use crate::config::{RemoteRepo, RemoteRepoKey};
-use crate::fs::LockedFile;
+use crate::fs::{LockedFile, expand_tilde};
 use crate::git::{self, TerminalPrompt};
 use crate::hook::InstallInfo;
 use crate::run::CONCURRENCY;
@@ -51,16 +51,6 @@ pub enum Error {
     },
     #[error(transparent)]
     Serde(#[from] serde_json::Error),
-}
-
-/// Expand a path starting with `~` to the user's home directory.
-fn expand_tilde(path: PathBuf) -> PathBuf {
-    if let Ok(stripped) = path.strip_prefix("~") {
-        if let Some(home) = std::env::home_dir() {
-            return home.join(stripped);
-        }
-    }
-    path
 }
 
 pub(crate) const REPO_MARKER: &str = ".prek-repo.json";

--- a/crates/prek/tests/common/mod.rs
+++ b/crates/prek/tests/common/mod.rs
@@ -113,14 +113,17 @@ impl TestContext {
 
     /// Generate an escaped regex pattern for the given path.
     fn path_pattern(path: impl AsRef<Path>) -> String {
+        let separator = r"(\\\\|\\|\/)";
         format!(
             // Trim the trailing separator for cross-platform directories filters
-            r"{}\\?/?",
+            r"{}{}?",
             regex::escape(&path.as_ref().display().to_string())
                 // Make separators platform-agnostic because on Windows we will display
-                // paths with Unix-style separators sometimes
-                .replace('/', r"(\\|\/)")
-                .replace(r"\\", r"(\\|\/)")
+                // paths with Unix-style separators sometimes. `PathBuf` debug output
+                // escapes backslash separators, so match those as well.
+                .replace('/', separator)
+                .replace(r"\\", separator),
+            separator,
         )
     }
 
@@ -429,7 +432,7 @@ pub const INSTA_FILTERS: &[(&str, &str)] = &[
     // File sizes
     (r"(\s|\()(\d+\.)?\d+\s?([KMGTPE]i)?B", "$1[SIZE]"),
     // Rewrite Windows output to Unix output
-    (r"\\([\w\d]|\.\.|\.)", "/$1"),
+    (r"\\{1,2}([\w\d]|\.\.|\.)", "/$1"),
     // The exact message is host language dependent
     (
         r"Caused by: .* \(os error 2\)",

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -1300,6 +1300,76 @@ fn subdirectory() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn global_path_options_expand_tilde() -> Result<()> {
+    let context = TestContext::new();
+    let cd = context.home_dir().child("project");
+    cd.create_dir_all()?;
+
+    cmd_snapshot!(context.filters(), context
+        .command()
+        .arg("--show-settings")
+        .arg("--config=~/prek.toml")
+        .arg("--cd=~/project")
+        .env("HOME", context.home_dir().path())
+        .env("USERPROFILE", context.home_dir().path()), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    GlobalArgs {
+        config: Some(
+            "[HOME]/prek.toml",
+        ),
+        cd: Some(
+            "[HOME]/project",
+        ),
+        color: Auto,
+        refresh: false,
+        help: (),
+        no_progress: false,
+        quiet: 0,
+        verbose: 0,
+        log_file: None,
+        no_log_file: false,
+        version: (),
+        show_settings: true,
+    }
+    RunArgs {
+        includes: [],
+        skips: [],
+        all_files: false,
+        files: [],
+        directory: [],
+        from_ref: None,
+        to_ref: None,
+        last_commit: false,
+        stage: None,
+        show_diff_on_failure: false,
+        fail_fast: false,
+        no_fail_fast: false,
+        dry_run: false,
+        extra: RunExtraArgs {
+            remote_branch: None,
+            local_branch: None,
+            pre_rebase_upstream: None,
+            pre_rebase_branch: None,
+            commit_msg_filename: None,
+            prepare_commit_message_source: None,
+            commit_object_name: None,
+            remote_name: None,
+            remote_url: None,
+            checkout_type: None,
+            is_squash_merge: false,
+            rewrite_command: None,
+        },
+    }
+
+    ----- stderr -----
+    "#);
+
+    Ok(())
+}
+
 /// Test hook `log_file` option.
 #[test]
 fn log_file() {


### PR DESCRIPTION
Expands leading `~` for path-valued CLI flags including `--config`, `--cd`, `--log-file`, and `--git-dir` so quoted shell values resolve consistently.

Closes #2062