### PR TITLE
Fix npm config env overrides for node hooks

### DIFF
--- a/crates/prek-consts/src/env_vars.rs
+++ b/crates/prek-consts/src/env_vars.rs
@@ -61,8 +61,6 @@ impl EnvVars {
     pub const UV_NO_MANAGED_PYTHON: &'static str = "UV_NO_MANAGED_PYTHON";
 
     // Node/Npm related
-    pub const NPM_CONFIG_USERCONFIG: &'static str = "NPM_CONFIG_USERCONFIG";
-    pub const NPM_CONFIG_PREFIX: &'static str = "NPM_CONFIG_PREFIX";
     pub const NODE_PATH: &'static str = "NODE_PATH";
 
     // Bun related

--- a/crates/prek/src/languages/node/node.rs
+++ b/crates/prek/src/languages/node/node.rs
@@ -22,6 +22,20 @@ use crate::store::{Store, ToolBucket};
 #[derive(Debug, Copy, Clone)]
 pub(crate) struct Node;
 
+const NPM_CONFIG_PREFIX_ENV: &str = "npm_config_prefix";
+// npm exports `global_prefix` and `local_prefix` as lowercase child-process
+// state, not npmrc config sources. It accepts either case when reading env, so
+// clear both forms to keep parent npm/npx context out of the hook env while
+// preserving user/global npmrc paths for auth.
+const NPM_CONFIG_ENVS_TO_REMOVE: &[&str] = &[
+    "NPM_CONFIG_PREFIX",
+    "npm_config_prefix",
+    "NPM_CONFIG_GLOBAL_PREFIX",
+    "npm_config_global_prefix",
+    "NPM_CONFIG_LOCAL_PREFIX",
+    "npm_config_local_prefix",
+];
+
 impl LanguageImpl for Node {
     async fn install(
         &self,
@@ -88,8 +102,8 @@ impl LanguageImpl for Node {
             let node_bin = node.node().parent().expect("Node binary must have parent");
             let new_path = prepend_paths(&[&bin_dir, node_bin]).context("Failed to join PATH")?;
 
-            Cmd::new(node.npm(), "npm install")
-                .arg("install")
+            let mut cmd = Cmd::new(node.npm(), "npm install");
+            cmd.arg("install")
                 .arg("-g")
                 .arg("--no-progress")
                 .arg("--no-save")
@@ -98,12 +112,9 @@ impl LanguageImpl for Node {
                 .arg("--install-links")
                 .args(&*deps)
                 .env(EnvVars::PATH, new_path)
-                .env(EnvVars::NPM_CONFIG_PREFIX, &info.env_path)
-                .env_remove(EnvVars::NPM_CONFIG_USERCONFIG)
-                .env(EnvVars::NODE_PATH, &lib_dir)
-                .check(true)
-                .output()
-                .await?;
+                .env(EnvVars::NODE_PATH, &lib_dir);
+            apply_npm_config_env(&mut cmd, &info.env_path);
+            cmd.check(true).output().await?;
         }
 
         info.persist_env_path();
@@ -148,15 +159,16 @@ impl LanguageImpl for Node {
             prepend_paths(&[&bin_dir(env_dir), node_bin]).context("Failed to join PATH")?;
 
         let entry = hook.entry.resolve(Some(&new_path), store)?;
+
         let run = async |batch: &[&Path]| {
-            let mut output = Cmd::new(&entry[0], "node hook")
-                .current_dir(hook.work_dir())
+            let mut cmd = Cmd::new(&entry[0], "node hook");
+            cmd.current_dir(hook.work_dir())
                 .args(&entry[1..])
                 .env(EnvVars::PATH, &new_path)
-                .env(EnvVars::NPM_CONFIG_PREFIX, env_dir)
-                .env_remove(EnvVars::NPM_CONFIG_USERCONFIG)
                 .env(EnvVars::NODE_PATH, lib_dir(env_dir))
-                .envs(&hook.env)
+                .envs(&hook.env);
+            apply_npm_config_env(&mut cmd, env_dir);
+            let mut output = cmd
                 .args(&hook.args)
                 .args(batch)
                 .check(false)
@@ -186,4 +198,11 @@ impl LanguageImpl for Node {
 
         Ok((combined_status, combined_output))
     }
+}
+
+fn apply_npm_config_env(cmd: &mut Cmd, prefix: &Path) {
+    for key in NPM_CONFIG_ENVS_TO_REMOVE {
+        cmd.env_remove(key);
+    }
+    cmd.env(NPM_CONFIG_PREFIX_ENV, prefix);
 }

--- a/crates/prek/tests/languages/node.rs
+++ b/crates/prek/tests/languages/node.rs
@@ -1,5 +1,5 @@
 use assert_fs::assert::PathAssert;
-use assert_fs::fixture::PathChild;
+use assert_fs::fixture::{FileWriteStr, PathChild, PathCreateDir};
 use prek_consts::env_vars::EnvVars;
 
 use crate::common::{TestContext, cmd_snapshot, remove_bin_from_path};
@@ -194,6 +194,94 @@ fn additional_dependencies() {
 
     ----- stderr -----
     ");
+}
+
+/// Test that lowercase npm config inherited from `npm exec` cannot redirect installs.
+#[test]
+fn additional_dependencies_ignore_inherited_npm_config_prefix() -> anyhow::Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    let package_dir = context.work_dir().child("prefix-fixture");
+    package_dir.create_dir_all()?;
+    package_dir
+        .child("package.json")
+        .write_str(indoc::indoc! {r#"
+        {
+          "name": "prek-prefix-fixture",
+          "version": "1.0.0",
+          "bin": {
+            "prek-prefix-fixture": "cli.js"
+          }
+        }
+    "#})?;
+    let cli = package_dir.child("cli.js");
+    cli.write_str(indoc::indoc! {r#"
+        #!/usr/bin/env node
+        console.log("prefix fixture ok")
+    "#})?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = fs_err::metadata(cli.path())?.permissions();
+        permissions.set_mode(0o755);
+        fs_err::set_permissions(cli.path(), permissions)?;
+    }
+
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: node
+                name: node
+                language: node
+                entry: prek-prefix-fixture
+                additional_dependencies: ["./prefix-fixture"]
+                always_run: true
+                verbose: true
+                pass_filenames: false
+    "#});
+
+    context.git_add(".");
+
+    let fake_prefix = context.home_dir().child("fake-prefix");
+    fake_prefix.create_dir_all()?;
+    let global_npmrc = fake_prefix.child("global-npmrc");
+    let user_npmrc = fake_prefix.child("user-npmrc");
+    global_npmrc.write_str("prefix=${HOME}/global-npmrc-prefix\n")?;
+    user_npmrc.write_str("//registry.example.test/:_authToken=fake-token\n")?;
+
+    cmd_snapshot!(
+        context.filters(),
+        context
+            .run()
+            .env("npm_config_prefix", fake_prefix.path())
+            .env("npm_config_global_prefix", fake_prefix.path())
+            .env("npm_config_local_prefix", fake_prefix.path())
+            .env("npm_config_globalconfig", global_npmrc.path())
+            .env("npm_config_userconfig", user_npmrc.path())
+            .env("npm_config_cache", fake_prefix.child("cache").path()),
+        @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    node.....................................................................Passed
+    - hook id: node
+    - duration: [TIME]
+
+      prefix fixture ok
+
+    ----- stderr -----
+    "#
+    );
+
+    fake_prefix
+        .child("lib")
+        .child("node_modules")
+        .assert(predicates::path::missing());
+
+    Ok(())
 }
 
 /// Test that npm install works without system node in PATH.


### PR DESCRIPTION
Node hook installs now isolate npm prefix/config/cache environment variables from inherited npm exec state, so installs land in the hook environment instead of an external prefix.

Closes #2073.