### PR TITLE
Migrate `std::fs` to `fs_err`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2217,6 +2217,7 @@ dependencies = [
 name = "prek-pty"
 version = "0.3.13"
 dependencies = [
+ "fs-err",
  "rustix",
  "tokio",
 ]

--- a/crates/prek-identify/src/lib.rs
+++ b/crates/prek-identify/src/lib.rs
@@ -242,7 +242,7 @@ pub enum Error {
 
 /// Identify tags for a file at the given path.
 pub fn tags_from_path(path: &Path) -> Result<TagSet, Error> {
-    let metadata = std::fs::symlink_metadata(path)?;
+    let metadata = fs_err::symlink_metadata(path)?;
     if metadata.is_dir() {
         return Ok(tags::TAG_SET_DIRECTORY);
     } else if metadata.is_symlink() {
@@ -414,7 +414,7 @@ fn parse_nix_shebang<R: BufRead>(reader: &mut R, mut cmd: Vec<String>) -> Vec<St
 }
 
 pub fn parse_shebang(path: &Path) -> Result<Vec<String>, ShebangError> {
-    let file = std::fs::File::open(path)?;
+    let file = fs_err::File::open(path)?;
     let mut reader = std::io::BufReader::new(file);
     let mut line = String::new();
     reader.read_line(&mut line)?;
@@ -518,7 +518,7 @@ mod tests {
         let src = dir.path().join("source.txt");
         let dest = dir.path().join("link.txt");
         fs_err::File::create(&src)?;
-        std::os::unix::fs::symlink(&src, &dest)?;
+        fs_err::os::unix::fs::symlink(&src, &dest)?;
 
         let tags = super::tags_from_path(dir.path())?;
         assert_tagset(&tags, &["directory"]);

--- a/crates/prek-pty/Cargo.toml
+++ b/crates/prek-pty/Cargo.toml
@@ -9,6 +9,7 @@ license = { workspace = true }
 
 [dependencies]
 rustix = { workspace = true }
+fs-err = { workspace = true }
 tokio = { workspace = true }
 
 [lints]

--- a/crates/prek-pty/src/lib.rs
+++ b/crates/prek-pty/src/lib.rs
@@ -3,7 +3,6 @@
 #![cfg(unix)]
 
 mod error;
-#[allow(clippy::module_inception)]
 mod pty;
 mod sys;
 mod types;

--- a/crates/prek-pty/src/pty.rs
+++ b/crates/prek-pty/src/pty.rs
@@ -1,5 +1,4 @@
-#![allow(clippy::module_name_repetitions)]
-use std::io::Write as _;
+use std::io::Write;
 
 type AsyncPty = tokio::io::unix::AsyncFd<crate::sys::Pty>;
 

--- a/crates/prek-pty/src/sys.rs
+++ b/crates/prek-pty/src/sys.rs
@@ -1,6 +1,7 @@
+use fs_err::os::unix::fs::OpenOptionsExt as _;
 use std::os::{
     fd::{AsRawFd as _, FromRawFd as _},
-    unix::prelude::{OpenOptionsExt as _, OsStrExt as _},
+    unix::prelude::OsStrExt as _,
 };
 
 #[derive(Debug)]
@@ -34,7 +35,7 @@ impl Pty {
     }
 
     pub fn pts(&self) -> crate::Result<Pts> {
-        Ok(Pts(std::fs::OpenOptions::new()
+        Ok(Pts(fs_err::OpenOptions::new()
             .read(true)
             .write(true)
             .custom_flags(rustix::fs::OFlags::NOCTTY.bits().try_into().unwrap())

--- a/crates/prek-pty/src/sys.rs
+++ b/crates/prek-pty/src/sys.rs
@@ -1,8 +1,8 @@
+use std::os::fd::AsRawFd;
+use std::os::fd::FromRawFd;
+use std::os::unix::ffi::OsStrExt;
+
 use fs_err::os::unix::fs::OpenOptionsExt as _;
-use std::os::{
-    fd::{AsRawFd as _, FromRawFd as _},
-    unix::prelude::OsStrExt as _,
-};
 
 #[derive(Debug)]
 pub struct Pty(std::os::fd::OwnedFd);

--- a/crates/prek/src/cli/cache_clean.rs
+++ b/crates/prek/src/cli/cache_clean.rs
@@ -136,7 +136,7 @@ fn remove_symlink(path: &Path, file_type: FileType) -> io::Result<()> {
 /// Go sets the permissions to read-only by default.
 #[cfg(not(windows))]
 pub fn fix_permissions<P: AsRef<Path>>(path: P) -> io::Result<()> {
-    use std::fs;
+    use fs_err as fs;
     use std::os::unix::fs::PermissionsExt;
 
     let path = path.as_ref();
@@ -236,7 +236,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn rm_rf_counts_symlink_entries() -> anyhow::Result<()> {
-        use std::os::unix::fs::symlink;
+        use fs_err::os::unix::fs::symlink;
 
         let temp = TempDir::new()?;
         let cache_root = temp.path().join("cache");

--- a/crates/prek/src/cli/cache_clean.rs
+++ b/crates/prek/src/cli/cache_clean.rs
@@ -136,11 +136,10 @@ fn remove_symlink(path: &Path, file_type: FileType) -> io::Result<()> {
 /// Go sets the permissions to read-only by default.
 #[cfg(not(windows))]
 pub fn fix_permissions<P: AsRef<Path>>(path: P) -> io::Result<()> {
-    use fs_err as fs;
     use std::os::unix::fs::PermissionsExt;
 
     let path = path.as_ref();
-    let metadata = fs::metadata(path)?;
+    let metadata = fs_err::metadata(path)?;
 
     let mut permissions = metadata.permissions();
     let current_mode = permissions.mode();
@@ -148,11 +147,11 @@ pub fn fix_permissions<P: AsRef<Path>>(path: P) -> io::Result<()> {
     // Add write permissions for owner, group, and others
     let new_mode = current_mode | 0o222;
     permissions.set_mode(new_mode);
-    fs::set_permissions(path, permissions)?;
+    fs_err::set_permissions(path, permissions)?;
 
     // If it's a directory, recursively process its contents
     if metadata.is_dir() {
-        let entries = fs::read_dir(path)?;
+        let entries = fs_err::read_dir(path)?;
         for entry in entries {
             let entry = entry?;
             fix_permissions(entry.path())?;

--- a/crates/prek/src/cli/run/filter.rs
+++ b/crates/prek/src/cli/run/filter.rs
@@ -405,7 +405,7 @@ async fn collect_files_from_args(
         // For `types: [directory]`, `pre-commit` passes the directory names to the hook directly.
         let (exists, non_exists): (FxHashSet<_>, Vec<_>) =
             files.into_iter().partition_map(|filename| {
-                if std::fs::exists(&filename).unwrap_or(false) {
+                if fs_err::exists(&filename).unwrap_or(false) {
                     Either::Left(filename)
                 } else {
                     Either::Right(filename)

--- a/crates/prek/src/cli/run/selector.rs
+++ b/crates/prek/src/cli/run/selector.rs
@@ -578,8 +578,8 @@ mod tests {
     fn create_test_workspace() -> anyhow::Result<MockFileSystem> {
         let temp_dir = TempDir::new()?;
 
-        std::fs::create_dir_all(temp_dir.path().join("src"))?;
-        std::fs::create_dir_all(temp_dir.path().join("src/backend"))?;
+        fs_err::create_dir_all(temp_dir.path().join("src"))?;
+        fs_err::create_dir_all(temp_dir.path().join("src/backend"))?;
 
         Ok(MockFileSystem {
             current_dir: temp_dir,

--- a/crates/prek/src/hooks/pre_commit_hooks/check_executables_have_shebangs.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_executables_have_shebangs.rs
@@ -113,7 +113,7 @@ mod tests {
     #[tokio::test]
     async fn test_os_check_shebangs_with_shebang() -> Result<(), anyhow::Error> {
         let file = NamedTempFile::new()?;
-        tokio::fs::write(file.path(), b"#!/bin/bash\necho ok\n").await?;
+        fs_err::tokio::write(file.path(), b"#!/bin/bash\necho ok\n").await?;
         let files = vec![file.path()];
         let (code, output) = os_check_shebangs(Path::new(""), &files).await?;
         assert_eq!(code, 0);
@@ -125,7 +125,7 @@ mod tests {
     #[tokio::test]
     async fn test_os_check_shebangs_without_shebang() -> Result<(), anyhow::Error> {
         let file = NamedTempFile::new()?;
-        tokio::fs::write(file.path(), b"echo ok\n").await?;
+        fs_err::tokio::write(file.path(), b"echo ok\n").await?;
         let files = vec![file.path()];
         let (code, output) = os_check_shebangs(Path::new(""), &files).await?;
         assert_eq!(code, 1);

--- a/crates/prek/src/hooks/pre_commit_hooks/check_symlinks.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_symlinks.rs
@@ -59,7 +59,7 @@ mod tests {
         let dir = tempdir()?;
         let target = create_test_file(&dir, "target.txt", b"content").await?;
         let link_path = dir.path().join("link.txt");
-        tokio::fs::symlink(&target, &link_path).await?;
+        fs_err::tokio::symlink(&target, &link_path).await?;
 
         let (code, output) = check_file(Path::new(""), &link_path).await?;
         assert_eq!(code, 0);
@@ -73,7 +73,7 @@ mod tests {
         let dir = tempdir()?;
         let link_path = dir.path().join("broken_link.txt");
         let nonexistent = dir.path().join("nonexistent.txt");
-        tokio::fs::symlink(&nonexistent, &link_path).await?;
+        fs_err::tokio::symlink(&nonexistent, &link_path).await?;
 
         let (code, output) = check_file(Path::new(""), &link_path).await?;
         assert_eq!(code, 1);
@@ -91,7 +91,10 @@ mod tests {
         let link_path = dir.path().join("link.txt");
 
         // Windows requires different APIs for file vs directory symlinks
-        if tokio::fs::symlink_file(&target, &link_path).await.is_err() {
+        if fs_err::tokio::symlink_file(&target, &link_path)
+            .await
+            .is_err()
+        {
             // Skipping test: insufficient permissions for symlink creation on Windows
             return Ok(());
         }
@@ -111,7 +114,7 @@ mod tests {
 
         // On Windows, symlink creation might require admin privileges
         // If this fails in CI, the test will be skipped
-        if tokio::fs::symlink_file(&nonexistent, &link_path)
+        if fs_err::tokio::symlink_file(&nonexistent, &link_path)
             .await
             .is_err()
         {
@@ -133,7 +136,7 @@ mod tests {
         let dir = tempdir()?;
         let target = create_test_file(&dir, "target.txt", b"content").await?;
         let link_path = dir.path().join("link.txt");
-        tokio::fs::symlink(&target, &link_path).await?;
+        fs_err::tokio::symlink(&target, &link_path).await?;
 
         let (code, output) = check_file(Path::new(""), &link_path).await?;
         assert_eq!(code, 0);
@@ -147,7 +150,7 @@ mod tests {
         let dir = tempdir()?;
         let link_path = dir.path().join("broken_link.txt");
         let nonexistent = dir.path().join("nonexistent.txt");
-        tokio::fs::symlink(&nonexistent, &link_path).await?;
+        fs_err::tokio::symlink(&nonexistent, &link_path).await?;
 
         let (code, output) = check_file(Path::new(""), &link_path).await?;
         assert_eq!(code, 1);

--- a/crates/prek/src/hooks/pre_commit_hooks/shebangs.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/shebangs.rs
@@ -102,7 +102,7 @@ mod tests {
     #[tokio::test]
     async fn file_has_shebang_detects_valid_shebang() -> Result<(), anyhow::Error> {
         let file = NamedTempFile::new()?;
-        tokio::fs::write(file.path(), b"#!/bin/sh\necho hi\n").await?;
+        fs_err::tokio::write(file.path(), b"#!/bin/sh\necho hi\n").await?;
 
         assert!(file_has_shebang(file.path()).await?);
         Ok(())
@@ -111,7 +111,7 @@ mod tests {
     #[tokio::test]
     async fn file_has_shebang_rejects_non_shebang_prefixes() -> Result<(), anyhow::Error> {
         let file = NamedTempFile::new()?;
-        tokio::fs::write(file.path(), b"##!/bin/sh\n").await?;
+        fs_err::tokio::write(file.path(), b"##!/bin/sh\n").await?;
 
         assert!(!file_has_shebang(file.path()).await?);
         Ok(())

--- a/crates/prek/src/languages/docker.rs
+++ b/crates/prek/src/languages/docker.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::collections::hash_map::DefaultHasher;
-use std::fs;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};

--- a/crates/prek/src/languages/docker.rs
+++ b/crates/prek/src/languages/docker.rs
@@ -1,3 +1,4 @@
+use fs_err as fs;
 use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::collections::hash_map::DefaultHasher;

--- a/crates/prek/src/languages/docker.rs
+++ b/crates/prek/src/languages/docker.rs
@@ -1,4 +1,3 @@
-use fs_err as fs;
 use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::collections::hash_map::DefaultHasher;
@@ -35,7 +34,7 @@ enum Error {
 /// Check if the current process is running inside a Docker container.
 /// see <https://stackoverflow.com/questions/23513045/how-to-check-if-a-process-is-running-inside-docker-container>
 fn is_in_docker() -> bool {
-    if fs::metadata("/.dockerenv").is_ok() || fs::metadata("/run/.containerenv").is_ok() {
+    if fs_err::metadata("/.dockerenv").is_ok() || fs_err::metadata("/run/.containerenv").is_ok() {
         return true;
     }
     false
@@ -65,7 +64,7 @@ fn current_container_id_from_paths(
 }
 
 fn container_id_from_cgroup_v1(cgroup: impl AsRef<Path>) -> Result<String> {
-    let content = fs::read_to_string(cgroup).context("Failed to read cgroup v1 info")?;
+    let content = fs_err::read_to_string(cgroup).context("Failed to read cgroup v1 info")?;
     content
         .lines()
         .find_map(parse_id_from_line)
@@ -100,7 +99,8 @@ fn parse_id_from_line(line: &str) -> Option<String> {
 }
 
 fn container_id_from_cgroup_v2(mount_info: impl AsRef<Path>) -> Result<String> {
-    let content = fs::read_to_string(mount_info).context("Failed to read cgroup v2 mount info")?;
+    let content =
+        fs_err::read_to_string(mount_info).context("Failed to read cgroup v2 mount info")?;
     regex!(r".*/(containers|overlay-containers)/([0-9a-f]{64})/.*")
         .captures(&content)
         .and_then(|caps| caps.get(2))

--- a/crates/prek/src/languages/dotnet/dotnet.rs
+++ b/crates/prek/src/languages/dotnet/dotnet.rs
@@ -234,7 +234,7 @@ mod tests {
     #[test]
     fn resolve_dotnet_root_uses_canonicalized_parent_for_symlink() -> anyhow::Result<()> {
         use assert_fs::fixture::{PathChild, PathCreateDir};
-        use std::os::unix::fs::symlink;
+        use fs_err::os::unix::fs::symlink;
 
         let temp_dir = assert_fs::TempDir::new()?;
         let real_root = temp_dir.child("real");

--- a/crates/prek/src/languages/lua.rs
+++ b/crates/prek/src/languages/lua.rs
@@ -212,7 +212,7 @@ impl Lua {
     }
 
     fn get_rockspec_file(root_path: &Path) -> Option<PathBuf> {
-        if let Ok(entries) = std::fs::read_dir(root_path) {
+        if let Ok(entries) = fs_err::read_dir(root_path) {
             for entry in entries.flatten() {
                 let path = entry.path();
                 if path.extension().and_then(|s| s.to_str()) == Some("rockspec") {

--- a/crates/prek/src/languages/python/python.rs
+++ b/crates/prek/src/languages/python/python.rs
@@ -1,3 +1,4 @@
+use fs_err as fs;
 use std::env::consts::EXE_EXTENSION;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;

--- a/crates/prek/src/languages/python/python.rs
+++ b/crates/prek/src/languages/python/python.rs
@@ -1,4 +1,3 @@
-use fs_err as fs;
 use std::env::consts::EXE_EXTENSION;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -84,7 +83,7 @@ async fn query_python_info(python: &Path) -> Result<PythonInfo, PythonInfoError>
 pub(crate) async fn query_python_info_cached(
     python: &Path,
 ) -> Result<Arc<PythonInfo>, PythonInfoError> {
-    let python = fs::canonicalize(python).unwrap_or_else(|_| python.to_path_buf());
+    let python = fs_err::canonicalize(python).unwrap_or_else(|_| python.to_path_buf());
     PYTHON_INFO_CACHE
         .try_compute(python.clone(), async move || {
             let info = query_python_info(&python).await?;

--- a/crates/prek/src/languages/python/python.rs
+++ b/crates/prek/src/languages/python/python.rs
@@ -1,5 +1,4 @@
 use std::env::consts::EXE_EXTENSION;
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::{Arc, LazyLock};

--- a/crates/prek/src/languages/ruby/installer.rs
+++ b/crates/prek/src/languages/ruby/installer.rs
@@ -459,7 +459,7 @@ async fn search_version_managers(request: &RubyRequest) -> Option<RubyResult> {
 /// Search a version manager directory for Ruby installations
 #[cfg(not(target_os = "windows"))]
 async fn search_ruby_installations(dir: &Path, request: &RubyRequest) -> Option<RubyResult> {
-    let entries = std::fs::read_dir(dir).ok()?;
+    let entries = fs_err::read_dir(dir).ok()?;
 
     for entry in entries.flatten() {
         let path = entry.path();
@@ -555,7 +555,7 @@ pub(crate) async fn query_ruby_info(ruby_path: &Path) -> Result<(semver::Version
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
+    use fs_err as fs;
     use std::str::FromStr;
     use target_lexicon::Triple;
     use tempfile::TempDir;

--- a/crates/prek/src/languages/rust/version.rs
+++ b/crates/prek/src/languages/rust/version.rs
@@ -315,7 +315,7 @@ mod tests {
     fn test_request_satisfied_by_install_info() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let toolchain_path = temp_dir.path().join("rust-toolchain");
-        std::fs::write(&toolchain_path, b"")?;
+        fs_err::write(&toolchain_path, b"")?;
 
         let mut install_info =
             InstallInfo::new(Language::Rust, FxHashSet::default(), temp_dir.path())?;

--- a/crates/prek/src/workspace.rs
+++ b/crates/prek/src/workspace.rs
@@ -442,7 +442,7 @@ impl WorkspaceCache {
         let mut config_files = Vec::new();
 
         for project in projects {
-            if let Ok(metadata) = std::fs::metadata(&project.config_path) {
+            if let Ok(metadata) = fs_err::metadata(&project.config_path) {
                 config_files.push(CachedConfigFile {
                     path: project.config_path.clone(),
                     modified: metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH),
@@ -475,7 +475,7 @@ impl WorkspaceCache {
 
         // Check if all config files still exist and haven't been modified
         for cached_file in &self.config_files {
-            if let Ok(metadata) = std::fs::metadata(&cached_file.path) {
+            if let Ok(metadata) = fs_err::metadata(&cached_file.path) {
                 let current_modified = metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH);
                 let current_size = metadata.len();
 
@@ -528,20 +528,20 @@ impl WorkspaceCache {
         }
         let cache_path = Self::cache_path(store, workspace_root);
 
-        match std::fs::read_to_string(&cache_path) {
+        match fs_err::read_to_string(&cache_path) {
             Ok(content) => match serde_json::from_str::<Self>(&content) {
                 Ok(cache) => {
                     if cache.version == Self::CURRENT_VERSION && cache.is_valid() {
                         Some(cache)
                     } else {
                         // Invalid cache, remove it
-                        let _ = std::fs::remove_file(&cache_path);
+                        let _ = fs_err::remove_file(&cache_path);
                         None
                     }
                 }
                 Err(e) => {
                     debug!("Failed to deserialize cache: {}", e);
-                    let _ = std::fs::remove_file(&cache_path);
+                    let _ = fs_err::remove_file(&cache_path);
                     None
                 }
             },
@@ -559,11 +559,11 @@ impl WorkspaceCache {
 
         // Create cache directory if it doesn't exist
         if let Some(parent) = cache_path.parent() {
-            std::fs::create_dir_all(parent)?;
+            fs_err::create_dir_all(parent)?;
         }
 
         let content = serde_json::to_string_pretty(self)?;
-        std::fs::write(&cache_path, content)?;
+        fs_err::write(&cache_path, content)?;
         Ok(())
     }
 

--- a/crates/prek/tests/auto_update.rs
+++ b/crates/prek/tests/auto_update.rs
@@ -385,7 +385,7 @@ fn auto_update_does_not_rewrite_config_when_up_to_date() -> Result<()> {
 
     let config_path = context.work_dir().child(PRE_COMMIT_CONFIG_YAML);
 
-    let before_secs = std::fs::metadata(config_path.path())?
+    let before_secs = fs_err::metadata(config_path.path())?
         .modified()?
         .duration_since(UNIX_EPOCH)?
         .as_secs();
@@ -399,7 +399,7 @@ fn auto_update_does_not_rewrite_config_when_up_to_date() -> Result<()> {
     let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
     assert!(stdout.is_empty());
 
-    let after_secs = std::fs::metadata(config_path.path())?
+    let after_secs = fs_err::metadata(config_path.path())?
         .modified()?
         .duration_since(UNIX_EPOCH)?
         .as_secs();

--- a/crates/prek/tests/builtin_hooks.rs
+++ b/crates/prek/tests/builtin_hooks.rs
@@ -1533,13 +1533,13 @@ fn check_symlinks_hook_unix() -> Result<()> {
     cwd.child("target.txt").write_str("target content")?;
 
     // Create valid symlink
-    std::os::unix::fs::symlink(
+    fs_err::os::unix::fs::symlink(
         cwd.child("target.txt").path(),
         cwd.child("valid_link.txt").path(),
     )?;
 
     // Create broken symlink
-    std::os::unix::fs::symlink(
+    fs_err::os::unix::fs::symlink(
         cwd.child("nonexistent.txt").path(),
         cwd.child("broken_link.txt").path(),
     )?;
@@ -1561,7 +1561,7 @@ fn check_symlinks_hook_unix() -> Result<()> {
     ");
 
     // Remove broken symlink
-    std::fs::remove_file(cwd.child("broken_link.txt").path())?;
+    fs_err::remove_file(cwd.child("broken_link.txt").path())?;
     context.git_add(".");
 
     // Second run: should pass
@@ -1597,13 +1597,13 @@ fn check_symlinks_hook_windows() -> Result<()> {
     cwd.child("target.txt").write_str("target content")?;
 
     // Try to create valid symlink (may fail without admin/developer mode)
-    let valid_link_result = std::os::windows::fs::symlink_file(
+    let valid_link_result = fs_err::os::windows::fs::symlink_file(
         cwd.child("target.txt").path(),
         cwd.child("valid_link.txt").path(),
     );
 
     // Try to create broken symlink (may fail without admin/developer mode)
-    let broken_link_result = std::os::windows::fs::symlink_file(
+    let broken_link_result = fs_err::os::windows::fs::symlink_file(
         cwd.child("nonexistent.txt").path(),
         cwd.child("broken_link.txt").path(),
     );
@@ -1631,7 +1631,7 @@ fn check_symlinks_hook_windows() -> Result<()> {
     "#);
 
     // Remove broken symlink
-    std::fs::remove_file(cwd.child("broken_link.txt").path())?;
+    fs_err::remove_file(cwd.child("broken_link.txt").path())?;
     context.git_add(".");
 
     // Second run: should pass
@@ -1658,7 +1658,7 @@ fn destroyed_symlinks_hook() -> Result<()> {
     let source = TestContext::new();
     source.init_project();
 
-    std::os::unix::fs::symlink(
+    fs_err::os::unix::fs::symlink(
         TEST_SYMLINK_TARGET,
         source.work_dir().child(TEST_SYMLINK).path(),
     )?;
@@ -2542,15 +2542,15 @@ fn check_executables_have_shebangs_hook() -> Result<()> {
     cwd.child("empty.sh").touch()?;
 
     // Mark scripts as executable
-    std::fs::set_permissions(
+    fs_err::set_permissions(
         cwd.child("script_with_shebang.sh").path(),
         std::fs::Permissions::from_mode(0o755),
     )?;
-    std::fs::set_permissions(
+    fs_err::set_permissions(
         cwd.child("script_without_shebang.sh").path(),
         std::fs::Permissions::from_mode(0o755),
     )?;
-    std::fs::set_permissions(
+    fs_err::set_permissions(
         cwd.child("empty.sh").path(),
         std::fs::Permissions::from_mode(0o755),
     )?;
@@ -2581,7 +2581,7 @@ fn check_executables_have_shebangs_hook() -> Result<()> {
     // Fix the files: remove executable bit or add shebang
     cwd.child("script_without_shebang.sh")
         .write_str("#!/bin/sh\necho fixed\n")?;
-    std::fs::set_permissions(
+    fs_err::set_permissions(
         cwd.child("empty.sh").path(),
         std::fs::Permissions::from_mode(0o644),
     )?;
@@ -2684,19 +2684,19 @@ fn check_executables_have_shebangs_various_cases() -> Result<()> {
         .write_str("##!/bin/bash\necho bad\n")?;
 
     // Mark scripts as executable
-    std::fs::set_permissions(
+    fs_err::set_permissions(
         cwd.child("partial_shebang.sh").path(),
         std::fs::Permissions::from_mode(0o755),
     )?;
-    std::fs::set_permissions(
+    fs_err::set_permissions(
         cwd.child("shebang_with_space.sh").path(),
         std::fs::Permissions::from_mode(0o755),
     )?;
-    std::fs::set_permissions(
+    fs_err::set_permissions(
         cwd.child("whitespace.sh").path(),
         std::fs::Permissions::from_mode(0o755),
     )?;
-    std::fs::set_permissions(
+    fs_err::set_permissions(
         cwd.child("invalid_shebang.sh").path(),
         std::fs::Permissions::from_mode(0o755),
     )?;
@@ -2839,7 +2839,7 @@ fn check_shebang_scripts_are_executable() -> Result<()> {
         .write_str("#!/bin/sh\necho hi\n")?;
 
     #[cfg(unix)]
-    std::fs::set_permissions(
+    fs_err::set_permissions(
         cwd.child("script_exec.sh").path(),
         std::fs::Permissions::from_mode(0o755),
     )?;
@@ -2867,7 +2867,7 @@ fn check_shebang_scripts_are_executable() -> Result<()> {
     ");
 
     #[cfg(unix)]
-    std::fs::set_permissions(
+    fs_err::set_permissions(
         cwd.child("script.sh").path(),
         std::fs::Permissions::from_mode(0o755),
     )?;
@@ -3232,7 +3232,7 @@ fn builtin_hooks_ignore_system_path_binaries() -> Result<()> {
 
     let fake_binary = fake_bin_dir.child("trailing-whitespace-fixer");
     fake_binary.write_str("#!/usr/bin/python3\n# fake binary\n")?;
-    std::fs::set_permissions(fake_binary.path(), std::fs::Permissions::from_mode(0o755))?;
+    fs_err::set_permissions(fake_binary.path(), std::fs::Permissions::from_mode(0o755))?;
 
     context.write_pre_commit_config(indoc::indoc! {r"
         repos:

--- a/crates/prek/tests/cache.rs
+++ b/crates/prek/tests/cache.rs
@@ -637,7 +637,7 @@ fn write_patch_file(path: &ChildPath, content: &str, modified: SystemTime) -> an
     let parent = path.path().parent().expect("patch file has parent");
     fs_err::create_dir_all(parent)?;
     fs_err::write(path.path(), content)?;
-    std::fs::OpenOptions::new()
+    fs_err::OpenOptions::new()
         .write(true)
         .open(path.path())?
         .set_modified(modified)?;

--- a/crates/prek/tests/hook_impl.rs
+++ b/crates/prek/tests/hook_impl.rs
@@ -155,7 +155,7 @@ fn hook_impl_pre_push() -> anyhow::Result<()> {
 
     // Set up a bare remote repository
     let remote_repo_path = context.home_dir().join("remote.git");
-    std::fs::create_dir_all(&remote_repo_path)?;
+    fs_err::create_dir_all(&remote_repo_path)?;
 
     let mut init_remote = git_cmd(&remote_repo_path);
     init_remote
@@ -321,7 +321,7 @@ fn hook_impl_pre_push_runs_legacy_and_prek() -> anyhow::Result<()> {
     set_executable(legacy_hook.path())?;
 
     let remote_repo_path = context.home_dir().join("remote.git");
-    std::fs::create_dir_all(&remote_repo_path)?;
+    fs_err::create_dir_all(&remote_repo_path)?;
 
     let mut init_remote = git_cmd(&remote_repo_path);
     init_remote

--- a/crates/prek/tests/identify.rs
+++ b/crates/prek/tests/identify.rs
@@ -31,7 +31,7 @@ fn identify_text_with_missing_paths() -> anyhow::Result<()> {
     hello.py: file, non-executable, python, text
 
     ----- stderr -----
-    error: missing.py: No such file or directory (os error 2)
+    error: missing.py: failed to query metadata of symlink `missing.py`: No such file or directory (os error 2)
     "
     );
 
@@ -81,7 +81,7 @@ fn identify_json_with_missing_paths() -> anyhow::Result<()> {
     ]
 
     ----- stderr -----
-    error: missing.py: No such file or directory (os error 2)
+    error: missing.py: failed to query metadata of symlink `missing.py`: No such file or directory (os error 2)
     "#);
 
     Ok(())

--- a/crates/prek/tests/install.rs
+++ b/crates/prek/tests/install.rs
@@ -618,7 +618,7 @@ fn install_uses_standard_permissions_by_default() {
 
     // Verify hook permissions are 0o755 (standard)
     let hook_path = context.work_dir().join(".git/hooks/pre-commit");
-    let metadata = std::fs::metadata(&hook_path).unwrap();
+    let metadata = fs_err::metadata(&hook_path).unwrap();
     let mode = metadata.permissions().mode() & 0o777;
     assert_eq!(
         mode, 0o755,
@@ -645,7 +645,7 @@ fn install_uses_group_permissions_for_shared_repository() {
 
     // Verify hook permissions are 0o775 (group-writable)
     let hook_path = context.work_dir().join(".git/hooks/pre-commit");
-    let metadata = std::fs::metadata(&hook_path).unwrap();
+    let metadata = fs_err::metadata(&hook_path).unwrap();
     let mode = metadata.permissions().mode() & 0o777;
     assert_eq!(
         mode, 0o775,
@@ -670,7 +670,7 @@ fn install_uses_explicit_shared_repository_mode() {
     context.install().assert().success();
 
     let hook_path = context.work_dir().join(".git/hooks/pre-commit");
-    let metadata = std::fs::metadata(&hook_path).unwrap();
+    let metadata = fs_err::metadata(&hook_path).unwrap();
     let mode = metadata.permissions().mode() & 0o777;
     assert_eq!(
         mode, 0o750,

--- a/crates/prek/tests/languages/dart.rs
+++ b/crates/prek/tests/languages/dart.rs
@@ -171,7 +171,7 @@ fn with_pubspec_and_dependencies() -> anyhow::Result<()> {
               ansicolor: ^2.0.1
         "})?;
 
-    std::fs::create_dir(context.work_dir().join("bin"))?;
+    fs_err::create_dir(context.work_dir().join("bin"))?;
     context
         .work_dir()
         .child("bin")
@@ -232,7 +232,7 @@ fn with_pubspec() -> anyhow::Result<()> {
               sdk: '>=2.17.0 <4.0.0'
         "})?;
 
-    std::fs::create_dir(context.work_dir().join("bin"))?;
+    fs_err::create_dir(context.work_dir().join("bin"))?;
     context
         .work_dir()
         .child("bin")
@@ -296,8 +296,8 @@ fn with_pubspec_and_additional_dependencies() -> anyhow::Result<()> {
               sdk: '>=2.17.0 <4.0.0'
         "})?;
 
-    std::fs::create_dir(context.work_dir().join("bin"))?;
-    std::fs::create_dir(context.work_dir().join("lib"))?;
+    fs_err::create_dir(context.work_dir().join("bin"))?;
+    fs_err::create_dir(context.work_dir().join("lib"))?;
     context
         .work_dir()
         .child("lib")
@@ -464,7 +464,7 @@ fn executable_alias() -> anyhow::Result<()> {
               cli: hello
         "})?;
 
-    std::fs::create_dir(context.work_dir().join("bin"))?;
+    fs_err::create_dir(context.work_dir().join("bin"))?;
     context
         .work_dir()
         .child("bin")

--- a/crates/prek/tests/languages/docker_image.rs
+++ b/crates/prek/tests/languages/docker_image.rs
@@ -98,9 +98,9 @@ fn docker_image_does_not_resolve_entry() -> Result<()> {
     let alpine_stub = bin_dir.child("alpine");
     alpine_stub.write_str("#!/bin/sh\necho host\n")?;
 
-    let mut perms = std::fs::metadata(alpine_stub.path())?.permissions();
+    let mut perms = fs_err::metadata(alpine_stub.path())?.permissions();
     perms.set_mode(0o755);
-    std::fs::set_permissions(alpine_stub.path(), perms)?;
+    fs_err::set_permissions(alpine_stub.path(), perms)?;
 
     Command::new("docker")
         .args(["pull", "docker.io/library/alpine:latest"])

--- a/crates/prek/tests/languages/dotnet.rs
+++ b/crates/prek/tests/languages/dotnet.rs
@@ -193,7 +193,7 @@ fn multiple_sdk_versions() -> anyhow::Result<()> {
     let mut found_8 = false;
     let mut found_10 = false;
 
-    for entry in std::fs::read_dir(dotnet_tool_root.path())?.flatten() {
+    for entry in fs_err::read_dir(dotnet_tool_root.path())?.flatten() {
         let name = entry.file_name().to_string_lossy().to_string();
         if name.starts_with('8') {
             found_8 = true;

--- a/crates/prek/tests/languages/python.rs
+++ b/crates/prek/tests/languages/python.rs
@@ -482,6 +482,7 @@ fn git_env_vars_not_leaked_to_pip_install() -> anyhow::Result<()> {
 #[test]
 #[cfg(unix)]
 fn health_check_with_symlinked_toolchain() -> anyhow::Result<()> {
+    use fs_err::os::unix::fs::symlink;
     use prek_consts::prepend_paths;
 
     let context = TestContext::new();

--- a/crates/prek/tests/languages/python.rs
+++ b/crates/prek/tests/languages/python.rs
@@ -483,7 +483,6 @@ fn git_env_vars_not_leaked_to_pip_install() -> anyhow::Result<()> {
 #[cfg(unix)]
 fn health_check_with_symlinked_toolchain() -> anyhow::Result<()> {
     use prek_consts::prepend_paths;
-    use std::os::unix::fs::symlink;
 
     let context = TestContext::new();
     context.init_project();

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -2409,8 +2409,8 @@ fn write_pre_commit_config(path: &Path, hooks: &[(&str, &str)]) -> Result<()> {
         yaml.push_str(&hook);
     }
 
-    std::fs::create_dir_all(path)?;
-    std::fs::write(path.join(PRE_COMMIT_CONFIG_YAML), yaml)?;
+    fs_err::create_dir_all(path)?;
+    fs_err::write(path.join(PRE_COMMIT_CONFIG_YAML), yaml)?;
 
     Ok(())
 }

--- a/crates/prek/tests/sample_config.rs
+++ b/crates/prek/tests/sample_config.rs
@@ -71,7 +71,7 @@ fn sample_config() -> anyhow::Result<()> {
     "##);
 
     let child = context.work_dir().join("child");
-    std::fs::create_dir(&child)?;
+    fs_err::create_dir(&child)?;
 
     cmd_snapshot!(context.filters(), context.sample_config().current_dir(&*child).arg("-f").arg("sample.yaml"), @r#"
     success: true

--- a/crates/prek/tests/workspace.rs
+++ b/crates/prek/tests/workspace.rs
@@ -1122,7 +1122,7 @@ fn submodule_discovery() -> Result<()> {
 
     // 3. Test that current directory is in the submodule without .pre-commit-config
     // Remove the config file in the submodule
-    std::fs::remove_file(submodule_path.join(".pre-commit-config.yaml"))?;
+    fs_err::remove_file(submodule_path.join(".pre-commit-config.yaml"))?;
     submodule_context.git_add(".");
     submodule_context.git_commit("Remove config");
 


### PR DESCRIPTION
`fs_err` appears to be a dependency in the repo but it is not used everywhere. There should be more benefit of having it as a dependency if it is used everywhere in that case.