### PR TITLE
Drain PTY output without timeout

### DIFF
--- a/crates/prek-pty/src/pty.rs
+++ b/crates/prek-pty/src/pty.rs
@@ -1,4 +1,4 @@
-use std::io::Write;
+use std::io::{Read, Write};
 
 type AsyncPty = tokio::io::unix::AsyncFd<crate::sys::Pty>;
 
@@ -39,6 +39,14 @@ impl Pty {
     /// Returns an error if we were unable to set the terminal size.
     pub fn resize(&self, size: crate::Size) -> crate::Result<()> {
         self.0.get_ref().set_term_size(size)
+    }
+
+    /// Read bytes currently available from the pty without waiting for readiness.
+    ///
+    /// # Errors
+    /// Returns an error if the underlying nonblocking read fails.
+    pub fn try_read(&self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.0.get_ref().read(buf)
     }
 
     /// Splits a `Pty` into a read half and a write half, which can be used to

--- a/crates/prek/src/process.rs
+++ b/crates/prek/src/process.rs
@@ -258,7 +258,16 @@ impl Cmd {
                 }
                 status = child.wait() => {
                     let status = status?;
-                    drain_ready_pty(&mut pty, &mut stdout, &mut buffer).await?;
+                    loop {
+                        match pty.try_read(&mut buffer) {
+                            Ok(0) => break,
+                            Ok(n) => stdout.extend_from_slice(&buffer[..n]),
+                            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => break,
+                            // Linux reports PTY master EOF as EIO after all slave handles close.
+                            Err(err) if err.raw_os_error() == Some(libc::EIO) => break,
+                            Err(err) => return Err(Error::PtySetup(err)),
+                        }
+                    }
                     break status;
                 }
             }
@@ -288,26 +297,6 @@ impl Cmd {
         })?;
         self.maybe_check_status(status)?;
         Ok(status)
-    }
-}
-
-#[cfg(not(windows))]
-async fn drain_ready_pty(
-    pty: &mut prek_pty::Pty,
-    stdout: &mut Vec<u8>,
-    buffer: &mut [u8; 4096],
-) -> Result<(), Error> {
-    use tokio::io::AsyncReadExt;
-    use tokio::time::{Duration, timeout};
-
-    loop {
-        match timeout(Duration::from_millis(20), pty.read(buffer)).await {
-            Ok(Ok(0)) => return Ok(()),
-            Ok(Ok(n)) => stdout.extend_from_slice(&buffer[..n]),
-            Err(_) => return Ok(()),
-            Ok(Err(err)) if err.kind() == std::io::ErrorKind::WouldBlock => return Ok(()),
-            Ok(Err(err)) => return Err(Error::PtySetup(err)),
-        }
     }
 }
 


### PR DESCRIPTION
Removes the timeout-based PTY drain after a child exits. The PTY output path now drains bytes already buffered on the nonblocking master and stops when no more data is immediately available, preserving trailing output without sleeping.