### PR TITLE
Remove unnecessary clones

### DIFF
--- a/crates/prek/src/cli/install.rs
+++ b/crates/prek/src/cli/install.rs
@@ -179,7 +179,7 @@ fn get_hook_types(
             .filter(|p| p.exists());
         if let Some(path) = config.into_iter().chain(fallbacks).next() {
             match load_config(path) {
-                Ok(cfg) => cfg.default_install_hook_types.clone().unwrap_or_default(),
+                Ok(cfg) => cfg.default_install_hook_types.unwrap_or_default(),
                 Err(err) => {
                     err.warn_parse_error();
                     vec![]

--- a/crates/prek/src/languages/python/version.rs
+++ b/crates/prek/src/languages/python/version.rs
@@ -216,10 +216,7 @@ mod tests {
         assert!(!PythonRequest::MajorMinorPatch(3, 12, 2).satisfied_by(&install_info));
 
         let range_req = semver::VersionReq::parse(">=3.12").unwrap();
-        assert!(
-            PythonRequest::Range(range_req.clone(), ">=3.12".to_string())
-                .satisfied_by(&install_info)
-        );
+        assert!(PythonRequest::Range(range_req, ">=3.12".to_string()).satisfied_by(&install_info));
 
         let range_req = semver::VersionReq::parse(">=4.0").unwrap();
         assert!(!PythonRequest::Range(range_req, ">=4.0".to_string()).satisfied_by(&install_info));

--- a/crates/prek/src/languages/rust/version.rs
+++ b/crates/prek/src/languages/rust/version.rs
@@ -318,7 +318,7 @@ mod tests {
             InstallInfo::new(Language::Rust, FxHashSet::default(), temp_dir.path())?;
         install_info
             .with_language_version(semver::Version::new(1, 71, 0))
-            .with_toolchain(toolchain_path.clone());
+            .with_toolchain(toolchain_path);
 
         assert!(RustRequest::Any.satisfied_by(&install_info));
         assert!(RustRequest::Major(1).satisfied_by(&install_info));


### PR DESCRIPTION
Remove unnecessary clones when the receiver can be moved instead, since it is no longer used afterwards.

CC @nunoplopes