### PR TITLE
Disable rust-cache bin caching to fix macOS cargo resolution

### DIFF
--- a/.github/workflows/build-dev-binaries.yml
+++ b/.github/workflows/build-dev-binaries.yml
@@ -88,6 +88,8 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           save-if: ${{ inputs.save-rust-cache == 'true' }}
+          # Workaround for https://github.com/Swatinem/rust-cache/issues/341
+          cache-bin: false
 
       - name: "Build"
         run: cargo build --profile no-debug --bin prek

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,6 +365,8 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           save-if: ${{ needs.plan.outputs.save-rust-cache == 'true' }}
+          # Workaround for https://github.com/Swatinem/rust-cache/issues/341
+          cache-bin: false
 
       - name: "Install Rust toolchain"
         run: rustup component add llvm-tools-preview
@@ -504,6 +506,8 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           save-if: ${{ needs.plan.outputs.save-rust-cache == 'true' }}
+          # Workaround for https://github.com/Swatinem/rust-cache/issues/341
+          cache-bin: false
 
       - name: "Install Rust toolchain"
         run: rustup component add llvm-tools-preview


### PR DESCRIPTION
New macOS runner images (20260511.0048+) ship a broken Homebrew rustup-init shim at /opt/homebrew/bin/cargo. When swatinem/rust-cache restores cached binaries, it can restore this shim over the real cargo binary installed by dtolnay/rust-toolchain, causing 'cargo metadata' to fail with 'Usage: rustup-init[EXE] [OPTIONS]'.

Setting `cache-bin: false` prevents rust-cache from caching or restoring the cargo/rustc binaries, letting the toolchain action's binaries take precedence.

Ref: actions/runner-images#14097, actions/runner-images#14099,
     Swatinem/rust-cache#341
