### PR TITLE
Reduce run filtering allocations

### DIFF
--- a/crates/prek/src/cli/run/filter.rs
+++ b/crates/prek/src/cli/run/filter.rs
@@ -102,7 +102,11 @@ impl<'a> HookFileFilter<'a> {
         tags.is_some_and(|tags| self.tags.matches(tags))
     }
 
-    fn matches_project_file(&self, file: &ProjectFile<'_>, tag_cache: &mut FileTagCache) -> bool {
+    fn matches_project_file<'p>(
+        &self,
+        file: &ProjectFile<'p>,
+        tag_cache: &mut FileTagCache<'p>,
+    ) -> bool {
         self.matches_filename(file.hook_path) && self.matches_tags(file.tags(tag_cache))
     }
 }
@@ -120,18 +124,18 @@ impl<'a> ProjectFile<'a> {
         }
     }
 
-    fn tags<'cache>(&self, tag_cache: &'cache mut FileTagCache) -> Option<&'cache TagSet> {
+    fn tags<'cache>(&self, tag_cache: &'cache mut FileTagCache<'a>) -> Option<&'cache TagSet> {
         tag_cache.tags(self.workspace_path)
     }
 }
 
 #[derive(Default)]
-pub(crate) struct FileTagCache {
-    tags_by_path: FxHashMap<PathBuf, Option<TagSet>>,
+pub(crate) struct FileTagCache<'a> {
+    tags_by_path: FxHashMap<&'a Path, Option<TagSet>>,
 }
 
-impl FileTagCache {
-    pub(crate) fn tags(&mut self, path: &Path) -> Option<&TagSet> {
+impl<'a> FileTagCache<'a> {
+    pub(crate) fn tags(&mut self, path: &'a Path) -> Option<&TagSet> {
         if !self.tags_by_path.contains_key(path) {
             let tags = match tags_from_path(path) {
                 Ok(tags) => Some(tags),
@@ -140,7 +144,7 @@ impl FileTagCache {
                     None
                 }
             };
-            self.tags_by_path.insert(path.to_path_buf(), tags);
+            self.tags_by_path.insert(path, tags);
         }
         self.tags_by_path.get(path).and_then(Option::as_ref)
     }
@@ -173,33 +177,37 @@ impl<'a> ProjectFiles<'a> {
         // *before* applying the project's include/exclude patterns. This ensures that even
         // files excluded by this project are still considered "owned" by it and hidden
         // from parent projects.
-        let files = filenames
-            .map(PathBuf::as_path)
+        let files_capacity = if relative_path.as_os_str().is_empty() {
+            filenames.size_hint().0
+        } else {
+            0
+        };
+        let mut files = Vec::with_capacity(files_capacity);
+        for filename in filenames {
             // Collect files that are inside the hook project directory.
-            .filter(|filename| filename.starts_with(relative_path))
+            if !filename.starts_with(relative_path) {
+                continue;
+            }
+
             // Skip files that have already been consumed by subprojects.
-            .filter(|filename| {
-                if let Some(consumed_files) = consumed_files.as_mut() {
-                    if orphan {
-                        return consumed_files.insert(filename);
+            if let Some(consumed_files) = consumed_files.as_mut() {
+                if orphan {
+                    if !consumed_files.insert(filename) {
+                        continue;
                     }
-                    !consumed_files.contains(filename)
-                } else {
-                    true
+                } else if consumed_files.contains(filename.as_path()) {
+                    continue;
                 }
-            })
+            }
+
             // Strip the project-relative prefix before applying project-level include/exclude patterns.
-            .filter_map(|filename| {
-                let relative = filename
-                    .strip_prefix(relative_path)
-                    .expect("Filename should start with project relative path");
-                if filename_filter.matches(relative) {
-                    Some(ProjectFile::new(filename, relative))
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
+            let relative = filename
+                .strip_prefix(relative_path)
+                .expect("Filename should start with project relative path");
+            if filename_filter.matches(relative) {
+                files.push(ProjectFile::new(filename, relative));
+            }
+        }
 
         Self { files }
     }
@@ -214,7 +222,7 @@ impl<'a> ProjectFiles<'a> {
         types: Option<&TagSet>,
         types_or: Option<&TagSet>,
         exclude_types: Option<&TagSet>,
-        tag_cache: &mut FileTagCache,
+        tag_cache: &mut FileTagCache<'a>,
     ) -> Vec<&Path> {
         let tag_filter = FileTagFilter::new(types, types_or, exclude_types);
         let mut filenames = Vec::new();
@@ -230,7 +238,7 @@ impl<'a> ProjectFiles<'a> {
 
     /// Filter filenames by file patterns and tags for a specific hook.
     #[instrument(level = "trace", skip_all, fields(hook = ?hook.id))]
-    pub(crate) fn for_hook(&self, hook: &Hook, tag_cache: &mut FileTagCache) -> Vec<&Path> {
+    pub(crate) fn for_hook(&self, hook: &Hook, tag_cache: &mut FileTagCache<'a>) -> Vec<&Path> {
         let hook_filter = HookFileFilter::new(hook);
         let mut filenames = Vec::new();
         for file in &self.files {
@@ -239,6 +247,17 @@ impl<'a> ProjectFiles<'a> {
             }
         }
         filenames
+    }
+
+    /// Return whether at least one file matches a hook without collecting every filename.
+    pub(crate) fn has_match_for_hook(&self, hook: &Hook, tag_cache: &mut FileTagCache<'a>) -> bool {
+        let hook_filter = HookFileFilter::new(hook);
+        for file in &self.files {
+            if hook_filter.matches_project_file(file, tag_cache) {
+                return true;
+            }
+        }
+        false
     }
 }
 

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -12,7 +12,7 @@ use prek_consts::env_vars::EnvVars;
 use prek_consts::{PRE_COMMIT_CONFIG_YAML, PREK_TOML};
 use rand::SeedableRng;
 use rand::prelude::{SliceRandom, StdRng};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use tracing::{debug, trace, warn};
 use unicode_width::UnicodeWidthStr;
 
@@ -606,9 +606,23 @@ impl<'a> ProjectHookInput<'a> {
         }
     }
 
-    fn for_hook(&self, hook: &Hook, tag_cache: &mut FileTagCache) -> Vec<&Path> {
+    fn for_hook<'input>(
+        &'input self,
+        hook: &Hook,
+        tag_cache: &mut FileTagCache<'a>,
+    ) -> HookRunInput<'input>
+    where
+        'a: 'input,
+    {
         match self {
-            Self::Files(project_files) => project_files.for_hook(hook, tag_cache),
+            Self::Files(project_files) => match hook.pass_filenames {
+                PassFilenames::None => HookRunInput::matched_without_filenames(
+                    project_files.has_match_for_hook(hook, tag_cache),
+                ),
+                PassFilenames::All | PassFilenames::Limited(_) => {
+                    HookRunInput::with_filenames(project_files.for_hook(hook, tag_cache))
+                }
+            },
             Self::MessageFile {
                 absolute_path,
                 hook_arg,
@@ -620,11 +634,38 @@ impl<'a> ProjectHookInput<'a> {
                 if hook_filter.matches_filename(hook_arg)
                     && hook_filter.matches_tags(tag_cache.tags(absolute_path))
                 {
-                    vec![hook_arg.as_path()]
+                    match hook.pass_filenames {
+                        PassFilenames::None => HookRunInput::matched_without_filenames(true),
+                        PassFilenames::All | PassFilenames::Limited(_) => {
+                            HookRunInput::with_filenames(vec![hook_arg.as_path()])
+                        }
+                    }
                 } else {
-                    vec![]
+                    HookRunInput::matched_without_filenames(false)
                 }
             }
+        }
+    }
+}
+
+struct HookRunInput<'a> {
+    has_matching_files: bool,
+    filenames: Vec<&'a Path>,
+}
+
+impl<'a> HookRunInput<'a> {
+    fn with_filenames(filenames: Vec<&'a Path>) -> Self {
+        let has_matching_files = !filenames.is_empty();
+        Self {
+            has_matching_files,
+            filenames,
+        }
+    }
+
+    fn matched_without_filenames(has_matching_files: bool) -> Self {
+        Self {
+            has_matching_files,
+            filenames: Vec::new(),
         }
     }
 }
@@ -651,7 +692,8 @@ async fn run_hooks(
 
     // Group hooks by project to run them in order of their depth in the workspace.
     #[allow(clippy::mutable_key_type)]
-    let mut project_to_hooks: FxHashMap<&Project, Vec<InstalledHook>> = FxHashMap::default();
+    let mut project_to_hooks: FxHashMap<&Project, Vec<InstalledHook>> =
+        FxHashMap::with_capacity_and_hasher(hooks.len(), FxBuildHasher);
     for hook in hooks {
         project_to_hooks
             .entry(hook.project())
@@ -834,14 +876,17 @@ impl Iterator for PriorityGroupRanges<'_> {
     }
 }
 
-async fn run_priority_group(
+async fn run_priority_group<'input, 'paths>(
     group_hooks: Vec<InstalledHook>,
-    input: &ProjectHookInput<'_>,
-    tag_cache: &mut FileTagCache,
+    input: &'input ProjectHookInput<'paths>,
+    tag_cache: &mut FileTagCache<'paths>,
     store: &Store,
     dry_run: bool,
     reporter: &HookRunReporter,
-) -> Result<Vec<RunResult>> {
+) -> Result<Vec<RunResult>>
+where
+    'paths: 'input,
+{
     debug!(
         "Running priority group with priority {} with concurrency {}: {:?}",
         group_hooks[0].priority,
@@ -851,13 +896,14 @@ async fn run_priority_group(
 
     let mut results = futures::stream::iter(group_hooks)
         .map(|hook| {
-            let filenames = input.for_hook(&hook, tag_cache);
+            let hook_input = input.for_hook(&hook, tag_cache);
             trace!(
-                "Files for hook `{}` after filtered: {}",
+                matched = hook_input.has_matching_files,
+                filenames = hook_input.filenames.len(),
+                "Files for hook `{}` after filtering",
                 hook.id,
-                filenames.len()
             );
-            run_hook(hook, filenames, store, dry_run, reporter)
+            run_hook(hook, hook_input, store, dry_run, reporter)
         })
         .buffer_unordered(*CONCURRENCY);
 
@@ -1073,12 +1119,12 @@ impl RunResult {
 
 async fn run_hook(
     hook: InstalledHook,
-    mut filenames: Vec<&Path>,
+    mut input: HookRunInput<'_>,
     store: &Store,
     dry_run: bool,
     reporter: &HookRunReporter,
 ) -> Result<RunResult> {
-    if filenames.is_empty() && !hook.always_run {
+    if !input.has_matching_files && !hook.always_run {
         return Ok(RunResult::from_status(hook, RunStatus::NoFiles));
     }
     if !Language::supported(hook.language) {
@@ -1088,8 +1134,8 @@ async fn run_hook(
 
     let filenames = match hook.pass_filenames {
         PassFilenames::All | PassFilenames::Limited(_) => {
-            shuffle(&mut filenames);
-            filenames
+            shuffle(&mut input.filenames);
+            input.filenames
         }
         PassFilenames::None => vec![],
     };


### PR DESCRIPTION
Reduces allocation pressure in `prek run` filtering by borrowing tag-cache path keys from the existing run input and avoiding full filename vector materialization for hooks with `pass_filenames: false`.

On the synthetic 16k-file workload used during profiling, allocator traffic dropped from about 59.9k to 43.9k allocations, and peak live heap dropped from about 5.33 MB to 2.95 MB.