### PR TITLE
Simplify workspace file handling

### DIFF
--- a/crates/prek/src/cli/run/filter.rs
+++ b/crates/prek/src/cli/run/filter.rs
@@ -288,6 +288,19 @@ pub(crate) enum RunInput {
     MessageFile(PathBuf),
 }
 
+impl RunInput {
+    /// Return workspace-relative file paths.
+    ///
+    /// `MessageFile` inputs are hook arguments, not workspace files, so this
+    /// compatibility helper discards them and returns an empty list.
+    pub(crate) fn into_files(self) -> Vec<PathBuf> {
+        match self {
+            Self::Files(files) => files,
+            Self::MessageFile(_) => vec![],
+        }
+    }
+}
+
 /// Get hook input for the selected stage.
 pub(crate) async fn collect_run_input(root: &Path, opts: CollectOptions) -> Result<RunInput> {
     let CollectOptions {
@@ -305,42 +318,6 @@ pub(crate) async fn collect_run_input(root: &Path, opts: CollectOptions) -> Resu
         return Ok(RunInput::MessageFile(GIT_ROOT.as_ref()?.join(path)));
     }
 
-    collect_workspace_files(
-        root,
-        hook_stage,
-        from_ref,
-        to_ref,
-        all_files,
-        files,
-        directories,
-    )
-    .await
-    .map(RunInput::Files)
-}
-
-/// Get workspace filenames to run hooks on.
-/// Returns a list of file paths relative to the workspace root.
-pub(crate) async fn collect_files(root: &Path, opts: CollectOptions) -> Result<Vec<PathBuf>> {
-    match collect_run_input(root, opts).await? {
-        RunInput::Files(files) => Ok(files),
-        // This compatibility API can only return workspace-relative files.
-        // Git message files are hook arguments, not workspace files, and are
-        // handled through `RunInput` by the main runner.
-        RunInput::MessageFile(_) => Ok(vec![]),
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-#[instrument(level = "trace", skip_all)]
-async fn collect_workspace_files(
-    root: &Path,
-    hook_stage: Stage,
-    from_ref: Option<String>,
-    to_ref: Option<String>,
-    all_files: bool,
-    files: Vec<String>,
-    directories: Vec<String>,
-) -> Result<Vec<PathBuf>> {
     let git_root = GIT_ROOT.as_ref()?;
 
     // The workspace root relative to the git root.
@@ -381,7 +358,7 @@ async fn collect_workspace_files(
         filenames.sort_unstable();
     }
 
-    Ok(filenames)
+    Ok(RunInput::Files(filenames))
 }
 
 fn adjust_relative_path(path: &str, new_cwd: &Path) -> Result<PathBuf, std::io::Error> {

--- a/crates/prek/src/cli/run/mod.rs
+++ b/crates/prek/src/cli/run/mod.rs
@@ -1,6 +1,4 @@
-pub(crate) use filter::{
-    CollectOptions, FileTagCache, ProjectFiles, RunInput, collect_files, collect_run_input,
-};
+pub(crate) use filter::{CollectOptions, FileTagCache, ProjectFiles, RunInput, collect_run_input};
 pub(crate) use run::{install_hooks, run};
 pub(crate) use selector::{SelectorSource, Selectors};
 

--- a/crates/prek/src/fs.rs
+++ b/crates/prek/src/fs.rs
@@ -208,34 +208,33 @@ impl Drop for LockedFile {
 
 /// Normalizes a path to use `/` as a separator everywhere, even on platforms
 /// that recognize other characters as separators.
-#[cfg(unix)]
+#[cfg(not(windows))]
 pub(crate) fn normalize_path(path: PathBuf) -> PathBuf {
-    // UNIX only uses /, so we're good.
     path
 }
 
 /// Normalizes a path to use `/` as a separator everywhere, even on platforms
 /// that recognize other characters as separators.
-#[cfg(not(unix))]
+#[cfg(windows)]
 pub(crate) fn normalize_path(path: PathBuf) -> PathBuf {
     use std::ffi::OsString;
-    use std::path::is_separator;
+
+    if !path.as_os_str().as_encoded_bytes().contains(&b'\\') {
+        return path;
+    }
 
     let mut path = path.into_os_string().into_encoded_bytes();
-    for c in &mut path {
-        if *c == b'/' || !is_separator(char::from(*c)) {
-            continue;
+    for byte in &mut path {
+        if *byte == b'\\' {
+            *byte = b'/';
         }
-        *c = b'/';
     }
 
-    match String::from_utf8(path) {
-        Ok(s) => PathBuf::from(s),
-        Err(e) => {
-            let path = e.into_bytes();
-            PathBuf::from(OsString::from(String::from_utf8_lossy(&path).as_ref()))
-        }
-    }
+    // SAFETY: `path` came from `OsString::into_encoded_bytes`, and we only
+    // replace ASCII `\` with ASCII `/`. ASCII bytes cannot appear inside a
+    // non-ASCII UTF-8/WTF-8 sequence, so this preserves the encoding invariant
+    // required by `from_encoded_bytes_unchecked`.
+    PathBuf::from(unsafe { OsString::from_encoded_bytes_unchecked(path) })
 }
 
 /// Compute a path describing `path` relative to `base`.
@@ -460,6 +459,51 @@ mod tests {
         for (input, expected) in cases {
             assert_eq!(Path::new(input).clean(), PathBuf::from(expected), "{input}");
         }
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn normalize_path_keeps_non_windows_paths_unchanged() {
+        let path = PathBuf::from(r"foo\bar/baz");
+
+        assert_eq!(super::normalize_path(path.clone()), path);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn normalize_path_replaces_windows_separators() {
+        let path = PathBuf::from(r"foo\bar/baz");
+        let normalized = super::normalize_path(path);
+
+        assert_eq!(normalized.as_os_str().as_encoded_bytes(), b"foo/bar/baz");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn normalize_path_preserves_non_utf8_windows_paths() {
+        use std::ffi::OsString;
+        use std::os::windows::ffi::{OsStrExt, OsStringExt};
+
+        let path = PathBuf::from(OsString::from_wide(&[
+            u16::from(b'a'),
+            u16::from(b'\\'),
+            0xD800,
+            u16::from(b'\\'),
+            u16::from(b'b'),
+        ]));
+        let normalized = super::normalize_path(path);
+        let normalized = normalized.as_os_str().encode_wide().collect::<Vec<_>>();
+
+        assert_eq!(
+            normalized,
+            vec![
+                u16::from(b'a'),
+                u16::from(b'/'),
+                0xD800,
+                u16::from(b'/'),
+                u16::from(b'b'),
+            ]
+        );
     }
 
     #[tokio::test]

--- a/crates/prek/src/hooks/meta_hooks.rs
+++ b/crates/prek/src/hooks/meta_hooks.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use prek_consts::CONFIG_FILENAMES;
 
 use crate::cli::reporter::HookRunReporter;
-use crate::cli::run::{CollectOptions, FileTagCache, ProjectFiles, collect_files};
+use crate::cli::run::{CollectOptions, FileTagCache, ProjectFiles, collect_run_input};
 use crate::config::{self, FilePattern, HookOptions, Language, MetaHook};
 use crate::hook::Hook;
 use crate::store::Store;
@@ -95,7 +95,9 @@ pub(crate) async fn check_hooks_apply(
 ) -> Result<(i32, Vec<u8>)> {
     let relative_path = hook.project().relative_path();
     // Collect all files in the project
-    let input = collect_files(hook.work_dir(), CollectOptions::all_files()).await?;
+    let input = collect_run_input(hook.work_dir(), CollectOptions::all_files())
+        .await?
+        .into_files();
     // Prepend the project relative path to each input file
     let input: Vec<_> = input.into_iter().map(|f| relative_path.join(f)).collect();
 
@@ -166,11 +168,13 @@ pub(crate) async fn check_useless_excludes(
     filenames: &[&Path],
 ) -> Result<(i32, Vec<u8>)> {
     let relative_path = hook.project().relative_path();
-    // `collect_files` returns paths relative to the hook's project root.
+    // `collect_run_input` returns paths relative to the hook's project root.
     // The meta hook itself runs from the workspace root, so we build both:
     // - `input_project`: for matching `files`/`exclude` patterns (project-relative)
     // - `input_workspace`: for `ProjectFiles` (workspace-relative)
-    let input_project = collect_files(hook.work_dir(), CollectOptions::all_files()).await?;
+    let input_project = collect_run_input(hook.work_dir(), CollectOptions::all_files())
+        .await?
+        .into_files();
     let input_workspace: Vec<_> = input_project
         .iter()
         .map(|f| relative_path.join(f))


### PR DESCRIPTION
Inline workspace file collection into collect_run_input and expose RunInput::into_files for meta hooks.

Also keep Windows path normalization lossless while avoiding an extra allocation when no separator rewrite is needed.