### PR TITLE
Skip installs for hooks that will not run

### DIFF
--- a/crates/prek/src/cli/cache_gc.rs
+++ b/crates/prek/src/cli/cache_gc.rs
@@ -165,7 +165,7 @@ pub(crate) async fn cache_gc(
     // Always keep Prek's own cache.
     used_cache.insert(CacheBucket::Prek);
 
-    let install_cache = InstallCache::load(store).await;
+    let install_cache = InstallCache::new();
 
     for config_path in &tracked_configs {
         let config = match load_config(config_path) {
@@ -214,7 +214,7 @@ pub(crate) async fn cache_gc(
     // Mark hook environments by matching already-installed env metadata.
     // While doing this, try to derive the specific tool *version* directories in use from
     // `InstallInfo.toolchain` (which is persisted in `.prek-hook.json`).
-    for installed in install_cache.installed_hooks() {
+    for installed in install_cache.installed_hooks(store).await {
         let info = installed.info_ref();
         if used_env_keys.iter().any(|k| k.matches_install_info(info)) {
             if let Some(dir) = info

--- a/crates/prek/src/cli/cache_gc.rs
+++ b/crates/prek/src/cli/cache_gc.rs
@@ -13,6 +13,7 @@ use tracing::{debug, trace, warn};
 
 use crate::cli::ExitStatus;
 use crate::cli::cache_size::{dir_size_bytes, human_readable_bytes};
+use crate::cli::run::install::InstallCache;
 use crate::config::{self, Error as ConfigError, Repo as ConfigRepo, load_config};
 use crate::hook::{HOOK_MARKER, HookEnvKey, HookSpec, InstallInfo, Repo as HookRepo};
 use crate::printer::Printer;
@@ -164,7 +165,7 @@ pub(crate) async fn cache_gc(
     // Always keep Prek's own cache.
     used_cache.insert(CacheBucket::Prek);
 
-    let installed = store.installed_hooks().await;
+    let install_cache = InstallCache::load(store).await;
 
     for config_path in &tracked_configs {
         let config = match load_config(config_path) {
@@ -213,7 +214,8 @@ pub(crate) async fn cache_gc(
     // Mark hook environments by matching already-installed env metadata.
     // While doing this, try to derive the specific tool *version* directories in use from
     // `InstallInfo.toolchain` (which is persisted in `.prek-hook.json`).
-    for info in &installed {
+    for installed in install_cache.installed_hooks() {
+        let info = installed.info_ref();
         if used_env_keys.iter().any(|k| k.matches_install_info(info)) {
             if let Some(dir) = info
                 .env_path

--- a/crates/prek/src/cli/install.rs
+++ b/crates/prek/src/cli/install.rs
@@ -12,6 +12,7 @@ use same_file::is_same_file;
 
 use crate::cli::reporter::{HookInitReporter, HookInstallReporter};
 use crate::cli::run;
+use crate::cli::run::install::InstallCache;
 use crate::cli::run::{SelectorSource, Selectors};
 use crate::cli::{ExitStatus, HookType};
 use crate::config::load_config;
@@ -152,7 +153,9 @@ pub(crate) async fn prepare_hooks(
         .collect();
 
     let reporter = HookInstallReporter::new(printer);
-    run::install_hooks(filtered_hooks, store, &reporter).await?;
+    let mut install_cache = InstallCache::new();
+    run::install_hooks(filtered_hooks, store, &reporter, &mut install_cache).await?;
+    reporter.on_complete();
 
     Ok(ExitStatus::Success)
 }

--- a/crates/prek/src/cli/reporter.rs
+++ b/crates/prek/src/cli/reporter.rs
@@ -147,13 +147,25 @@ impl workspace::HookInitReporter for HookInitReporter {
 
 pub(crate) struct HookInstallReporter {
     reporter: Arc<ProgressReporter>,
+    root_message: &'static str,
 }
 
 impl HookInstallReporter {
     pub(crate) fn new(printer: Printer) -> Self {
         let reporter = Arc::new(ProgressReporter::from(printer));
         set_current_reporter(Some(&reporter));
-        Self { reporter }
+        Self {
+            reporter,
+            root_message: "Installing hooks...",
+        }
+    }
+
+    /// Reuse the run reporter so install and run progress can share one root message.
+    pub(crate) fn from_run(reporter: &HookRunReporter) -> Self {
+        Self {
+            reporter: Arc::clone(&reporter.reporter),
+            root_message: reporter.root_message,
+        }
     }
 }
 
@@ -161,7 +173,7 @@ impl HookInstallReporter {
     pub fn on_install_start(&self, hook: &Hook) -> usize {
         self.reporter
             .root
-            .set_message(format!("{}", "Installing hooks...".bold().cyan()));
+            .set_message(format!("{}", self.root_message.bold().cyan()));
 
         self.reporter.on_start(format!(
             "{} {}",
@@ -182,20 +194,33 @@ impl HookInstallReporter {
 pub(crate) struct HookRunReporter {
     reporter: Arc<ProgressReporter>,
     dots: usize,
+    root_message: &'static str,
 }
 
 impl HookRunReporter {
     pub fn new(printer: Printer, dots: usize) -> Self {
+        Self::with_root_message(printer, dots, "Running hooks...")
+    }
+
+    pub fn new_execution(printer: Printer, dots: usize) -> Self {
+        Self::with_root_message(printer, dots, "Installing and running hooks...")
+    }
+
+    fn with_root_message(printer: Printer, dots: usize, root_message: &'static str) -> Self {
         let reporter = Arc::new(ProgressReporter::from(printer));
         set_current_reporter(Some(&reporter));
 
-        Self { reporter, dots }
+        Self {
+            reporter,
+            dots,
+            root_message,
+        }
     }
 
     pub fn on_run_start(&self, hook: &Hook, len: usize) -> usize {
         self.reporter
             .root
-            .set_message(format!("{}", "Running hooks...".bold().cyan()));
+            .set_message(format!("{}", self.root_message.bold().cyan()));
 
         let mut state = self.reporter.state.lock().unwrap();
         let id = state.id();

--- a/crates/prek/src/cli/reporter.rs
+++ b/crates/prek/src/cli/reporter.rs
@@ -145,6 +145,7 @@ impl workspace::HookInitReporter for HookInitReporter {
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct HookInstallReporter {
     reporter: Arc<ProgressReporter>,
     root_message: &'static str,
@@ -160,16 +161,6 @@ impl HookInstallReporter {
         }
     }
 
-    /// Reuse the run reporter so install and run progress can share one root message.
-    pub(crate) fn from_run(reporter: &HookRunReporter) -> Self {
-        Self {
-            reporter: Arc::clone(&reporter.reporter),
-            root_message: reporter.root_message,
-        }
-    }
-}
-
-impl HookInstallReporter {
     pub fn on_install_start(&self, hook: &Hook) -> usize {
         self.reporter
             .root
@@ -200,10 +191,6 @@ pub(crate) struct HookRunReporter {
 impl HookRunReporter {
     pub fn new(printer: Printer, dots: usize) -> Self {
         Self::with_root_message(printer, dots, "Running hooks...")
-    }
-
-    pub fn new_execution(printer: Printer, dots: usize) -> Self {
-        Self::with_root_message(printer, dots, "Installing and running hooks...")
     }
 
     fn with_root_message(printer: Printer, dots: usize, root_message: &'static str) -> Self {

--- a/crates/prek/src/cli/run/install.rs
+++ b/crates/prek/src/cli/run/install.rs
@@ -113,7 +113,7 @@ pub(super) struct Installer<'a> {
 
 impl<'a> Installer<'a> {
     pub(super) async fn for_jobs<T>(
-        store: &'a Store,
+        store: &Store,
         reporter: &'a HookInstallReporter,
         cache: &mut Option<InstallCache>,
         hooks: &[InstallJob<T>],

--- a/crates/prek/src/cli/run/install.rs
+++ b/crates/prek/src/cli/run/install.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use futures::stream::{FuturesUnordered, StreamExt};
+use mea::once::OnceCell;
 use mea::semaphore::Semaphore;
 use rustc_hash::FxHashMap;
 use tracing::{debug, warn};
@@ -13,71 +14,15 @@ use crate::hook::{Hook, InstallInfo, InstalledHook};
 use crate::run::CONCURRENCY;
 use crate::store::Store;
 
-#[derive(Clone, Copy)]
-struct InstallPlan {
-    /// Language used for install partitioning. This may differ from the runtime language.
-    install_language: Language,
-    needs_environment: bool,
-}
-
-impl InstallPlan {
-    fn new(hook: &Hook) -> Self {
-        let install_language = if hook.language == Language::Pygrep {
-            // Treat `pygrep` hooks as `python` hooks for installation purposes.
-            // They share the same installation logic.
-            Language::Python
-        } else {
-            hook.language
-        };
-
-        let needs_environment = hook.needs_install_env();
-
-        Self {
-            install_language,
-            needs_environment,
-        }
-    }
-
-    fn needs_environment(self) -> bool {
-        self.needs_environment
-    }
-}
-
-struct InstallJob {
-    hook: Arc<Hook>,
-    install: InstallPlan,
-}
-
-impl InstallJob {
-    fn new(hook: Arc<Hook>) -> Self {
-        let install = InstallPlan::new(&hook);
-        Self { hook, install }
-    }
-
-    fn hook(&self) -> &Hook {
-        self.hook.as_ref()
-    }
-
-    fn needs_environment(&self) -> bool {
-        self.install.needs_environment()
-    }
-
-    fn into_parts(self) -> (Arc<Hook>, InstallPlan) {
-        (self.hook, self.install)
-    }
-}
-
 pub(crate) async fn install_hooks(
     hooks: Vec<Arc<Hook>>,
     store: &Store,
     reporter: &HookInstallReporter,
+    cache: &mut InstallCache,
 ) -> Result<Vec<InstalledHook>> {
-    let hooks = hooks.into_iter().map(InstallJob::new).collect::<Vec<_>>();
     let num_hooks = hooks.len();
-    let mut cache = None;
-    let installer = Installer::for_jobs(store, reporter, &mut cache, &hooks).await;
-    let result = installer.install_all(store, hooks).await?;
-    reporter.on_complete();
+    let result = resolve_and_install_hooks(hooks, store, reporter, cache).await?;
+    cache.add_installed(&result);
 
     debug_assert_eq!(
         num_hooks,
@@ -88,275 +33,194 @@ pub(crate) async fn install_hooks(
     Ok(result)
 }
 
-pub(crate) async fn install_hooks_with_cache(
+async fn resolve_and_install_hooks(
     hooks: Vec<Arc<Hook>>,
     store: &Store,
     reporter: &HookInstallReporter,
-    cache: &mut Option<InstallCache>,
+    cache: &mut InstallCache,
 ) -> Result<Vec<InstalledHook>> {
-    let hooks = hooks.into_iter().map(InstallJob::new).collect::<Vec<_>>();
-    let num_hooks = hooks.len();
-    let installer = Installer::for_jobs(store, reporter, cache, &hooks).await;
-    let result = installer.install_all(store, hooks).await?;
-    if let Some(cache) = cache {
-        cache.add_installed(&result);
-    }
+    let mut installed_hooks = Vec::with_capacity(hooks.len());
+    let mut hooks_to_install = Vec::new();
 
-    debug_assert_eq!(
-        num_hooks,
-        result.len(),
-        "Number of hooks installed should match the number of hooks provided"
-    );
-
-    Ok(result)
-}
-
-#[derive(Clone)]
-pub(super) struct Installer {
-    /// Result of the run-level install cache at the time this batch starts.
-    store_hooks: Rc<[CachedInstallInfo]>,
-    /// Environments installed by earlier batches in this command.
-    created_hooks: Rc<[CachedInstallInfo]>,
-    /// Shared by all install partitions for this batch.
-    semaphore: Rc<Semaphore>,
-    reporter: HookInstallReporter,
-}
-
-impl Installer {
-    async fn for_jobs(
-        store: &Store,
-        reporter: &HookInstallReporter,
-        cache: &mut Option<InstallCache>,
-        hooks: &[InstallJob],
-    ) -> Self {
-        let needs_environment = hooks.iter().any(InstallJob::needs_environment);
-        let (store_hooks, created_hooks) = if needs_environment {
-            if let Some(cache) = cache.as_ref() {
-                cache.snapshot()
-            } else {
-                let loaded_cache = InstallCache::load(store).await;
-                let snapshot = loaded_cache.snapshot();
-                *cache = Some(loaded_cache);
-                snapshot
-            }
-        } else {
-            let empty = Rc::<[CachedInstallInfo]>::from(Vec::new().into_boxed_slice());
-            (Rc::clone(&empty), empty)
-        };
-
-        Self {
-            store_hooks,
-            created_hooks,
-            semaphore: Rc::new(Semaphore::new(*CONCURRENCY)),
-            reporter: reporter.clone(),
-        }
-    }
-
-    async fn install_all(
-        &self,
-        store: &Store,
-        hooks: Vec<InstallJob>,
-    ) -> Result<Vec<InstalledHook>> {
-        let mut result = Vec::with_capacity(hooks.len());
-        let mut futures = FuturesUnordered::new();
-
-        for partition in InstallPartitions::new(hooks) {
-            let installer = self.partition();
-            futures.push(async move { installer.install_all(store, partition).await });
+    for hook in hooks {
+        if !hook.needs_install_env() {
+            installed_hooks.push(InstalledHook::NoNeedInstall(hook));
+            continue;
         }
 
-        while let Some(hooks) = futures.next().await {
-            result.extend(hooks?);
-        }
-
-        Ok(result)
-    }
-
-    pub(super) fn partition(&self) -> PartitionInstaller {
-        PartitionInstaller {
-            installer: self.clone(),
-            newly_installed: Vec::new(),
-        }
-    }
-
-    async fn install_new(&self, store: &Store, hook: Arc<Hook>) -> Result<InstalledHook> {
-        let _permit = self.semaphore.acquire(1).await;
-
-        let installed_hook = hook
-            .language
-            .install(hook.clone(), store, &self.reporter)
-            .await
-            .with_context(|| format!("Failed to install hook `{hook}`"))?;
-
-        installed_hook
-            .mark_as_installed(store)
-            .await
-            .with_context(|| format!("Failed to mark hook `{hook}` as installed"))?;
-
-        match &installed_hook {
-            InstalledHook::Installed { info, .. } => {
-                debug!("Installed hook `{hook}` in `{}`", info.env_path.display());
-            }
-            InstalledHook::NoNeedInstall { .. } => {
-                debug!("Hook `{hook}` does not need installation");
-            }
-        }
-
-        Ok(installed_hook)
-    }
-
-    async fn installed_info_for_hook(&self, hook: &Hook) -> Option<Arc<InstallInfo>> {
-        for env in self.created_hooks.iter().chain(self.store_hooks.iter()) {
-            if env.matches(hook) && env.ensure_healthy().await {
-                return Some(env.info());
-            }
-        }
-
-        None
-    }
-}
-
-pub(super) struct PartitionInstaller {
-    installer: Installer,
-    /// Environments installed earlier in this partition.
-    ///
-    /// Partitions contain hooks with the same install language and dependency set, so later hooks
-    /// can safely reuse an environment installed by an earlier hook in the same partition.
-    newly_installed: Vec<InstalledHook>,
-}
-
-impl PartitionInstaller {
-    async fn install_all(
-        mut self,
-        store: &Store,
-        hooks: Vec<InstallJob>,
-    ) -> Result<Vec<InstalledHook>> {
-        let mut installed_hooks = Vec::with_capacity(hooks.len());
-
-        for hook in hooks {
-            let installed_hook = self.install_job(store, hook).await?;
+        if let Some(installed_hook) = cache.installed_hook(store, hook.clone()).await {
             installed_hooks.push(installed_hook);
+        } else {
+            hooks_to_install.push(hook);
         }
-
-        Ok(installed_hooks)
     }
 
-    async fn install_job(&mut self, store: &Store, job: InstallJob) -> Result<InstalledHook> {
-        let (hook, install) = job.into_parts();
-        let installed_hook = self.install(store, hook, install).await?;
-        Ok(installed_hook)
+    installed_hooks.extend(install_missing_hooks(hooks_to_install, store, reporter).await?);
+
+    Ok(installed_hooks)
+}
+
+async fn install_missing_hooks(
+    hooks: Vec<Arc<Hook>>,
+    store: &Store,
+    reporter: &HookInstallReporter,
+) -> Result<Vec<InstalledHook>> {
+    let semaphore = Rc::new(Semaphore::new(*CONCURRENCY));
+    let mut installed_hooks = Vec::with_capacity(hooks.len());
+    let mut futures = FuturesUnordered::new();
+
+    for partition in partition_hooks(hooks) {
+        let semaphore = Rc::clone(&semaphore);
+        let reporter = reporter.clone();
+        futures
+            .push(async move { install_partition(partition, store, &reporter, semaphore).await });
     }
 
-    async fn install(
-        &mut self,
-        store: &Store,
-        hook: Arc<Hook>,
-        install: InstallPlan,
-    ) -> Result<InstalledHook> {
-        if !install.needs_environment {
-            return Ok(InstalledHook::NoNeedInstall(hook));
-        }
+    while let Some(partition_hooks) = futures.next().await {
+        installed_hooks.extend(partition_hooks?);
+    }
 
-        if let Some(info) = self.installed_info_for_hook(&hook).await {
+    Ok(installed_hooks)
+}
+
+async fn install_partition(
+    hooks: Vec<Arc<Hook>>,
+    store: &Store,
+    reporter: &HookInstallReporter,
+    semaphore: Rc<Semaphore>,
+) -> Result<Vec<InstalledHook>> {
+    let mut installed_hooks = Vec::with_capacity(hooks.len());
+
+    for hook in hooks {
+        debug_assert!(hook.needs_install_env());
+        let installed_hook = if let Some(info) = installed_info_for_hook(&installed_hooks, &hook) {
             debug!(
                 "Found installed environment for hook `{hook}` at `{}`",
                 info.env_path.display()
             );
-            return Ok(InstalledHook::Installed { hook, info });
-        }
-
-        let installed_hook = self.installer.install_new(store, hook).await?;
-        self.newly_installed.push(installed_hook.clone());
-
-        Ok(installed_hook)
+            InstalledHook::Installed { hook, info }
+        } else {
+            install_new(hook, store, reporter, &semaphore).await?
+        };
+        installed_hooks.push(installed_hook);
     }
 
-    async fn installed_info_for_hook(&self, hook: &Hook) -> Option<Arc<InstallInfo>> {
-        for env in &self.newly_installed {
-            if let InstalledHook::Installed { info, .. } = env
-                && info.matches(hook)
-            {
-                return Some(info.clone());
-            }
-        }
+    Ok(installed_hooks)
+}
 
-        self.installer.installed_info_for_hook(hook).await
+async fn install_new(
+    hook: Arc<Hook>,
+    store: &Store,
+    reporter: &HookInstallReporter,
+    semaphore: &Semaphore,
+) -> Result<InstalledHook> {
+    let _permit = semaphore.acquire(1).await;
+
+    let installed_hook = hook
+        .language
+        .install(hook.clone(), store, reporter)
+        .await
+        .with_context(|| format!("Failed to install hook `{hook}`"))?;
+
+    installed_hook
+        .mark_as_installed(store)
+        .await
+        .with_context(|| format!("Failed to mark hook `{hook}` as installed"))?;
+
+    match &installed_hook {
+        InstalledHook::Installed { info, .. } => {
+            debug!("Installed hook `{hook}` in `{}`", info.env_path.display());
+        }
+        InstalledHook::NoNeedInstall { .. } => {
+            debug!("Hook `{hook}` does not need installation");
+        }
+    }
+
+    Ok(installed_hook)
+}
+
+fn installed_info_for_hook(
+    installed_hooks: &[InstalledHook],
+    hook: &Hook,
+) -> Option<Arc<InstallInfo>> {
+    for installed_hook in installed_hooks {
+        if let InstalledHook::Installed { info, .. } = installed_hook
+            && info.matches(hook)
+        {
+            return Some(info.clone());
+        }
+    }
+
+    None
+}
+
+/// Group hooks so each partition can install independently.
+///
+/// Different languages can install concurrently. Hooks with the same language and dependency set
+/// stay in one partition so later hooks can reuse an environment installed by an earlier hook.
+fn partition_hooks(hooks: Vec<Arc<Hook>>) -> Vec<Vec<Arc<Hook>>> {
+    let mut hooks_by_language = FxHashMap::default();
+    for hook in hooks {
+        hooks_by_language
+            .entry(install_language(&hook))
+            .or_insert_with(Vec::new)
+            .push(hook);
+    }
+
+    let mut partitions = Vec::new();
+    for (_, hooks) in hooks_by_language {
+        partitions.extend(partition_hooks_by_dependencies(hooks));
+    }
+
+    partitions
+}
+
+fn install_language(hook: &Hook) -> Language {
+    if hook.language == Language::Pygrep {
+        // Treat `pygrep` hooks as `python` hooks for installation purposes.
+        // They share the same installation logic.
+        Language::Python
+    } else {
+        hook.language
     }
 }
 
-struct InstallPartitions {
-    partitions: Vec<Vec<InstallJob>>,
-}
+fn partition_hooks_by_dependencies(hooks: Vec<Arc<Hook>>) -> Vec<Vec<Arc<Hook>>> {
+    let mut groups: Vec<Vec<Arc<Hook>>> = Vec::new();
 
-impl InstallPartitions {
-    /// Group hooks so each partition can install independently.
-    ///
-    /// Different languages can install concurrently. Hooks with the same language and dependency
-    /// set stay in one partition so later hooks can reuse an environment installed by an earlier
-    /// hook.
-    fn new(hooks: Vec<InstallJob>) -> Self {
-        let mut hooks_by_language = FxHashMap::default();
-        for hook in hooks {
-            hooks_by_language
-                .entry(hook.install.install_language)
-                .or_insert_with(Vec::new)
-                .push(hook);
+    for hook in hooks {
+        let group_index = groups
+            .iter()
+            .position(|group| group[0].env_key_dependencies() == hook.env_key_dependencies());
+
+        if let Some(index) = group_index {
+            groups[index].push(hook);
+        } else {
+            groups.push(vec![hook]);
         }
-
-        let mut partitions = Vec::new();
-        for (_, hooks) in hooks_by_language {
-            partitions.extend(Self::partition_by_dependencies(hooks));
-        }
-
-        Self { partitions }
     }
 
-    fn partition_by_dependencies(hooks: Vec<InstallJob>) -> Vec<Vec<InstallJob>> {
-        let mut groups: Vec<Vec<InstallJob>> = Vec::new();
-
-        for hook in hooks {
-            let group_index = groups.iter().position(|group| {
-                group[0].hook().env_key_dependencies() == hook.hook().env_key_dependencies()
-            });
-
-            if let Some(index) = group_index {
-                groups[index].push(hook);
-            } else {
-                groups.push(vec![hook]);
-            }
-        }
-
-        groups
-    }
-}
-
-impl IntoIterator for InstallPartitions {
-    type Item = Vec<InstallJob>;
-    type IntoIter = std::vec::IntoIter<Vec<InstallJob>>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.partitions.into_iter()
-    }
+    groups
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct CachedInstallInfo {
     info: Arc<InstallInfo>,
-    health: mea::once::OnceCell<bool>,
+    health: OnceCell<bool>,
 }
 
 impl CachedInstallInfo {
     fn new(info: Arc<InstallInfo>) -> Self {
         Self {
             info,
-            health: mea::once::OnceCell::new(),
+            health: OnceCell::new(),
         }
     }
 
     fn healthy(info: Arc<InstallInfo>) -> Self {
         Self {
             info,
-            health: mea::once::OnceCell::from_value(true),
+            health: OnceCell::from_value(true),
         }
     }
 
@@ -393,25 +257,33 @@ impl CachedInstallInfo {
 
 pub(crate) struct InstallCache {
     /// Result of the expensive hooks-dir scan. Loaded at most once per command.
-    store_hooks: Rc<[CachedInstallInfo]>,
+    store_hooks: OnceCell<Vec<CachedInstallInfo>>,
     /// Environments installed after the scan and therefore absent from `store_hooks`.
     created_hooks: Vec<CachedInstallInfo>,
 }
 
 impl InstallCache {
-    pub(crate) async fn load(store: &Store) -> Self {
+    pub(crate) fn new() -> Self {
         Self {
-            store_hooks: Self::load_store_installed_hooks(store).await,
+            store_hooks: OnceCell::new(),
             created_hooks: Vec::new(),
         }
     }
 
-    pub(crate) fn installed_hooks(&self) -> impl Iterator<Item = &CachedInstallInfo> {
-        self.created_hooks.iter().chain(self.store_hooks.iter())
+    pub(crate) async fn installed_hooks<'a>(
+        &'a self,
+        store: &Store,
+    ) -> impl Iterator<Item = &'a CachedInstallInfo> + 'a {
+        let store_hooks = self.store_hooks(store).await;
+        self.created_hooks.iter().chain(store_hooks.iter())
     }
 
-    pub(crate) async fn installed_hook(&self, hook: Arc<Hook>) -> Option<InstalledHook> {
-        for env in self.installed_hooks() {
+    pub(crate) async fn installed_hook(
+        &self,
+        store: &Store,
+        hook: Arc<Hook>,
+    ) -> Option<InstalledHook> {
+        for env in self.installed_hooks(store).await {
             if env.matches(&hook) && env.ensure_healthy().await {
                 return Some(InstalledHook::Installed {
                     hook,
@@ -423,8 +295,14 @@ impl InstallCache {
         None
     }
 
-    async fn load_store_installed_hooks(store: &Store) -> Rc<[CachedInstallInfo]> {
-        let store_installed_hooks = match fs_err::read_dir(store.hooks_dir()) {
+    async fn store_hooks(&self, store: &Store) -> &[CachedInstallInfo] {
+        self.store_hooks
+            .get_or_init(async || Self::load_store_installed_hooks(store).await)
+            .await
+    }
+
+    async fn load_store_installed_hooks(store: &Store) -> Vec<CachedInstallInfo> {
+        match fs_err::read_dir(store.hooks_dir()) {
             Ok(dirs) => {
                 let mut tasks = futures::stream::iter(dirs)
                     .map(async |entry| {
@@ -455,15 +333,7 @@ impl InstallCache {
                 hooks
             }
             Err(_) => Vec::new(),
-        };
-        Rc::from(store_installed_hooks.into_boxed_slice())
-    }
-
-    fn snapshot(&self) -> (Rc<[CachedInstallInfo]>, Rc<[CachedInstallInfo]>) {
-        (
-            Rc::clone(&self.store_hooks),
-            Rc::from(self.created_hooks.clone().into_boxed_slice()),
-        )
+        }
     }
 
     pub(crate) fn add_installed(&mut self, installed_hooks: &[InstalledHook]) {
@@ -483,9 +353,10 @@ impl InstallCache {
         self.created_hooks
             .iter()
             .any(|existing| existing.info.env_path == info.env_path)
-            || self
-                .store_hooks
-                .iter()
-                .any(|existing| existing.info.env_path == info.env_path)
+            || self.store_hooks.get().is_some_and(|store_hooks| {
+                store_hooks
+                    .iter()
+                    .any(|existing| existing.info.env_path == info.env_path)
+            })
     }
 }

--- a/crates/prek/src/cli/run/install.rs
+++ b/crates/prek/src/cli/run/install.rs
@@ -1,0 +1,489 @@
+use std::rc::Rc;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use futures::stream::{FuturesUnordered, StreamExt};
+use mea::semaphore::Semaphore;
+use rustc_hash::FxHashMap;
+use tracing::{debug, warn};
+
+use crate::cli::reporter::HookInstallReporter;
+use crate::config::Language;
+use crate::hook::{Hook, InstallInfo, InstalledHook};
+use crate::run::CONCURRENCY;
+use crate::store::Store;
+
+#[derive(Clone, Copy)]
+struct InstallPlan {
+    /// Language used for install partitioning. This may differ from the runtime language.
+    install_language: Language,
+    needs_environment: bool,
+}
+
+impl InstallPlan {
+    fn new(hook: &Hook) -> Self {
+        let install_language = if hook.language == Language::Pygrep {
+            // Treat `pygrep` hooks as `python` hooks for installation purposes.
+            // They share the same installation logic.
+            Language::Python
+        } else {
+            hook.language
+        };
+
+        let needs_environment = hook.needs_install_env();
+
+        Self {
+            install_language,
+            needs_environment,
+        }
+    }
+
+    fn needs_environment(self) -> bool {
+        self.needs_environment
+    }
+}
+
+/// A hook plus the data that should continue after install resolution.
+///
+/// `payload` carries the next stage's data through install partitioning without making the install
+/// layer know what that stage will do with it.
+pub(super) struct InstallJob<T> {
+    hook: Arc<Hook>,
+    install: InstallPlan,
+    payload: T,
+}
+
+impl<T> InstallJob<T> {
+    pub(super) fn new(hook: Arc<Hook>, payload: T) -> Self {
+        let install = InstallPlan::new(&hook);
+        Self {
+            hook,
+            install,
+            payload,
+        }
+    }
+
+    fn hook(&self) -> &Hook {
+        self.hook.as_ref()
+    }
+
+    fn needs_environment(&self) -> bool {
+        self.install.needs_environment()
+    }
+
+    fn into_parts(self) -> (Arc<Hook>, InstallPlan, T) {
+        (self.hook, self.install, self.payload)
+    }
+}
+
+pub(crate) async fn install_hooks(
+    hooks: Vec<Arc<Hook>>,
+    store: &Store,
+    reporter: &HookInstallReporter,
+) -> Result<Vec<InstalledHook>> {
+    let hooks = hooks
+        .into_iter()
+        .map(|hook| InstallJob::new(hook, ()))
+        .collect::<Vec<_>>();
+    let num_hooks = hooks.len();
+    let mut cache = None;
+    let installer = Installer::for_jobs(store, reporter, &mut cache, &hooks).await;
+    let result = installer.install_all(hooks).await?;
+    reporter.on_complete();
+
+    debug_assert_eq!(
+        num_hooks,
+        result.len(),
+        "Number of hooks installed should match the number of hooks provided"
+    );
+
+    Ok(result)
+}
+
+#[derive(Clone)]
+pub(super) struct Installer<'a> {
+    store: &'a Store,
+    installed_envs: InstalledEnvs,
+    /// Shared by all install partitions for this batch.
+    semaphore: Rc<Semaphore>,
+    reporter: &'a HookInstallReporter,
+}
+
+impl<'a> Installer<'a> {
+    pub(super) async fn for_jobs<T>(
+        store: &'a Store,
+        reporter: &'a HookInstallReporter,
+        cache: &mut Option<InstallCache>,
+        hooks: &[InstallJob<T>],
+    ) -> Self {
+        let needs_environment = hooks.iter().any(InstallJob::needs_environment);
+        let installed_envs = if needs_environment {
+            if let Some(cache) = cache.as_ref() {
+                cache.snapshot()
+            } else {
+                let loaded_cache = InstallCache::load(store).await;
+                let installed_envs = loaded_cache.snapshot();
+                *cache = Some(loaded_cache);
+                installed_envs
+            }
+        } else {
+            InstalledEnvs::empty()
+        };
+
+        Self {
+            store,
+            installed_envs,
+            semaphore: Rc::new(Semaphore::new(*CONCURRENCY)),
+            reporter,
+        }
+    }
+
+    async fn install_all(&self, hooks: Vec<InstallJob<()>>) -> Result<Vec<InstalledHook>> {
+        let mut result = Vec::with_capacity(hooks.len());
+        let mut futures = FuturesUnordered::new();
+
+        for partition in InstallPartitions::new(hooks) {
+            let installer = self.partition();
+            futures.push(async move { installer.install_all(partition).await });
+        }
+
+        while let Some(hooks) = futures.next().await {
+            result.extend(hooks?);
+        }
+
+        Ok(result)
+    }
+
+    pub(super) fn partition(&self) -> PartitionInstaller<'a> {
+        PartitionInstaller {
+            installer: self.clone(),
+            newly_installed: Vec::new(),
+        }
+    }
+
+    pub(super) fn store(&self) -> &'a Store {
+        self.store
+    }
+
+    async fn install_new(&self, hook: Arc<Hook>) -> Result<InstalledHook> {
+        let _permit = self.semaphore.acquire(1).await;
+
+        let installed_hook = hook
+            .language
+            .install(hook.clone(), self.store, self.reporter)
+            .await
+            .with_context(|| format!("Failed to install hook `{hook}`"))?;
+
+        installed_hook
+            .mark_as_installed(self.store)
+            .await
+            .with_context(|| format!("Failed to mark hook `{hook}` as installed"))?;
+
+        match &installed_hook {
+            InstalledHook::Installed { info, .. } => {
+                debug!("Installed hook `{hook}` in `{}`", info.env_path.display());
+            }
+            InstalledHook::NoNeedInstall { .. } => {
+                debug!("Hook `{hook}` does not need installation");
+            }
+        }
+
+        Ok(installed_hook)
+    }
+
+    async fn installed_info_for_hook(&self, hook: &Hook) -> Option<Arc<InstallInfo>> {
+        for env in self.installed_envs.iter() {
+            if env.matches(hook) && env.ensure_healthy().await {
+                return Some(env.info());
+            }
+        }
+
+        None
+    }
+}
+
+pub(super) struct PartitionInstaller<'a> {
+    installer: Installer<'a>,
+    /// Environments installed earlier in this partition.
+    ///
+    /// Partitions contain hooks with the same install language and dependency set, so later hooks
+    /// can safely reuse an environment installed by an earlier hook in the same partition.
+    newly_installed: Vec<InstalledHook>,
+}
+
+impl PartitionInstaller<'_> {
+    async fn install_all(mut self, hooks: Vec<InstallJob<()>>) -> Result<Vec<InstalledHook>> {
+        let mut installed_hooks = Vec::with_capacity(hooks.len());
+
+        for hook in hooks {
+            let (installed_hook, ()) = self.install_job(hook).await?;
+            installed_hooks.push(installed_hook);
+        }
+
+        Ok(installed_hooks)
+    }
+
+    pub(super) async fn install_job<T>(
+        &mut self,
+        job: InstallJob<T>,
+    ) -> Result<(InstalledHook, T)> {
+        let (hook, install, payload) = job.into_parts();
+        let installed_hook = self.install(hook, install).await?;
+        Ok((installed_hook, payload))
+    }
+
+    async fn install(&mut self, hook: Arc<Hook>, install: InstallPlan) -> Result<InstalledHook> {
+        if !install.needs_environment {
+            debug!("Hook `{}` does not need an installed environment", &hook);
+            return Ok(InstalledHook::NoNeedInstall(hook));
+        }
+
+        if let Some(info) = self.installed_info_for_hook(&hook).await {
+            debug!(
+                "Found installed environment for hook `{hook}` at `{}`",
+                info.env_path.display()
+            );
+            return Ok(InstalledHook::Installed { hook, info });
+        }
+
+        let installed_hook = self.installer.install_new(hook).await?;
+        self.newly_installed.push(installed_hook.clone());
+
+        Ok(installed_hook)
+    }
+
+    async fn installed_info_for_hook(&self, hook: &Hook) -> Option<Arc<InstallInfo>> {
+        for env in &self.newly_installed {
+            if let InstalledHook::Installed { info, .. } = env
+                && info.matches(hook)
+            {
+                return Some(info.clone());
+            }
+        }
+
+        self.installer.installed_info_for_hook(hook).await
+    }
+}
+
+pub(super) struct InstallPartitions<T> {
+    partitions: Vec<Vec<InstallJob<T>>>,
+}
+
+impl<T> InstallPartitions<T> {
+    /// Group hooks so each partition can install independently.
+    ///
+    /// Different languages can install concurrently. Hooks with the same language and dependency
+    /// set stay in one partition so later hooks can reuse an environment installed by an earlier
+    /// hook.
+    pub(super) fn new(hooks: Vec<InstallJob<T>>) -> Self {
+        let mut hooks_by_language = FxHashMap::default();
+        for hook in hooks {
+            hooks_by_language
+                .entry(hook.install.install_language)
+                .or_insert_with(Vec::new)
+                .push(hook);
+        }
+
+        let mut partitions = Vec::new();
+        for (_, hooks) in hooks_by_language {
+            partitions.extend(Self::partition_by_dependencies(hooks));
+        }
+
+        Self { partitions }
+    }
+
+    fn partition_by_dependencies(hooks: Vec<InstallJob<T>>) -> Vec<Vec<InstallJob<T>>> {
+        let mut groups: Vec<Vec<InstallJob<T>>> = Vec::new();
+
+        for hook in hooks {
+            let group_index = groups.iter().position(|group| {
+                group[0].hook().env_key_dependencies() == hook.hook().env_key_dependencies()
+            });
+
+            if let Some(index) = group_index {
+                groups[index].push(hook);
+            } else {
+                groups.push(vec![hook]);
+            }
+        }
+
+        groups
+    }
+}
+
+impl<T> IntoIterator for InstallPartitions<T> {
+    type Item = Vec<InstallJob<T>>;
+    type IntoIter = std::vec::IntoIter<Vec<InstallJob<T>>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.partitions.into_iter()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CachedInstallInfo {
+    info: Arc<InstallInfo>,
+    health: mea::once::OnceCell<bool>,
+}
+
+impl CachedInstallInfo {
+    fn new(info: Arc<InstallInfo>) -> Self {
+        Self {
+            info,
+            health: mea::once::OnceCell::new(),
+        }
+    }
+
+    fn healthy(info: Arc<InstallInfo>) -> Self {
+        Self {
+            info,
+            health: mea::once::OnceCell::from_value(true),
+        }
+    }
+
+    fn matches(&self, hook: &Hook) -> bool {
+        self.info.matches(hook)
+    }
+
+    fn info(&self) -> Arc<InstallInfo> {
+        self.info.clone()
+    }
+
+    pub(crate) fn info_ref(&self) -> &InstallInfo {
+        &self.info
+    }
+
+    async fn ensure_healthy(&self) -> bool {
+        let info = self.info.clone();
+        *self
+            .health
+            .get_or_init(async move || match info.check_health().await {
+                Ok(()) => true,
+                Err(err) => {
+                    warn!(
+                        %err,
+                        path = %info.env_path.display(),
+                        "Skipping unhealthy installed hook"
+                    );
+                    false
+                }
+            })
+            .await
+    }
+}
+
+pub(crate) struct InstallCache {
+    /// Result of the expensive hooks-dir scan. Loaded at most once per command.
+    store_hooks: Rc<[CachedInstallInfo]>,
+    /// Environments installed after the scan and therefore absent from `store_hooks`.
+    created_hooks: Vec<CachedInstallInfo>,
+}
+
+impl InstallCache {
+    pub(crate) async fn load(store: &Store) -> Self {
+        Self {
+            store_hooks: Self::load_store_installed_hooks(store).await,
+            created_hooks: Vec::new(),
+        }
+    }
+
+    pub(crate) fn installed_hooks(&self) -> impl Iterator<Item = &CachedInstallInfo> {
+        self.created_hooks.iter().chain(self.store_hooks.iter())
+    }
+
+    async fn load_store_installed_hooks(store: &Store) -> Rc<[CachedInstallInfo]> {
+        let store_installed_hooks = match fs_err::read_dir(store.hooks_dir()) {
+            Ok(dirs) => {
+                let mut tasks = futures::stream::iter(dirs)
+                    .map(async |entry| {
+                        let path = match entry {
+                            Ok(entry) => entry.path(),
+                            Err(err) => {
+                                warn!(%err, "Failed to read hook dir");
+                                return None;
+                            }
+                        };
+                        let info = match InstallInfo::from_env_path(&path).await {
+                            Ok(info) => info,
+                            Err(err) => {
+                                warn!(%err, path = %path.display(), "Skipping invalid installed hook");
+                                return None;
+                            }
+                        };
+                        Some(CachedInstallInfo::new(Arc::new(info)))
+                    })
+                    .buffer_unordered(*CONCURRENCY);
+
+                let mut hooks = Vec::new();
+                while let Some(hook) = tasks.next().await {
+                    if let Some(hook) = hook {
+                        hooks.push(hook);
+                    }
+                }
+                hooks
+            }
+            Err(_) => Vec::new(),
+        };
+        Rc::from(store_installed_hooks.into_boxed_slice())
+    }
+
+    fn snapshot(&self) -> InstalledEnvs {
+        InstalledEnvs::new(
+            Rc::clone(&self.store_hooks),
+            Rc::from(self.created_hooks.clone().into_boxed_slice()),
+        )
+    }
+
+    pub(crate) fn add_installed(&mut self, installed_hooks: &[InstalledHook]) {
+        for hook in installed_hooks {
+            let InstalledHook::Installed { info, .. } = hook else {
+                continue;
+            };
+            if self.has_info(info) {
+                continue;
+            }
+            self.created_hooks
+                .push(CachedInstallInfo::healthy(info.clone()));
+        }
+    }
+
+    fn has_info(&self, info: &InstallInfo) -> bool {
+        self.created_hooks
+            .iter()
+            .any(|existing| existing.info.env_path == info.env_path)
+            || self
+                .store_hooks
+                .iter()
+                .any(|existing| existing.info.env_path == info.env_path)
+    }
+}
+
+/// Installed environments visible to one installer batch.
+///
+/// This is intentionally a snapshot: installers can run concurrently without borrowing the mutable
+/// run-level cache. Newly installed environments are merged back into that cache after the batch.
+#[derive(Clone)]
+struct InstalledEnvs {
+    store_hooks: Rc<[CachedInstallInfo]>,
+    created_hooks: Rc<[CachedInstallInfo]>,
+}
+
+impl InstalledEnvs {
+    fn new(store_hooks: Rc<[CachedInstallInfo]>, created_hooks: Rc<[CachedInstallInfo]>) -> Self {
+        Self {
+            store_hooks,
+            created_hooks,
+        }
+    }
+
+    fn empty() -> Self {
+        Self {
+            store_hooks: Rc::from(Vec::new().into_boxed_slice()),
+            created_hooks: Rc::from(Vec::new().into_boxed_slice()),
+        }
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &CachedInstallInfo> {
+        self.created_hooks.iter().chain(self.store_hooks.iter())
+    }
+}

--- a/crates/prek/src/cli/run/install.rs
+++ b/crates/prek/src/cli/run/install.rs
@@ -161,10 +161,6 @@ impl<'a> Installer<'a> {
         }
     }
 
-    pub(super) fn store(&self) -> &'a Store {
-        self.store
-    }
-
     async fn install_new(&self, hook: Arc<Hook>) -> Result<InstalledHook> {
         let _permit = self.semaphore.acquire(1).await;
 

--- a/crates/prek/src/cli/run/install.rs
+++ b/crates/prek/src/cli/run/install.rs
@@ -43,24 +43,15 @@ impl InstallPlan {
     }
 }
 
-/// A hook plus the data that should continue after install resolution.
-///
-/// `payload` carries the next stage's data through install partitioning without making the install
-/// layer know what that stage will do with it.
-pub(super) struct InstallJob<T> {
+struct InstallJob {
     hook: Arc<Hook>,
     install: InstallPlan,
-    payload: T,
 }
 
-impl<T> InstallJob<T> {
-    pub(super) fn new(hook: Arc<Hook>, payload: T) -> Self {
+impl InstallJob {
+    fn new(hook: Arc<Hook>) -> Self {
         let install = InstallPlan::new(&hook);
-        Self {
-            hook,
-            install,
-            payload,
-        }
+        Self { hook, install }
     }
 
     fn hook(&self) -> &Hook {
@@ -71,8 +62,8 @@ impl<T> InstallJob<T> {
         self.install.needs_environment()
     }
 
-    fn into_parts(self) -> (Arc<Hook>, InstallPlan, T) {
-        (self.hook, self.install, self.payload)
+    fn into_parts(self) -> (Arc<Hook>, InstallPlan) {
+        (self.hook, self.install)
     }
 }
 
@@ -81,10 +72,7 @@ pub(crate) async fn install_hooks(
     store: &Store,
     reporter: &HookInstallReporter,
 ) -> Result<Vec<InstalledHook>> {
-    let hooks = hooks
-        .into_iter()
-        .map(|hook| InstallJob::new(hook, ()))
-        .collect::<Vec<_>>();
+    let hooks = hooks.into_iter().map(InstallJob::new).collect::<Vec<_>>();
     let num_hooks = hooks.len();
     let mut cache = None;
     let installer = Installer::for_jobs(store, reporter, &mut cache, &hooks).await;
@@ -100,23 +88,46 @@ pub(crate) async fn install_hooks(
     Ok(result)
 }
 
+pub(crate) async fn install_hooks_with_cache(
+    hooks: Vec<Arc<Hook>>,
+    store: &Store,
+    reporter: &HookInstallReporter,
+    cache: &mut Option<InstallCache>,
+) -> Result<Vec<InstalledHook>> {
+    let hooks = hooks.into_iter().map(InstallJob::new).collect::<Vec<_>>();
+    let num_hooks = hooks.len();
+    let installer = Installer::for_jobs(store, reporter, cache, &hooks).await;
+    let result = installer.install_all(store, hooks).await?;
+    if let Some(cache) = cache {
+        cache.add_installed(&result);
+    }
+
+    debug_assert_eq!(
+        num_hooks,
+        result.len(),
+        "Number of hooks installed should match the number of hooks provided"
+    );
+
+    Ok(result)
+}
+
 #[derive(Clone)]
-pub(super) struct Installer<'a> {
+pub(super) struct Installer {
     /// Result of the run-level install cache at the time this batch starts.
     store_hooks: Rc<[CachedInstallInfo]>,
     /// Environments installed by earlier batches in this command.
     created_hooks: Rc<[CachedInstallInfo]>,
     /// Shared by all install partitions for this batch.
     semaphore: Rc<Semaphore>,
-    reporter: &'a HookInstallReporter,
+    reporter: HookInstallReporter,
 }
 
-impl<'a> Installer<'a> {
-    pub(super) async fn for_jobs<T>(
+impl Installer {
+    async fn for_jobs(
         store: &Store,
-        reporter: &'a HookInstallReporter,
+        reporter: &HookInstallReporter,
         cache: &mut Option<InstallCache>,
-        hooks: &[InstallJob<T>],
+        hooks: &[InstallJob],
     ) -> Self {
         let needs_environment = hooks.iter().any(InstallJob::needs_environment);
         let (store_hooks, created_hooks) = if needs_environment {
@@ -137,14 +148,14 @@ impl<'a> Installer<'a> {
             store_hooks,
             created_hooks,
             semaphore: Rc::new(Semaphore::new(*CONCURRENCY)),
-            reporter,
+            reporter: reporter.clone(),
         }
     }
 
     async fn install_all(
         &self,
         store: &Store,
-        hooks: Vec<InstallJob<()>>,
+        hooks: Vec<InstallJob>,
     ) -> Result<Vec<InstalledHook>> {
         let mut result = Vec::with_capacity(hooks.len());
         let mut futures = FuturesUnordered::new();
@@ -161,7 +172,7 @@ impl<'a> Installer<'a> {
         Ok(result)
     }
 
-    pub(super) fn partition(&self) -> PartitionInstaller<'a> {
+    pub(super) fn partition(&self) -> PartitionInstaller {
         PartitionInstaller {
             installer: self.clone(),
             newly_installed: Vec::new(),
@@ -173,7 +184,7 @@ impl<'a> Installer<'a> {
 
         let installed_hook = hook
             .language
-            .install(hook.clone(), store, self.reporter)
+            .install(hook.clone(), store, &self.reporter)
             .await
             .with_context(|| format!("Failed to install hook `{hook}`"))?;
 
@@ -205,8 +216,8 @@ impl<'a> Installer<'a> {
     }
 }
 
-pub(super) struct PartitionInstaller<'a> {
-    installer: Installer<'a>,
+pub(super) struct PartitionInstaller {
+    installer: Installer,
     /// Environments installed earlier in this partition.
     ///
     /// Partitions contain hooks with the same install language and dependency set, so later hooks
@@ -214,30 +225,26 @@ pub(super) struct PartitionInstaller<'a> {
     newly_installed: Vec<InstalledHook>,
 }
 
-impl PartitionInstaller<'_> {
+impl PartitionInstaller {
     async fn install_all(
         mut self,
         store: &Store,
-        hooks: Vec<InstallJob<()>>,
+        hooks: Vec<InstallJob>,
     ) -> Result<Vec<InstalledHook>> {
         let mut installed_hooks = Vec::with_capacity(hooks.len());
 
         for hook in hooks {
-            let (installed_hook, ()) = self.install_job(store, hook).await?;
+            let installed_hook = self.install_job(store, hook).await?;
             installed_hooks.push(installed_hook);
         }
 
         Ok(installed_hooks)
     }
 
-    pub(super) async fn install_job<T>(
-        &mut self,
-        store: &Store,
-        job: InstallJob<T>,
-    ) -> Result<(InstalledHook, T)> {
-        let (hook, install, payload) = job.into_parts();
+    async fn install_job(&mut self, store: &Store, job: InstallJob) -> Result<InstalledHook> {
+        let (hook, install) = job.into_parts();
         let installed_hook = self.install(store, hook, install).await?;
-        Ok((installed_hook, payload))
+        Ok(installed_hook)
     }
 
     async fn install(
@@ -277,17 +284,17 @@ impl PartitionInstaller<'_> {
     }
 }
 
-pub(super) struct InstallPartitions<T> {
-    partitions: Vec<Vec<InstallJob<T>>>,
+struct InstallPartitions {
+    partitions: Vec<Vec<InstallJob>>,
 }
 
-impl<T> InstallPartitions<T> {
+impl InstallPartitions {
     /// Group hooks so each partition can install independently.
     ///
     /// Different languages can install concurrently. Hooks with the same language and dependency
     /// set stay in one partition so later hooks can reuse an environment installed by an earlier
     /// hook.
-    pub(super) fn new(hooks: Vec<InstallJob<T>>) -> Self {
+    fn new(hooks: Vec<InstallJob>) -> Self {
         let mut hooks_by_language = FxHashMap::default();
         for hook in hooks {
             hooks_by_language
@@ -304,8 +311,8 @@ impl<T> InstallPartitions<T> {
         Self { partitions }
     }
 
-    fn partition_by_dependencies(hooks: Vec<InstallJob<T>>) -> Vec<Vec<InstallJob<T>>> {
-        let mut groups: Vec<Vec<InstallJob<T>>> = Vec::new();
+    fn partition_by_dependencies(hooks: Vec<InstallJob>) -> Vec<Vec<InstallJob>> {
+        let mut groups: Vec<Vec<InstallJob>> = Vec::new();
 
         for hook in hooks {
             let group_index = groups.iter().position(|group| {
@@ -323,9 +330,9 @@ impl<T> InstallPartitions<T> {
     }
 }
 
-impl<T> IntoIterator for InstallPartitions<T> {
-    type Item = Vec<InstallJob<T>>;
-    type IntoIter = std::vec::IntoIter<Vec<InstallJob<T>>>;
+impl IntoIterator for InstallPartitions {
+    type Item = Vec<InstallJob>;
+    type IntoIter = std::vec::IntoIter<Vec<InstallJob>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.partitions.into_iter()
@@ -401,6 +408,19 @@ impl InstallCache {
 
     pub(crate) fn installed_hooks(&self) -> impl Iterator<Item = &CachedInstallInfo> {
         self.created_hooks.iter().chain(self.store_hooks.iter())
+    }
+
+    pub(crate) async fn installed_hook(&self, hook: Arc<Hook>) -> Option<InstalledHook> {
+        for env in self.installed_hooks() {
+            if env.matches(&hook) && env.ensure_healthy().await {
+                return Some(InstalledHook::Installed {
+                    hook,
+                    info: env.info(),
+                });
+            }
+        }
+
+        None
     }
 
     async fn load_store_installed_hooks(store: &Store) -> Rc<[CachedInstallInfo]> {

--- a/crates/prek/src/cli/run/install.rs
+++ b/crates/prek/src/cli/run/install.rs
@@ -247,7 +247,6 @@ impl PartitionInstaller<'_> {
         install: InstallPlan,
     ) -> Result<InstalledHook> {
         if !install.needs_environment {
-            debug!("Hook `{}` does not need an installed environment", &hook);
             return Ok(InstalledHook::NoNeedInstall(hook));
         }
 

--- a/crates/prek/src/cli/run/install.rs
+++ b/crates/prek/src/cli/run/install.rs
@@ -88,7 +88,7 @@ pub(crate) async fn install_hooks(
     let num_hooks = hooks.len();
     let mut cache = None;
     let installer = Installer::for_jobs(store, reporter, &mut cache, &hooks).await;
-    let result = installer.install_all(hooks).await?;
+    let result = installer.install_all(store, hooks).await?;
     reporter.on_complete();
 
     debug_assert_eq!(
@@ -102,8 +102,10 @@ pub(crate) async fn install_hooks(
 
 #[derive(Clone)]
 pub(super) struct Installer<'a> {
-    store: &'a Store,
-    installed_envs: InstalledEnvs,
+    /// Result of the run-level install cache at the time this batch starts.
+    store_hooks: Rc<[CachedInstallInfo]>,
+    /// Environments installed by earlier batches in this command.
+    created_hooks: Rc<[CachedInstallInfo]>,
     /// Shared by all install partitions for this batch.
     semaphore: Rc<Semaphore>,
     reporter: &'a HookInstallReporter,
@@ -117,34 +119,39 @@ impl<'a> Installer<'a> {
         hooks: &[InstallJob<T>],
     ) -> Self {
         let needs_environment = hooks.iter().any(InstallJob::needs_environment);
-        let installed_envs = if needs_environment {
+        let (store_hooks, created_hooks) = if needs_environment {
             if let Some(cache) = cache.as_ref() {
                 cache.snapshot()
             } else {
                 let loaded_cache = InstallCache::load(store).await;
-                let installed_envs = loaded_cache.snapshot();
+                let snapshot = loaded_cache.snapshot();
                 *cache = Some(loaded_cache);
-                installed_envs
+                snapshot
             }
         } else {
-            InstalledEnvs::empty()
+            let empty = Rc::<[CachedInstallInfo]>::from(Vec::new().into_boxed_slice());
+            (Rc::clone(&empty), empty)
         };
 
         Self {
-            store,
-            installed_envs,
+            store_hooks,
+            created_hooks,
             semaphore: Rc::new(Semaphore::new(*CONCURRENCY)),
             reporter,
         }
     }
 
-    async fn install_all(&self, hooks: Vec<InstallJob<()>>) -> Result<Vec<InstalledHook>> {
+    async fn install_all(
+        &self,
+        store: &Store,
+        hooks: Vec<InstallJob<()>>,
+    ) -> Result<Vec<InstalledHook>> {
         let mut result = Vec::with_capacity(hooks.len());
         let mut futures = FuturesUnordered::new();
 
         for partition in InstallPartitions::new(hooks) {
             let installer = self.partition();
-            futures.push(async move { installer.install_all(partition).await });
+            futures.push(async move { installer.install_all(store, partition).await });
         }
 
         while let Some(hooks) = futures.next().await {
@@ -161,17 +168,17 @@ impl<'a> Installer<'a> {
         }
     }
 
-    async fn install_new(&self, hook: Arc<Hook>) -> Result<InstalledHook> {
+    async fn install_new(&self, store: &Store, hook: Arc<Hook>) -> Result<InstalledHook> {
         let _permit = self.semaphore.acquire(1).await;
 
         let installed_hook = hook
             .language
-            .install(hook.clone(), self.store, self.reporter)
+            .install(hook.clone(), store, self.reporter)
             .await
             .with_context(|| format!("Failed to install hook `{hook}`"))?;
 
         installed_hook
-            .mark_as_installed(self.store)
+            .mark_as_installed(store)
             .await
             .with_context(|| format!("Failed to mark hook `{hook}` as installed"))?;
 
@@ -188,7 +195,7 @@ impl<'a> Installer<'a> {
     }
 
     async fn installed_info_for_hook(&self, hook: &Hook) -> Option<Arc<InstallInfo>> {
-        for env in self.installed_envs.iter() {
+        for env in self.created_hooks.iter().chain(self.store_hooks.iter()) {
             if env.matches(hook) && env.ensure_healthy().await {
                 return Some(env.info());
             }
@@ -208,11 +215,15 @@ pub(super) struct PartitionInstaller<'a> {
 }
 
 impl PartitionInstaller<'_> {
-    async fn install_all(mut self, hooks: Vec<InstallJob<()>>) -> Result<Vec<InstalledHook>> {
+    async fn install_all(
+        mut self,
+        store: &Store,
+        hooks: Vec<InstallJob<()>>,
+    ) -> Result<Vec<InstalledHook>> {
         let mut installed_hooks = Vec::with_capacity(hooks.len());
 
         for hook in hooks {
-            let (installed_hook, ()) = self.install_job(hook).await?;
+            let (installed_hook, ()) = self.install_job(store, hook).await?;
             installed_hooks.push(installed_hook);
         }
 
@@ -221,14 +232,20 @@ impl PartitionInstaller<'_> {
 
     pub(super) async fn install_job<T>(
         &mut self,
+        store: &Store,
         job: InstallJob<T>,
     ) -> Result<(InstalledHook, T)> {
         let (hook, install, payload) = job.into_parts();
-        let installed_hook = self.install(hook, install).await?;
+        let installed_hook = self.install(store, hook, install).await?;
         Ok((installed_hook, payload))
     }
 
-    async fn install(&mut self, hook: Arc<Hook>, install: InstallPlan) -> Result<InstalledHook> {
+    async fn install(
+        &mut self,
+        store: &Store,
+        hook: Arc<Hook>,
+        install: InstallPlan,
+    ) -> Result<InstalledHook> {
         if !install.needs_environment {
             debug!("Hook `{}` does not need an installed environment", &hook);
             return Ok(InstalledHook::NoNeedInstall(hook));
@@ -242,7 +259,7 @@ impl PartitionInstaller<'_> {
             return Ok(InstalledHook::Installed { hook, info });
         }
 
-        let installed_hook = self.installer.install_new(hook).await?;
+        let installed_hook = self.installer.install_new(store, hook).await?;
         self.newly_installed.push(installed_hook.clone());
 
         Ok(installed_hook)
@@ -423,8 +440,8 @@ impl InstallCache {
         Rc::from(store_installed_hooks.into_boxed_slice())
     }
 
-    fn snapshot(&self) -> InstalledEnvs {
-        InstalledEnvs::new(
+    fn snapshot(&self) -> (Rc<[CachedInstallInfo]>, Rc<[CachedInstallInfo]>) {
+        (
             Rc::clone(&self.store_hooks),
             Rc::from(self.created_hooks.clone().into_boxed_slice()),
         )
@@ -451,35 +468,5 @@ impl InstallCache {
                 .store_hooks
                 .iter()
                 .any(|existing| existing.info.env_path == info.env_path)
-    }
-}
-
-/// Installed environments visible to one installer batch.
-///
-/// This is intentionally a snapshot: installers can run concurrently without borrowing the mutable
-/// run-level cache. Newly installed environments are merged back into that cache after the batch.
-#[derive(Clone)]
-struct InstalledEnvs {
-    store_hooks: Rc<[CachedInstallInfo]>,
-    created_hooks: Rc<[CachedInstallInfo]>,
-}
-
-impl InstalledEnvs {
-    fn new(store_hooks: Rc<[CachedInstallInfo]>, created_hooks: Rc<[CachedInstallInfo]>) -> Self {
-        Self {
-            store_hooks,
-            created_hooks,
-        }
-    }
-
-    fn empty() -> Self {
-        Self {
-            store_hooks: Rc::from(Vec::new().into_boxed_slice()),
-            created_hooks: Rc::from(Vec::new().into_boxed_slice()),
-        }
-    }
-
-    fn iter(&self) -> impl Iterator<Item = &CachedInstallInfo> {
-        self.created_hooks.iter().chain(self.store_hooks.iter())
     }
 }

--- a/crates/prek/src/cli/run/install.rs
+++ b/crates/prek/src/cli/run/install.rs
@@ -21,24 +21,6 @@ pub(crate) async fn install_hooks(
     cache: &mut InstallCache,
 ) -> Result<Vec<InstalledHook>> {
     let num_hooks = hooks.len();
-    let result = resolve_and_install_hooks(hooks, store, reporter, cache).await?;
-    cache.add_installed(&result);
-
-    debug_assert_eq!(
-        num_hooks,
-        result.len(),
-        "Number of hooks installed should match the number of hooks provided"
-    );
-
-    Ok(result)
-}
-
-async fn resolve_and_install_hooks(
-    hooks: Vec<Arc<Hook>>,
-    store: &Store,
-    reporter: &HookInstallReporter,
-    cache: &mut InstallCache,
-) -> Result<Vec<InstalledHook>> {
     let mut installed_hooks = Vec::with_capacity(hooks.len());
     let mut hooks_to_install = Vec::new();
 
@@ -55,21 +37,10 @@ async fn resolve_and_install_hooks(
         }
     }
 
-    installed_hooks.extend(install_missing_hooks(hooks_to_install, store, reporter).await?);
-
-    Ok(installed_hooks)
-}
-
-async fn install_missing_hooks(
-    hooks: Vec<Arc<Hook>>,
-    store: &Store,
-    reporter: &HookInstallReporter,
-) -> Result<Vec<InstalledHook>> {
     let semaphore = Rc::new(Semaphore::new(*CONCURRENCY));
-    let mut installed_hooks = Vec::with_capacity(hooks.len());
     let mut futures = FuturesUnordered::new();
 
-    for partition in partition_hooks(hooks) {
+    for partition in partition_hooks(hooks_to_install) {
         let semaphore = Rc::clone(&semaphore);
         let reporter = reporter.clone();
         futures
@@ -79,6 +50,14 @@ async fn install_missing_hooks(
     while let Some(partition_hooks) = futures.next().await {
         installed_hooks.extend(partition_hooks?);
     }
+
+    cache.add_installed(&installed_hooks);
+
+    debug_assert_eq!(
+        num_hooks,
+        installed_hooks.len(),
+        "Number of hooks installed should match the number of hooks provided"
+    );
 
     Ok(installed_hooks)
 }
@@ -93,65 +72,47 @@ async fn install_partition(
 
     for hook in hooks {
         debug_assert!(hook.needs_install_env());
-        let installed_hook = if let Some(info) = installed_info_for_hook(&installed_hooks, &hook) {
+
+        let installed_hook = if let Some(info) = installed_hooks.iter().find_map(|installed| {
+            let InstalledHook::Installed { info, .. } = installed else {
+                return None;
+            };
+            info.matches(&hook).then(|| info.clone())
+        }) {
             debug!(
                 "Found installed environment for hook `{hook}` at `{}`",
                 info.env_path.display()
             );
             InstalledHook::Installed { hook, info }
         } else {
-            install_new(hook, store, reporter, &semaphore).await?
+            let _permit = semaphore.acquire(1).await;
+
+            let installed_hook = hook
+                .language
+                .install(hook.clone(), store, reporter)
+                .await
+                .with_context(|| format!("Failed to install hook `{hook}`"))?;
+
+            installed_hook
+                .mark_as_installed(store)
+                .await
+                .with_context(|| format!("Failed to mark hook `{hook}` as installed"))?;
+
+            match &installed_hook {
+                InstalledHook::Installed { info, .. } => {
+                    debug!("Installed hook `{hook}` in `{}`", info.env_path.display());
+                }
+                InstalledHook::NoNeedInstall { .. } => {
+                    debug!("Hook `{hook}` does not need installation");
+                }
+            }
+
+            installed_hook
         };
         installed_hooks.push(installed_hook);
     }
 
     Ok(installed_hooks)
-}
-
-async fn install_new(
-    hook: Arc<Hook>,
-    store: &Store,
-    reporter: &HookInstallReporter,
-    semaphore: &Semaphore,
-) -> Result<InstalledHook> {
-    let _permit = semaphore.acquire(1).await;
-
-    let installed_hook = hook
-        .language
-        .install(hook.clone(), store, reporter)
-        .await
-        .with_context(|| format!("Failed to install hook `{hook}`"))?;
-
-    installed_hook
-        .mark_as_installed(store)
-        .await
-        .with_context(|| format!("Failed to mark hook `{hook}` as installed"))?;
-
-    match &installed_hook {
-        InstalledHook::Installed { info, .. } => {
-            debug!("Installed hook `{hook}` in `{}`", info.env_path.display());
-        }
-        InstalledHook::NoNeedInstall { .. } => {
-            debug!("Hook `{hook}` does not need installation");
-        }
-    }
-
-    Ok(installed_hook)
-}
-
-fn installed_info_for_hook(
-    installed_hooks: &[InstalledHook],
-    hook: &Hook,
-) -> Option<Arc<InstallInfo>> {
-    for installed_hook in installed_hooks {
-        if let InstalledHook::Installed { info, .. } = installed_hook
-            && info.matches(hook)
-        {
-            return Some(info.clone());
-        }
-    }
-
-    None
 }
 
 /// Group hooks so each partition can install independently.
@@ -161,46 +122,36 @@ fn installed_info_for_hook(
 fn partition_hooks(hooks: Vec<Arc<Hook>>) -> Vec<Vec<Arc<Hook>>> {
     let mut hooks_by_language = FxHashMap::default();
     for hook in hooks {
+        // `pygrep` hooks use Python installation and can share Python environments.
+        let language = if hook.language == Language::Pygrep {
+            Language::Python
+        } else {
+            hook.language
+        };
         hooks_by_language
-            .entry(install_language(&hook))
+            .entry(language)
             .or_insert_with(Vec::new)
             .push(hook);
     }
 
     let mut partitions = Vec::new();
     for (_, hooks) in hooks_by_language {
-        partitions.extend(partition_hooks_by_dependencies(hooks));
+        let mut groups: Vec<Vec<Arc<Hook>>> = Vec::new();
+        for hook in hooks {
+            let group_index = groups
+                .iter()
+                .position(|group| group[0].env_key_dependencies() == hook.env_key_dependencies());
+
+            if let Some(index) = group_index {
+                groups[index].push(hook);
+            } else {
+                groups.push(vec![hook]);
+            }
+        }
+        partitions.extend(groups);
     }
 
     partitions
-}
-
-fn install_language(hook: &Hook) -> Language {
-    if hook.language == Language::Pygrep {
-        // Treat `pygrep` hooks as `python` hooks for installation purposes.
-        // They share the same installation logic.
-        Language::Python
-    } else {
-        hook.language
-    }
-}
-
-fn partition_hooks_by_dependencies(hooks: Vec<Arc<Hook>>) -> Vec<Vec<Arc<Hook>>> {
-    let mut groups: Vec<Vec<Arc<Hook>>> = Vec::new();
-
-    for hook in hooks {
-        let group_index = groups
-            .iter()
-            .position(|group| group[0].env_key_dependencies() == hook.env_key_dependencies());
-
-        if let Some(index) = group_index {
-            groups[index].push(hook);
-        } else {
-            groups.push(vec![hook]);
-        }
-    }
-
-    groups
 }
 
 #[derive(Debug, Clone)]

--- a/crates/prek/src/cli/run/mod.rs
+++ b/crates/prek/src/cli/run/mod.rs
@@ -1,8 +1,10 @@
 pub(crate) use filter::{CollectOptions, FileTagCache, ProjectFiles, RunInput, collect_run_input};
-pub(crate) use run::{install_hooks, run};
+pub(crate) use install::install_hooks;
+pub(crate) use run::run;
 pub(crate) use selector::{SelectorSource, Selectors};
 
 mod filter;
+pub(crate) mod install;
 mod keeper;
 #[allow(clippy::module_inception)]
 mod run;

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -300,7 +300,7 @@ impl<'a> InstalledHookResolver<'a> {
 
         let _lock = self.store.lock_async().await?;
         let mut install_cache = InstallCache::new();
-        let mut installed_by_idx = FxHashMap::default();
+        let mut installed_by_hook = FxHashMap::default();
         let mut missing_env_hooks = Vec::new();
 
         // Resolve the cache before file filtering so already-installed hooks keep their exact
@@ -309,7 +309,7 @@ impl<'a> InstalledHookResolver<'a> {
             if let Some(installed_hook) =
                 install_cache.installed_hook(self.store, hook.clone()).await
             {
-                installed_by_idx.insert(hook.idx, installed_hook);
+                installed_by_hook.insert(hook_key(&hook), installed_hook);
             } else {
                 missing_env_hooks.push(hook.clone());
             }
@@ -324,15 +324,15 @@ impl<'a> InstalledHookResolver<'a> {
             reporter.on_complete();
 
             for installed_hook in installed_hooks {
-                installed_by_idx.insert(installed_hook.idx, installed_hook);
+                installed_by_hook.insert(hook_key(&installed_hook), installed_hook);
             }
         }
 
         Ok(hooks
             .iter()
             .map(|hook| {
-                installed_by_idx
-                    .remove(&hook.idx)
+                installed_by_hook
+                    .remove(&hook_key(hook))
                     .unwrap_or_else(|| InstalledHook::NoNeedInstall(hook.clone()))
             })
             .collect())
@@ -384,6 +384,11 @@ impl<'a> InstalledHookResolver<'a> {
 
         hook.always_run || project_input.has_match_for_hook(hook, tag_cache)
     }
+}
+
+fn hook_key(hook: &Hook) -> (usize, usize) {
+    // Hook indexes are scoped to a project config, so workspace runs need the project index too.
+    (hook.project().idx(), hook.idx)
 }
 
 #[allow(clippy::fn_params_excessive_bools)]

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -803,8 +803,9 @@ impl<'a> HookRunPipeline<'a> {
         for partition in InstallPartitions::new(hooks) {
             let mut partition_installer = installer.partition();
             let ready_tx = ready_tx.clone();
+            let store = self.store;
             futures.push(async move {
-                Self::install_partition(&mut partition_installer, partition, ready_tx).await
+                Self::install_partition(store, &mut partition_installer, partition, ready_tx).await
             });
         }
 
@@ -817,6 +818,7 @@ impl<'a> HookRunPipeline<'a> {
     }
 
     async fn install_partition<'input>(
+        store: &Store,
         installer: &mut PartitionInstaller<'a>,
         hooks: Vec<PlannedHookRun<'input>>,
         ready_tx: mpsc::UnboundedSender<ReadyHookRun<'input>>,
@@ -824,7 +826,7 @@ impl<'a> HookRunPipeline<'a> {
         let mut installed_hooks = Vec::with_capacity(hooks.len());
 
         for hook in hooks {
-            let (installed_hook, input) = installer.install_job(hook).await?;
+            let (installed_hook, input) = installer.install_job(store, hook).await?;
             installed_hooks.push(installed_hook.clone());
 
             if ready_tx.send((installed_hook, input)).is_err() {

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -1,19 +1,16 @@
 use std::fmt::Write as _;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
-use std::rc::Rc;
 use std::sync::{Arc, LazyLock};
 
 use anyhow::{Context, Result};
-use futures::stream::{FuturesUnordered, StreamExt};
-use mea::semaphore::Semaphore;
+use futures::stream::StreamExt;
 use owo_colors::OwoColorize;
 use prek_consts::env_vars::EnvVars;
 use prek_consts::{PRE_COMMIT_CONFIG_YAML, PREK_TOML};
 use rand::SeedableRng;
 use rand::prelude::{SliceRandom, StdRng};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
-use tokio::sync::mpsc;
 use tracing::{debug, trace};
 use unicode_width::UnicodeWidthStr;
 
@@ -34,7 +31,7 @@ use crate::store::Store;
 use crate::workspace::{Project, Workspace};
 use crate::{fs, git, warn_user};
 
-use super::install::{InstallCache, InstallJob, InstallPartitions, Installer, PartitionInstaller};
+use super::install::{InstallCache, install_hooks_with_cache};
 
 #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 pub(crate) async fn run(
@@ -202,9 +199,12 @@ pub(crate) async fn run(
         )
     })?;
 
+    let installed_hooks =
+        prepare_hooks_for_run(&workspace, &filtered_hooks, &input, store, printer).await?;
+
     run_hooks(
         &workspace,
-        &filtered_hooks,
+        &installed_hooks,
         input,
         store,
         show_diff_on_failure,
@@ -450,19 +450,110 @@ impl<'a> HookRunInput<'a> {
     }
 }
 
-type PlannedHookRun<'a> = InstallJob<HookRunInput<'a>>;
-type ReadyHookRun<'a> = (InstalledHook, HookRunInput<'a>);
+async fn prepare_hooks_for_run(
+    workspace: &Workspace,
+    hooks: &[Arc<Hook>],
+    input: &RunInput,
+    store: &Store,
+    printer: Printer,
+) -> Result<Vec<InstalledHook>> {
+    let env_hooks = hooks
+        .iter()
+        .filter(|hook| hook.needs_install_env())
+        .cloned()
+        .collect::<Vec<_>>();
 
-struct PriorityGroupPlan<'a> {
-    skipped_results: Vec<RunResult>,
-    runnable_hooks: Vec<PlannedHookRun<'a>>,
+    if env_hooks.is_empty() {
+        return Ok(hooks
+            .iter()
+            .map(|hook| InstalledHook::NoNeedInstall(hook.clone()))
+            .collect());
+    }
+
+    let _lock = store.lock_async().await?;
+    let mut install_cache = Some(InstallCache::load(store).await);
+    let cache = install_cache
+        .as_ref()
+        .expect("install cache should be loaded above");
+    let mut installed_by_idx = FxHashMap::default();
+    let mut missing_env_hooks = Vec::new();
+
+    // Resolve the cache before file filtering so already-installed hooks keep their exact
+    // environment, while missing hooks still avoid install when they would not run.
+    for hook in env_hooks {
+        if let Some(installed_hook) = cache.installed_hook(hook.clone()).await {
+            installed_by_idx.insert(hook.idx, installed_hook);
+        } else {
+            missing_env_hooks.push(hook.clone());
+        }
+    }
+
+    let hooks_to_install = hooks_to_install_after_filter(workspace, &missing_env_hooks, input)?;
+    if !hooks_to_install.is_empty() {
+        let reporter = HookInstallReporter::new(printer);
+        let installed_hooks =
+            install_hooks_with_cache(hooks_to_install, store, &reporter, &mut install_cache)
+                .await?;
+        reporter.on_complete();
+
+        for installed_hook in installed_hooks {
+            installed_by_idx.insert(installed_hook.idx, installed_hook);
+        }
+    }
+
+    Ok(hooks
+        .iter()
+        .map(|hook| {
+            installed_by_idx
+                .remove(&hook.idx)
+                .unwrap_or_else(|| InstalledHook::NoNeedInstall(hook.clone()))
+        })
+        .collect())
 }
 
-/// Run all hooks.
+fn hooks_to_install_after_filter(
+    workspace: &Workspace,
+    hooks: &[Arc<Hook>],
+    input: &RunInput,
+) -> Result<Vec<Arc<Hook>>> {
+    #[allow(clippy::mutable_key_type)]
+    let mut project_to_hooks: FxHashMap<&Project, Vec<Arc<Hook>>> =
+        FxHashMap::with_capacity_and_hasher(hooks.len(), FxBuildHasher);
+    for hook in hooks {
+        project_to_hooks
+            .entry(hook.project())
+            .or_default()
+            .push(hook.clone());
+    }
+
+    let mut hooks_to_install = Vec::new();
+    let mut consumed_files = FxHashSet::default();
+    let mut tag_cache = FileTagCache::default();
+
+    for project in workspace.all_projects() {
+        let project_input = ProjectHookInput::new(input, project, Some(&mut consumed_files))?;
+        let Some(hooks) = project_to_hooks.remove(project) else {
+            continue;
+        };
+
+        for hook in hooks {
+            let hook_input = project_input.for_hook(&hook, &mut tag_cache);
+
+            if (hook_input.has_matching_files || hook.always_run)
+                && Language::supported(hook.language)
+            {
+                hooks_to_install.push(hook);
+            }
+        }
+    }
+
+    Ok(hooks_to_install)
+}
+
 #[allow(clippy::fn_params_excessive_bools)]
 async fn run_hooks(
     workspace: &Workspace,
-    hooks: &[Arc<Hook>],
+    hooks: &[InstalledHook],
     input: RunInput,
     store: &Store,
     show_diff_on_failure: bool,
@@ -474,13 +565,13 @@ async fn run_hooks(
     debug_assert!(!hooks.is_empty(), "No hooks to run");
 
     let status_printer = StatusPrinter::for_hooks(hooks, printer);
-    let reporter = HookRunReporter::new_execution(printer, status_printer.bar_len());
+    let reporter = HookRunReporter::new(printer, status_printer.bar_len());
 
     let mut success = true;
 
     // Group hooks by project to run them in order of their depth in the workspace.
     #[allow(clippy::mutable_key_type)]
-    let mut project_to_hooks: FxHashMap<&Project, Vec<Arc<Hook>>> =
+    let mut project_to_hooks: FxHashMap<&Project, Vec<InstalledHook>> =
         FxHashMap::with_capacity_and_hasher(hooks.len(), FxBuildHasher);
     for hook in hooks {
         project_to_hooks
@@ -497,7 +588,6 @@ async fn run_hooks(
     // Track files that have been consumed by orphan projects.
     let mut consumed_files = FxHashSet::default();
     let mut tag_cache = FileTagCache::default();
-    let mut executor = HookRunExecutor::new(dry_run, &reporter);
 
     'outer: for project in workspace.all_projects() {
         let project_input = ProjectHookInput::new(&input, project, Some(&mut consumed_files))?;
@@ -530,51 +620,29 @@ async fn run_hooks(
         let project_fail_fast = fail_fast.or(project.config().fail_fast).unwrap_or(false);
 
         for group_hooks in PriorityGroups::new(hooks) {
-            let PriorityGroupPlan {
-                skipped_results: mut group_results,
-                runnable_hooks,
-            } = plan_priority_group(group_hooks, &project_input, &mut tag_cache);
+            let group_results = run_priority_group(
+                group_hooks,
+                &project_input,
+                &mut tag_cache,
+                store,
+                dry_run,
+                &reporter,
+            )
+            .await?;
 
-            if !runnable_hooks.is_empty() {
-                let mut run_results = executor.run(store, runnable_hooks).await?;
-                group_results.append(&mut run_results);
-            }
-
-            // Print results in a stable order (same order as config within the project).
-            group_results.sort_unstable_by_key(|a| a.hook.idx);
-
-            // Check if any files were modified by this group of hooks.
-            let all_skipped = group_results.iter().all(|r| r.status.is_skipped());
-            let group_modified_files = if !all_skipped {
-                let curr_diff = git::get_diff(project.path()).await?;
-                let group_modified_files = curr_diff != prev_diff;
-                prev_diff = curr_diff;
-                group_modified_files
-            } else {
-                false
-            };
-
-            if group_modified_files {
-                file_modified = true;
-            }
-
-            reporter.clear_completed();
-            reporter.suspend(|| {
-                render_priority_group(
-                    printer,
-                    &status_printer,
-                    &group_results,
-                    verbose,
-                    group_modified_files,
-                )
-            })?;
-
-            let hook_fail_fast = apply_group_outcome(
-                &group_results,
-                group_modified_files,
+            let hook_fail_fast = finish_priority_group(
+                group_results,
+                project,
+                &mut prev_diff,
+                &mut file_modified,
+                &reporter,
+                printer,
+                &status_printer,
+                verbose,
                 &mut success,
                 &mut has_unimplemented,
-            );
+            )
+            .await?;
 
             if !success && (project_fail_fast || hook_fail_fast) {
                 break 'outer;
@@ -634,19 +702,68 @@ async fn run_hooks(
     }
 }
 
+async fn finish_priority_group(
+    mut group_results: Vec<RunResult>,
+    project: &Project,
+    prev_diff: &mut Vec<u8>,
+    file_modified: &mut bool,
+    reporter: &HookRunReporter,
+    printer: Printer,
+    status_printer: &StatusPrinter,
+    verbose: bool,
+    success: &mut bool,
+    has_unimplemented: &mut bool,
+) -> Result<bool> {
+    // Print results in a stable order (same order as config within the project).
+    group_results.sort_unstable_by_key(|a| a.hook.idx);
+
+    // Check if any files were modified by this group of hooks.
+    let all_skipped = group_results.iter().all(|r| r.status.is_skipped());
+    let group_modified_files = if !all_skipped {
+        let curr_diff = git::get_diff(project.path()).await?;
+        let group_modified_files = curr_diff != *prev_diff;
+        *prev_diff = curr_diff;
+        group_modified_files
+    } else {
+        false
+    };
+
+    if group_modified_files {
+        *file_modified = true;
+    }
+
+    reporter.clear_completed();
+    reporter.suspend(|| {
+        render_priority_group(
+            printer,
+            status_printer,
+            &group_results,
+            verbose,
+            group_modified_files,
+        )
+    })?;
+
+    Ok(apply_group_outcome(
+        &group_results,
+        group_modified_files,
+        success,
+        has_unimplemented,
+    ))
+}
+
 struct PriorityGroups {
-    hooks: Vec<Arc<Hook>>,
+    hooks: Vec<InstalledHook>,
     idx: usize,
 }
 
 impl PriorityGroups {
-    fn new(hooks: Vec<Arc<Hook>>) -> Self {
+    fn new(hooks: Vec<InstalledHook>) -> Self {
         Self { hooks, idx: 0 }
     }
 }
 
 impl Iterator for PriorityGroups {
-    type Item = Vec<Arc<Hook>>;
+    type Item = Vec<InstalledHook>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let first = self.hooks.get(self.idx)?;
@@ -665,11 +782,14 @@ impl Iterator for PriorityGroups {
     }
 }
 
-fn plan_priority_group<'input, 'paths>(
-    group_hooks: Vec<Arc<Hook>>,
+async fn run_priority_group<'input, 'paths>(
+    group_hooks: Vec<InstalledHook>,
     input: &'input ProjectHookInput<'paths>,
     tag_cache: &mut FileTagCache<'paths>,
-) -> PriorityGroupPlan<'input>
+    store: &Store,
+    dry_run: bool,
+    reporter: &HookRunReporter,
+) -> Result<Vec<RunResult>>
 where
     'paths: 'input,
 {
@@ -680,196 +800,24 @@ where
         group_hooks.iter().map(|h| &h.id).collect::<Vec<_>>()
     );
 
-    let mut skipped_results = Vec::new();
-    let mut runnable_hooks = Vec::new();
+    let mut runs = futures::stream::iter(group_hooks)
+        .map(|hook| {
+            let hook_input = input.for_hook(&hook, tag_cache);
+            trace!(
+                matched = hook_input.has_matching_files,
+                filenames = hook_input.filenames.len(),
+                "Files for hook `{}` after filtering",
+                hook.id,
+            );
+            run_hook(hook, hook_input, store, dry_run, reporter)
+        })
+        .buffer_unordered(*CONCURRENCY);
 
-    for hook in group_hooks {
-        let hook_input = input.for_hook(&hook, tag_cache);
-        trace!(
-            matched = hook_input.has_matching_files,
-            filenames = hook_input.filenames.len(),
-            "Files for hook `{}` after filtering",
-            hook.id,
-        );
-
-        if !hook_input.has_matching_files && !hook.always_run {
-            skipped_results.push(RunResult::from_status(
-                InstalledHook::NoNeedInstall(hook),
-                RunStatus::NoFiles,
-            ));
-            continue;
-        }
-
-        if !Language::supported(hook.language) {
-            skipped_results.push(RunResult::from_status(
-                InstalledHook::NoNeedInstall(hook),
-                RunStatus::Unimplemented,
-            ));
-            continue;
-        }
-
-        runnable_hooks.push(InstallJob::new(hook, hook_input));
+    let mut group_results = Vec::new();
+    while let Some(result) = runs.next().await {
+        group_results.push(result?);
     }
-
-    PriorityGroupPlan {
-        skipped_results,
-        runnable_hooks,
-    }
-}
-
-struct HookRunExecutor<'a> {
-    install_cache: Option<InstallCache>,
-    dry_run: bool,
-    reporter: &'a HookRunReporter,
-}
-
-impl<'a> HookRunExecutor<'a> {
-    fn new(dry_run: bool, reporter: &'a HookRunReporter) -> Self {
-        Self {
-            install_cache: None,
-            dry_run,
-            reporter,
-        }
-    }
-
-    async fn run(
-        &mut self,
-        store: &Store,
-        hooks: Vec<PlannedHookRun<'_>>,
-    ) -> Result<Vec<RunResult>> {
-        if hooks.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        let install_reporter = HookInstallReporter::from_run(self.reporter);
-        let pipeline = HookRunPipeline::new(self.reporter, self.dry_run);
-        // Install holds the store lock. The ready queue must not block on run concurrency, or a
-        // hook that recursively invokes prek could wait on the same lock while install is stalled.
-        let (ready_tx, ready_rx) = mpsc::unbounded_channel();
-
-        let install_future = async {
-            let _lock = store.lock_async().await?;
-            let installer =
-                Installer::for_jobs(store, &install_reporter, &mut self.install_cache, &hooks)
-                    .await;
-            pipeline
-                .install_ready_hooks(store, installer, hooks, ready_tx)
-                .await
-        };
-        let run_future = pipeline.run_ready_hooks(store, ready_rx);
-
-        let (install_result, run_result) = futures::future::join(install_future, run_future).await;
-        let installed_hooks = install_result?;
-        let results = run_result?;
-
-        if let Some(cache) = &mut self.install_cache {
-            cache.add_installed(&installed_hooks);
-        }
-
-        Ok(results)
-    }
-}
-
-#[derive(Clone)]
-struct HookRunPipeline<'a> {
-    /// Run concurrency is independent from install concurrency.
-    run_semaphore: Rc<Semaphore>,
-    reporter: &'a HookRunReporter,
-    dry_run: bool,
-}
-
-impl<'a> HookRunPipeline<'a> {
-    fn new(reporter: &'a HookRunReporter, dry_run: bool) -> Self {
-        Self {
-            run_semaphore: Rc::new(Semaphore::new(*CONCURRENCY)),
-            reporter,
-            dry_run,
-        }
-    }
-
-    async fn install_ready_hooks<'input>(
-        &self,
-        store: &Store,
-        installer: Installer<'a>,
-        hooks: Vec<PlannedHookRun<'input>>,
-        ready_tx: mpsc::UnboundedSender<ReadyHookRun<'input>>,
-    ) -> Result<Vec<InstalledHook>> {
-        let mut installed_hooks = Vec::new();
-        let mut futures = FuturesUnordered::new();
-
-        for partition in InstallPartitions::new(hooks) {
-            let mut partition_installer = installer.partition();
-            let ready_tx = ready_tx.clone();
-            futures.push(async move {
-                Self::install_partition(store, &mut partition_installer, partition, ready_tx).await
-            });
-        }
-
-        while let Some(result) = futures.next().await {
-            let mut partition_installed_hooks = result?;
-            installed_hooks.append(&mut partition_installed_hooks);
-        }
-
-        Ok(installed_hooks)
-    }
-
-    async fn install_partition<'input>(
-        store: &Store,
-        installer: &mut PartitionInstaller<'a>,
-        hooks: Vec<PlannedHookRun<'input>>,
-        ready_tx: mpsc::UnboundedSender<ReadyHookRun<'input>>,
-    ) -> Result<Vec<InstalledHook>> {
-        let mut installed_hooks = Vec::with_capacity(hooks.len());
-
-        for hook in hooks {
-            let (installed_hook, input) = installer.install_job(store, hook).await?;
-            installed_hooks.push(installed_hook.clone());
-
-            if ready_tx.send((installed_hook, input)).is_err() {
-                break;
-            }
-        }
-
-        Ok(installed_hooks)
-    }
-
-    async fn run_ready_hooks(
-        &self,
-        store: &Store,
-        mut ready_rx: mpsc::UnboundedReceiver<ReadyHookRun<'_>>,
-    ) -> Result<Vec<RunResult>> {
-        let mut results = Vec::new();
-        let mut runs = FuturesUnordered::new();
-        let mut ready_open = true;
-
-        loop {
-            tokio::select! {
-                ready = ready_rx.recv(), if ready_open => {
-                    match ready {
-                        Some((installed_hook, input)) => {
-                            let run_semaphore = Rc::clone(&self.run_semaphore);
-                            let reporter = self.reporter;
-                            let dry_run = self.dry_run;
-
-                            runs.push(async move {
-                                let _permit = run_semaphore.acquire(1).await;
-                                run_hook(installed_hook, input, store, dry_run, reporter).await
-                            });
-                        }
-                        None => ready_open = false,
-                    }
-                }
-                result = runs.next(), if !runs.is_empty() => {
-                    if let Some(result) = result {
-                        results.push(result?);
-                    }
-                }
-                else => break,
-            }
-        }
-
-        Ok(results)
-    }
+    Ok(group_results)
 }
 
 fn render_priority_group(

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -13,6 +13,7 @@ use prek_consts::{PRE_COMMIT_CONFIG_YAML, PREK_TOML};
 use rand::SeedableRng;
 use rand::prelude::{SliceRandom, StdRng};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
+use tokio::sync::mpsc;
 use tracing::{debug, trace};
 use unicode_width::UnicodeWidthStr;
 
@@ -33,7 +34,7 @@ use crate::store::Store;
 use crate::workspace::{Project, Workspace};
 use crate::{fs, git, warn_user};
 
-use super::install::{InstallCache, InstallJob, InstallPartitions, Installer};
+use super::install::{InstallCache, InstallJob, InstallPartitions, Installer, PartitionInstaller};
 
 #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 pub(crate) async fn run(
@@ -450,6 +451,7 @@ impl<'a> HookRunInput<'a> {
 }
 
 type PlannedHookRun<'a> = InstallJob<HookRunInput<'a>>;
+type ReadyHookRun<'a> = (InstalledHook, HookRunInput<'a>);
 
 struct PriorityGroupPlan<'a> {
     skipped_results: Vec<RunResult>,
@@ -737,17 +739,30 @@ impl<'a> HookRunExecutor<'a> {
             return Ok(Vec::new());
         }
 
-        let _lock = self.store.lock_async().await?;
         let install_reporter = HookInstallReporter::from_run(self.reporter);
-        let installer = Installer::for_jobs(
-            self.store,
-            &install_reporter,
-            &mut self.install_cache,
-            &hooks,
-        )
-        .await;
-        let pipeline = HookRunPipeline::new(installer, self.reporter, self.dry_run);
-        let (results, installed_hooks) = pipeline.run_all(hooks).await?;
+        let pipeline = HookRunPipeline::new(self.store, self.reporter, self.dry_run);
+        // Install holds the store lock. The ready queue must not block on run concurrency, or a
+        // hook that recursively invokes prek could wait on the same lock while install is stalled.
+        let (ready_tx, ready_rx) = mpsc::unbounded_channel();
+
+        let install_future = async {
+            let _lock = self.store.lock_async().await?;
+            let installer = Installer::for_jobs(
+                self.store,
+                &install_reporter,
+                &mut self.install_cache,
+                &hooks,
+            )
+            .await;
+            pipeline
+                .install_ready_hooks(installer, hooks, ready_tx)
+                .await
+        };
+        let run_future = pipeline.run_ready_hooks(ready_rx);
+
+        let (install_result, run_result) = futures::future::join(install_future, run_future).await;
+        let installed_hooks = install_result?;
+        let results = run_result?;
 
         if let Some(cache) = &mut self.install_cache {
             cache.add_installed(&installed_hooks);
@@ -759,7 +774,7 @@ impl<'a> HookRunExecutor<'a> {
 
 #[derive(Clone)]
 struct HookRunPipeline<'a> {
-    installer: Installer<'a>,
+    store: &'a Store,
     /// Run concurrency is independent from install concurrency.
     run_semaphore: Rc<Semaphore>,
     reporter: &'a HookRunReporter,
@@ -767,67 +782,95 @@ struct HookRunPipeline<'a> {
 }
 
 impl<'a> HookRunPipeline<'a> {
-    fn new(installer: Installer<'a>, reporter: &'a HookRunReporter, dry_run: bool) -> Self {
+    fn new(store: &'a Store, reporter: &'a HookRunReporter, dry_run: bool) -> Self {
         Self {
-            installer,
+            store,
             run_semaphore: Rc::new(Semaphore::new(*CONCURRENCY)),
             reporter,
             dry_run,
         }
     }
 
-    async fn run_all(
+    async fn install_ready_hooks<'input>(
         &self,
-        hooks: Vec<PlannedHookRun<'_>>,
-    ) -> Result<(Vec<RunResult>, Vec<InstalledHook>)> {
-        let mut results = Vec::new();
+        installer: Installer<'a>,
+        hooks: Vec<PlannedHookRun<'input>>,
+        ready_tx: mpsc::UnboundedSender<ReadyHookRun<'input>>,
+    ) -> Result<Vec<InstalledHook>> {
         let mut installed_hooks = Vec::new();
         let mut futures = FuturesUnordered::new();
 
         for partition in InstallPartitions::new(hooks) {
-            let pipeline = self.clone();
-            futures.push(async move { pipeline.run_partition(partition).await });
-        }
-
-        while let Some(result) = futures.next().await {
-            let (mut partition_results, mut partition_installed_hooks) = result?;
-            results.append(&mut partition_results);
-            installed_hooks.append(&mut partition_installed_hooks);
-        }
-
-        Ok((results, installed_hooks))
-    }
-
-    async fn run_partition(
-        &self,
-        hooks: Vec<PlannedHookRun<'_>>,
-    ) -> Result<(Vec<RunResult>, Vec<InstalledHook>)> {
-        let mut results = Vec::new();
-        let mut installed_hooks = Vec::with_capacity(hooks.len());
-        let mut runs = FuturesUnordered::new();
-        let mut installer = self.installer.partition();
-
-        for hook in hooks {
-            // Installation is sequential within a partition to preserve environment reuse, but each
-            // hook starts running as soon as its own environment is ready.
-            let (installed_hook, input) = installer.install_job(hook).await?;
-            let run_semaphore = Rc::clone(&self.run_semaphore);
-            let store = self.installer.store();
-            let reporter = self.reporter;
-            let dry_run = self.dry_run;
-
-            installed_hooks.push(installed_hook.clone());
-            runs.push(async move {
-                let _permit = run_semaphore.acquire(1).await;
-                run_hook(installed_hook, input, store, dry_run, reporter).await
+            let mut partition_installer = installer.partition();
+            let ready_tx = ready_tx.clone();
+            futures.push(async move {
+                Self::install_partition(&mut partition_installer, partition, ready_tx).await
             });
         }
 
-        while let Some(result) = runs.next().await {
-            results.push(result?);
+        while let Some(result) = futures.next().await {
+            let mut partition_installed_hooks = result?;
+            installed_hooks.append(&mut partition_installed_hooks);
         }
 
-        Ok((results, installed_hooks))
+        Ok(installed_hooks)
+    }
+
+    async fn install_partition<'input>(
+        installer: &mut PartitionInstaller<'a>,
+        hooks: Vec<PlannedHookRun<'input>>,
+        ready_tx: mpsc::UnboundedSender<ReadyHookRun<'input>>,
+    ) -> Result<Vec<InstalledHook>> {
+        let mut installed_hooks = Vec::with_capacity(hooks.len());
+
+        for hook in hooks {
+            let (installed_hook, input) = installer.install_job(hook).await?;
+            installed_hooks.push(installed_hook.clone());
+
+            if ready_tx.send((installed_hook, input)).is_err() {
+                break;
+            }
+        }
+
+        Ok(installed_hooks)
+    }
+
+    async fn run_ready_hooks(
+        &self,
+        mut ready_rx: mpsc::UnboundedReceiver<ReadyHookRun<'_>>,
+    ) -> Result<Vec<RunResult>> {
+        let mut results = Vec::new();
+        let mut runs = FuturesUnordered::new();
+        let mut ready_open = true;
+
+        loop {
+            tokio::select! {
+                ready = ready_rx.recv(), if ready_open => {
+                    match ready {
+                        Some((installed_hook, input)) => {
+                            let run_semaphore = Rc::clone(&self.run_semaphore);
+                            let store = self.store;
+                            let reporter = self.reporter;
+                            let dry_run = self.dry_run;
+
+                            runs.push(async move {
+                                let _permit = run_semaphore.acquire(1).await;
+                                run_hook(installed_hook, input, store, dry_run, reporter).await
+                            });
+                        }
+                        None => ready_open = false,
+                    }
+                }
+                result = runs.next(), if !runs.is_empty() => {
+                    if let Some(result) = result {
+                        results.push(result?);
+                    }
+                }
+                else => break,
+            }
+        }
+
+        Ok(results)
     }
 }
 

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -497,7 +497,7 @@ async fn run_hooks(
     // Track files that have been consumed by orphan projects.
     let mut consumed_files = FxHashSet::default();
     let mut tag_cache = FileTagCache::default();
-    let mut executor = HookRunExecutor::new(store, dry_run, &reporter);
+    let mut executor = HookRunExecutor::new(dry_run, &reporter);
 
     'outer: for project in workspace.all_projects() {
         let project_input = ProjectHookInput::new(&input, project, Some(&mut consumed_files))?;
@@ -536,7 +536,7 @@ async fn run_hooks(
             } = plan_priority_group(group_hooks, &project_input, &mut tag_cache);
 
             if !runnable_hooks.is_empty() {
-                let mut run_results = executor.run(runnable_hooks).await?;
+                let mut run_results = executor.run(store, runnable_hooks).await?;
                 group_results.append(&mut run_results);
             }
 
@@ -718,47 +718,45 @@ where
 }
 
 struct HookRunExecutor<'a> {
-    store: &'a Store,
     install_cache: Option<InstallCache>,
     dry_run: bool,
     reporter: &'a HookRunReporter,
 }
 
 impl<'a> HookRunExecutor<'a> {
-    fn new(store: &'a Store, dry_run: bool, reporter: &'a HookRunReporter) -> Self {
+    fn new(dry_run: bool, reporter: &'a HookRunReporter) -> Self {
         Self {
-            store,
             install_cache: None,
             dry_run,
             reporter,
         }
     }
 
-    async fn run(&mut self, hooks: Vec<PlannedHookRun<'_>>) -> Result<Vec<RunResult>> {
+    async fn run(
+        &mut self,
+        store: &Store,
+        hooks: Vec<PlannedHookRun<'_>>,
+    ) -> Result<Vec<RunResult>> {
         if hooks.is_empty() {
             return Ok(Vec::new());
         }
 
         let install_reporter = HookInstallReporter::from_run(self.reporter);
-        let pipeline = HookRunPipeline::new(self.store, self.reporter, self.dry_run);
+        let pipeline = HookRunPipeline::new(self.reporter, self.dry_run);
         // Install holds the store lock. The ready queue must not block on run concurrency, or a
         // hook that recursively invokes prek could wait on the same lock while install is stalled.
         let (ready_tx, ready_rx) = mpsc::unbounded_channel();
 
         let install_future = async {
-            let _lock = self.store.lock_async().await?;
-            let installer = Installer::for_jobs(
-                self.store,
-                &install_reporter,
-                &mut self.install_cache,
-                &hooks,
-            )
-            .await;
+            let _lock = store.lock_async().await?;
+            let installer =
+                Installer::for_jobs(store, &install_reporter, &mut self.install_cache, &hooks)
+                    .await;
             pipeline
-                .install_ready_hooks(installer, hooks, ready_tx)
+                .install_ready_hooks(store, installer, hooks, ready_tx)
                 .await
         };
-        let run_future = pipeline.run_ready_hooks(ready_rx);
+        let run_future = pipeline.run_ready_hooks(store, ready_rx);
 
         let (install_result, run_result) = futures::future::join(install_future, run_future).await;
         let installed_hooks = install_result?;
@@ -774,7 +772,6 @@ impl<'a> HookRunExecutor<'a> {
 
 #[derive(Clone)]
 struct HookRunPipeline<'a> {
-    store: &'a Store,
     /// Run concurrency is independent from install concurrency.
     run_semaphore: Rc<Semaphore>,
     reporter: &'a HookRunReporter,
@@ -782,9 +779,8 @@ struct HookRunPipeline<'a> {
 }
 
 impl<'a> HookRunPipeline<'a> {
-    fn new(store: &'a Store, reporter: &'a HookRunReporter, dry_run: bool) -> Self {
+    fn new(reporter: &'a HookRunReporter, dry_run: bool) -> Self {
         Self {
-            store,
             run_semaphore: Rc::new(Semaphore::new(*CONCURRENCY)),
             reporter,
             dry_run,
@@ -793,6 +789,7 @@ impl<'a> HookRunPipeline<'a> {
 
     async fn install_ready_hooks<'input>(
         &self,
+        store: &Store,
         installer: Installer<'a>,
         hooks: Vec<PlannedHookRun<'input>>,
         ready_tx: mpsc::UnboundedSender<ReadyHookRun<'input>>,
@@ -803,7 +800,6 @@ impl<'a> HookRunPipeline<'a> {
         for partition in InstallPartitions::new(hooks) {
             let mut partition_installer = installer.partition();
             let ready_tx = ready_tx.clone();
-            let store = self.store;
             futures.push(async move {
                 Self::install_partition(store, &mut partition_installer, partition, ready_tx).await
             });
@@ -839,6 +835,7 @@ impl<'a> HookRunPipeline<'a> {
 
     async fn run_ready_hooks(
         &self,
+        store: &Store,
         mut ready_rx: mpsc::UnboundedReceiver<ReadyHookRun<'_>>,
     ) -> Result<Vec<RunResult>> {
         let mut results = Vec::new();
@@ -851,7 +848,6 @@ impl<'a> HookRunPipeline<'a> {
                     match ready {
                         Some((installed_hook, input)) => {
                             let run_semaphore = Rc::clone(&self.run_semaphore);
-                            let store = self.store;
                             let reporter = self.reporter;
                             let dry_run = self.dry_run;
 

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -88,13 +88,15 @@ pub(crate) async fn run(
     }
 
     let reporter = HookInitReporter::new(printer);
-    let lock = store.lock_async().await?;
-    store.track_configs(workspace.projects().iter().map(|p| p.config_file()))?;
+    let hooks = {
+        let _lock = store.lock_async().await?;
+        store.track_configs(workspace.projects().iter().map(|p| p.config_file()))?;
 
-    let hooks = workspace
-        .init_hooks(store, Some(&reporter))
-        .await
-        .context("Failed to init hooks")?;
+        workspace
+            .init_hooks(store, Some(&reporter))
+            .await
+            .context("Failed to init hooks")?
+    };
     let selected_hooks: Vec<_> = hooks
         .into_iter()
         .filter(|h| selectors.matches_hook(h))
@@ -161,11 +163,6 @@ pub(crate) async fn run(
         "Hooks going to run: {:?}",
         filtered_hooks.iter().map(|h| &h.id).collect::<Vec<_>>()
     );
-    let reporter = HookInstallReporter::new(printer);
-    let installed_hooks = install_hooks(filtered_hooks, store, &reporter).await?;
-
-    // Release the store lock.
-    drop(lock);
 
     // Clear any unstaged changes from the git working directory.
     let mut _guard = None;
@@ -204,7 +201,7 @@ pub(crate) async fn run(
 
     run_hooks(
         &workspace,
-        &installed_hooks,
+        &filtered_hooks,
         input,
         store,
         show_diff_on_failure,
@@ -265,7 +262,7 @@ fn set_env_vars(from_ref: Option<&String>, to_ref: Option<&String>, args: &RunEx
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct LazyInstallInfo {
     info: Arc<InstallInfo>,
     health: mea::once::OnceCell<bool>,
@@ -276,6 +273,13 @@ impl LazyInstallInfo {
         Self {
             info,
             health: mea::once::OnceCell::new(),
+        }
+    }
+
+    fn healthy(info: Arc<InstallInfo>) -> Self {
+        Self {
+            info,
+            health: mea::once::OnceCell::from_value(true),
         }
     }
 
@@ -306,22 +310,98 @@ impl LazyInstallInfo {
     }
 }
 
+#[derive(Default)]
+struct HookInstallCache {
+    store_hooks: Option<Rc<[LazyInstallInfo]>>,
+    run_hooks: Vec<LazyInstallInfo>,
+}
+
+impl HookInstallCache {
+    async fn store_hooks(&mut self, store: &Store) -> Rc<[LazyInstallInfo]> {
+        if let Some(store_hooks) = &self.store_hooks {
+            return Rc::clone(store_hooks);
+        }
+
+        let store_hooks = load_store_hooks(store).await;
+        self.store_hooks = Some(Rc::clone(&store_hooks));
+        store_hooks
+    }
+
+    fn run_hooks(&self) -> Rc<[LazyInstallInfo]> {
+        Rc::from(self.run_hooks.clone().into_boxed_slice())
+    }
+
+    fn add_installed(&mut self, installed_hooks: &[InstalledHook]) {
+        for hook in installed_hooks {
+            let InstalledHook::Installed { info, .. } = hook else {
+                continue;
+            };
+            if self.has_info(info) {
+                continue;
+            }
+            self.run_hooks.push(LazyInstallInfo::healthy(info.clone()));
+        }
+    }
+
+    fn has_info(&self, info: &InstallInfo) -> bool {
+        self.run_hooks
+            .iter()
+            .any(|existing| existing.info.env_path == info.env_path)
+            || self.store_hooks.as_deref().is_some_and(|store_hooks| {
+                store_hooks
+                    .iter()
+                    .any(|existing| existing.info.env_path == info.env_path)
+            })
+    }
+}
+
+fn empty_install_infos() -> Rc<[LazyInstallInfo]> {
+    Rc::from(Vec::new().into_boxed_slice())
+}
+
+async fn load_store_hooks(store: &Store) -> Rc<[LazyInstallInfo]> {
+    let hooks = store
+        .installed_hooks()
+        .await
+        .into_iter()
+        .map(LazyInstallInfo::new)
+        .collect::<Vec<_>>();
+    Rc::from(hooks.into_boxed_slice())
+}
+
+fn hook_needs_environment(hook: &Hook) -> bool {
+    if matches!(hook.repo(), Repo::Meta { .. } | Repo::Builtin { .. }) {
+        return false;
+    }
+
+    !matches!(
+        hook.language,
+        Language::DockerImage | Language::Fail | Language::Script | Language::System
+    )
+}
+
 pub async fn install_hooks(
     hooks: Vec<Arc<Hook>>,
     store: &Store,
     reporter: &HookInstallReporter,
 ) -> Result<Vec<InstalledHook>> {
+    let store_hooks = if hooks.iter().any(|hook| hook_needs_environment(hook)) {
+        load_store_hooks(store).await
+    } else {
+        empty_install_infos()
+    };
+    install_hooks_with_store_hooks(hooks, store, reporter, store_hooks, empty_install_infos()).await
+}
+
+async fn install_hooks_with_store_hooks(
+    hooks: Vec<Arc<Hook>>,
+    store: &Store,
+    reporter: &HookInstallReporter,
+    store_hooks: Rc<[LazyInstallInfo]>,
+    run_hooks: Rc<[LazyInstallInfo]>,
+) -> Result<Vec<InstalledHook>> {
     let num_hooks = hooks.len();
     let mut result = Vec::with_capacity(hooks.len());
-
-    let store_hooks = Rc::new(
-        store
-            .installed_hooks()
-            .await
-            .into_iter()
-            .map(LazyInstallInfo::new)
-            .collect::<Vec<_>>(),
-    );
 
     // Group hooks by language to enable parallel installation across different languages.
     let mut hooks_by_language = FxHashMap::default();
@@ -347,17 +427,15 @@ pub async fn install_hooks(
         for hooks in partitions {
             let semaphore = Rc::clone(&semaphore);
             let store_hooks = Rc::clone(&store_hooks);
+            let run_hooks = Rc::clone(&run_hooks);
 
             futures.push(async move {
                 let mut hook_envs = Vec::with_capacity(hooks.len());
                 let mut newly_installed = Vec::new();
 
                 for hook in hooks {
-                    if matches!(hook.repo(), Repo::Meta { .. } | Repo::Builtin { .. }) {
-                        debug!(
-                            "Hook `{}` is a meta or builtin hook, no installation needed",
-                            &hook
-                        );
+                    if !hook_needs_environment(&hook) {
+                        debug!("Hook `{}` does not need an installed environment", &hook);
                         hook_envs.push(InstalledHook::NoNeedInstall(hook));
                         continue;
                     }
@@ -374,7 +452,7 @@ pub async fn install_hooks(
                     }
 
                     if matched_info.is_none() {
-                        for env in store_hooks.iter() {
+                        for env in run_hooks.iter().chain(store_hooks.iter()) {
                             if env.matches(&hook) {
                                 if env.ensure_healthy().await {
                                     matched_info = Some(env.info());
@@ -501,7 +579,10 @@ impl StatusPrinter {
     const NO_FILES: &'static str = "(no files to check)";
     const UNIMPLEMENTED: &'static str = "(unimplemented yet)";
 
-    fn for_hooks(hooks: &[InstalledHook], printer: Printer) -> Self {
+    fn for_hooks<T>(hooks: &[T], printer: Printer) -> Self
+    where
+        T: std::ops::Deref<Target = Hook>,
+    {
         let name_len = hooks
             .iter()
             .map(|hook| hook.name.width())
@@ -670,11 +751,21 @@ impl<'a> HookRunInput<'a> {
     }
 }
 
+struct PendingHookRun<'a> {
+    hook: Arc<Hook>,
+    input: HookRunInput<'a>,
+}
+
+struct PreparedHookRun<'a> {
+    hook: InstalledHook,
+    input: HookRunInput<'a>,
+}
+
 /// Run all hooks.
 #[allow(clippy::fn_params_excessive_bools)]
 async fn run_hooks(
     workspace: &Workspace,
-    hooks: &[InstalledHook],
+    hooks: &[Arc<Hook>],
     input: RunInput,
     store: &Store,
     show_diff_on_failure: bool,
@@ -692,7 +783,7 @@ async fn run_hooks(
 
     // Group hooks by project to run them in order of their depth in the workspace.
     #[allow(clippy::mutable_key_type)]
-    let mut project_to_hooks: FxHashMap<&Project, Vec<InstalledHook>> =
+    let mut project_to_hooks: FxHashMap<&Project, Vec<Arc<Hook>>> =
         FxHashMap::with_capacity_and_hasher(hooks.len(), FxBuildHasher);
     for hook in hooks {
         project_to_hooks
@@ -709,6 +800,7 @@ async fn run_hooks(
     // Track files that have been consumed by orphan projects.
     let mut consumed_files = FxHashSet::default();
     let mut tag_cache = FileTagCache::default();
+    let mut install_cache = HookInstallCache::default();
 
     'outer: for project in workspace.all_projects() {
         let project_input = ProjectHookInput::new(&input, project, Some(&mut consumed_files))?;
@@ -742,15 +834,26 @@ async fn run_hooks(
 
         for group_range in PriorityGroupRanges::new(&hooks) {
             let group_hooks = hooks[group_range].to_vec();
-            let mut group_results = run_priority_group(
+            let (mut group_results, prepared_hooks) = prepare_priority_group(
                 group_hooks,
                 &project_input,
                 &mut tag_cache,
                 store,
-                dry_run,
-                &reporter,
+                &mut install_cache,
+                printer,
             )
             .await?;
+
+            if !prepared_hooks.is_empty() {
+                // Installation may touch files in the hook project (for example build metadata
+                // from a local package). Match the old eager-install behavior by excluding those
+                // setup side effects from hook modification detection.
+                prev_diff = git::get_diff(project.path()).await?;
+
+                let mut run_results =
+                    run_priority_group(prepared_hooks, store, dry_run, &reporter).await?;
+                group_results.append(&mut run_results);
+            }
 
             // Print results in a stable order (same order as config within the project).
             group_results.sort_unstable_by_key(|a| a.hook.idx);
@@ -847,12 +950,12 @@ async fn run_hooks(
 }
 
 struct PriorityGroupRanges<'a> {
-    hooks: &'a [InstalledHook],
+    hooks: &'a [Arc<Hook>],
     idx: usize,
 }
 
 impl<'a> PriorityGroupRanges<'a> {
-    fn new(hooks: &'a [InstalledHook]) -> Self {
+    fn new(hooks: &'a [Arc<Hook>]) -> Self {
         Self { hooks, idx: 0 }
     }
 }
@@ -876,14 +979,14 @@ impl Iterator for PriorityGroupRanges<'_> {
     }
 }
 
-async fn run_priority_group<'input, 'paths>(
-    group_hooks: Vec<InstalledHook>,
+async fn prepare_priority_group<'input, 'paths>(
+    group_hooks: Vec<Arc<Hook>>,
     input: &'input ProjectHookInput<'paths>,
     tag_cache: &mut FileTagCache<'paths>,
     store: &Store,
-    dry_run: bool,
-    reporter: &HookRunReporter,
-) -> Result<Vec<RunResult>>
+    install_cache: &mut HookInstallCache,
+    printer: Printer,
+) -> Result<(Vec<RunResult>, Vec<PreparedHookRun<'input>>)>
 where
     'paths: 'input,
 {
@@ -894,17 +997,100 @@ where
         group_hooks.iter().map(|h| &h.id).collect::<Vec<_>>()
     );
 
+    let mut group_results = Vec::new();
+    let mut pending_hooks = Vec::new();
+
+    for hook in group_hooks {
+        let hook_input = input.for_hook(&hook, tag_cache);
+        trace!(
+            matched = hook_input.has_matching_files,
+            filenames = hook_input.filenames.len(),
+            "Files for hook `{}` after filtering",
+            hook.id,
+        );
+
+        if !hook_input.has_matching_files && !hook.always_run {
+            group_results.push(RunResult::from_status(
+                InstalledHook::NoNeedInstall(hook),
+                RunStatus::NoFiles,
+            ));
+            continue;
+        }
+
+        if !Language::supported(hook.language) {
+            group_results.push(RunResult::from_status(
+                InstalledHook::NoNeedInstall(hook),
+                RunStatus::Unimplemented,
+            ));
+            continue;
+        }
+
+        pending_hooks.push(PendingHookRun {
+            hook,
+            input: hook_input,
+        });
+    }
+
+    let prepared_hooks =
+        install_pending_hooks(pending_hooks, store, install_cache, printer).await?;
+
+    Ok((group_results, prepared_hooks))
+}
+
+async fn install_pending_hooks<'input>(
+    pending_hooks: Vec<PendingHookRun<'input>>,
+    store: &Store,
+    install_cache: &mut HookInstallCache,
+    printer: Printer,
+) -> Result<Vec<PreparedHookRun<'input>>> {
+    if pending_hooks.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let hooks = pending_hooks
+        .iter()
+        .map(|pending| pending.hook.clone())
+        .collect::<Vec<_>>();
+
+    let _lock = store.lock_async().await?;
+    let reporter = HookInstallReporter::new(printer);
+    let store_hooks = if hooks.iter().any(|hook| hook_needs_environment(hook)) {
+        install_cache.store_hooks(store).await
+    } else {
+        empty_install_infos()
+    };
+    let run_hooks = install_cache.run_hooks();
+    let installed_hooks =
+        install_hooks_with_store_hooks(hooks, store, &reporter, store_hooks, run_hooks).await?;
+    install_cache.add_installed(&installed_hooks);
+
+    let mut installed_by_idx = installed_hooks
+        .into_iter()
+        .map(|hook| (hook.idx, hook))
+        .collect::<FxHashMap<_, _>>();
+
+    let mut prepared_hooks = Vec::with_capacity(pending_hooks.len());
+    for pending in pending_hooks {
+        let Some(hook) = installed_by_idx.remove(&pending.hook.idx) else {
+            anyhow::bail!("Missing installed hook for `{}`", pending.hook);
+        };
+        prepared_hooks.push(PreparedHookRun {
+            hook,
+            input: pending.input,
+        });
+    }
+
+    Ok(prepared_hooks)
+}
+
+async fn run_priority_group(
+    group_hooks: Vec<PreparedHookRun<'_>>,
+    store: &Store,
+    dry_run: bool,
+    reporter: &HookRunReporter,
+) -> Result<Vec<RunResult>> {
     let mut results = futures::stream::iter(group_hooks)
-        .map(|hook| {
-            let hook_input = input.for_hook(&hook, tag_cache);
-            trace!(
-                matched = hook_input.has_matching_files,
-                filenames = hook_input.filenames.len(),
-                "Files for hook `{}` after filtering",
-                hook.id,
-            );
-            run_hook(hook, hook_input, store, dry_run, reporter)
-        })
+        .map(|hook| run_hook(hook.hook, hook.input, store, dry_run, reporter))
         .buffer_unordered(*CONCURRENCY);
 
     let mut group_results = Vec::new();

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -13,7 +13,7 @@ use prek_consts::{PRE_COMMIT_CONFIG_YAML, PREK_TOML};
 use rand::SeedableRng;
 use rand::prelude::{SliceRandom, StdRng};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
-use tracing::{debug, trace, warn};
+use tracing::{debug, trace};
 use unicode_width::UnicodeWidthStr;
 
 use crate::cli::reporter::{HookInitReporter, HookInstallReporter, HookRunReporter};
@@ -26,12 +26,14 @@ use crate::cli::{ExitStatus, RunExtraArgs};
 use crate::config::{Language, PassFilenames, Stage};
 use crate::fs::CWD;
 use crate::git::GIT_ROOT;
-use crate::hook::{Hook, InstallInfo, InstalledHook, Repo};
+use crate::hook::{Hook, InstalledHook};
 use crate::printer::Printer;
 use crate::run::{CONCURRENCY, USE_COLOR};
 use crate::store::Store;
 use crate::workspace::{Project, Workspace};
 use crate::{fs, git, warn_user};
+
+use super::install::{InstallCache, InstallJob, InstallPartitions, Installer};
 
 #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 pub(crate) async fn run(
@@ -262,310 +264,6 @@ fn set_env_vars(from_ref: Option<&String>, to_ref: Option<&String>, args: &RunEx
     }
 }
 
-#[derive(Debug, Clone)]
-struct LazyInstallInfo {
-    info: Arc<InstallInfo>,
-    health: mea::once::OnceCell<bool>,
-}
-
-impl LazyInstallInfo {
-    fn new(info: Arc<InstallInfo>) -> Self {
-        Self {
-            info,
-            health: mea::once::OnceCell::new(),
-        }
-    }
-
-    fn healthy(info: Arc<InstallInfo>) -> Self {
-        Self {
-            info,
-            health: mea::once::OnceCell::from_value(true),
-        }
-    }
-
-    fn matches(&self, hook: &Hook) -> bool {
-        self.info.matches(hook)
-    }
-
-    fn info(&self) -> Arc<InstallInfo> {
-        self.info.clone()
-    }
-
-    async fn ensure_healthy(&self) -> bool {
-        let info = self.info.clone();
-        *self
-            .health
-            .get_or_init(async move || match info.check_health().await {
-                Ok(()) => true,
-                Err(err) => {
-                    warn!(
-                        %err,
-                        path = %info.env_path.display(),
-                        "Skipping unhealthy installed hook"
-                    );
-                    false
-                }
-            })
-            .await
-    }
-}
-
-#[derive(Default)]
-struct HookInstallCache {
-    store_hooks: Option<Rc<[LazyInstallInfo]>>,
-    run_hooks: Vec<LazyInstallInfo>,
-}
-
-impl HookInstallCache {
-    async fn store_hooks(&mut self, store: &Store) -> Rc<[LazyInstallInfo]> {
-        if let Some(store_hooks) = &self.store_hooks {
-            return Rc::clone(store_hooks);
-        }
-
-        let store_hooks = load_store_hooks(store).await;
-        self.store_hooks = Some(Rc::clone(&store_hooks));
-        store_hooks
-    }
-
-    fn run_hooks(&self) -> Rc<[LazyInstallInfo]> {
-        Rc::from(self.run_hooks.clone().into_boxed_slice())
-    }
-
-    fn add_installed(&mut self, installed_hooks: &[InstalledHook]) {
-        for hook in installed_hooks {
-            let InstalledHook::Installed { info, .. } = hook else {
-                continue;
-            };
-            if self.has_info(info) {
-                continue;
-            }
-            self.run_hooks.push(LazyInstallInfo::healthy(info.clone()));
-        }
-    }
-
-    fn has_info(&self, info: &InstallInfo) -> bool {
-        self.run_hooks
-            .iter()
-            .any(|existing| existing.info.env_path == info.env_path)
-            || self.store_hooks.as_deref().is_some_and(|store_hooks| {
-                store_hooks
-                    .iter()
-                    .any(|existing| existing.info.env_path == info.env_path)
-            })
-    }
-}
-
-fn empty_install_infos() -> Rc<[LazyInstallInfo]> {
-    Rc::from(Vec::new().into_boxed_slice())
-}
-
-async fn load_store_hooks(store: &Store) -> Rc<[LazyInstallInfo]> {
-    let hooks = store
-        .installed_hooks()
-        .await
-        .into_iter()
-        .map(LazyInstallInfo::new)
-        .collect::<Vec<_>>();
-    Rc::from(hooks.into_boxed_slice())
-}
-
-fn hook_needs_environment(hook: &Hook) -> bool {
-    if matches!(hook.repo(), Repo::Meta { .. } | Repo::Builtin { .. }) {
-        return false;
-    }
-
-    !matches!(
-        hook.language,
-        Language::DockerImage | Language::Fail | Language::Script | Language::System
-    )
-}
-
-pub async fn install_hooks(
-    hooks: Vec<Arc<Hook>>,
-    store: &Store,
-    reporter: &HookInstallReporter,
-) -> Result<Vec<InstalledHook>> {
-    let store_hooks = if hooks.iter().any(|hook| hook_needs_environment(hook)) {
-        load_store_hooks(store).await
-    } else {
-        empty_install_infos()
-    };
-    install_hooks_with_store_hooks(hooks, store, reporter, store_hooks, empty_install_infos()).await
-}
-
-async fn install_hooks_with_store_hooks(
-    hooks: Vec<Arc<Hook>>,
-    store: &Store,
-    reporter: &HookInstallReporter,
-    store_hooks: Rc<[LazyInstallInfo]>,
-    run_hooks: Rc<[LazyInstallInfo]>,
-) -> Result<Vec<InstalledHook>> {
-    let num_hooks = hooks.len();
-    let mut result = Vec::with_capacity(hooks.len());
-
-    // Group hooks by language to enable parallel installation across different languages.
-    let mut hooks_by_language = FxHashMap::default();
-    for hook in hooks {
-        let mut language = hook.language;
-        if hook.language == Language::Pygrep {
-            // Treat `pygrep` hooks as `python` hooks for installation purposes.
-            // They share the same installation logic.
-            language = Language::Python;
-        }
-        hooks_by_language
-            .entry(language)
-            .or_insert_with(Vec::new)
-            .push(hook);
-    }
-
-    let mut futures = FuturesUnordered::new();
-    let semaphore = Rc::new(Semaphore::new(*CONCURRENCY));
-
-    for (_, hooks) in hooks_by_language {
-        let partitions = partition_hooks(&hooks);
-
-        for hooks in partitions {
-            let semaphore = Rc::clone(&semaphore);
-            let store_hooks = Rc::clone(&store_hooks);
-            let run_hooks = Rc::clone(&run_hooks);
-
-            futures.push(async move {
-                let mut hook_envs = Vec::with_capacity(hooks.len());
-                let mut newly_installed = Vec::new();
-
-                for hook in hooks {
-                    if !hook_needs_environment(&hook) {
-                        debug!("Hook `{}` does not need an installed environment", &hook);
-                        hook_envs.push(InstalledHook::NoNeedInstall(hook));
-                        continue;
-                    }
-
-                    let mut matched_info = None;
-
-                    for env in &newly_installed {
-                        if let InstalledHook::Installed { info, .. } = env {
-                            if info.matches(&hook) {
-                                matched_info = Some(info.clone());
-                                break;
-                            }
-                        }
-                    }
-
-                    if matched_info.is_none() {
-                        for env in run_hooks.iter().chain(store_hooks.iter()) {
-                            if env.matches(&hook) {
-                                if env.ensure_healthy().await {
-                                    matched_info = Some(env.info());
-                                    break;
-                                }
-                            }
-                        }
-                    }
-
-                    if let Some(info) = matched_info {
-                        debug!(
-                            "Found installed environment for hook `{hook}` at `{}`",
-                            info.env_path.display()
-                        );
-                        hook_envs.push(InstalledHook::Installed { hook, info });
-                        continue;
-                    }
-
-                    let _permit = semaphore.acquire(1).await;
-
-                    let installed_hook = hook
-                        .language
-                        .install(hook.clone(), store, reporter)
-                        .await
-                        .with_context(|| format!("Failed to install hook `{hook}`"))?;
-
-                    installed_hook
-                        .mark_as_installed(store)
-                        .await
-                        .with_context(|| format!("Failed to mark hook `{hook}` as installed"))?;
-
-                    match &installed_hook {
-                        InstalledHook::Installed { info, .. } => {
-                            debug!("Installed hook `{hook}` in `{}`", info.env_path.display());
-                        }
-                        InstalledHook::NoNeedInstall { .. } => {
-                            debug!("Hook `{hook}` does not need installation");
-                        }
-                    }
-
-                    newly_installed.push(installed_hook);
-                }
-
-                // Add newly installed hooks to the list.
-                hook_envs.extend(newly_installed);
-                anyhow::Ok(hook_envs)
-            });
-        }
-    }
-
-    while let Some(hooks) = futures.next().await {
-        result.extend(hooks?);
-    }
-    reporter.on_complete();
-
-    debug_assert_eq!(
-        num_hooks,
-        result.len(),
-        "Number of hooks installed should match the number of hooks provided"
-    );
-
-    Ok(result)
-}
-
-/// Partition hooks into groups where hooks in the same group have same dependencies.
-/// Hooks in different groups can be installed in parallel.
-fn partition_hooks(hooks: &[Arc<Hook>]) -> Vec<Vec<Arc<Hook>>> {
-    if hooks.is_empty() {
-        return vec![];
-    }
-
-    let n = hooks.len();
-    let mut visited = vec![false; n];
-    let mut groups = Vec::new();
-
-    // DFS to find all connected sets
-    #[allow(clippy::items_after_statements)]
-    fn dfs(
-        index: usize,
-        hooks: &[Arc<Hook>],
-        visited: &mut [bool],
-        current_group: &mut Vec<usize>,
-    ) {
-        visited[index] = true;
-        current_group.push(index);
-
-        for i in 0..hooks.len() {
-            if !visited[i] && hooks[index].env_key_dependencies() == hooks[i].env_key_dependencies()
-            {
-                dfs(i, hooks, visited, current_group);
-            }
-        }
-    }
-
-    // Find all connected components
-    for i in 0..n {
-        if !visited[i] {
-            let mut current_group = Vec::new();
-            dfs(i, hooks, &mut visited, &mut current_group);
-
-            // Convert indices back to actual sets
-            let group_sets: Vec<Arc<Hook>> = current_group
-                .into_iter()
-                .map(|idx| hooks[idx].clone())
-                .collect();
-
-            groups.push(group_sets);
-        }
-    }
-
-    groups
-}
-
 struct StatusPrinter {
     printer: Printer,
     columns: usize,
@@ -751,14 +449,11 @@ impl<'a> HookRunInput<'a> {
     }
 }
 
-struct PendingHookRun<'a> {
-    hook: Arc<Hook>,
-    input: HookRunInput<'a>,
-}
+type PlannedHookRun<'a> = InstallJob<HookRunInput<'a>>;
 
-struct PreparedHookRun<'a> {
-    hook: InstalledHook,
-    input: HookRunInput<'a>,
+struct PriorityGroupPlan<'a> {
+    skipped_results: Vec<RunResult>,
+    runnable_hooks: Vec<PlannedHookRun<'a>>,
 }
 
 /// Run all hooks.
@@ -777,7 +472,7 @@ async fn run_hooks(
     debug_assert!(!hooks.is_empty(), "No hooks to run");
 
     let status_printer = StatusPrinter::for_hooks(hooks, printer);
-    let reporter = HookRunReporter::new(printer, status_printer.bar_len());
+    let reporter = HookRunReporter::new_execution(printer, status_printer.bar_len());
 
     let mut success = true;
 
@@ -800,7 +495,7 @@ async fn run_hooks(
     // Track files that have been consumed by orphan projects.
     let mut consumed_files = FxHashSet::default();
     let mut tag_cache = FileTagCache::default();
-    let mut install_cache = HookInstallCache::default();
+    let mut executor = HookRunExecutor::new(store, dry_run, &reporter);
 
     'outer: for project in workspace.all_projects() {
         let project_input = ProjectHookInput::new(&input, project, Some(&mut consumed_files))?;
@@ -832,26 +527,14 @@ async fn run_hooks(
 
         let project_fail_fast = fail_fast.or(project.config().fail_fast).unwrap_or(false);
 
-        for group_range in PriorityGroupRanges::new(&hooks) {
-            let group_hooks = hooks[group_range].to_vec();
-            let (mut group_results, prepared_hooks) = prepare_priority_group(
-                group_hooks,
-                &project_input,
-                &mut tag_cache,
-                store,
-                &mut install_cache,
-                printer,
-            )
-            .await?;
+        for group_hooks in PriorityGroups::new(hooks) {
+            let PriorityGroupPlan {
+                skipped_results: mut group_results,
+                runnable_hooks,
+            } = plan_priority_group(group_hooks, &project_input, &mut tag_cache);
 
-            if !prepared_hooks.is_empty() {
-                // Installation may touch files in the hook project (for example build metadata
-                // from a local package). Match the old eager-install behavior by excluding those
-                // setup side effects from hook modification detection.
-                prev_diff = git::get_diff(project.path()).await?;
-
-                let mut run_results =
-                    run_priority_group(prepared_hooks, store, dry_run, &reporter).await?;
+            if !runnable_hooks.is_empty() {
+                let mut run_results = executor.run(runnable_hooks).await?;
                 group_results.append(&mut run_results);
             }
 
@@ -949,44 +632,42 @@ async fn run_hooks(
     }
 }
 
-struct PriorityGroupRanges<'a> {
-    hooks: &'a [Arc<Hook>],
+struct PriorityGroups {
+    hooks: Vec<Arc<Hook>>,
     idx: usize,
 }
 
-impl<'a> PriorityGroupRanges<'a> {
-    fn new(hooks: &'a [Arc<Hook>]) -> Self {
+impl PriorityGroups {
+    fn new(hooks: Vec<Arc<Hook>>) -> Self {
         Self { hooks, idx: 0 }
     }
 }
 
-impl Iterator for PriorityGroupRanges<'_> {
-    type Item = std::ops::Range<usize>;
+impl Iterator for PriorityGroups {
+    type Item = Vec<Arc<Hook>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.idx >= self.hooks.len() {
-            return None;
+        let first = self.hooks.get(self.idx)?;
+        let priority = first.priority;
+        let start = self.idx;
+
+        while self
+            .hooks
+            .get(self.idx)
+            .is_some_and(|hook| hook.priority == priority)
+        {
+            self.idx += 1;
         }
 
-        let start = self.idx;
-        let priority = self.hooks[start].priority;
-        let mut end = start + 1;
-        while end < self.hooks.len() && self.hooks[end].priority == priority {
-            end += 1;
-        }
-        self.idx = end;
-        Some(start..end)
+        Some(self.hooks[start..self.idx].to_vec())
     }
 }
 
-async fn prepare_priority_group<'input, 'paths>(
+fn plan_priority_group<'input, 'paths>(
     group_hooks: Vec<Arc<Hook>>,
     input: &'input ProjectHookInput<'paths>,
     tag_cache: &mut FileTagCache<'paths>,
-    store: &Store,
-    install_cache: &mut HookInstallCache,
-    printer: Printer,
-) -> Result<(Vec<RunResult>, Vec<PreparedHookRun<'input>>)>
+) -> PriorityGroupPlan<'input>
 where
     'paths: 'input,
 {
@@ -997,8 +678,8 @@ where
         group_hooks.iter().map(|h| &h.id).collect::<Vec<_>>()
     );
 
-    let mut group_results = Vec::new();
-    let mut pending_hooks = Vec::new();
+    let mut skipped_results = Vec::new();
+    let mut runnable_hooks = Vec::new();
 
     for hook in group_hooks {
         let hook_input = input.for_hook(&hook, tag_cache);
@@ -1010,7 +691,7 @@ where
         );
 
         if !hook_input.has_matching_files && !hook.always_run {
-            group_results.push(RunResult::from_status(
+            skipped_results.push(RunResult::from_status(
                 InstalledHook::NoNeedInstall(hook),
                 RunStatus::NoFiles,
             ));
@@ -1018,86 +699,136 @@ where
         }
 
         if !Language::supported(hook.language) {
-            group_results.push(RunResult::from_status(
+            skipped_results.push(RunResult::from_status(
                 InstalledHook::NoNeedInstall(hook),
                 RunStatus::Unimplemented,
             ));
             continue;
         }
 
-        pending_hooks.push(PendingHookRun {
-            hook,
-            input: hook_input,
-        });
+        runnable_hooks.push(InstallJob::new(hook, hook_input));
     }
 
-    let prepared_hooks =
-        install_pending_hooks(pending_hooks, store, install_cache, printer).await?;
-
-    Ok((group_results, prepared_hooks))
+    PriorityGroupPlan {
+        skipped_results,
+        runnable_hooks,
+    }
 }
 
-async fn install_pending_hooks<'input>(
-    pending_hooks: Vec<PendingHookRun<'input>>,
-    store: &Store,
-    install_cache: &mut HookInstallCache,
-    printer: Printer,
-) -> Result<Vec<PreparedHookRun<'input>>> {
-    if pending_hooks.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let hooks = pending_hooks
-        .iter()
-        .map(|pending| pending.hook.clone())
-        .collect::<Vec<_>>();
-
-    let _lock = store.lock_async().await?;
-    let reporter = HookInstallReporter::new(printer);
-    let store_hooks = if hooks.iter().any(|hook| hook_needs_environment(hook)) {
-        install_cache.store_hooks(store).await
-    } else {
-        empty_install_infos()
-    };
-    let run_hooks = install_cache.run_hooks();
-    let installed_hooks =
-        install_hooks_with_store_hooks(hooks, store, &reporter, store_hooks, run_hooks).await?;
-    install_cache.add_installed(&installed_hooks);
-
-    let mut installed_by_idx = installed_hooks
-        .into_iter()
-        .map(|hook| (hook.idx, hook))
-        .collect::<FxHashMap<_, _>>();
-
-    let mut prepared_hooks = Vec::with_capacity(pending_hooks.len());
-    for pending in pending_hooks {
-        let Some(hook) = installed_by_idx.remove(&pending.hook.idx) else {
-            anyhow::bail!("Missing installed hook for `{}`", pending.hook);
-        };
-        prepared_hooks.push(PreparedHookRun {
-            hook,
-            input: pending.input,
-        });
-    }
-
-    Ok(prepared_hooks)
-}
-
-async fn run_priority_group(
-    group_hooks: Vec<PreparedHookRun<'_>>,
-    store: &Store,
+struct HookRunExecutor<'a> {
+    store: &'a Store,
+    install_cache: Option<InstallCache>,
     dry_run: bool,
-    reporter: &HookRunReporter,
-) -> Result<Vec<RunResult>> {
-    let mut results = futures::stream::iter(group_hooks)
-        .map(|hook| run_hook(hook.hook, hook.input, store, dry_run, reporter))
-        .buffer_unordered(*CONCURRENCY);
+    reporter: &'a HookRunReporter,
+}
 
-    let mut group_results = Vec::new();
-    while let Some(result) = results.next().await {
-        group_results.push(result?);
+impl<'a> HookRunExecutor<'a> {
+    fn new(store: &'a Store, dry_run: bool, reporter: &'a HookRunReporter) -> Self {
+        Self {
+            store,
+            install_cache: None,
+            dry_run,
+            reporter,
+        }
     }
-    Ok(group_results)
+
+    async fn run(&mut self, hooks: Vec<PlannedHookRun<'_>>) -> Result<Vec<RunResult>> {
+        if hooks.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let _lock = self.store.lock_async().await?;
+        let install_reporter = HookInstallReporter::from_run(self.reporter);
+        let installer = Installer::for_jobs(
+            self.store,
+            &install_reporter,
+            &mut self.install_cache,
+            &hooks,
+        )
+        .await;
+        let pipeline = HookRunPipeline::new(installer, self.reporter, self.dry_run);
+        let (results, installed_hooks) = pipeline.run_all(hooks).await?;
+
+        if let Some(cache) = &mut self.install_cache {
+            cache.add_installed(&installed_hooks);
+        }
+
+        Ok(results)
+    }
+}
+
+#[derive(Clone)]
+struct HookRunPipeline<'a> {
+    installer: Installer<'a>,
+    /// Run concurrency is independent from install concurrency.
+    run_semaphore: Rc<Semaphore>,
+    reporter: &'a HookRunReporter,
+    dry_run: bool,
+}
+
+impl<'a> HookRunPipeline<'a> {
+    fn new(installer: Installer<'a>, reporter: &'a HookRunReporter, dry_run: bool) -> Self {
+        Self {
+            installer,
+            run_semaphore: Rc::new(Semaphore::new(*CONCURRENCY)),
+            reporter,
+            dry_run,
+        }
+    }
+
+    async fn run_all(
+        &self,
+        hooks: Vec<PlannedHookRun<'_>>,
+    ) -> Result<(Vec<RunResult>, Vec<InstalledHook>)> {
+        let mut results = Vec::new();
+        let mut installed_hooks = Vec::new();
+        let mut futures = FuturesUnordered::new();
+
+        for partition in InstallPartitions::new(hooks) {
+            let pipeline = self.clone();
+            futures.push(async move { pipeline.run_partition(partition).await });
+        }
+
+        while let Some(result) = futures.next().await {
+            let (mut partition_results, mut partition_installed_hooks) = result?;
+            results.append(&mut partition_results);
+            installed_hooks.append(&mut partition_installed_hooks);
+        }
+
+        Ok((results, installed_hooks))
+    }
+
+    async fn run_partition(
+        &self,
+        hooks: Vec<PlannedHookRun<'_>>,
+    ) -> Result<(Vec<RunResult>, Vec<InstalledHook>)> {
+        let mut results = Vec::new();
+        let mut installed_hooks = Vec::with_capacity(hooks.len());
+        let mut runs = FuturesUnordered::new();
+        let mut installer = self.installer.partition();
+
+        for hook in hooks {
+            // Installation is sequential within a partition to preserve environment reuse, but each
+            // hook starts running as soon as its own environment is ready.
+            let (installed_hook, input) = installer.install_job(hook).await?;
+            let run_semaphore = Rc::clone(&self.run_semaphore);
+            let store = self.installer.store();
+            let reporter = self.reporter;
+            let dry_run = self.dry_run;
+
+            installed_hooks.push(installed_hook.clone());
+            runs.push(async move {
+                let _permit = run_semaphore.acquire(1).await;
+                run_hook(installed_hook, input, store, dry_run, reporter).await
+            });
+        }
+
+        while let Some(result) = runs.next().await {
+            results.push(result?);
+        }
+
+        Ok((results, installed_hooks))
+    }
 }
 
 fn render_priority_group(

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -31,7 +31,7 @@ use crate::store::Store;
 use crate::workspace::{Project, Workspace};
 use crate::{fs, git, warn_user};
 
-use super::install::{InstallCache, install_hooks_with_cache};
+use super::install::{InstallCache, install_hooks};
 
 #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 pub(crate) async fn run(
@@ -199,13 +199,16 @@ pub(crate) async fn run(
         )
     })?;
 
-    let installed_hooks =
-        prepare_hooks_for_run(&workspace, &filtered_hooks, &input, store, printer).await?;
+    let mut tag_cache = FileTagCache::default();
+    let installed_hooks = InstalledHookResolver::new(store, printer)
+        .resolve(&workspace, &input, &mut tag_cache, &filtered_hooks)
+        .await?;
 
     run_hooks(
         &workspace,
+        &input,
+        &mut tag_cache,
         &installed_hooks,
-        input,
         store,
         show_diff_on_failure,
         fail_fast,
@@ -262,6 +265,678 @@ fn set_env_vars(from_ref: Option<&String>, to_ref: Option<&String>, args: &RunEx
         if let Some(command) = &args.rewrite_command {
             std::env::set_var("PRE_COMMIT_REWRITE_COMMAND", command);
         }
+    }
+}
+
+struct InstalledHookResolver<'a> {
+    store: &'a Store,
+    printer: Printer,
+}
+
+impl<'a> InstalledHookResolver<'a> {
+    fn new(store: &'a Store, printer: Printer) -> Self {
+        Self { store, printer }
+    }
+
+    async fn resolve<'paths>(
+        &self,
+        workspace: &Workspace,
+        input: &'paths RunInput,
+        tag_cache: &mut FileTagCache<'paths>,
+        hooks: &[Arc<Hook>],
+    ) -> Result<Vec<InstalledHook>> {
+        let env_hooks = hooks
+            .iter()
+            .filter(|hook| hook.needs_install_env())
+            .cloned()
+            .collect::<Vec<_>>();
+
+        if env_hooks.is_empty() {
+            return Ok(hooks
+                .iter()
+                .map(|hook| InstalledHook::NoNeedInstall(hook.clone()))
+                .collect());
+        }
+
+        let _lock = self.store.lock_async().await?;
+        let mut install_cache = InstallCache::new();
+        let mut installed_by_idx = FxHashMap::default();
+        let mut missing_env_hooks = Vec::new();
+
+        // Resolve the cache before file filtering so already-installed hooks keep their exact
+        // environment, while missing hooks still avoid install when they would not run.
+        for hook in env_hooks {
+            if let Some(installed_hook) =
+                install_cache.installed_hook(self.store, hook.clone()).await
+            {
+                installed_by_idx.insert(hook.idx, installed_hook);
+            } else {
+                missing_env_hooks.push(hook.clone());
+            }
+        }
+
+        let hooks_to_install =
+            Self::hooks_to_install_after_filter(workspace, input, tag_cache, &missing_env_hooks)?;
+        if !hooks_to_install.is_empty() {
+            let reporter = HookInstallReporter::new(self.printer);
+            let installed_hooks =
+                install_hooks(hooks_to_install, self.store, &reporter, &mut install_cache).await?;
+            reporter.on_complete();
+
+            for installed_hook in installed_hooks {
+                installed_by_idx.insert(installed_hook.idx, installed_hook);
+            }
+        }
+
+        Ok(hooks
+            .iter()
+            .map(|hook| {
+                installed_by_idx
+                    .remove(&hook.idx)
+                    .unwrap_or_else(|| InstalledHook::NoNeedInstall(hook.clone()))
+            })
+            .collect())
+    }
+
+    fn hooks_to_install_after_filter<'paths>(
+        workspace: &Workspace,
+        input: &'paths RunInput,
+        tag_cache: &mut FileTagCache<'paths>,
+        hooks: &[Arc<Hook>],
+    ) -> Result<Vec<Arc<Hook>>> {
+        #[allow(clippy::mutable_key_type)]
+        let mut project_to_hooks: FxHashMap<&Project, Vec<Arc<Hook>>> =
+            FxHashMap::with_capacity_and_hasher(hooks.len(), FxBuildHasher);
+        for hook in hooks {
+            project_to_hooks
+                .entry(hook.project())
+                .or_default()
+                .push(hook.clone());
+        }
+
+        let mut hooks_to_install = Vec::new();
+        let mut consumed_files = FxHashSet::default();
+
+        for project in workspace.all_projects() {
+            let project_input = ProjectHookInput::new(input, project, Some(&mut consumed_files))?;
+            let Some(hooks) = project_to_hooks.remove(project) else {
+                continue;
+            };
+
+            for hook in hooks {
+                if Self::should_install_after_filter(&project_input, &hook, tag_cache) {
+                    hooks_to_install.push(hook);
+                }
+            }
+        }
+
+        Ok(hooks_to_install)
+    }
+
+    fn should_install_after_filter<'paths>(
+        project_input: &ProjectHookInput<'paths>,
+        hook: &Hook,
+        tag_cache: &mut FileTagCache<'paths>,
+    ) -> bool {
+        if !Language::supported(hook.language) {
+            return false;
+        }
+
+        hook.always_run || project_input.has_match_for_hook(hook, tag_cache)
+    }
+}
+
+#[allow(clippy::fn_params_excessive_bools)]
+async fn run_hooks<'paths>(
+    workspace: &Workspace,
+    input: &'paths RunInput,
+    tag_cache: &mut FileTagCache<'paths>,
+    hooks: &[InstalledHook],
+    store: &Store,
+    show_diff_on_failure: bool,
+    fail_fast: Option<bool>,
+    dry_run: bool,
+    verbose: bool,
+    printer: Printer,
+) -> Result<ExitStatus> {
+    debug_assert!(!hooks.is_empty(), "No hooks to run");
+
+    let mut session = HookRunSession::new(hooks, store, dry_run, verbose, printer);
+
+    // Group hooks by project to run them in order of their depth in the workspace.
+    #[allow(clippy::mutable_key_type)]
+    let mut project_to_hooks: FxHashMap<&Project, Vec<InstalledHook>> =
+        FxHashMap::with_capacity_and_hasher(hooks.len(), FxBuildHasher);
+    for hook in hooks {
+        project_to_hooks
+            .entry(hook.project())
+            .or_default()
+            .push(hook.clone());
+    }
+
+    let projects_len = project_to_hooks.len();
+    let mut consumed_files = FxHashSet::default();
+
+    'outer: for project in workspace.all_projects() {
+        let project_input = ProjectHookInput::new(input, project, Some(&mut consumed_files))?;
+        let Some(mut hooks) = project_to_hooks.remove(project) else {
+            continue;
+        };
+        trace!(
+            "Files for project `{project}` after filtered: {}",
+            project_input.len()
+        );
+
+        // Sort hooks by priority (lower number means higher priority).
+        // If two hooks have the same priority, preserve their original order from the config.
+        hooks.sort_by(|a, b| a.priority.cmp(&b.priority).then(a.idx.cmp(&b.idx)));
+
+        session.render_project_header(project, projects_len)?;
+        let mut prev_diff = git::get_diff(project.path()).await?;
+
+        let project_fail_fast = fail_fast.or(project.config().fail_fast).unwrap_or(false);
+
+        for group_hooks in PriorityGroups::new(hooks) {
+            let group_results = session
+                .run_priority_group(group_hooks, &project_input, tag_cache)
+                .await?;
+
+            let hook_fail_fast = session
+                .finish_priority_group(group_results, project, &mut prev_diff)
+                .await?;
+
+            if !session.success && (project_fail_fast || hook_fail_fast) {
+                break 'outer;
+            }
+        }
+    }
+
+    session.finish(workspace, show_diff_on_failure).await
+}
+
+#[allow(clippy::struct_excessive_bools)]
+struct HookRunSession<'a> {
+    store: &'a Store,
+    reporter: HookRunReporter,
+    status_printer: StatusPrinter,
+    printer: Printer,
+    dry_run: bool,
+    verbose: bool,
+    rendered_projects: usize,
+    success: bool,
+    file_modified: bool,
+    has_unimplemented: bool,
+}
+
+impl<'a> HookRunSession<'a> {
+    fn new(
+        hooks: &[InstalledHook],
+        store: &'a Store,
+        dry_run: bool,
+        verbose: bool,
+        printer: Printer,
+    ) -> Self {
+        let status_printer = StatusPrinter::for_hooks(hooks, printer);
+        let reporter = HookRunReporter::new(printer, status_printer.bar_len());
+
+        Self {
+            store,
+            reporter,
+            status_printer,
+            printer,
+            dry_run,
+            verbose,
+            rendered_projects: 0,
+            success: true,
+            file_modified: false,
+            has_unimplemented: false,
+        }
+    }
+
+    fn render_project_header(&mut self, project: &Project, projects_len: usize) -> Result<()> {
+        if projects_len == 1 && project.is_root() {
+            return Ok(());
+        }
+
+        self.reporter.suspend(|| {
+            writeln!(
+                self.status_printer.printer().stdout(),
+                "{}{}",
+                if self.rendered_projects == 0 {
+                    ""
+                } else {
+                    "\n"
+                },
+                format!("Running hooks for `{}`:", project.to_string().cyan()).bold()
+            )
+        })?;
+        self.rendered_projects += 1;
+
+        Ok(())
+    }
+
+    async fn run_priority_group<'input, 'paths>(
+        &self,
+        group_hooks: Vec<InstalledHook>,
+        input: &'input ProjectHookInput<'paths>,
+        tag_cache: &mut FileTagCache<'paths>,
+    ) -> Result<Vec<RunResult>>
+    where
+        'paths: 'input,
+    {
+        debug!(
+            "Running priority group with priority {} with concurrency {}: {:?}",
+            group_hooks[0].priority,
+            *CONCURRENCY,
+            group_hooks.iter().map(|h| &h.id).collect::<Vec<_>>()
+        );
+
+        let mut runs = futures::stream::iter(group_hooks)
+            .map(|hook| {
+                let hook_input = input.for_hook(&hook, tag_cache);
+                trace!(
+                    matched = hook_input.has_matching_files,
+                    filenames = hook_input.filenames.len(),
+                    "Files for hook `{}` after filtering",
+                    hook.id,
+                );
+                run_hook(hook, hook_input, self.store, self.dry_run, &self.reporter)
+            })
+            .buffer_unordered(*CONCURRENCY);
+
+        let mut group_results = Vec::new();
+        while let Some(result) = runs.next().await {
+            group_results.push(result?);
+        }
+        Ok(group_results)
+    }
+
+    async fn finish_priority_group(
+        &mut self,
+        mut group_results: Vec<RunResult>,
+        project: &Project,
+        prev_diff: &mut Vec<u8>,
+    ) -> Result<bool> {
+        // Print results in a stable order (same order as config within the project).
+        group_results.sort_unstable_by_key(|a| a.hook.idx);
+
+        // Check if any files were modified by this group of hooks.
+        let all_skipped = group_results.iter().all(|r| r.status.is_skipped());
+        let group_modified_files = if !all_skipped {
+            let curr_diff = git::get_diff(project.path()).await?;
+            let group_modified_files = curr_diff != *prev_diff;
+            *prev_diff = curr_diff;
+            group_modified_files
+        } else {
+            false
+        };
+
+        self.file_modified |= group_modified_files;
+
+        self.reporter.clear_completed();
+        self.reporter
+            .suspend(|| self.render_priority_group(&group_results, group_modified_files))?;
+
+        let mut hook_fail_fast = false;
+        for RunResult { hook, status, .. } in &group_results {
+            self.has_unimplemented |= status.is_unimplemented();
+
+            let ok = if group_modified_files {
+                false
+            } else {
+                status.as_bool()
+            };
+            self.success &= ok;
+
+            if !ok && hook.fail_fast {
+                hook_fail_fast = true;
+            }
+        }
+
+        Ok(hook_fail_fast)
+    }
+
+    fn render_priority_group(
+        &self,
+        group_results: &[RunResult],
+        group_modified_files: bool,
+    ) -> Result<()> {
+        // Only show a special group UI when the group failed due to file modifications.
+        // Hooks in a priority group run in parallel, so we can't attribute modifications to a single hook.
+        let show_group_ui = group_modified_files && group_results.len() > 1;
+        let single_hook_modified_files = group_results.len() == 1 && group_modified_files;
+        let group_prefix = if show_group_ui {
+            format!("{}", "  │ ".dimmed())
+        } else {
+            String::new()
+        };
+
+        if show_group_ui {
+            self.status_printer.write(
+                "Files were modified by following hooks",
+                "",
+                RunStatus::Failed,
+            )?;
+        }
+
+        for (i, result) in group_results.iter().enumerate() {
+            let prefix = if show_group_ui {
+                if i == 0 {
+                    "  ┌ "
+                } else if i + 1 == group_results.len() {
+                    "  └ "
+                } else {
+                    "  │ "
+                }
+            } else {
+                ""
+            };
+
+            // If a single hook modified files, treat it as failed.
+            let status = if single_hook_modified_files && result.status == RunStatus::Success {
+                RunStatus::Failed
+            } else {
+                result.status
+            };
+
+            self.status_printer
+                .write(&result.hook.name, prefix, status)?;
+
+            if matches!(status, RunStatus::NoFiles | RunStatus::Unimplemented) {
+                continue;
+            }
+
+            let mut stdout = match status {
+                RunStatus::Failed => self.printer.stdout_important(),
+                _ => self.printer.stdout(),
+            };
+
+            if self.verbose || result.hook.verbose || status == RunStatus::Failed {
+                writeln!(
+                    stdout,
+                    "{group_prefix}{}",
+                    format!("- hook id: {}", result.hook.id).dimmed()
+                )?;
+                if self.verbose || result.hook.verbose {
+                    writeln!(
+                        stdout,
+                        "{group_prefix}{}",
+                        format!("- duration: {:.2?}s", result.duration.as_secs_f64()).dimmed()
+                    )?;
+                }
+                if result.exit_status != 0 {
+                    writeln!(
+                        stdout,
+                        "{group_prefix}{}",
+                        format!("- exit code: {}", result.exit_status).dimmed()
+                    )?;
+                }
+                if single_hook_modified_files {
+                    writeln!(
+                        stdout,
+                        "{group_prefix}{}",
+                        "- files were modified by this hook".dimmed()
+                    )?;
+                }
+
+                let output = result.output.trim_ascii();
+                if !output.is_empty() {
+                    if let Some(file) = result.hook.log_file.as_deref() {
+                        let mut file = fs_err::OpenOptions::new()
+                            .create(true)
+                            .append(true)
+                            .open(file)?;
+                        file.write_all(output)?;
+                        file.flush()?;
+                    } else {
+                        if show_group_ui {
+                            writeln!(stdout, "{}", "  │".dimmed())?;
+                        } else {
+                            writeln!(stdout)?;
+                        }
+                        let text = String::from_utf8_lossy(output);
+                        for line in text.lines() {
+                            if line.is_empty() {
+                                if show_group_ui {
+                                    writeln!(stdout, "{}", "  │".dimmed())?;
+                                } else {
+                                    writeln!(stdout)?;
+                                }
+                            } else if show_group_ui {
+                                writeln!(stdout, "{group_prefix}{line}")?;
+                            } else {
+                                writeln!(stdout, "  {line}")?;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn finish(
+        &self,
+        workspace: &Workspace,
+        show_diff_on_failure: bool,
+    ) -> Result<ExitStatus> {
+        self.reporter.on_complete();
+
+        if self.has_unimplemented {
+            warn_user!(
+                "Some hooks were skipped because their languages are unimplemented.\nWe're working hard to support more languages. Check out current support status at {}.",
+                "https://prek.j178.dev/languages/".cyan().underline()
+            );
+        }
+
+        if !self.success && show_diff_on_failure && self.file_modified {
+            if EnvVars::is_under_ci() {
+                writeln!(
+                    self.printer.stdout(),
+                    "{}",
+                    indoc::formatdoc! {
+                        "\n{}: Some hooks made changes to the files.
+                        If you are seeing this message in CI, reproduce locally with: `{}`
+                        To run prek as part of Git workflow, use `{}` to set up Git shims.\n",
+                        "hint".yellow().bold(),
+                        "prek run --all-files".cyan(),
+                        "prek install".cyan()
+                    }
+                )?;
+            }
+
+            writeln!(
+                self.printer.stdout_important(),
+                "All changes made by hooks:"
+            )?;
+
+            let color = if *USE_COLOR {
+                "--color=always"
+            } else {
+                "--color=never"
+            };
+            git::git_cmd("git diff")?
+                .arg("--no-pager")
+                .arg("diff")
+                .arg("--no-ext-diff")
+                .arg(color)
+                .arg("--")
+                .arg(workspace.root())
+                .check(true)
+                .spawn()?
+                .wait()
+                .await?;
+        }
+
+        if self.success {
+            Ok(ExitStatus::Success)
+        } else {
+            Ok(ExitStatus::Failure)
+        }
+    }
+}
+
+struct PriorityGroups {
+    hooks: Vec<InstalledHook>,
+    idx: usize,
+}
+
+impl PriorityGroups {
+    fn new(hooks: Vec<InstalledHook>) -> Self {
+        Self { hooks, idx: 0 }
+    }
+}
+
+impl Iterator for PriorityGroups {
+    type Item = Vec<InstalledHook>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let first = self.hooks.get(self.idx)?;
+        let priority = first.priority;
+        let start = self.idx;
+
+        while self
+            .hooks
+            .get(self.idx)
+            .is_some_and(|hook| hook.priority == priority)
+        {
+            self.idx += 1;
+        }
+
+        Some(self.hooks[start..self.idx].to_vec())
+    }
+}
+
+enum ProjectHookInput<'a> {
+    Files(ProjectFiles<'a>),
+    MessageFile {
+        absolute_path: &'a Path,
+        hook_arg: PathBuf,
+    },
+}
+
+impl<'a> ProjectHookInput<'a> {
+    fn new(
+        input: &'a RunInput,
+        project: &Project,
+        consumed_files: Option<&mut FxHashSet<&'a Path>>,
+    ) -> Result<Self> {
+        match input {
+            RunInput::Files(files) => Ok(Self::Files(ProjectFiles::for_project(
+                files.iter(),
+                project,
+                consumed_files,
+            ))),
+            RunInput::MessageFile(path) => Ok(Self::MessageFile {
+                absolute_path: path,
+                hook_arg: fs::normalize_path(fs::relative_to(path, project.path())?),
+            }),
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Self::Files(project_files) => project_files.len(),
+            Self::MessageFile { .. } => 1,
+        }
+    }
+
+    fn for_hook<'input>(
+        &'input self,
+        hook: &Hook,
+        tag_cache: &mut FileTagCache<'a>,
+    ) -> HookRunInput<'input>
+    where
+        'a: 'input,
+    {
+        match self {
+            Self::Files(project_files) => match hook.pass_filenames {
+                PassFilenames::None => HookRunInput::matched_without_filenames(
+                    project_files.has_match_for_hook(hook, tag_cache),
+                ),
+                PassFilenames::All | PassFilenames::Limited(_) => {
+                    HookRunInput::with_filenames(project_files.for_hook(hook, tag_cache))
+                }
+            },
+            Self::MessageFile { hook_arg, .. } => {
+                if self.has_match_for_hook(hook, tag_cache) {
+                    match hook.pass_filenames {
+                        PassFilenames::None => HookRunInput::matched_without_filenames(true),
+                        PassFilenames::All | PassFilenames::Limited(_) => {
+                            HookRunInput::with_filenames(vec![hook_arg.as_path()])
+                        }
+                    }
+                } else {
+                    HookRunInput::matched_without_filenames(false)
+                }
+            }
+        }
+    }
+
+    fn has_match_for_hook(&self, hook: &Hook, tag_cache: &mut FileTagCache<'a>) -> bool {
+        match self {
+            Self::Files(project_files) => project_files.has_match_for_hook(hook, tag_cache),
+            Self::MessageFile {
+                absolute_path,
+                hook_arg,
+            } => {
+                // `commit-msg` and `prepare-commit-msg` receive Git's special message file,
+                // which can live outside a project root, so it bypasses project ownership
+                // filtering. Hook-level `files`/`exclude`/`types` filters still apply.
+                let hook_filter = HookFileFilter::new(hook);
+                hook_filter.matches_filename(hook_arg)
+                    && hook_filter.matches_tags(tag_cache.tags(absolute_path))
+            }
+        }
+    }
+}
+
+struct HookRunInput<'a> {
+    has_matching_files: bool,
+    filenames: Vec<&'a Path>,
+}
+
+impl<'a> HookRunInput<'a> {
+    fn with_filenames(filenames: Vec<&'a Path>) -> Self {
+        let has_matching_files = !filenames.is_empty();
+        Self {
+            has_matching_files,
+            filenames,
+        }
+    }
+
+    fn matched_without_filenames(has_matching_files: bool) -> Self {
+        Self {
+            has_matching_files,
+            filenames: Vec::new(),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum RunStatus {
+    Success,
+    Failed,
+    DryRun,
+    NoFiles,
+    Unimplemented,
+}
+
+impl RunStatus {
+    fn as_bool(self) -> bool {
+        matches!(
+            self,
+            Self::Success | Self::NoFiles | Self::DryRun | Self::Unimplemented
+        )
+    }
+
+    fn is_unimplemented(self) -> bool {
+        matches!(self, Self::Unimplemented)
+    }
+
+    fn is_skipped(self) -> bool {
+        matches!(self, Self::DryRun | Self::NoFiles | Self::Unimplemented)
     }
 }
 
@@ -352,657 +1027,6 @@ impl StatusPrinter {
     }
 }
 
-enum ProjectHookInput<'a> {
-    Files(ProjectFiles<'a>),
-    MessageFile {
-        absolute_path: &'a Path,
-        hook_arg: PathBuf,
-    },
-}
-
-impl<'a> ProjectHookInput<'a> {
-    fn new(
-        input: &'a RunInput,
-        project: &Project,
-        consumed_files: Option<&mut FxHashSet<&'a Path>>,
-    ) -> Result<Self> {
-        match input {
-            RunInput::Files(files) => Ok(Self::Files(ProjectFiles::for_project(
-                files.iter(),
-                project,
-                consumed_files,
-            ))),
-            RunInput::MessageFile(path) => Ok(Self::MessageFile {
-                absolute_path: path,
-                hook_arg: fs::normalize_path(fs::relative_to(path, project.path())?),
-            }),
-        }
-    }
-
-    fn len(&self) -> usize {
-        match self {
-            Self::Files(project_files) => project_files.len(),
-            Self::MessageFile { .. } => 1,
-        }
-    }
-
-    fn for_hook<'input>(
-        &'input self,
-        hook: &Hook,
-        tag_cache: &mut FileTagCache<'a>,
-    ) -> HookRunInput<'input>
-    where
-        'a: 'input,
-    {
-        match self {
-            Self::Files(project_files) => match hook.pass_filenames {
-                PassFilenames::None => HookRunInput::matched_without_filenames(
-                    project_files.has_match_for_hook(hook, tag_cache),
-                ),
-                PassFilenames::All | PassFilenames::Limited(_) => {
-                    HookRunInput::with_filenames(project_files.for_hook(hook, tag_cache))
-                }
-            },
-            Self::MessageFile {
-                absolute_path,
-                hook_arg,
-            } => {
-                // `commit-msg` and `prepare-commit-msg` receive Git's special message file,
-                // which can live outside a project root, so it bypasses project ownership
-                // filtering. Hook-level `files`/`exclude`/`types` filters still apply.
-                let hook_filter = HookFileFilter::new(hook);
-                if hook_filter.matches_filename(hook_arg)
-                    && hook_filter.matches_tags(tag_cache.tags(absolute_path))
-                {
-                    match hook.pass_filenames {
-                        PassFilenames::None => HookRunInput::matched_without_filenames(true),
-                        PassFilenames::All | PassFilenames::Limited(_) => {
-                            HookRunInput::with_filenames(vec![hook_arg.as_path()])
-                        }
-                    }
-                } else {
-                    HookRunInput::matched_without_filenames(false)
-                }
-            }
-        }
-    }
-}
-
-struct HookRunInput<'a> {
-    has_matching_files: bool,
-    filenames: Vec<&'a Path>,
-}
-
-impl<'a> HookRunInput<'a> {
-    fn with_filenames(filenames: Vec<&'a Path>) -> Self {
-        let has_matching_files = !filenames.is_empty();
-        Self {
-            has_matching_files,
-            filenames,
-        }
-    }
-
-    fn matched_without_filenames(has_matching_files: bool) -> Self {
-        Self {
-            has_matching_files,
-            filenames: Vec::new(),
-        }
-    }
-}
-
-async fn prepare_hooks_for_run(
-    workspace: &Workspace,
-    hooks: &[Arc<Hook>],
-    input: &RunInput,
-    store: &Store,
-    printer: Printer,
-) -> Result<Vec<InstalledHook>> {
-    let env_hooks = hooks
-        .iter()
-        .filter(|hook| hook.needs_install_env())
-        .cloned()
-        .collect::<Vec<_>>();
-
-    if env_hooks.is_empty() {
-        return Ok(hooks
-            .iter()
-            .map(|hook| InstalledHook::NoNeedInstall(hook.clone()))
-            .collect());
-    }
-
-    let _lock = store.lock_async().await?;
-    let mut install_cache = Some(InstallCache::load(store).await);
-    let cache = install_cache
-        .as_ref()
-        .expect("install cache should be loaded above");
-    let mut installed_by_idx = FxHashMap::default();
-    let mut missing_env_hooks = Vec::new();
-
-    // Resolve the cache before file filtering so already-installed hooks keep their exact
-    // environment, while missing hooks still avoid install when they would not run.
-    for hook in env_hooks {
-        if let Some(installed_hook) = cache.installed_hook(hook.clone()).await {
-            installed_by_idx.insert(hook.idx, installed_hook);
-        } else {
-            missing_env_hooks.push(hook.clone());
-        }
-    }
-
-    let hooks_to_install = hooks_to_install_after_filter(workspace, &missing_env_hooks, input)?;
-    if !hooks_to_install.is_empty() {
-        let reporter = HookInstallReporter::new(printer);
-        let installed_hooks =
-            install_hooks_with_cache(hooks_to_install, store, &reporter, &mut install_cache)
-                .await?;
-        reporter.on_complete();
-
-        for installed_hook in installed_hooks {
-            installed_by_idx.insert(installed_hook.idx, installed_hook);
-        }
-    }
-
-    Ok(hooks
-        .iter()
-        .map(|hook| {
-            installed_by_idx
-                .remove(&hook.idx)
-                .unwrap_or_else(|| InstalledHook::NoNeedInstall(hook.clone()))
-        })
-        .collect())
-}
-
-fn hooks_to_install_after_filter(
-    workspace: &Workspace,
-    hooks: &[Arc<Hook>],
-    input: &RunInput,
-) -> Result<Vec<Arc<Hook>>> {
-    #[allow(clippy::mutable_key_type)]
-    let mut project_to_hooks: FxHashMap<&Project, Vec<Arc<Hook>>> =
-        FxHashMap::with_capacity_and_hasher(hooks.len(), FxBuildHasher);
-    for hook in hooks {
-        project_to_hooks
-            .entry(hook.project())
-            .or_default()
-            .push(hook.clone());
-    }
-
-    let mut hooks_to_install = Vec::new();
-    let mut consumed_files = FxHashSet::default();
-    let mut tag_cache = FileTagCache::default();
-
-    for project in workspace.all_projects() {
-        let project_input = ProjectHookInput::new(input, project, Some(&mut consumed_files))?;
-        let Some(hooks) = project_to_hooks.remove(project) else {
-            continue;
-        };
-
-        for hook in hooks {
-            let hook_input = project_input.for_hook(&hook, &mut tag_cache);
-
-            if (hook_input.has_matching_files || hook.always_run)
-                && Language::supported(hook.language)
-            {
-                hooks_to_install.push(hook);
-            }
-        }
-    }
-
-    Ok(hooks_to_install)
-}
-
-#[allow(clippy::fn_params_excessive_bools)]
-async fn run_hooks(
-    workspace: &Workspace,
-    hooks: &[InstalledHook],
-    input: RunInput,
-    store: &Store,
-    show_diff_on_failure: bool,
-    fail_fast: Option<bool>,
-    dry_run: bool,
-    verbose: bool,
-    printer: Printer,
-) -> Result<ExitStatus> {
-    debug_assert!(!hooks.is_empty(), "No hooks to run");
-
-    let status_printer = StatusPrinter::for_hooks(hooks, printer);
-    let reporter = HookRunReporter::new(printer, status_printer.bar_len());
-
-    let mut success = true;
-
-    // Group hooks by project to run them in order of their depth in the workspace.
-    #[allow(clippy::mutable_key_type)]
-    let mut project_to_hooks: FxHashMap<&Project, Vec<InstalledHook>> =
-        FxHashMap::with_capacity_and_hasher(hooks.len(), FxBuildHasher);
-    for hook in hooks {
-        project_to_hooks
-            .entry(hook.project())
-            .or_default()
-            .push(hook.clone());
-    }
-
-    let projects_len = project_to_hooks.len();
-    let mut first = true;
-    let mut file_modified = false;
-    let mut has_unimplemented = false;
-
-    // Track files that have been consumed by orphan projects.
-    let mut consumed_files = FxHashSet::default();
-    let mut tag_cache = FileTagCache::default();
-
-    'outer: for project in workspace.all_projects() {
-        let project_input = ProjectHookInput::new(&input, project, Some(&mut consumed_files))?;
-
-        let Some(mut hooks) = project_to_hooks.remove(project) else {
-            continue;
-        };
-        trace!(
-            "Files for project `{project}` after filtered: {}",
-            project_input.len()
-        );
-
-        // Sort hooks by priority (lower number means higher priority).
-        // If two hooks have the same priority, preserve their original order from the config.
-        hooks.sort_by(|a, b| a.priority.cmp(&b.priority).then(a.idx.cmp(&b.idx)));
-
-        if projects_len > 1 || !project.is_root() {
-            reporter.suspend(|| {
-                writeln!(
-                    status_printer.printer().stdout(),
-                    "{}{}",
-                    if first { "" } else { "\n" },
-                    format!("Running hooks for `{}`:", project.to_string().cyan()).bold()
-                )
-            })?;
-            first = false;
-        }
-        let mut prev_diff = git::get_diff(project.path()).await?;
-
-        let project_fail_fast = fail_fast.or(project.config().fail_fast).unwrap_or(false);
-
-        for group_hooks in PriorityGroups::new(hooks) {
-            let group_results = run_priority_group(
-                group_hooks,
-                &project_input,
-                &mut tag_cache,
-                store,
-                dry_run,
-                &reporter,
-            )
-            .await?;
-
-            let hook_fail_fast = finish_priority_group(
-                group_results,
-                project,
-                &mut prev_diff,
-                &mut file_modified,
-                &reporter,
-                printer,
-                &status_printer,
-                verbose,
-                &mut success,
-                &mut has_unimplemented,
-            )
-            .await?;
-
-            if !success && (project_fail_fast || hook_fail_fast) {
-                break 'outer;
-            }
-        }
-    }
-
-    reporter.on_complete();
-
-    if has_unimplemented {
-        warn_user!(
-            "Some hooks were skipped because their languages are unimplemented.\nWe're working hard to support more languages. Check out current support status at {}.",
-            "https://prek.j178.dev/languages/".cyan().underline()
-        );
-    }
-
-    if !success && show_diff_on_failure && file_modified {
-        if EnvVars::is_under_ci() {
-            writeln!(
-                printer.stdout(),
-                "{}",
-                indoc::formatdoc! {
-                    "\n{}: Some hooks made changes to the files.
-                    If you are seeing this message in CI, reproduce locally with: `{}`
-                    To run prek as part of Git workflow, use `{}` to set up Git shims.\n",
-                    "hint".yellow().bold(),
-                    "prek run --all-files".cyan(),
-                    "prek install".cyan()
-                }
-            )?;
-        }
-
-        writeln!(printer.stdout_important(), "All changes made by hooks:")?;
-
-        let color = if *USE_COLOR {
-            "--color=always"
-        } else {
-            "--color=never"
-        };
-        git::git_cmd("git diff")?
-            .arg("--no-pager")
-            .arg("diff")
-            .arg("--no-ext-diff")
-            .arg(color)
-            .arg("--")
-            .arg(workspace.root())
-            .check(true)
-            .spawn()?
-            .wait()
-            .await?;
-    }
-
-    if success {
-        Ok(ExitStatus::Success)
-    } else {
-        Ok(ExitStatus::Failure)
-    }
-}
-
-async fn finish_priority_group(
-    mut group_results: Vec<RunResult>,
-    project: &Project,
-    prev_diff: &mut Vec<u8>,
-    file_modified: &mut bool,
-    reporter: &HookRunReporter,
-    printer: Printer,
-    status_printer: &StatusPrinter,
-    verbose: bool,
-    success: &mut bool,
-    has_unimplemented: &mut bool,
-) -> Result<bool> {
-    // Print results in a stable order (same order as config within the project).
-    group_results.sort_unstable_by_key(|a| a.hook.idx);
-
-    // Check if any files were modified by this group of hooks.
-    let all_skipped = group_results.iter().all(|r| r.status.is_skipped());
-    let group_modified_files = if !all_skipped {
-        let curr_diff = git::get_diff(project.path()).await?;
-        let group_modified_files = curr_diff != *prev_diff;
-        *prev_diff = curr_diff;
-        group_modified_files
-    } else {
-        false
-    };
-
-    if group_modified_files {
-        *file_modified = true;
-    }
-
-    reporter.clear_completed();
-    reporter.suspend(|| {
-        render_priority_group(
-            printer,
-            status_printer,
-            &group_results,
-            verbose,
-            group_modified_files,
-        )
-    })?;
-
-    Ok(apply_group_outcome(
-        &group_results,
-        group_modified_files,
-        success,
-        has_unimplemented,
-    ))
-}
-
-struct PriorityGroups {
-    hooks: Vec<InstalledHook>,
-    idx: usize,
-}
-
-impl PriorityGroups {
-    fn new(hooks: Vec<InstalledHook>) -> Self {
-        Self { hooks, idx: 0 }
-    }
-}
-
-impl Iterator for PriorityGroups {
-    type Item = Vec<InstalledHook>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let first = self.hooks.get(self.idx)?;
-        let priority = first.priority;
-        let start = self.idx;
-
-        while self
-            .hooks
-            .get(self.idx)
-            .is_some_and(|hook| hook.priority == priority)
-        {
-            self.idx += 1;
-        }
-
-        Some(self.hooks[start..self.idx].to_vec())
-    }
-}
-
-async fn run_priority_group<'input, 'paths>(
-    group_hooks: Vec<InstalledHook>,
-    input: &'input ProjectHookInput<'paths>,
-    tag_cache: &mut FileTagCache<'paths>,
-    store: &Store,
-    dry_run: bool,
-    reporter: &HookRunReporter,
-) -> Result<Vec<RunResult>>
-where
-    'paths: 'input,
-{
-    debug!(
-        "Running priority group with priority {} with concurrency {}: {:?}",
-        group_hooks[0].priority,
-        *CONCURRENCY,
-        group_hooks.iter().map(|h| &h.id).collect::<Vec<_>>()
-    );
-
-    let mut runs = futures::stream::iter(group_hooks)
-        .map(|hook| {
-            let hook_input = input.for_hook(&hook, tag_cache);
-            trace!(
-                matched = hook_input.has_matching_files,
-                filenames = hook_input.filenames.len(),
-                "Files for hook `{}` after filtering",
-                hook.id,
-            );
-            run_hook(hook, hook_input, store, dry_run, reporter)
-        })
-        .buffer_unordered(*CONCURRENCY);
-
-    let mut group_results = Vec::new();
-    while let Some(result) = runs.next().await {
-        group_results.push(result?);
-    }
-    Ok(group_results)
-}
-
-fn render_priority_group(
-    printer: Printer,
-    status_printer: &StatusPrinter,
-    group_results: &[RunResult],
-    verbose: bool,
-    group_modified_files: bool,
-) -> Result<()> {
-    // Only show a special group UI when the group failed due to file modifications.
-    // Hooks in a priority group run in parallel, so we can't attribute modifications to a single hook.
-    let show_group_ui = group_modified_files && group_results.len() > 1;
-    let single_hook_modified_files = group_results.len() == 1 && group_modified_files;
-    let group_prefix = if show_group_ui {
-        format!("{}", "  │ ".dimmed())
-    } else {
-        String::new()
-    };
-
-    if show_group_ui {
-        status_printer.write(
-            "Files were modified by following hooks",
-            "",
-            RunStatus::Failed,
-        )?;
-    }
-
-    for (i, result) in group_results.iter().enumerate() {
-        let prefix = if show_group_ui {
-            if i == 0 {
-                "  ┌ "
-            } else if i + 1 == group_results.len() {
-                "  └ "
-            } else {
-                "  │ "
-            }
-        } else {
-            ""
-        };
-
-        // If a single hook modified files, treat it as failed.
-        let status = if single_hook_modified_files && result.status == RunStatus::Success {
-            RunStatus::Failed
-        } else {
-            result.status
-        };
-
-        status_printer.write(&result.hook.name, prefix, status)?;
-
-        if matches!(status, RunStatus::NoFiles | RunStatus::Unimplemented) {
-            continue;
-        }
-
-        let mut stdout = match status {
-            RunStatus::Failed => printer.stdout_important(),
-            _ => printer.stdout(),
-        };
-
-        if verbose || result.hook.verbose || status == RunStatus::Failed {
-            writeln!(
-                stdout,
-                "{group_prefix}{}",
-                format!("- hook id: {}", result.hook.id).dimmed()
-            )?;
-            if verbose || result.hook.verbose {
-                writeln!(
-                    stdout,
-                    "{group_prefix}{}",
-                    format!("- duration: {:.2?}s", result.duration.as_secs_f64()).dimmed()
-                )?;
-            }
-            if result.exit_status != 0 {
-                writeln!(
-                    stdout,
-                    "{group_prefix}{}",
-                    format!("- exit code: {}", result.exit_status).dimmed()
-                )?;
-            }
-            if single_hook_modified_files {
-                writeln!(
-                    stdout,
-                    "{group_prefix}{}",
-                    "- files were modified by this hook".dimmed()
-                )?;
-            }
-
-            let output = result.output.trim_ascii();
-            if !output.is_empty() {
-                if let Some(file) = result.hook.log_file.as_deref() {
-                    let mut file = fs_err::OpenOptions::new()
-                        .create(true)
-                        .append(true)
-                        .open(file)?;
-                    file.write_all(output)?;
-                    file.flush()?;
-                } else {
-                    if show_group_ui {
-                        writeln!(stdout, "{}", "  │".dimmed())?;
-                    } else {
-                        writeln!(stdout)?;
-                    }
-                    let text = String::from_utf8_lossy(output);
-                    for line in text.lines() {
-                        if line.is_empty() {
-                            if show_group_ui {
-                                writeln!(stdout, "{}", "  │".dimmed())?;
-                            } else {
-                                writeln!(stdout)?;
-                            }
-                        } else {
-                            if show_group_ui {
-                                writeln!(stdout, "{group_prefix}{line}")?;
-                            } else {
-                                writeln!(stdout, "  {line}")?;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    Ok(())
-}
-
-fn apply_group_outcome(
-    group_results: &[RunResult],
-    group_modified_files: bool,
-    success: &mut bool,
-    has_unimplemented: &mut bool,
-) -> bool {
-    let mut hook_fail_fast = false;
-
-    for RunResult { hook, status, .. } in group_results {
-        *has_unimplemented |= status.is_unimplemented();
-
-        let ok = if group_modified_files {
-            false
-        } else {
-            status.as_bool()
-        };
-        *success &= ok;
-
-        if !ok && hook.fail_fast {
-            hook_fail_fast = true;
-        }
-    }
-
-    hook_fail_fast
-}
-
-/// Shuffle the files so that they more evenly fill out the xargs
-/// partitions, but do it deterministically in case a hook cares about ordering.
-fn shuffle<T>(filenames: &mut [T]) {
-    const SEED: u64 = 1_542_676_187;
-    let mut rng = StdRng::seed_from_u64(SEED);
-    filenames.shuffle(&mut rng);
-}
-
-#[derive(Copy, Clone, Eq, PartialEq)]
-enum RunStatus {
-    Success,
-    Failed,
-    DryRun,
-    NoFiles,
-    Unimplemented,
-}
-
-impl RunStatus {
-    fn as_bool(self) -> bool {
-        matches!(
-            self,
-            Self::Success | Self::NoFiles | Self::DryRun | Self::Unimplemented
-        )
-    }
-
-    fn is_unimplemented(self) -> bool {
-        matches!(self, Self::Unimplemented)
-    }
-
-    fn is_skipped(self) -> bool {
-        matches!(self, Self::DryRun | Self::NoFiles | Self::Unimplemented)
-    }
-}
-
 struct RunResult {
     hook: InstalledHook,
     status: RunStatus,
@@ -1084,6 +1108,14 @@ async fn run_hook(
         exit_status,
         output: hook_output,
     })
+}
+
+/// Shuffle the files so that they more evenly fill out the xargs
+/// partitions, but do it deterministically in case a hook cares about ordering.
+fn shuffle<T>(filenames: &mut [T]) {
+    const SEED: u64 = 1_542_676_187;
+    let mut rng = StdRng::seed_from_u64(SEED);
+    filenames.shuffle(&mut rng);
 }
 
 #[cfg(test)]

--- a/crates/prek/src/hook.rs
+++ b/crates/prek/src/hook.rs
@@ -508,6 +508,11 @@ impl Hook {
         matches!(&*self.repo, Repo::Remote { .. })
     }
 
+    pub(crate) fn needs_install_env(&self) -> bool {
+        !matches!(self.repo(), Repo::Meta { .. } | Repo::Builtin { .. })
+            && self.language.supports_install_env()
+    }
+
     /// Dependencies used to identify whether an existing hook environment can be reused.
     ///
     /// For remote hooks, the repo URL is included to avoid reusing an environment created
@@ -523,9 +528,9 @@ impl Hook {
 
     /// Returns a lightweight view of the hook environment identity used for reusing installs.
     ///
-    /// Returns `None` for languages that do not install an environment.
+    /// Returns `None` for hooks that do not install an environment.
     pub(crate) fn env_key(&self) -> Option<HookEnvKeyRef<'_>> {
-        if !self.language.supports_install_env() {
+        if !self.needs_install_env() {
             return None;
         }
 

--- a/crates/prek/src/store.rs
+++ b/crates/prek/src/store.rs
@@ -1,7 +1,6 @@
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 use anyhow::Result;
 use etcetera::BaseStrategy;
@@ -15,7 +14,6 @@ use tracing::{debug, warn};
 use crate::config::{RemoteRepo, RemoteRepoKey};
 use crate::fs::{LockedFile, expand_tilde};
 use crate::git::{self, TerminalPrompt};
-use crate::hook::InstallInfo;
 use crate::run::CONCURRENCY;
 use crate::warn_user;
 use crate::workspace::{HookInitReporter, WorkspaceCache};
@@ -275,42 +273,6 @@ impl Store {
                 repo: repo.repo.clone(),
                 error: git::Error::Io(std::io::Error::other("repo was not cloned")),
             })
-    }
-
-    /// Returns installed hooks in the store.
-    pub(crate) async fn installed_hooks(&self) -> Vec<Arc<InstallInfo>> {
-        let Ok(dirs) = fs_err::read_dir(self.hooks_dir()) else {
-            return vec![];
-        };
-
-        let mut tasks = futures::stream::iter(dirs)
-            .map(async |entry| {
-                let path = match entry {
-                    Ok(entry) => entry.path(),
-                    Err(err) => {
-                        warn!(%err, "Failed to read hook dir");
-                        return None;
-                    }
-                };
-                let info = match InstallInfo::from_env_path(&path).await {
-                    Ok(info) => info,
-                    Err(err) => {
-                        warn!(%err, path = %path.display(), "Skipping invalid installed hook");
-                        return None;
-                    }
-                };
-                Some(info)
-            })
-            .buffer_unordered(*CONCURRENCY);
-
-        let mut hooks = Vec::new();
-        while let Some(hook) = tasks.next().await {
-            if let Some(hook) = hook {
-                hooks.push(Arc::new(hook));
-            }
-        }
-
-        hooks
     }
 
     pub(crate) async fn lock_async(&self) -> Result<LockedFile, std::io::Error> {

--- a/crates/prek/tests/skipped_hooks.rs
+++ b/crates/prek/tests/skipped_hooks.rs
@@ -294,53 +294,6 @@ fn skipped_workspace_project_installable_hook_does_not_install_env() -> Result<(
     Ok(())
 }
 
-/// Hooks in later priority groups should not install when fail-fast stops before them.
-#[test]
-fn fail_fast_skips_installing_later_priority_groups() -> Result<()> {
-    let context = TestContext::new();
-    context.init_project();
-
-    context.write_pre_commit_config(indoc::indoc! {r#"
-        repos:
-          - repo: local
-            hooks:
-              - id: fail-now
-                name: fail-now
-                language: fail
-                entry: fail
-                always_run: true
-                pass_filenames: false
-                priority: 0
-                fail_fast: true
-              - id: later-python
-                name: later-python
-                language: python
-                entry: python -c "print('later')"
-                always_run: true
-                pass_filenames: false
-                priority: 10
-    "#});
-
-    context.git_add(".");
-
-    cmd_snapshot!(context.filters(), context.run(), @r#"
-    success: false
-    exit_code: 1
-    ----- stdout -----
-    fail-now.................................................................Failed
-    - hook id: fail-now
-    - exit code: 1
-
-      fail
-
-    ----- stderr -----
-    "#);
-
-    assert_eq!(hook_env_count(&context)?, 0);
-
-    Ok(())
-}
-
 /// Skipped hooks across multiple priority groups
 ///
 /// Hooks with different `priority` values form separate priority groups. Each

--- a/crates/prek/tests/skipped_hooks.rs
+++ b/crates/prek/tests/skipped_hooks.rs
@@ -14,6 +14,14 @@ use crate::common::{TestContext, cmd_snapshot};
 
 mod common;
 
+fn hook_env_count(context: &TestContext) -> Result<usize> {
+    let hooks_dir = context.home_dir().child("hooks");
+    if !hooks_dir.exists() {
+        return Ok(0);
+    }
+    Ok(hooks_dir.read_dir()?.count())
+}
+
 /// All hooks skip when no staged files match their file patterns.
 #[test]
 fn all_hooks_skipped_no_matching_files() -> Result<()> {
@@ -59,6 +67,80 @@ fn all_hooks_skipped_no_matching_files() -> Result<()> {
 
     ----- stderr -----
     "#);
+
+    Ok(())
+}
+
+/// Installable hooks with no matching files should not create environments.
+#[test]
+fn skipped_installable_hook_does_not_install_env() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    let cwd = context.work_dir();
+
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: python-check
+                name: python-check
+                language: python
+                entry: python -c "print('checking python')"
+                files: \.py$
+    "#});
+
+    cwd.child("README.md").write_str("Hello")?;
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run(), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    python-check.........................................(no files to check)Skipped
+
+    ----- stderr -----
+    "#);
+
+    assert_eq!(hook_env_count(&context)?, 0);
+
+    Ok(())
+}
+
+/// `always_run` installable hooks still install and run without matching files.
+#[test]
+fn always_run_installable_hook_installs_without_matching_files() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    let cwd = context.work_dir();
+
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: always-python
+                name: always-python
+                language: python
+                entry: python -c "print('ran')"
+                files: \.py$
+                always_run: true
+                pass_filenames: false
+    "#});
+
+    cwd.child("README.md").write_str("Hello")?;
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run(), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    always-python............................................................Passed
+
+    ----- stderr -----
+    "#);
+
+    assert_eq!(hook_env_count(&context)?, 1);
 
     Ok(())
 }
@@ -147,6 +229,114 @@ fn mixed_skipped_and_executed_hooks() -> Result<()> {
 
     ----- stderr -----
     "#);
+
+    Ok(())
+}
+
+/// Skipped hooks in untouched workspace projects should not install environments.
+#[test]
+fn skipped_workspace_project_installable_hook_does_not_install_env() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    let cwd = context.work_dir();
+    let proj_a = cwd.child("proj-a");
+    let proj_b = cwd.child("proj-b");
+    proj_a.create_dir_all()?;
+    proj_b.create_dir_all()?;
+
+    context.write_pre_commit_config(indoc::indoc! {r"
+        repos:
+          - repo: local
+            hooks:
+              - id: root-skip
+                name: root-skip
+                language: system
+                entry: echo root
+                files: \.root$
+    "});
+    proj_a
+        .child(".pre-commit-config.yaml")
+        .write_str(indoc::indoc! {r"
+        repos:
+          - repo: local
+            hooks:
+              - id: proj-a-check
+                name: proj-a-check
+                language: system
+                entry: echo proj-a
+                files: \.txt$
+    "})?;
+    proj_b
+        .child(".pre-commit-config.yaml")
+        .write_str(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: proj-b-python
+                name: proj-b-python
+                language: python
+                entry: python -c "print('proj-b')"
+                files: \.py$
+    "#})?;
+
+    proj_a.child("README.txt").write_str("Hello")?;
+    context.git_add(".");
+
+    let output = context.run().output()?;
+    assert!(output.status.success(), "prek should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("proj-a-check") && stdout.contains("Passed"));
+    assert!(stdout.contains("proj-b-python") && stdout.contains("Skipped"));
+    assert_eq!(hook_env_count(&context)?, 0);
+
+    Ok(())
+}
+
+/// Hooks in later priority groups should not install when fail-fast stops before them.
+#[test]
+fn fail_fast_skips_installing_later_priority_groups() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: fail-now
+                name: fail-now
+                language: fail
+                entry: fail
+                always_run: true
+                pass_filenames: false
+                priority: 0
+                fail_fast: true
+              - id: later-python
+                name: later-python
+                language: python
+                entry: python -c "print('later')"
+                always_run: true
+                pass_filenames: false
+                priority: 10
+    "#});
+
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    fail-now.................................................................Failed
+    - hook id: fail-now
+    - exit code: 1
+
+      fail
+
+    ----- stderr -----
+    "#);
+
+    assert_eq!(hook_env_count(&context)?, 0);
 
     Ok(())
 }


### PR DESCRIPTION
Closes #1459.

This refactors `prek run` to collect files and apply hook filters before resolving install environments. Hooks that will not run no longer cause their environments to be installed.