### PR TITLE
Optimize meta hook file scans

### DIFF
--- a/crates/prek/src/cli/cache_gc.rs
+++ b/crates/prek/src/cli/cache_gc.rs
@@ -13,7 +13,7 @@ use tracing::{debug, trace, warn};
 
 use crate::cli::ExitStatus;
 use crate::cli::cache_size::{dir_size_bytes, human_readable_bytes};
-use crate::cli::run::install::InstallCache;
+use crate::cli::run::InstallCache;
 use crate::config::{self, Error as ConfigError, Repo as ConfigRepo, load_config};
 use crate::hook::{HOOK_MARKER, HookEnvKey, HookSpec, InstallInfo, Repo as HookRepo};
 use crate::printer::Printer;

--- a/crates/prek/src/cli/hook_impl.rs
+++ b/crates/prek/src/cli/hook_impl.rs
@@ -105,11 +105,12 @@ pub(crate) async fn hook_impl(
         }
     }
 
-    if !hook_type.num_args().contains(&args.len()) {
+    let expected_args = hook_num_args(hook_type);
+    if !expected_args.contains(&args.len()) {
         anyhow::bail!(
             "hook `{}` expects {} but received {}{}",
             hook_type.to_string().cyan(),
-            format_expected_args(hook_type.num_args()),
+            format_expected_args(expected_args),
             format_received_args(args.len()),
             format_argument_dump(&args)
         );
@@ -146,6 +147,21 @@ pub(crate) async fn hook_impl(
     } else {
         legacy_code.into()
     })
+}
+
+fn hook_num_args(hook_type: HookType) -> RangeInclusive<usize> {
+    match hook_type {
+        HookType::CommitMsg => 1..=1,
+        HookType::PostCheckout => 3..=3,
+        HookType::PreCommit => 0..=0,
+        HookType::PostCommit => 0..=0,
+        HookType::PreMergeCommit => 0..=0,
+        HookType::PostMerge => 1..=1,
+        HookType::PostRewrite => 1..=1,
+        HookType::PrePush => 2..=2,
+        HookType::PreRebase => 1..=2,
+        HookType::PrepareCommitMsg => 1..=3,
+    }
 }
 
 async fn read_hook_stdin(hook_type: HookType) -> Result<Vec<u8>> {

--- a/crates/prek/src/cli/install.rs
+++ b/crates/prek/src/cli/install.rs
@@ -12,7 +12,7 @@ use same_file::is_same_file;
 
 use crate::cli::reporter::{HookInitReporter, HookInstallReporter};
 use crate::cli::run;
-use crate::cli::run::install::InstallCache;
+use crate::cli::run::InstallCache;
 use crate::cli::run::{SelectorSource, Selectors};
 use crate::cli::{ExitStatus, HookType};
 use crate::config::load_config;

--- a/crates/prek/src/cli/run/filter.rs
+++ b/crates/prek/src/cli/run/filter.rs
@@ -1,3 +1,4 @@
+use std::ops::ControlFlow;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -48,7 +49,8 @@ pub(crate) struct FileTagFilter<'a> {
 }
 
 impl<'a> FileTagFilter<'a> {
-    fn new(
+    /// Create a tag filter from a hook's type selectors.
+    pub(crate) fn new(
         types: Option<&'a TagSet>,
         types_or: Option<&'a TagSet>,
         exclude_types: Option<&'a TagSet>,
@@ -126,6 +128,11 @@ impl<'a> ProjectFile<'a> {
         }
     }
 
+    /// Return the path relative to the owning project, which is what hook patterns match.
+    pub(crate) fn hook_path(&self) -> &Path {
+        self.hook_path
+    }
+
     /// Return cached tags for the workspace-relative path.
     pub(crate) fn tags<'cache>(
         &self,
@@ -178,24 +185,41 @@ impl<'a> ProjectFiles<'a> {
             0
         };
         let mut files = Vec::with_capacity(files_capacity);
-        Self::visit_project_files(filenames, project, consumed_files, |file| files.push(file));
+        Self::visit_for_project(filenames, project, consumed_files, |file| {
+            files.push(file);
+            ControlFlow::Continue(())
+        });
 
         Self { files }
+    }
+
+    /// Mark files owned by this project without collecting or visiting them.
+    pub(crate) fn consume_for_project<I>(
+        filenames: I,
+        project: &Project,
+        consumed_files: &mut FxHashSet<&'a Path>,
+    ) where
+        I: Iterator<Item = &'a PathBuf> + Send,
+    {
+        Self::visit_for_project(filenames, project, Some(consumed_files), |_| {
+            ControlFlow::Continue(())
+        });
     }
 
     /// Visit project-owned files without collecting them.
     ///
     /// This shares the same ownership, orphan-project, and project-level filtering rules as
     /// `for_project`, but lets callers that only need a boolean result avoid allocating a
-    /// `Vec<ProjectFile>`.
-    pub(crate) fn visit_project_files<I, F>(
+    /// `Vec<ProjectFile>`. Return [`ControlFlow::Break`] from `visit` to stop calling the visitor.
+    /// Orphan projects still finish marking owned files as consumed before returning.
+    pub(crate) fn visit_for_project<I, F>(
         filenames: I,
         project: &Project,
         mut consumed_files: Option<&mut FxHashSet<&'a Path>>,
         mut visit: F,
     ) where
         I: Iterator<Item = &'a PathBuf> + Send,
-        F: FnMut(ProjectFile<'a>),
+        F: FnMut(ProjectFile<'a>) -> ControlFlow<()>,
     {
         let filename_filter = FilenameFilter::new(
             project.config().files.as_ref(),
@@ -203,6 +227,8 @@ impl<'a> ProjectFiles<'a> {
         );
         let relative_path = project.relative_path();
         let orphan = project.config().orphan.unwrap_or(false);
+        let must_finish_consuming = orphan && consumed_files.is_some();
+        let mut visiting = true;
 
         // The order of below filters matters.
         // If this is an orphan project, we must mark all files in its directory as consumed
@@ -226,12 +252,22 @@ impl<'a> ProjectFiles<'a> {
                 }
             }
 
+            if !visiting {
+                continue;
+            }
+
             // Strip the project-relative prefix before applying project-level include/exclude patterns.
             let relative = filename
                 .strip_prefix(relative_path)
                 .expect("Filename should start with project relative path");
-            if filename_filter.matches(relative) {
-                visit(ProjectFile::new(filename, relative));
+            if filename_filter.matches(relative)
+                && visit(ProjectFile::new(filename, relative)).is_break()
+            {
+                if must_finish_consuming {
+                    visiting = false;
+                } else {
+                    break;
+                }
             }
         }
     }
@@ -240,29 +276,13 @@ impl<'a> ProjectFiles<'a> {
         self.files.len()
     }
 
-    /// Filter filenames by type tags for a specific hook.
-    pub(crate) fn by_type(
-        &self,
-        types: Option<&TagSet>,
-        types_or: Option<&TagSet>,
-        exclude_types: Option<&TagSet>,
-        tag_cache: &mut FileTagCache<'a>,
-    ) -> Vec<&Path> {
-        let tag_filter = FileTagFilter::new(types, types_or, exclude_types);
-        let mut filenames = Vec::new();
-        for file in &self.files {
-            if let Some(tags) = file.tags(tag_cache) {
-                if tag_filter.matches(tags) {
-                    filenames.push(file.workspace_path);
-                }
-            }
-        }
-        filenames
-    }
-
     /// Filter filenames by file patterns and tags for a specific hook.
     #[instrument(level = "trace", skip_all, fields(hook = ?hook.id))]
-    pub(crate) fn for_hook(&self, hook: &Hook, tag_cache: &mut FileTagCache<'a>) -> Vec<&Path> {
+    pub(crate) fn matching_filenames(
+        &self,
+        hook: &Hook,
+        tag_cache: &mut FileTagCache<'a>,
+    ) -> Vec<&Path> {
         let hook_filter = HookFileFilter::new(hook);
         let mut filenames = Vec::new();
         for file in &self.files {
@@ -274,7 +294,7 @@ impl<'a> ProjectFiles<'a> {
     }
 
     /// Return whether at least one file matches a hook without collecting every filename.
-    pub(crate) fn has_match_for_hook(&self, hook: &Hook, tag_cache: &mut FileTagCache<'a>) -> bool {
+    pub(crate) fn has_matching_file(&self, hook: &Hook, tag_cache: &mut FileTagCache<'a>) -> bool {
         let hook_filter = HookFileFilter::new(hook);
         for file in &self.files {
             if hook_filter.matches_project_file(file, tag_cache) {
@@ -392,7 +412,6 @@ fn adjust_relative_path(path: &str, new_cwd: &Path) -> Result<PathBuf, std::io::
 
 /// Collect files to run hooks on.
 /// Returns a list of file paths relative to the git root.
-#[allow(clippy::too_many_arguments)]
 async fn collect_files_from_args(
     git_root: &Path,
     workspace_root: &Path,

--- a/crates/prek/src/cli/run/mod.rs
+++ b/crates/prek/src/cli/run/mod.rs
@@ -1,10 +1,13 @@
-pub(crate) use filter::{CollectOptions, FileTagCache, ProjectFiles, RunInput, collect_run_input};
-pub(crate) use install::install_hooks;
+pub(crate) use filter::{
+    CollectOptions, FileTagCache, FileTagFilter, HookFileFilter, ProjectFiles, RunInput,
+    collect_run_input,
+};
+pub(crate) use install::{InstallCache, install_hooks};
 pub(crate) use run::run;
 pub(crate) use selector::{SelectorSource, Selectors};
 
 mod filter;
-pub(crate) mod install;
+mod install;
 mod keeper;
 #[allow(clippy::module_inception)]
 mod run;

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -1,5 +1,6 @@
 use std::fmt::Write as _;
 use std::io::Write as _;
+use std::ops::ControlFlow;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock};
 
@@ -15,13 +16,13 @@ use tracing::{debug, trace};
 use unicode_width::UnicodeWidthStr;
 
 use crate::cli::reporter::{HookInitReporter, HookInstallReporter, HookRunReporter};
-use crate::cli::run::filter::HookFileFilter;
 use crate::cli::run::keeper::WorkTreeKeeper;
 use crate::cli::run::{
-    CollectOptions, FileTagCache, ProjectFiles, RunInput, Selectors, collect_run_input,
+    CollectOptions, FileTagCache, HookFileFilter, ProjectFiles, RunInput, Selectors,
+    collect_run_input,
 };
 use crate::cli::{ExitStatus, RunExtraArgs};
-use crate::config::{Language, PassFilenames, Stage};
+use crate::config::{PassFilenames, Stage};
 use crate::fs::CWD;
 use crate::git::GIT_ROOT;
 use crate::hook::{Hook, InstalledHook};
@@ -366,25 +367,21 @@ fn filter_missing_hooks_to_install<'paths>(
         match input {
             RunInput::Files(files) => {
                 let Some(hooks) = project_to_hooks.remove(project) else {
-                    ProjectFiles::visit_project_files(
-                        files.iter(),
-                        project,
-                        Some(&mut consumed_files),
-                        |_| {},
-                    );
+                    ProjectFiles::consume_for_project(files.iter(), project, &mut consumed_files);
                     continue;
                 };
 
                 let mut candidates = hooks
                     .into_iter()
-                    .filter(|hook| Language::supported(hook.language))
+                    .filter(|hook| hook.language.supported())
                     .map(|hook| {
                         let matches = hook.always_run;
                         (hook, matches)
                     })
                     .collect::<Vec<_>>();
+                let mut remaining = candidates.iter().filter(|(_, matches)| !*matches).count();
 
-                ProjectFiles::visit_project_files(
+                ProjectFiles::visit_for_project(
                     files.iter(),
                     project,
                     Some(&mut consumed_files),
@@ -397,8 +394,15 @@ fn filter_missing_hooks_to_install<'paths>(
                             let hook_filter = HookFileFilter::new(hook);
                             if hook_filter.matches_project_file(&project_file, tag_cache) {
                                 *matches = true;
+                                remaining -= 1;
                             }
                         }
+
+                        if remaining == 0 {
+                            return ControlFlow::Break(());
+                        }
+
+                        ControlFlow::Continue(())
                     },
                 );
 
@@ -414,11 +418,8 @@ fn filter_missing_hooks_to_install<'paths>(
                 };
 
                 let project_input = ProjectHookInput::new(input, project, None)?;
-                for hook in hooks
-                    .into_iter()
-                    .filter(|hook| Language::supported(hook.language))
-                {
-                    if hook.always_run || project_input.has_match_for_hook(&hook, tag_cache) {
+                for hook in hooks.into_iter().filter(|hook| hook.language.supported()) {
+                    if hook.always_run || project_input.matches_hook(&hook, tag_cache) {
                         hooks_to_install.push(hook);
                     }
                 }
@@ -581,7 +582,7 @@ impl<'a> HookRunSession<'a> {
 
         let mut runs = futures::stream::iter(group_hooks)
             .map(|hook| {
-                let hook_input = input.for_hook(&hook, tag_cache);
+                let hook_input = input.run_input_for_hook(&hook, tag_cache);
                 trace!(
                     matched = hook_input.has_matching_files,
                     filenames = hook_input.filenames.len(),
@@ -890,7 +891,7 @@ impl<'a> ProjectHookInput<'a> {
         }
     }
 
-    fn for_hook<'input>(
+    fn run_input_for_hook<'input>(
         &'input self,
         hook: &Hook,
         tag_cache: &mut FileTagCache<'a>,
@@ -901,14 +902,14 @@ impl<'a> ProjectHookInput<'a> {
         match self {
             Self::Files(project_files) => match hook.pass_filenames {
                 PassFilenames::None => HookRunInput::without_filenames(
-                    project_files.has_match_for_hook(hook, tag_cache),
+                    project_files.has_matching_file(hook, tag_cache),
                 ),
                 PassFilenames::All | PassFilenames::Limited(_) => {
-                    HookRunInput::with_filenames(project_files.for_hook(hook, tag_cache))
+                    HookRunInput::with_filenames(project_files.matching_filenames(hook, tag_cache))
                 }
             },
             Self::MessageFile { hook_arg, .. } => {
-                if self.has_match_for_hook(hook, tag_cache) {
+                if self.matches_hook(hook, tag_cache) {
                     match hook.pass_filenames {
                         PassFilenames::None => HookRunInput::without_filenames(true),
                         PassFilenames::All | PassFilenames::Limited(_) => {
@@ -922,9 +923,9 @@ impl<'a> ProjectHookInput<'a> {
         }
     }
 
-    fn has_match_for_hook(&self, hook: &Hook, tag_cache: &mut FileTagCache<'a>) -> bool {
+    fn matches_hook(&self, hook: &Hook, tag_cache: &mut FileTagCache<'a>) -> bool {
         match self {
-            Self::Files(project_files) => project_files.has_match_for_hook(hook, tag_cache),
+            Self::Files(project_files) => project_files.has_matching_file(hook, tag_cache),
             Self::MessageFile {
                 absolute_path,
                 hook_arg,
@@ -1114,7 +1115,7 @@ async fn run_hook(
     if !input.has_matching_files && !hook.always_run {
         return Ok(RunResult::from_status(hook, RunStatus::NoFiles));
     }
-    if !Language::supported(hook.language) {
+    if !hook.language.supported() {
         return Ok(RunResult::from_status(hook, RunStatus::Unimplemented));
     }
     let start = std::time::Instant::now();

--- a/crates/prek/src/config.rs
+++ b/crates/prek/src/config.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 use std::error::Error as _;
 use std::fmt::Display;
-use std::ops::RangeInclusive;
 use std::path::Path;
 
 use anyhow::Result;
@@ -290,24 +289,6 @@ pub(crate) enum HookType {
     PrePush,
     PreRebase,
     PrepareCommitMsg,
-}
-
-impl HookType {
-    /// Return the number of arguments this hook type expects.
-    pub fn num_args(self) -> RangeInclusive<usize> {
-        match self {
-            Self::CommitMsg => 1..=1,
-            Self::PostCheckout => 3..=3,
-            Self::PreCommit => 0..=0,
-            Self::PostCommit => 0..=0,
-            Self::PreMergeCommit => 0..=0,
-            Self::PostMerge => 1..=1,
-            Self::PostRewrite => 1..=1,
-            Self::PrePush => 2..=2,
-            Self::PreRebase => 1..=2,
-            Self::PrepareCommitMsg => 1..=3,
-        }
-    }
 }
 
 #[derive(

--- a/crates/prek/src/hooks/meta_hooks.rs
+++ b/crates/prek/src/hooks/meta_hooks.rs
@@ -1,4 +1,5 @@
 use std::io::Write;
+use std::ops::ControlFlow;
 use std::path::Path;
 use std::str::FromStr;
 
@@ -7,7 +8,9 @@ use itertools::Itertools;
 use prek_consts::CONFIG_FILENAMES;
 
 use crate::cli::reporter::HookRunReporter;
-use crate::cli::run::{CollectOptions, FileTagCache, ProjectFiles, collect_run_input};
+use crate::cli::run::{
+    CollectOptions, FileTagCache, FileTagFilter, HookFileFilter, ProjectFiles, collect_run_input,
+};
 use crate::config::{self, FilePattern, HookOptions, Language, MetaHook};
 use crate::hook::Hook;
 use crate::store::Store;
@@ -93,6 +96,11 @@ pub(crate) async fn check_hooks_apply(
     hook: &Hook,
     filenames: &[&Path],
 ) -> Result<(i32, Vec<u8>)> {
+    let projects = load_meta_projects(hook, filenames)?;
+    if projects.is_empty() {
+        return Ok((0, Vec::new()));
+    }
+
     let relative_path = hook.project().relative_path();
     // Collect all files in the project
     let input = collect_run_input(hook.work_dir(), CollectOptions::all_files())
@@ -105,25 +113,47 @@ pub(crate) async fn check_hooks_apply(
     let mut output = Vec::new();
     let mut tag_cache = FileTagCache::default();
 
-    for filename in filenames {
-        let path = relative_path.join(filename);
-        let mut project = Project::from_config_file(path.into(), None)?;
-        project.with_relative_path(relative_path.to_path_buf());
-        let project_files = ProjectFiles::for_project(input.iter(), &project, None);
-
+    for project in projects {
         let project_hooks = project
             .init_hooks(store, None)
             .await
             .context("Failed to init hooks")?;
+        let hooks = project_hooks
+            .iter()
+            .filter(|hook| !hook.always_run && hook.language != Language::Fail)
+            .collect::<Vec<_>>();
+        if hooks.is_empty() {
+            continue;
+        }
 
-        for project_hook in project_hooks {
-            if project_hook.always_run || matches!(project_hook.language, Language::Fail) {
-                continue;
+        let filters = hooks
+            .iter()
+            .map(|hook| HookFileFilter::new(hook))
+            .collect::<Vec<_>>();
+        let mut matches = vec![false; hooks.len()];
+        let mut remaining = matches.len();
+
+        ProjectFiles::visit_for_project(input.iter(), hooks[0].project(), None, |file| {
+            let tags = file.tags(&mut tag_cache);
+            for (matched, filter) in matches.iter_mut().zip(&filters) {
+                if *matched {
+                    continue;
+                }
+                if filter.matches_filename(file.hook_path()) && filter.matches_tags(tags) {
+                    *matched = true;
+                    remaining -= 1;
+                }
             }
 
-            let filenames = project_files.for_hook(&project_hook, &mut tag_cache);
+            if remaining == 0 {
+                return ControlFlow::Break(());
+            }
 
-            if filenames.is_empty() {
+            ControlFlow::Continue(())
+        });
+
+        for (project_hook, matches) in hooks.iter().zip(matches) {
+            if !matches {
                 code = 1;
                 writeln!(
                     &mut output,
@@ -137,6 +167,57 @@ pub(crate) async fn check_hooks_apply(
     Ok((code, output))
 }
 
+fn load_meta_projects(hook: &Hook, filenames: &[&Path]) -> Result<Vec<Project>> {
+    let relative_path = hook.project().relative_path();
+    filenames
+        .iter()
+        .map(|filename| {
+            let path = relative_path.join(filename);
+            let mut project = Project::from_config_file(path.into(), None)?;
+            project.with_relative_path(relative_path.to_path_buf());
+            Ok(project)
+        })
+        .collect()
+}
+
+fn extend_hook_options<'a>(
+    repo: &'a config::Repo,
+    hook_options: &mut Vec<(&'a String, &'a HookOptions)>,
+) {
+    match repo {
+        config::Repo::Remote(repo) => {
+            hook_options.extend(repo.hooks.iter().map(|hook| (&hook.id, &hook.options)));
+        }
+        config::Repo::Local(repo) => {
+            hook_options.extend(repo.hooks.iter().map(|hook| (&hook.id, &hook.options)));
+        }
+        config::Repo::Meta(repo) => {
+            hook_options.extend(repo.hooks.iter().map(|hook| (&hook.id, &hook.options)));
+        }
+        config::Repo::Builtin(repo) => {
+            hook_options.extend(repo.hooks.iter().map(|hook| (&hook.id, &hook.options)));
+        }
+    }
+}
+
+fn matches_patterns(
+    filename: &Path,
+    include: Option<&FilePattern>,
+    exclude: Option<&FilePattern>,
+) -> bool {
+    if let Some(pattern) = include {
+        if !pattern.is_match(filename) {
+            return false;
+        }
+    }
+    if let Some(pattern) = exclude {
+        if !pattern.is_match(filename) {
+            return false;
+        }
+    }
+    true
+}
+
 // Returns true if the exclude pattern matches any files matching the include pattern.
 fn excludes_any(
     files: &[impl AsRef<Path>],
@@ -147,19 +228,9 @@ fn excludes_any(
         return true;
     }
 
-    files.iter().any(|f| {
-        if let Some(pattern) = &include {
-            if !pattern.is_match(f.as_ref()) {
-                return false;
-            }
-        }
-        if let Some(pattern) = &exclude {
-            if !pattern.is_match(f.as_ref()) {
-                return false;
-            }
-        }
-        true
-    })
+    files
+        .iter()
+        .any(|f| matches_patterns(f.as_ref(), include, exclude))
 }
 
 /// Ensures that exclude directives apply to any file in the repository.
@@ -167,11 +238,16 @@ pub(crate) async fn check_useless_excludes(
     hook: &Hook,
     filenames: &[&Path],
 ) -> Result<(i32, Vec<u8>)> {
+    let projects = load_meta_projects(hook, filenames)?;
+    if projects.is_empty() {
+        return Ok((0, Vec::new()));
+    }
+
     let relative_path = hook.project().relative_path();
     // `collect_run_input` returns paths relative to the hook's project root.
     // The meta hook itself runs from the workspace root, so we build both:
     // - `input_project`: for matching `files`/`exclude` patterns (project-relative)
-    // - `input_workspace`: for `ProjectFiles` (workspace-relative)
+    // - `input_workspace`: for project ownership and type matching (workspace-relative)
     let input_project = collect_run_input(hook.work_dir(), CollectOptions::all_files())
         .await?
         .into_files();
@@ -184,11 +260,7 @@ pub(crate) async fn check_useless_excludes(
     let mut output = Vec::new();
     let mut tag_cache = FileTagCache::default();
 
-    for filename in filenames {
-        let path = relative_path.join(filename);
-        let mut project = Project::from_config_file(path.into(), None)?;
-        project.with_relative_path(relative_path.to_path_buf());
-
+    for project in projects {
         let config = project.config();
         if !excludes_any(&input_project, None, config.exclude.as_ref()) {
             code = 1;
@@ -203,51 +275,66 @@ pub(crate) async fn check_useless_excludes(
             )?;
         }
 
-        let project_files = ProjectFiles::for_project(input_workspace.iter(), &project, None);
-
+        let mut hook_options = Vec::new();
         for repo in &config.repos {
-            let hooks_iter: Box<dyn Iterator<Item = (&String, &HookOptions)>> = match repo {
-                config::Repo::Remote(r) => Box::new(r.hooks.iter().map(|h| (&h.id, &h.options))),
-                config::Repo::Local(r) => Box::new(r.hooks.iter().map(|h| (&h.id, &h.options))),
-                config::Repo::Meta(r) => Box::new(r.hooks.iter().map(|h| (&h.id, &h.options))),
-                config::Repo::Builtin(r) => Box::new(r.hooks.iter().map(|h| (&h.id, &h.options))),
-            };
+            extend_hook_options(repo, &mut hook_options);
+        }
+        if hook_options.iter().all(|(_, opts)| opts.exclude.is_none()) {
+            continue;
+        }
 
-            for (hook_id, opts) in hooks_iter {
-                let filtered_files = project_files.by_type(
+        let tag_filters = hook_options
+            .iter()
+            .map(|(_, opts)| {
+                FileTagFilter::new(
                     opts.types.as_ref(),
                     opts.types_or.as_ref(),
                     opts.exclude_types.as_ref(),
-                    &mut tag_cache,
-                );
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut exclude_matches = hook_options
+            .iter()
+            .map(|(_, opts)| opts.exclude.is_none())
+            .collect::<Vec<_>>();
+        let mut remaining = exclude_matches.iter().filter(|matched| !**matched).count();
 
-                // `filtered_files` is workspace-relative (it includes the project prefix).
-                // Match patterns against paths relative to the project root.
-                let filtered_files_relative: Vec<&Path> = if relative_path.as_os_str().is_empty() {
-                    filtered_files
-                } else {
-                    filtered_files
-                        .into_iter()
-                        .filter_map(|f| f.strip_prefix(relative_path).ok())
-                        .collect()
-                };
-
-                if !excludes_any(
-                    &filtered_files_relative,
-                    opts.files.as_ref(),
-                    opts.exclude.as_ref(),
-                ) {
-                    code = 1;
-                    let display = opts
-                        .exclude
-                        .as_ref()
-                        .map(ToString::to_string)
-                        .unwrap_or_default();
-                    writeln!(
-                        &mut output,
-                        "The exclude pattern `{display}` for `{hook_id}` does not match any files"
-                    )?;
+        ProjectFiles::visit_for_project(input_workspace.iter(), &project, None, |file| {
+            let tags = file.tags(&mut tag_cache);
+            for ((matched, (_, opts)), tag_filter) in exclude_matches
+                .iter_mut()
+                .zip(&hook_options)
+                .zip(&tag_filters)
+            {
+                if *matched || tags.is_none_or(|tags| !tag_filter.matches(tags)) {
+                    continue;
                 }
+
+                if matches_patterns(file.hook_path(), opts.files.as_ref(), opts.exclude.as_ref()) {
+                    *matched = true;
+                    remaining -= 1;
+                }
+            }
+
+            if remaining == 0 {
+                return ControlFlow::Break(());
+            }
+
+            ControlFlow::Continue(())
+        });
+
+        for ((hook_id, opts), exclude_matches) in hook_options.iter().zip(exclude_matches) {
+            if !exclude_matches {
+                code = 1;
+                let display = opts
+                    .exclude
+                    .as_ref()
+                    .map(ToString::to_string)
+                    .unwrap_or_default();
+                writeln!(
+                    &mut output,
+                    "The exclude pattern `{display}` for `{hook_id}` does not match any files"
+                )?;
             }
         }
     }

--- a/crates/prek/src/languages/mod.rs
+++ b/crates/prek/src/languages/mod.rs
@@ -137,8 +137,8 @@ impl LanguageImpl for Unimplemented {
 // system: only system version, no env, no additional deps
 
 impl Language {
-    pub(crate) fn supported(lang: Language) -> bool {
-        match lang {
+    pub(crate) fn supported(self) -> bool {
+        match self {
             Self::Bun
             | Self::Dart
             | Self::Deno

--- a/crates/prek/tests/skipped_hooks.rs
+++ b/crates/prek/tests/skipped_hooks.rs
@@ -294,6 +294,60 @@ fn skipped_workspace_project_installable_hook_does_not_install_env() -> Result<(
     Ok(())
 }
 
+#[test]
+fn orphan_project_early_match_still_hides_child_files_from_parent_install() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    let cwd = context.work_dir();
+    let child = cwd.child("child");
+    child.create_dir_all()?;
+
+    context.write_pre_commit_config(indoc::indoc! {r"
+        repos:
+          - repo: local
+            hooks:
+              - id: root-pygrep
+                name: root-pygrep
+                language: pygrep
+                entry: ROOT_SHOULD_NOT_RUN
+                files: \.py$
+    "});
+    child
+        .child(".pre-commit-config.yaml")
+        .write_str(indoc::indoc! {r#"
+        orphan: true
+        repos:
+          - repo: local
+            hooks:
+              - id: child-python
+                name: child-python
+                language: python
+                entry: python -c "print('child')"
+                always_run: true
+                pass_filenames: false
+    "#})?;
+
+    child.child("child.py").write_str("print('child')\n")?;
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run().arg("--all-files"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Running hooks for `child`:
+    child-python.............................................................Passed
+
+    Running hooks for `.`:
+    root-pygrep..........................................(no files to check)Skipped
+
+    ----- stderr -----
+    ");
+    assert_eq!(hook_env_count(&context)?, 1);
+
+    Ok(())
+}
+
 /// Skipped hooks across multiple priority groups
 ///
 /// Hooks with different `priority` values form separate priority groups. Each


### PR DESCRIPTION
Optimize the meta hook checks so they scan project files for boolean matches instead of collecting per-hook filename lists.

The shared scan helper can now stop early once all candidates have matched.