### PR TITLE
Skip diff checks for read-only hooks

### DIFF
--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -30,7 +30,7 @@ use crate::printer::Printer;
 use crate::run::{CONCURRENCY, USE_COLOR};
 use crate::store::Store;
 use crate::workspace::{Project, Workspace};
-use crate::{fs, git, warn_user};
+use crate::{fs, git, hooks, warn_user};
 
 use super::install::{InstallCache, install_hooks};
 
@@ -481,17 +481,28 @@ async fn run_hooks<'paths>(
         hooks.sort_by(|a, b| a.priority.cmp(&b.priority).then(a.idx.cmp(&b.idx)));
 
         session.render_project_header(project, projects_len)?;
-        let mut prev_diff = git::get_diff(project.path()).await?;
+        let mut prev_diff = None;
 
         let project_fail_fast = fail_fast.or(project.config().fail_fast).unwrap_or(false);
 
         for group_hooks in PriorityGroups::new(hooks) {
+            let group_may_modify_files =
+                !session.dry_run && group_hooks.iter().any(|hook| hooks::may_modify_files(hook));
+            if group_may_modify_files && prev_diff.is_none() {
+                prev_diff = Some(git::get_diff(project.path()).await?);
+            }
+
             let group_results = session
                 .run_priority_group(group_hooks, &project_input, tag_cache)
                 .await?;
 
             let hook_fail_fast = session
-                .finish_priority_group(group_results, project, &mut prev_diff)
+                .finish_priority_group(
+                    group_results,
+                    project,
+                    group_may_modify_files,
+                    &mut prev_diff,
+                )
                 .await?;
 
             if !session.success && (project_fail_fast || hook_fail_fast) {
@@ -604,14 +615,18 @@ impl<'a> HookRunSession<'a> {
         &mut self,
         mut group_results: Vec<RunResult>,
         project: &Project,
-        prev_diff: &mut Vec<u8>,
+        group_may_modify_files: bool,
+        prev_diff: &mut Option<Vec<u8>>,
     ) -> Result<bool> {
         // Print results in a stable order (same order as config within the project).
         group_results.sort_unstable_by_key(|a| a.hook.idx);
 
         // Check if any files were modified by this group of hooks.
         let all_skipped = group_results.iter().all(|r| r.status.is_skipped());
-        let group_modified_files = if !all_skipped {
+        let group_modified_files = if group_may_modify_files && !all_skipped {
+            let prev_diff = prev_diff
+                .as_mut()
+                .expect("previous diff must be captured before file-modifying hooks run");
             let curr_diff = git::get_diff(project.path()).await?;
             let group_modified_files = curr_diff != *prev_diff;
             *prev_diff = curr_diff;

--- a/crates/prek/src/hooks/builtin_hooks/mod.rs
+++ b/crates/prek/src/hooks/builtin_hooks/mod.rs
@@ -54,6 +54,35 @@ pub(crate) enum BuiltinHooks {
 }
 
 impl BuiltinHooks {
+    pub(crate) fn may_modify_files(self) -> bool {
+        match self {
+            Self::EndOfFileFixer
+            | Self::FileContentsSorter
+            | Self::FixByteOrderMarker
+            | Self::MixedLineEnding
+            | Self::PrettyFormatJson
+            | Self::TrailingWhitespace => true,
+
+            Self::CheckAddedLargeFiles
+            | Self::CheckCaseConflict
+            | Self::CheckExecutablesHaveShebangs
+            | Self::CheckIllegalWindowsNames
+            | Self::CheckJson
+            | Self::CheckJson5
+            | Self::CheckMergeConflict
+            | Self::CheckShebangScriptsAreExecutable
+            | Self::CheckSymlinks
+            | Self::CheckToml
+            | Self::CheckVcsPermalinks
+            | Self::CheckXml
+            | Self::CheckYaml
+            | Self::DestroyedSymlinks
+            | Self::DetectPrivateKey
+            | Self::ForbidNewSubmodules
+            | Self::NoCommitToBranch => false,
+        }
+    }
+
     pub(crate) async fn run(
         self,
         _store: &Store,

--- a/crates/prek/src/hooks/mod.rs
+++ b/crates/prek/src/hooks/mod.rs
@@ -20,18 +20,38 @@ static NO_FAST_PATH: LazyLock<bool> = LazyLock::new(|| EnvVars::is_set(EnvVars::
 
 /// Returns true if the hook has a builtin Rust implementation.
 pub fn check_fast_path(hook: &Hook) -> bool {
+    fast_path_hook(hook).is_some()
+}
+
+fn fast_path_hook(hook: &Hook) -> Option<PreCommitHooks> {
     if *NO_FAST_PATH {
-        return false;
+        return None;
     }
 
+    let Repo::Remote { url, .. } = hook.repo() else {
+        return None;
+    };
+    if !is_pre_commit_hooks(url) {
+        return None;
+    }
+
+    let implemented = PreCommitHooks::from_str(hook.id.as_str()).ok()?;
+    if implemented.check_supported(hook) {
+        Some(implemented)
+    } else {
+        None
+    }
+}
+
+pub(crate) fn may_modify_files(hook: &Hook) -> bool {
     match hook.repo() {
-        Repo::Remote { url, .. } if is_pre_commit_hooks(url) => {
-            let Ok(implemented) = PreCommitHooks::from_str(hook.id.as_str()) else {
-                return false;
-            };
-            implemented.check_supported(hook)
+        Repo::Builtin { .. } => {
+            BuiltinHooks::from_str(hook.id.as_str()).map_or(true, BuiltinHooks::may_modify_files)
         }
-        _ => false,
+        Repo::Remote { .. } => {
+            fast_path_hook(hook).is_none_or(|implemented| implemented.may_modify_files())
+        }
+        _ => true,
     }
 }
 
@@ -43,15 +63,10 @@ pub async fn run_fast_path(
 ) -> anyhow::Result<(i32, Vec<u8>)> {
     let progress = reporter.on_run_start(hook, filenames.len());
 
-    let result = match hook.repo() {
-        Repo::Remote { url, .. } if is_pre_commit_hooks(url) => {
-            PreCommitHooks::from_str(hook.id.as_str())
-                .unwrap()
-                .run(hook, filenames)
-                .await
-        }
-        _ => unreachable!(),
+    let Some(implemented) = fast_path_hook(hook) else {
+        unreachable!("run_fast_path requires a supported pre-commit hook");
     };
+    let result = implemented.run(hook, filenames).await;
 
     reporter.on_run_complete(progress);
 

--- a/crates/prek/src/hooks/pre_commit_hooks/mod.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/mod.rs
@@ -89,6 +89,32 @@ impl PreCommitHooks {
         }
     }
 
+    pub(crate) fn may_modify_files(&self) -> bool {
+        match self {
+            Self::EndOfFileFixer
+            | Self::FileContentsSorter
+            | Self::FixByteOrderMarker
+            | Self::MixedLineEnding
+            | Self::TrailingWhitespace => true,
+
+            Self::CheckAddedLargeFiles
+            | Self::CheckCaseConflict
+            | Self::CheckExecutablesHaveShebangs
+            | Self::CheckShebangScriptsAreExecutable
+            | Self::CheckVcsPermalinks
+            | Self::ForbidNewSubmodules
+            | Self::CheckJson
+            | Self::CheckSymlinks
+            | Self::CheckMergeConflict
+            | Self::CheckToml
+            | Self::CheckXml
+            | Self::CheckYaml
+            | Self::DestroyedSymlinks
+            | Self::DetectPrivateKey
+            | Self::NoCommitToBranch => false,
+        }
+    }
+
     pub(crate) async fn run(self, hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
         debug!("Running hook `{}` in fast path", hook.id);
         match self {

--- a/crates/prek/tests/skipped_hooks.rs
+++ b/crates/prek/tests/skipped_hooks.rs
@@ -415,3 +415,39 @@ fn all_hooks_skipped_multiple_priority_groups() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn read_only_builtin_hook_does_not_run_diff_detection() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    let cwd = context.work_dir();
+    context.write_pre_commit_config(indoc::indoc! {r"
+        repos:
+          - repo: builtin
+            hooks:
+              - id: check-toml
+    "});
+
+    cwd.child("pyproject.toml")
+        .write_str("[project]\nname = \"demo\"\n")?;
+    context.git_add(".");
+
+    let output = context
+        .run()
+        .arg("--all-files")
+        .env("RUST_LOG", "prek::git=trace")
+        .output()?;
+
+    assert!(output.status.success(), "prek should succeed");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let get_diff_calls = stderr.matches("get_diff").count();
+    assert_eq!(
+        get_diff_calls, 0,
+        "Expected no get_diff calls for read-only builtin hooks, found {get_diff_calls}.\n\
+         Trace output:\n{stderr}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Avoid before-and-after git diff checks for native hooks that cannot modify files, while keeping modification detection for fixers and other hooks that may write files.

For https://github.com/j178/prek/issues/1327