### PR TITLE
Optimize diff checks for clean worktrees

### DIFF
--- a/crates/prek/src/cli/run/diff.rs
+++ b/crates/prek/src/cli/run/diff.rs
@@ -1,0 +1,77 @@
+use std::path::Path;
+
+use anyhow::Result;
+
+use crate::git;
+
+pub(super) struct DiffTracker<'a> {
+    path: &'a Path,
+    baseline: DiffBaseline,
+}
+
+enum DiffBaseline {
+    Clean,
+    Unknown,
+    Snapshot(Vec<u8>),
+}
+
+impl<'a> DiffTracker<'a> {
+    pub(super) fn clean_baseline(path: &'a Path) -> Self {
+        Self {
+            path,
+            baseline: DiffBaseline::Clean,
+        }
+    }
+
+    pub(super) fn unknown_baseline(path: &'a Path) -> Self {
+        Self {
+            path,
+            baseline: DiffBaseline::Unknown,
+        }
+    }
+
+    pub(super) async fn prepare_for_group(&mut self, may_modify_files: bool) -> Result<()> {
+        if may_modify_files && let DiffBaseline::Unknown = self.baseline {
+            self.baseline = DiffBaseline::Snapshot(git::get_diff(self.path).await?);
+        }
+        Ok(())
+    }
+
+    pub(super) async fn changed_after_group(
+        &mut self,
+        may_modify_files: bool,
+        all_skipped: bool,
+    ) -> Result<bool> {
+        // Read-only groups and fully skipped groups cannot change files, so avoid
+        // asking git about the working tree.
+        if !may_modify_files || all_skipped {
+            return Ok(false);
+        }
+
+        match &mut self.baseline {
+            DiffBaseline::Clean => {
+                // `WorkTreeKeeper` already removed unstaged changes. A quiet
+                // worktree check is enough unless the hook actually wrote files.
+                if !git::has_worktree_diff(self.path).await? {
+                    return Ok(false);
+                }
+                // Capture the dirty state after this group so later groups can
+                // compare against the exact diff left by previous hooks.
+                self.baseline = DiffBaseline::Snapshot(git::get_diff(self.path).await?);
+                Ok(true)
+            }
+            DiffBaseline::Snapshot(prev_diff) => {
+                // Unknown initial state, `--all-files`, and later dirty groups
+                // need a full before/after diff comparison to avoid confusing
+                // pre-existing user changes with hook changes.
+                let curr_diff = git::get_diff(self.path).await?;
+                let modified = curr_diff != *prev_diff;
+                *prev_diff = curr_diff;
+                Ok(modified)
+            }
+            DiffBaseline::Unknown => {
+                unreachable!("diff baseline must be captured before hooks can modify files")
+            }
+        }
+    }
+}

--- a/crates/prek/src/cli/run/mod.rs
+++ b/crates/prek/src/cli/run/mod.rs
@@ -6,6 +6,7 @@ pub(crate) use install::{InstallCache, install_hooks};
 pub(crate) use run::run;
 pub(crate) use selector::{SelectorSource, Selectors};
 
+mod diff;
 mod filter;
 mod install;
 mod keeper;

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -16,6 +16,7 @@ use tracing::{debug, trace};
 use unicode_width::UnicodeWidthStr;
 
 use crate::cli::reporter::{HookInitReporter, HookInstallReporter, HookRunReporter};
+use crate::cli::run::diff::DiffTracker;
 use crate::cli::run::keeper::WorkTreeKeeper;
 use crate::cli::run::{
     CollectOptions, FileTagCache, HookFileFilter, ProjectFiles, RunInput, Selectors,
@@ -220,6 +221,7 @@ pub(crate) async fn run(
         show_diff_on_failure,
         fail_fast,
         dry_run,
+        should_stash,
         verbose,
         printer,
     )
@@ -445,6 +447,7 @@ async fn run_hooks<'paths>(
     show_diff_on_failure: bool,
     fail_fast: Option<bool>,
     dry_run: bool,
+    worktree_cleaned: bool,
     verbose: bool,
     printer: Printer,
 ) -> Result<ExitStatus> {
@@ -481,28 +484,30 @@ async fn run_hooks<'paths>(
         hooks.sort_by(|a, b| a.priority.cmp(&b.priority).then(a.idx.cmp(&b.idx)));
 
         session.render_project_header(project, projects_len)?;
-        let mut prev_diff = None;
+        // The worktree is only known clean at the start of the whole run. Once
+        // an earlier project leaves a diff behind, later projects need a fresh
+        // per-project snapshot to avoid attributing that diff to their hooks.
+        let mut diff_tracker = if worktree_cleaned && !session.file_modified {
+            DiffTracker::clean_baseline(project.path())
+        } else {
+            DiffTracker::unknown_baseline(project.path())
+        };
 
         let project_fail_fast = fail_fast.or(project.config().fail_fast).unwrap_or(false);
 
         for group_hooks in PriorityGroups::new(hooks) {
             let group_may_modify_files =
                 !session.dry_run && group_hooks.iter().any(|hook| hooks::may_modify_files(hook));
-            if group_may_modify_files && prev_diff.is_none() {
-                prev_diff = Some(git::get_diff(project.path()).await?);
-            }
+            diff_tracker
+                .prepare_for_group(group_may_modify_files)
+                .await?;
 
             let group_results = session
                 .run_priority_group(group_hooks, &project_input, tag_cache)
                 .await?;
 
             let hook_fail_fast = session
-                .finish_priority_group(
-                    group_results,
-                    project,
-                    group_may_modify_files,
-                    &mut prev_diff,
-                )
+                .finish_priority_group(group_results, group_may_modify_files, &mut diff_tracker)
                 .await?;
 
             if !session.success && (project_fail_fast || hook_fail_fast) {
@@ -614,26 +619,17 @@ impl<'a> HookRunSession<'a> {
     async fn finish_priority_group(
         &mut self,
         mut group_results: Vec<RunResult>,
-        project: &Project,
         group_may_modify_files: bool,
-        prev_diff: &mut Option<Vec<u8>>,
+        diff_tracker: &mut DiffTracker<'_>,
     ) -> Result<bool> {
         // Print results in a stable order (same order as config within the project).
         group_results.sort_unstable_by_key(|a| a.hook.idx);
 
         // Check if any files were modified by this group of hooks.
         let all_skipped = group_results.iter().all(|r| r.status.is_skipped());
-        let group_modified_files = if group_may_modify_files && !all_skipped {
-            let prev_diff = prev_diff
-                .as_mut()
-                .expect("previous diff must be captured before file-modifying hooks run");
-            let curr_diff = git::get_diff(project.path()).await?;
-            let group_modified_files = curr_diff != *prev_diff;
-            *prev_diff = curr_diff;
-            group_modified_files
-        } else {
-            false
-        };
+        let group_modified_files = diff_tracker
+            .changed_after_group(group_may_modify_files, all_skipped)
+            .await?;
 
         self.file_modified |= group_modified_files;
 

--- a/crates/prek/src/git.rs
+++ b/crates/prek/src/git.rs
@@ -356,6 +356,32 @@ async fn parse_merge_msg_for_conflicts() -> Result<Vec<PathBuf>, Error> {
 }
 
 #[instrument(level = "trace")]
+pub(crate) async fn has_worktree_diff(path: &Path) -> Result<bool, Error> {
+    let mut cmd = git_cmd("check worktree diff")?;
+    let status = cmd
+        .arg("diff-files")
+        .arg("--quiet")
+        .arg("--no-ext-diff")
+        .arg("--no-textconv")
+        .arg("--ignore-submodules")
+        .arg("--")
+        .arg(path)
+        .check(false)
+        .status()
+        .await?;
+
+    if status.success() {
+        return Ok(false);
+    }
+    if status.code() == Some(1) {
+        return Ok(true);
+    }
+
+    cmd.check_status(status)?;
+    Ok(true)
+}
+
+#[instrument(level = "trace")]
 pub(crate) async fn get_diff(path: &Path) -> Result<Vec<u8>, Error> {
     let output = git_cmd("git diff")?
         .arg("diff")

--- a/crates/prek/tests/skipped_hooks.rs
+++ b/crates/prek/tests/skipped_hooks.rs
@@ -353,7 +353,7 @@ fn orphan_project_early_match_still_hides_child_files_from_parent_install() -> R
 /// Hooks with different `priority` values form separate priority groups. Each
 /// group is processed sequentially. This test verifies:
 /// 1. Skip behavior works correctly across group boundaries
-/// 2. `git diff` is only called once (initial baseline), not per-group
+/// 2. `git diff` is not called when every hook is skipped
 ///
 /// Note: This test uses manual output capture instead of `cmd_snapshot!` because
 /// we need to count `get_diff` occurrences in trace-level stderr. Trace output
@@ -403,13 +403,219 @@ fn all_hooks_skipped_multiple_priority_groups() -> Result<()> {
     assert!(stdout.contains("priority-20") && stdout.contains("Skipped"));
     assert!(stdout.contains("priority-30") && stdout.contains("Skipped"));
 
-    // Regression test for #1335: only 1 get_diff call (initial baseline)
-    // Without fix: 4 calls (1 initial + 3 per priority group)
+    // Regression test for #1335: skipped hooks do not need modification checks.
     let stderr = String::from_utf8_lossy(&output.stderr);
     let get_diff_calls = stderr.matches("get_diff").count();
     assert_eq!(
+        get_diff_calls, 0,
+        "Expected no get_diff calls when all hooks skip, found {get_diff_calls}.\n\
+         Trace output:\n{stderr}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn may_modify_hook_without_changes_uses_quiet_diff_check() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    let cwd = context.work_dir();
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: noop
+                name: noop
+                language: system
+                entry: python3 -c "pass"
+                pass_filenames: false
+    "#});
+
+    cwd.child("file.txt").write_str("original\n")?;
+    context.git_add(".");
+
+    let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
+
+    assert!(output.status.success(), "noop hook should pass");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let has_worktree_diff_calls = stderr.matches("has_worktree_diff").count();
+    assert_eq!(
+        has_worktree_diff_calls, 1,
+        "Expected one cheap worktree diff check, found {has_worktree_diff_calls}.\n\
+         Trace output:\n{stderr}"
+    );
+
+    let get_diff_calls = stderr.matches("get_diff").count();
+    assert_eq!(
+        get_diff_calls, 0,
+        "Expected no full get_diff calls when the hook leaves files unchanged, found {get_diff_calls}.\n\
+         Trace output:\n{stderr}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn modifying_hook_uses_clean_baseline_diff_detection() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    let cwd = context.work_dir();
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: modify
+                name: modify
+                language: system
+                entry: python3 -c "from pathlib import Path; Path('file.txt').write_text('changed\n')"
+                pass_filenames: false
+    "#});
+
+    cwd.child("file.txt").write_str("original\n")?;
+    context.git_add(".");
+
+    let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
+
+    assert!(
+        !output.status.success(),
+        "prek should fail when hooks modify files"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("files were modified by this hook"));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let has_worktree_diff_calls = stderr.matches("has_worktree_diff").count();
+    assert_eq!(
+        has_worktree_diff_calls, 1,
+        "Expected one cheap worktree diff check, found {has_worktree_diff_calls}.\n\
+         Trace output:\n{stderr}"
+    );
+
+    let get_diff_calls = stderr.matches("get_diff").count();
+    assert_eq!(
         get_diff_calls, 1,
-        "Expected 1 get_diff call (initial baseline) when all hooks skip, found {get_diff_calls}.\n\
+        "Expected one full get_diff call after detecting modifications, found {get_diff_calls}.\n\
+         Trace output:\n{stderr}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn all_files_with_existing_unstaged_changes_uses_snapshot_baseline() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    let cwd = context.work_dir();
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: modify
+                name: modify
+                language: system
+                entry: python3 -c "from pathlib import Path; Path('hook.txt').write_text('changed\n')"
+                pass_filenames: false
+    "#});
+
+    cwd.child("file.txt").write_str("original\n")?;
+    cwd.child("hook.txt").write_str("original\n")?;
+    context.git_add(".");
+    cwd.child("file.txt").write_str("unstaged\n")?;
+
+    let output = context
+        .run()
+        .arg("--all-files")
+        .env("RUST_LOG", "prek::git=trace")
+        .output()?;
+
+    assert!(
+        !output.status.success(),
+        "--all-files should still detect hook modifications when the worktree starts dirty"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("files were modified by this hook"));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let has_worktree_diff_calls = stderr.matches("has_worktree_diff").count();
+    assert_eq!(
+        has_worktree_diff_calls, 0,
+        "`--all-files` should not use the clean-baseline diff check.\n\
+         Trace output:\n{stderr}"
+    );
+
+    let get_diff_calls = stderr.matches("get_diff").count();
+    assert_eq!(
+        get_diff_calls, 2,
+        "Expected a full before/after diff comparison for dirty `--all-files`, found {get_diff_calls}.\n\
+         Trace output:\n{stderr}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn later_project_snapshots_diff_left_by_previous_project() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    let cwd = context.work_dir();
+    let child = cwd.child("child");
+    child.create_dir_all()?;
+
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: root-noop
+                name: root-noop
+                language: system
+                entry: python3 -c "pass"
+                always_run: true
+                pass_filenames: false
+    "#});
+    child
+        .child(".pre-commit-config.yaml")
+        .write_str(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: child-modify
+                name: child-modify
+                language: system
+                entry: python3 -c "from pathlib import Path; Path('child.txt').write_text('changed\n')"
+                always_run: true
+                pass_filenames: false
+    "#})?;
+
+    child.child("child.txt").write_str("original\n")?;
+    context.git_add(".");
+
+    let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
+
+    assert!(
+        !output.status.success(),
+        "prek should fail because the child hook modified files"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("child-modify") && stdout.contains("files were modified by this hook"));
+    assert!(
+        stdout.contains("root-noop") && stdout.contains("Passed"),
+        "root hook should not be blamed for the child project's diff.\n\
+         stdout:\n{stdout}"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let has_worktree_diff_calls = stderr.matches("has_worktree_diff").count();
+    assert_eq!(
+        has_worktree_diff_calls, 1,
+        "Only the first project should use the clean-baseline check.\n\
          Trace output:\n{stderr}"
     );
 


### PR DESCRIPTION
Avoid full before-and-after git diff calls when hooks run from a cleaned worktree and leave it unchanged.

Based on #1464, thanks @shaanmajid!
Closes #1464
Related #1327