### PR TITLE
Make rustup install profile configurable

### DIFF
--- a/crates/prek-consts/src/env_vars.rs
+++ b/crates/prek-consts/src/env_vars.rs
@@ -95,6 +95,7 @@ impl EnvVars {
     pub const BUNDLE_GEMFILE: &'static str = "BUNDLE_GEMFILE";
 
     // Rust related
+    pub const PREK_RUST_PROFILE: &'static str = "PREK_RUST_PROFILE";
     pub const RUSTUP_TOOLCHAIN: &'static str = "RUSTUP_TOOLCHAIN";
     pub const RUSTUP_AUTO_INSTALL: &'static str = "RUSTUP_AUTO_INSTALL";
     pub const CARGO_HOME: &'static str = "CARGO_HOME";

--- a/crates/prek/src/languages/rust/rustup.rs
+++ b/crates/prek/src/languages/rust/rustup.rs
@@ -33,7 +33,20 @@ static RUSTUP_BINARY_NAME: LazyLock<String> = LazyLock::new(|| {
 });
 
 static RUSTUP_PROFILE: LazyLock<String> = LazyLock::new(|| {
-    EnvVars::var(EnvVars::PREK_RUST_PROFILE).unwrap_or_else(|_| "minimal".to_string())
+    let Ok(val) = EnvVars::var(EnvVars::PREK_RUST_PROFILE) else {
+        return "minimal".to_string();
+    };
+    match val.as_str() {
+        "minimal" | "default" | "complete" => val,
+        _ => {
+            warn!(
+                "Invalid value for {}: {}, falling back to `minimal`",
+                EnvVars::PREK_RUST_PROFILE,
+                val
+            );
+            "minimal".to_string()
+        }
+    }
 });
 
 impl Rustup {

--- a/crates/prek/src/languages/rust/rustup.rs
+++ b/crates/prek/src/languages/rust/rustup.rs
@@ -14,6 +14,7 @@ use crate::http::REQWEST_CLIENT;
 use crate::languages::rust::version::RustVersion;
 use crate::process::Cmd;
 use crate::store::Store;
+use crate::warn_user;
 
 #[derive(Clone)]
 pub(crate) struct Rustup {
@@ -32,22 +33,31 @@ static RUSTUP_BINARY_NAME: LazyLock<String> = LazyLock::new(|| {
         .unwrap_or_else(|_| "rustup".to_string())
 });
 
-static RUSTUP_PROFILE: LazyLock<String> = LazyLock::new(|| {
-    let Ok(val) = EnvVars::var(EnvVars::PREK_RUST_PROFILE) else {
-        return "minimal".to_string();
+#[derive(Clone, Copy, Default, strum::AsRefStr, strum::EnumString)]
+#[strum(serialize_all = "lowercase")]
+enum RustupProfile {
+    #[default]
+    Minimal,
+    Default,
+    Complete,
+}
+
+fn rustup_profile() -> RustupProfile {
+    let Ok(value) = EnvVars::var(EnvVars::PREK_RUST_PROFILE) else {
+        return RustupProfile::default();
     };
-    match val.as_str() {
-        "minimal" | "default" | "complete" => val,
-        _ => {
-            warn!(
-                "Invalid value for {}: {}, falling back to `minimal`",
-                EnvVars::PREK_RUST_PROFILE,
-                val
-            );
-            "minimal".to_string()
-        }
-    }
-});
+
+    value.parse().unwrap_or_else(|_| {
+        let default = RustupProfile::default();
+        warn_user!(
+            "Invalid value for {}: {:?}. Expected one of `minimal`, `default`, or `complete`; falling back to `{}`",
+            EnvVars::PREK_RUST_PROFILE,
+            value,
+            default.as_ref(),
+        );
+        default
+    })
+}
 
 impl Rustup {
     pub(crate) fn rustup_home(&self) -> &Path {
@@ -148,7 +158,7 @@ impl Rustup {
             .arg("install")
             .arg("--no-self-update")
             .arg("--profile")
-            .arg(&*RUSTUP_PROFILE)
+            .arg(rustup_profile().as_ref())
             .arg(toolchain)
             .check(true)
             .output()

--- a/crates/prek/src/languages/rust/rustup.rs
+++ b/crates/prek/src/languages/rust/rustup.rs
@@ -32,6 +32,10 @@ static RUSTUP_BINARY_NAME: LazyLock<String> = LazyLock::new(|| {
         .unwrap_or_else(|_| "rustup".to_string())
 });
 
+static RUSTUP_PROFILE: LazyLock<String> = LazyLock::new(|| {
+    EnvVars::var(EnvVars::PREK_RUST_PROFILE).unwrap_or_else(|_| "minimal".to_string())
+});
+
 impl Rustup {
     pub(crate) fn rustup_home(&self) -> &Path {
         &self.rustup_home
@@ -131,7 +135,7 @@ impl Rustup {
             .arg("install")
             .arg("--no-self-update")
             .arg("--profile")
-            .arg("minimal")
+            .arg(&*RUSTUP_PROFILE)
             .arg(toolchain)
             .check(true)
             .output()

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -422,6 +422,10 @@ Supported formats:
 - `1`, `1.70`, `1.70.0`
 - Semver ranges like `>=1.70, <1.72`
 
+#### Toolchain profile
+
+When prek installs a managed Rust toolchain it uses `rustup`'s `minimal` profile by default (just `rustc`, `rust-std`, and `cargo`). Set the [`PREK_RUST_PROFILE`](reference/environment-variables.md#prek_rust_profile) environment variable to `default` or `complete` to include extra components such as `rustfmt` and `clippy`.
+
 !!! note "prek-only"
 
     - prek supports installing packages from virtual workspaces. See [#1180](https://github.com/j178/prek/pull/1180).

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -84,6 +84,11 @@ Defaults to `120` characters of arguments; set a larger value to reduce truncati
 Override the Ruby installer base URL used for downloaded Ruby toolchains (for example, when using mirrors or air-gapped CI environments).
 See [Ruby language support](../languages.md#ruby) for details.
 
+### `PREK_RUST_PROFILE`
+
+Override the `rustup` profile used when installing managed Rust toolchains (`minimal`, `default`, or `complete`). Defaults to `minimal`. Set to `default` to include `rustfmt` and `clippy`.
+See [Rust language support](../languages.md#rust) for details.
+
 ## Compatibility fallbacks
 
 ### `PRE_COMMIT_ALLOW_NO_CONFIG`


### PR DESCRIPTION
 If rust is not already present on the system, `language: rust` toolchains are always installed with `rustup toolchain install --profile minimal`, which omits rustfmt and clippy and breaks possible `cargo fmt`/`cargo clippy` pre-commit hooks. Added PREK_RUST_PROFILE envvar so users can opt into `default` (rustfmt + clippy) or `complete`. Default is unchanged from `minimal`.