### PR TITLE
Serialize Lua language tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -12,4 +12,4 @@ default-filter = "binary_id(prek::languages)"
 [[profile.ci-language.overrides]]
 # LuaRocks can hit a race condition when multiple processes are installing the same package.
 filter = "test(lua::)"
-threads-required = "num-cpus"
+threads-required = "num-test-threads"


### PR DESCRIPTION
Lua language tests already had a LuaRocks race-condition override, but `threads-required = "num-cpus"` did not always consume all configured CI test threads.

This switches the override to `num-test-threads` so LuaRocks-dependent tests run one at a time under the CI language-test profile.