### PR TITLE
Ignore stat-only hook rewrites

### DIFF
--- a/crates/prek/src/cli/run/diff.rs
+++ b/crates/prek/src/cli/run/diff.rs
@@ -51,19 +51,22 @@ impl<'a> DiffTracker<'a> {
         match &mut self.baseline {
             DiffBaseline::Clean => {
                 // `WorkTreeKeeper` already removed unstaged changes. A quiet
-                // worktree check is enough unless the hook actually wrote files.
+                // worktree check keeps the common no-op path cheap.
                 if !git::has_worktree_diff(self.path).await? {
                     return Ok(false);
                 }
-                // `git diff-files --quiet` is stat-based and reports dirty for any in-place rewrite
-                // (mtime bump) even when content is unchanged 
+                // `diff-files --quiet` is stat-based, so an in-place rewrite
+                // can look dirty even when the content is unchanged. Do a full
+                // diff here to ignore stat-only changes and reuse the content
+                // diff as the baseline if the hook really modified files.
                 let curr_diff = git::get_diff(self.path).await?;
                 if curr_diff.is_empty() {
                     return Ok(false);
                 }
+
                 // Capture the dirty state after this group so later groups can
                 // compare against the exact diff left by previous hooks.
-                self.baseline = DiffBaseline::Snapshot(git::get_diff(self.path).await?);
+                self.baseline = DiffBaseline::Snapshot(curr_diff);
                 Ok(true)
             }
             DiffBaseline::Snapshot(prev_diff) => {

--- a/crates/prek/src/cli/run/diff.rs
+++ b/crates/prek/src/cli/run/diff.rs
@@ -55,6 +55,12 @@ impl<'a> DiffTracker<'a> {
                 if !git::has_worktree_diff(self.path).await? {
                     return Ok(false);
                 }
+                // `git diff-files --quiet` is stat-based and reports dirty for any in-place rewrite
+                // (mtime bump) even when content is unchanged 
+                let curr_diff = git::get_diff(self.path).await?;
+                if curr_diff.is_empty() {
+                    return Ok(false);
+                }
                 // Capture the dirty state after this group so later groups can
                 // compare against the exact diff left by previous hooks.
                 self.baseline = DiffBaseline::Snapshot(git::get_diff(self.path).await?);

--- a/crates/prek/tests/skipped_hooks.rs
+++ b/crates/prek/tests/skipped_hooks.rs
@@ -457,6 +457,67 @@ fn may_modify_hook_without_changes_uses_quiet_diff_check() -> Result<()> {
 }
 
 #[test]
+fn identical_rewrite_with_stat_change_is_not_modified() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    let cwd = context.work_dir();
+    context.write_pre_commit_config(indoc::indoc! {r"
+        repos:
+          - repo: local
+            hooks:
+              - id: rewrite-identical
+                name: rewrite-identical
+                language: system
+                entry: python3 rewrite.py
+                files: \.txt$
+    "});
+    cwd.child("rewrite.py").write_str(indoc::indoc! {r"
+        from pathlib import Path
+        import os
+        import sys
+        import time
+
+        for filename in sys.argv[1:]:
+            path = Path(filename)
+            path.write_text(path.read_text())
+            timestamp = time.time() + 10
+            os.utime(path, (timestamp, timestamp))
+    "})?;
+
+    cwd.child("file.txt").write_str("original\n")?;
+    context.git_add(".");
+
+    let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
+
+    assert!(
+        output.status.success(),
+        "rewriting identical content should not be treated as a hook modification"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("rewrite-identical") && stdout.contains("Passed"));
+    assert!(!stdout.contains("files were modified by this hook"));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let has_worktree_diff_calls = stderr.matches("has_worktree_diff").count();
+    assert_eq!(
+        has_worktree_diff_calls, 1,
+        "Expected one cheap worktree diff check, found {has_worktree_diff_calls}.\n\
+         Trace output:\n{stderr}"
+    );
+
+    let get_diff_calls = stderr.matches("get_diff").count();
+    assert_eq!(
+        get_diff_calls, 1,
+        "Expected one content diff to filter out stat-only changes, found {get_diff_calls}.\n\
+         Trace output:\n{stderr}"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn modifying_hook_uses_clean_baseline_diff_detection() -> Result<()> {
     let context = TestContext::new();
     context.init_project();


### PR DESCRIPTION
PR for @GnoX solution in #2127

Add check for empty git diff in diff.rs that that fixes a breaking change in some workflows introduced in j178@d3b112b

The issue is encountered when formatters that rewrite files that change the modified timestamp (mtime) but do not change the content. These modified files get flagged as dirty but are actually clean files from a git and workflow perspective.

Closes #2127
