### PR TITLE
Avoid extra matching work for selected hooks

### DIFF
--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -1207,8 +1207,11 @@ impl<'a> ProjectHookInput<'a> {
     fn run_input_for_hook(&self, hook: &Hook, tag_cache: &FileTagCache<'a>) -> HookRunInput<'a> {
         match self {
             Self::Files(project_files) => match hook.pass_filenames {
-                // Always-run hooks without filename arguments run regardless of file matches.
-                PassFilenames::None if hook.always_run => HookRunInput::without_filenames(true),
+                PassFilenames::None if hook.always_run => {
+                    // The hook will run regardless of file matches, and this mode will not pass
+                    // filenames, so avoid scanning the project input just to compute `matched`.
+                    HookRunInput::without_filenames(true)
+                }
                 PassFilenames::None => HookRunInput::without_filenames(
                     project_files.has_matching_file(hook, tag_cache),
                 ),

--- a/crates/prek/src/hooks/pre_commit_hooks/fix_trailing_whitespace.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/fix_trailing_whitespace.rs
@@ -101,13 +101,7 @@ async fn fix_file(
     force_markdown: bool,
     markdown_exts: &[String],
 ) -> Result<(i32, Vec<u8>)> {
-    let is_markdown = force_markdown || {
-        Path::new(filename)
-            .extension()
-            .and_then(|e| e.to_str())
-            .map(|e| format!(".{}", e.to_ascii_lowercase()))
-            .is_some_and(|e| markdown_exts.contains(&e))
-    };
+    let is_markdown = is_markdown_file(filename, force_markdown, markdown_exts);
 
     let file_path = file_base.join(filename);
     let content = fs_err::tokio::read(&file_path).await?;
@@ -145,6 +139,20 @@ async fn fix_file(
     } else {
         Ok((0, Vec::new()))
     }
+}
+
+fn is_markdown_file(filename: &Path, force_markdown: bool, markdown_exts: &[String]) -> bool {
+    if force_markdown {
+        return true;
+    }
+
+    let Some(extension) = filename.extension().and_then(|ext| ext.to_str()) else {
+        return false;
+    };
+
+    markdown_exts
+        .iter()
+        .any(|markdown_ext| extension.eq_ignore_ascii_case(markdown_ext.trim_start_matches('.')))
 }
 
 fn detect_line_ending(line: &[u8]) -> &[u8] {


### PR DESCRIPTION
## Summary
- avoid scanning project input for always-run hooks that do not receive filenames
- avoid per-file markdown extension string allocation in fix-trailing-whitespace

## Tests
- cargo test -p prek --bin prek hooks::pre_commit_hooks::fix_trailing_whitespace::tests
- cargo test -p prek --test skipped_hooks always_run_installable_hook_installs_without_matching_files
- git -c safe.directory=D:/Projects/Rust/prek diff --check origin/master..HEAD