### PR TITLE
Write hook failure output directly

### DIFF
--- a/crates/prek/src/hooks/builtin_hooks/check_illegal_windows_names.rs
+++ b/crates/prek/src/hooks/builtin_hooks/check_illegal_windows_names.rs
@@ -1,3 +1,4 @@
+use std::io::Write;
 use std::path::Path;
 
 use crate::hook::Hook;
@@ -16,19 +17,21 @@ pub(crate) fn check_illegal_windows_names(_hook: &Hook, filenames: &[&Path]) -> 
         return (0, Vec::new());
     }
 
+    (1, illegal_windows_names_output(filenames))
+}
+
+fn illegal_windows_names_output(filenames: &[&Path]) -> Vec<u8> {
     let mut output = Vec::new();
     for filename in filenames {
-        output.extend_from_slice(
-            format!("{}: Illegal Windows filename\n", filename.display()).as_bytes(),
-        );
+        writeln!(output, "{}: Illegal Windows filename", filename.display())
+            .expect("writing to Vec should never fail");
     }
-
-    (1, output)
+    output
 }
 
 #[cfg(test)]
 mod tests {
-    use super::ILLEGAL_WINDOWS_PATTERN;
+    use super::*;
     use fancy_regex::Regex;
 
     fn illegal_windows_re() -> Regex {
@@ -75,5 +78,15 @@ mod tests {
         assert!(re.is_match("file.").unwrap());
         assert!(re.is_match("file ").unwrap());
         assert!(re.is_match("dir/file./next").unwrap());
+    }
+
+    #[test]
+    fn test_output_lines() {
+        let filenames = [Path::new("CON.txt"), Path::new("bad:name.txt")];
+        let output = illegal_windows_names_output(&filenames);
+        assert_eq!(
+            String::from_utf8(output).unwrap(),
+            "CON.txt: Illegal Windows filename\nbad:name.txt: Illegal Windows filename\n"
+        );
     }
 }

--- a/crates/prek/src/hooks/pre_commit_hooks/check_case_conflict.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_case_conflict.rs
@@ -1,4 +1,5 @@
 use std::collections::hash_map::Entry;
+use std::io::Write;
 use std::path::Path;
 
 use anyhow::Result;
@@ -86,11 +87,11 @@ pub(crate) async fn check_case_conflict(
     conflicting_files.sort();
 
     for filename in conflicting_files {
-        let line = format!(
-            "Case-insensitivity conflict found: {}\n",
+        writeln!(
+            output,
+            "Case-insensitivity conflict found: {}",
             filename.display()
-        );
-        output.extend(line.into_bytes());
+        )?;
     }
 
     Ok((1, output))


### PR DESCRIPTION
## Summary
- write check-case-conflict failure lines directly into the output buffer
- write check-illegal-windows-names output directly into the output buffer
- add direct coverage for illegal Windows filename output text

## Tests
- cargo test -p prek --bin prek hooks::builtin_hooks::check_illegal_windows_names::tests
- cargo test -p prek --bin prek hooks::pre_commit_hooks::check_case_conflict::tests
- PREK_INTERNAL__TEST_DIR=D:/Projects/Rust/prek/target/prek-tests cargo test -p prek --test builtin_hooks check_case_conflict_hook
- git -c safe.directory=D:/Projects/Rust/prek diff --check