### PR TITLE
Use fixed buffer for EOF scan

### DIFF
--- a/crates/prek/src/hooks/pre_commit_hooks/fix_end_of_file.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/fix_end_of_file.rs
@@ -84,7 +84,7 @@ where
 
     let mut read_len = 0;
     let mut next_char = 0;
-    let mut buf = vec![0u8; MAX_SCAN_SIZE];
+    let mut buf = [0u8; MAX_SCAN_SIZE];
     let mut line_ending = None;
 
     while read_len < data_len {


### PR DESCRIPTION
## Summary
- use a fixed-size scan buffer in end-of-file-fixer instead of allocating a Vec per file

## Tests
- cargo test -p prek --bin prek hooks::pre_commit_hooks::fix_end_of_file::tests
- PREK_INTERNAL__TEST_DIR=D:/Projects/Rust/prek/target/prek-tests cargo test -p prek --test builtin_hooks end_of_file_fixer_hook
- git -c safe.directory=D:/Projects/Rust/prek diff --check