### PR TITLE
Use fixed buffer for private key scan

### DIFF
--- a/crates/prek/src/hooks/pre_commit_hooks/detect_private_key.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/detect_private_key.rs
@@ -55,7 +55,7 @@ pub(crate) async fn detect_private_key(hook: &Hook, filenames: &[&Path]) -> Resu
 /// read, and search the combined window so `BEGIN RSA PRIVATE KEY` is still found.
 async fn check_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)> {
     let mut file = fs_err::tokio::File::open(file_base.join(filename)).await?;
-    let mut buf = vec![0u8; BUFFER_SIZE + CARRY_CAPACITY];
+    let mut buf = [0u8; BUFFER_SIZE + CARRY_CAPACITY];
     let mut carry_len = 0;
 
     loop {


### PR DESCRIPTION
## Summary
- use a fixed-size scan buffer in detect-private-key instead of allocating a Vec per file

## Tests
- cargo test -p prek --bin prek hooks::pre_commit_hooks::detect_private_key::tests
- PREK_INTERNAL__TEST_DIR=D:/Projects/Rust/prek/target/prek-tests cargo test -p prek --test builtin_hooks detect_private_key_hook
- git -c safe.directory=D:/Projects/Rust/prek diff --check