### PR TITLE
Use async metadata for symlink checks

### DIFF
--- a/crates/prek/src/hooks/pre_commit_hooks/check_symlinks.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_symlinks.rs
@@ -13,12 +13,15 @@ pub(crate) async fn check_symlinks(hook: &Hook, filenames: &[&Path]) -> Result<(
     .await
 }
 
-#[allow(clippy::unused_async)]
 async fn check_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)> {
     let path = file_base.join(filename);
 
     // Check if it's a symlink and if it's broken
-    if path.is_symlink() && !path.exists() {
+    let Ok(metadata) = fs_err::tokio::symlink_metadata(&path).await else {
+        return Ok((0, Vec::new()));
+    };
+
+    if metadata.file_type().is_symlink() && fs_err::tokio::metadata(&path).await.is_err() {
         let error_message = format!("{}: Broken symlink\n", filename.display());
         return Ok((1, error_message.into_bytes()));
     }


### PR DESCRIPTION
## Summary
- replace synchronous Path metadata checks in check-symlinks with tokio metadata calls
- keep missing-path behavior aligned with the previous Path::is_symlink path

## Tests
- cargo test -p prek --bin prek hooks::pre_commit_hooks::check_symlinks::tests
- PREK_INTERNAL__TEST_DIR=D:/Projects/Rust/prek/target/prek-tests cargo test -p prek --test builtin_hooks check_symlinks_hook_windows
- git -c safe.directory=D:/Projects/Rust/prek diff --check