### PR TITLE
Write submodule warning directly

### DIFF
--- a/crates/prek/src/hooks/pre_commit_hooks/forbid_new_submodules.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/forbid_new_submodules.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
+use std::fmt::Write;
 use std::path::Path;
 
-use itertools::Itertools;
 use prek_consts::env_vars::EnvVars;
 
 use crate::git;
@@ -46,12 +46,13 @@ pub(crate) async fn forbid_new_submodules(
 }
 
 fn render_message(new_submodules: &[&str]) -> String {
-    let mut message = new_submodules
-        .iter()
-        .map(|filename| format!("{filename}: new submodule introduced"))
-        .join("\n");
+    let mut message = String::new();
+    for filename in new_submodules {
+        writeln!(message, "{filename}: new submodule introduced")
+            .expect("writing to String should never fail");
+    }
 
-    message.push_str("\n\n");
+    message.push('\n');
     message.push_str(indoc::indoc! {"
         This commit introduces new git submodules.
         Did you unintentionally `git add .`?


### PR DESCRIPTION
## Summary
- build forbid-new-submodules warning text directly instead of formatting each line and joining
- remove the local itertools import from that hook implementation

## Tests
- cargo test -p prek --bin prek hooks::pre_commit_hooks::forbid_new_submodules::tests
- PREK_INTERNAL__TEST_DIR=D:/Projects/Rust/prek/target/prek-tests cargo test -p prek --test builtin_hooks forbid_new_submodules_hook_in_workspace_project
- git -c safe.directory=D:/Projects/Rust/prek diff --check