### PR TITLE
Short-circuit branch pattern checks

### DIFF
--- a/crates/prek/src/hooks/pre_commit_hooks/no_commit_to_branch.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/no_commit_to_branch.rs
@@ -26,16 +26,14 @@ impl Args {
             return Ok(false);
         }
 
-        let patterns = self
-            .patterns
-            .iter()
-            .map(|p| Regex::new(p))
-            .collect::<Result<Vec<Regex>, _>>()
-            .context("Failed to compile regex patterns")?;
+        for pattern in &self.patterns {
+            let pattern = Regex::new(pattern).context("Failed to compile regex patterns")?;
+            if pattern.is_match(branch).unwrap_or(false) {
+                return Ok(true);
+            }
+        }
 
-        Ok(patterns
-            .iter()
-            .any(|pattern| pattern.is_match(branch).unwrap_or(false)))
+        Ok(false)
     }
 }
 


### PR DESCRIPTION
## Summary
- avoid collecting no-commit-to-branch regex patterns into a Vec before matching
- compile and test patterns one by one so the first match can return immediately

## Tests
- PREK_INTERNAL__TEST_DIR=D:/Projects/Rust/prek/target/prek-tests cargo test -p prek --test builtin_hooks no_commit_to_branch_hook_with_patterns
- git -c safe.directory=D:/Projects/Rust/prek diff --check