### PR TITLE
Write TOML errors directly

### DIFF
--- a/crates/prek/src/hooks/pre_commit_hooks/check_toml.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_toml.rs
@@ -1,3 +1,4 @@
+use std::io::Write;
 use std::path::Path;
 
 use anyhow::Result;
@@ -33,15 +34,15 @@ async fn check_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)>
     if errors.is_empty() {
         Ok((0, Vec::new()))
     } else {
-        let mut error_messages = Vec::new();
+        let mut output = Vec::new();
         for error in errors {
-            error_messages.push(format!(
+            writeln!(
+                output,
                 "{}: Failed to toml decode ({error})",
                 filename.display()
-            ));
+            )?;
         }
-        let combined_errors = error_messages.join("\n") + "\n";
-        Ok((1, combined_errors.into_bytes()))
+        Ok((1, output))
     }
 }
 


### PR DESCRIPTION
## Summary
- write recoverable TOML parse errors directly into the output buffer
- avoid collecting formatted error strings and joining them afterward

## Tests
- cargo test -p prek --bin prek hooks::pre_commit_hooks::check_toml::tests
- git -c safe.directory=D:/Projects/Rust/prek diff --check