### PR TITLE
Skip unused JSON key reordering

### DIFF
--- a/crates/prek/src/hooks/pre_commit_hooks/pretty_format_json.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/pretty_format_json.rs
@@ -110,7 +110,9 @@ async fn check_file(
 
 fn prettify_json(json: &str, args: &PreparedArgs) -> Result<String> {
     let mut value: Value = serde_json::from_str(json)?;
-    reorder_keys(&mut value, &args.ordered_top_keys, args.sort_keys);
+    if args.sort_keys || !args.ordered_top_keys.is_empty() {
+        reorder_keys(&mut value, &args.ordered_top_keys, args.sort_keys);
+    }
 
     let mut buf = Vec::with_capacity(json.len());
     let formatter = JsonFormatter::with_indent(&args.indent_bytes, args.ensure_ascii);


### PR DESCRIPTION
## Summary
- skip the recursive JSON key reordering pass when --no-sort-keys is set and no top keys are configured
- keep sorting and top-key behavior unchanged when either feature is active

## Tests
- cargo test -p prek --bin prek hooks::pre_commit_hooks::pretty_format_json::tests
- PREK_INTERNAL__TEST_DIR=D:/Projects/Rust/prek/target/prek-tests cargo test -p prek --test builtin_hooks pretty_format_json_with_options
- git -c safe.directory=D:/Projects/Rust/prek diff --check