### PR TITLE
Use borrowed XML events

### DIFF
--- a/crates/prek/src/hooks/pre_commit_hooks/check_xml.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_xml.rs
@@ -29,12 +29,11 @@ async fn check_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)>
     reader.config_mut().check_end_names = true;
     reader.config_mut().expand_empty_elements = true;
 
-    let mut buf = Vec::new();
     let mut root_count = 0;
     let mut depth = 0;
 
     loop {
-        match reader.read_event_into(&mut buf) {
+        match reader.read_event() {
             Ok(quick_xml::events::Event::Eof) => break,
             Ok(quick_xml::events::Event::Start(_)) => {
                 if depth == 0 {
@@ -58,7 +57,6 @@ async fn check_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)>
             }
             Ok(_) => {}
         }
-        buf.clear();
     }
 
     Ok((0, Vec::new()))


### PR DESCRIPTION
## Summary
- use quick-xml's slice-reader read_event API for in-memory XML contents
- avoid maintaining an intermediate event buffer in check-xml

## Tests
- cargo test -p prek --bin prek hooks::pre_commit_hooks::check_xml::tests
- PREK_INTERNAL__TEST_DIR=D:/Projects/Rust/prek/target/prek-tests cargo test -p prek --test builtin_hooks check_xml_hook
- git -c safe.directory=D:/Projects/Rust/prek diff --check