### PR TITLE
Deduplicate JSON top keys with a set

### DIFF
--- a/crates/prek/src/hooks/pre_commit_hooks/pretty_format_json.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/pretty_format_json.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use anyhow::Result;
 use clap::Parser;
+use rustc_hash::FxHashSet;
 use serde::Serialize;
 use serde_json::Value;
 use serde_json::ser::{Formatter, PrettyFormatter};
@@ -51,8 +52,9 @@ impl From<&Args> for PreparedArgs {
         // Keep only the first occurrence of each key so reordering can follow
         // the same "first index wins" rule as Python's `top_keys.index(key)`.
         let mut ordered_top_keys = Vec::with_capacity(args.top_keys.len());
+        let mut seen_top_keys = FxHashSet::default();
         for top_key in &args.top_keys {
-            if !ordered_top_keys.contains(top_key) {
+            if seen_top_keys.insert(top_key.as_str()) {
                 ordered_top_keys.push(top_key.clone());
             }
         }


### PR DESCRIPTION
## Summary
- deduplicate ordered JSON top keys with an FxHashSet during argument preparation
- keep the existing top-key order while avoiding repeated linear contains checks

## Tests
- cargo test -p prek --bin prek hooks::pre_commit_hooks::pretty_format_json::tests
- ='D:\Projects\Rust\prek\target\prek-tests'; cargo test -p prek --test builtin_hooks pretty_format_json_with_top_keys
- git -c safe.directory=D:/Projects/Rust/prek diff --check