### PR TITLE
Skip shebang checks for empty inputs

### DIFF
--- a/crates/prek/src/hooks/pre_commit_hooks/check_executables_have_shebangs.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_executables_have_shebangs.rs
@@ -16,6 +16,10 @@ pub(crate) async fn check_executables_have_shebangs(
     hook: &Hook,
     filenames: &[&Path],
 ) -> Result<(i32, Vec<u8>), anyhow::Error> {
+    if filenames.is_empty() {
+        return Ok((0, Vec::new()));
+    }
+
     let stdout = git::git_cmd("get file file mode")?
         .arg("config")
         .arg("core.fileMode")
@@ -133,6 +137,14 @@ mod tests {
             String::from_utf8_lossy(&output)
                 .contains("marked executable but has no (or invalid) shebang!")
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_os_check_shebangs_empty_input() -> Result<(), anyhow::Error> {
+        let (code, output) = os_check_shebangs(Path::new(""), &[]).await?;
+        assert_eq!(code, 0);
+        assert!(output.is_empty());
         Ok(())
     }
 }

--- a/crates/prek/src/hooks/pre_commit_hooks/check_shebang_scripts_are_executable.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_shebang_scripts_are_executable.rs
@@ -15,6 +15,10 @@ pub(crate) async fn check_shebang_scripts_are_executable(
     hook: &Hook,
     filenames: &[&Path],
 ) -> Result<(i32, Vec<u8>), anyhow::Error> {
+    if filenames.is_empty() {
+        return Ok((0, Vec::new()));
+    }
+
     let file_base = hook.project().relative_path();
     let stdout = git_index_stage_output(file_base).await?;
     let filenames: FxHashSet<_> = filenames.iter().copied().collect();


### PR DESCRIPTION
## Summary
- return early from shebang builtin hooks when no filenames are selected
- avoid starting git config / git ls-files subprocesses for empty candidate lists

## Tests
- cargo test -p prek --bin prek hooks::pre_commit_hooks::check_executables_have_shebangs::tests
- cargo test -p prek --bin prek hooks::pre_commit_hooks::check_shebang_scripts_are_executable::tests
- ='D:\Projects\Rust\prek\target\prek-tests'; cargo test -p prek --test builtin_hooks check_executables_have_shebangs
- ='D:\Projects\Rust\prek\target\prek-tests'; cargo test -p prek --test builtin_hooks check_shebang_scripts_are_executable
- cargo fmt --check
- git -c safe.directory=D:/Projects/Rust/prek diff --check