### PR TITLE
Avoid building YAML value trees

### DIFF
--- a/crates/prek/src/hooks/pre_commit_hooks/check_yaml.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_yaml.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use anyhow::Result;
 use clap::Parser;
+use serde::de::IgnoredAny;
 
 use crate::hook::Hook;
 use crate::hooks::run_concurrent_file_checks;
@@ -53,14 +54,14 @@ async fn check_file(
     };
     if allow_multi_docs {
         if let Err(e) =
-            serde_saphyr::from_slice_multiple_with_options::<serde_json::Value>(&content, options)
+            serde_saphyr::from_slice_multiple_with_options::<IgnoredAny>(&content, options)
         {
             let error_message = format!("{}: Failed to yaml decode ({e})\n", filename.display());
             return Ok((1, error_message.into_bytes()));
         }
         Ok((0, Vec::new()))
     } else {
-        match serde_saphyr::from_slice_with_options::<serde_json::Value>(&content, options) {
+        match serde_saphyr::from_slice_with_options::<IgnoredAny>(&content, options) {
             Ok(_) => Ok((0, Vec::new())),
             Err(e) => {
                 let err = e.render_with_formatter(&serde_saphyr::UserMessageFormatter);


### PR DESCRIPTION
## Summary
- deserialize check-yaml inputs into IgnoredAny instead of serde_json::Value
- keep parsing and duplicate-key validation while avoiding construction of a full value tree

## Tests
- cargo test -p prek --bin prek hooks::pre_commit_hooks::check_yaml::tests
- ='D:\Projects\Rust\prek\target\prek-tests'; cargo test -p prek --test builtin_hooks check_yaml_hook
- cargo fmt --check
- git -c safe.directory=D:/Projects/Rust/prek diff --check