### PR TITLE
fix: avoid duplicate lock file maintenance title

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,7 +20,6 @@
   // Refresh lock files to keep them up-to-date
   lockFileMaintenance: {
     enabled: true,
-    groupName: 'Lock file maintenance',
   },
   semanticCommits: 'disabled',
   // pre-commit is currently in beta testing, must opt in


### PR DESCRIPTION
#2192 currently shows the repetetive title "Lock file maintenance Lock file maintenance". Notably, similar previous PRs (e.g., #2123) had the correct title "Lock file maintenance", with no repeated phrasing. This change appears to be a result of renovatebot/renovate#43629.