### PR TITLE
Verify managed toolchain downloads before installation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,6 +2058,7 @@ dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
  "async-compression",
+ "aws-lc-rs",
  "axoupdater",
  "bstr",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,9 @@ reqwest = { version = "0.13.2", default-features = false, features = [
   "system-proxy",
   "socks",
 ] }
+aws-lc-rs = { version = "1.17.0", default-features = false, features = [
+  "aws-lc-sys",
+] }
 rustc-hash = { version = "2.1.1" }
 rustix = { version = "1.0.8", features = ["pty", "process", "fs", "termios"] }
 same-file = { version = "1.0.6" }

--- a/crates/prek-consts/src/env_vars.rs
+++ b/crates/prek-consts/src/env_vars.rs
@@ -27,6 +27,7 @@ impl EnvVars {
     pub const PREK_NO_FAST_PATH: &'static str = "PREK_NO_FAST_PATH";
     pub const PREK_UV_SOURCE: &'static str = "PREK_UV_SOURCE";
     pub const PREK_NATIVE_TLS: &'static str = "PREK_NATIVE_TLS";
+    pub const PREK_DOWNLOAD_CHECKSUM_POLICY: &'static str = "PREK_DOWNLOAD_CHECKSUM_POLICY";
     pub const SSL_CERT_FILE: &'static str = "SSL_CERT_FILE";
     pub const SSL_CERT_DIR: &'static str = "SSL_CERT_DIR";
     pub const PREK_CONTAINER_RUNTIME: &'static str = "PREK_CONTAINER_RUNTIME";

--- a/crates/prek/Cargo.toml
+++ b/crates/prek/Cargo.toml
@@ -63,6 +63,7 @@ quick-xml = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
+aws-lc-rs = { workspace = true }
 rustc-hash = { workspace = true }
 same-file = { workspace = true }
 schemars = { workspace = true, optional = true }

--- a/crates/prek/src/archive.rs
+++ b/crates/prek/src/archive.rs
@@ -126,6 +126,23 @@ pub fn strip_component(source: impl AsRef<Path>) -> Result<PathBuf, Error> {
     }
 }
 
+/// Extract an archive file next to the archive and return the usable extracted path.
+pub async fn extract_archive(path: impl AsRef<Path>) -> Result<PathBuf, Error> {
+    let path = path.as_ref();
+    let ext = ArchiveExtension::from_path(path)?;
+    let extract_dir = path.with_file_name("extract");
+    fs_err::tokio::create_dir_all(&extract_dir).await?;
+
+    let file = fs_err::tokio::File::open(path).await?;
+    unpack(file, ext, &extract_dir).await?;
+
+    match strip_component(&extract_dir) {
+        Ok(top_level) => Ok(top_level),
+        Err(Error::NonSingularArchive(_)) => Ok(extract_dir),
+        Err(err) => Err(err),
+    }
+}
+
 /// Unpack a `.zip` archive into the target directory, without requiring `Seek`.
 ///
 /// This is useful for unzipping files as they're being downloaded. If the archive
@@ -318,5 +335,22 @@ pub async fn unpack<R: AsyncRead + Unpin>(
         ArchiveExtension::TarGz => untar_gz(reader, target).await,
         ArchiveExtension::TarXz => untar_xz(reader, target).await,
         _ => Err(Error::UnsupportedArchive(target.as_ref().to_path_buf())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+
+    #[tokio::test]
+    async fn extract_archive_rejects_unsupported_archive() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let archive = temp.path().join("archive.rar");
+        fs_err::write(&archive, b"data")?;
+
+        let err = super::extract_archive(&archive).await.unwrap_err();
+
+        assert!(err.to_string().contains("Unsupported archive type"));
+        Ok(())
     }
 }

--- a/crates/prek/src/checksum.rs
+++ b/crates/prek/src/checksum.rs
@@ -1,117 +1,27 @@
 use std::fmt;
-use std::path::Path;
 use std::pin::Pin;
 use std::str::FromStr;
 use std::task::{Context as TaskContext, Poll};
 
 use anyhow::{Context, Result, bail};
 use aws_lc_rs::digest::{Context as Sha256Context, SHA256};
-use tokio::io::{AsyncRead, AsyncReadExt, ReadBuf};
+use tokio::io::{AsyncRead, ReadBuf};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub(crate) struct Sha256Digest([u8; 32]);
 
-pub(crate) struct Sha256Hasher(Sha256Context);
-
-impl Sha256Hasher {
-    pub(crate) fn new() -> Self {
-        Self(Sha256Context::new(&SHA256))
-    }
-
-    pub(crate) fn update(&mut self, data: &[u8]) {
-        Sha256Context::update(&mut self.0, data);
-    }
-
-    pub(crate) fn finish(self) -> Sha256Digest {
-        let digest = self.0.finish();
-        Sha256Digest::from_bytes(digest.as_ref())
-    }
-}
-
-pub(crate) struct HashReader<R> {
-    inner: R,
-    hasher: Sha256Hasher,
-}
-
-impl<R> HashReader<R> {
-    pub(crate) fn new(inner: R) -> Self {
-        Self {
-            inner,
-            hasher: Sha256Hasher::new(),
-        }
-    }
-
-    pub(crate) fn finish(self) -> Sha256Digest {
-        self.hasher.finish()
-    }
-}
-
-impl<R: AsyncRead + Unpin> AsyncRead for HashReader<R> {
-    fn poll_read(
-        self: Pin<&mut Self>,
-        cx: &mut TaskContext<'_>,
-        buf: &mut ReadBuf<'_>,
-    ) -> Poll<std::io::Result<()>> {
-        let this = self.get_mut();
-        let filled_before = buf.filled().len();
-
-        match Pin::new(&mut this.inner).poll_read(cx, buf) {
-            Poll::Ready(Ok(())) => {
-                let filled = buf.filled();
-                if filled.len() > filled_before {
-                    this.hasher.update(&filled[filled_before..]);
-                }
-                Poll::Ready(Ok(()))
-            }
-            other => other,
-        }
-    }
-}
-
 impl Sha256Digest {
+    fn from_bytes(bytes: &[u8]) -> Self {
+        let mut digest = [0_u8; 32];
+        digest.copy_from_slice(bytes);
+        Self(digest)
+    }
+
     pub(crate) fn verify(self, actual: Self, subject: impl fmt::Display) -> Result<()> {
         if actual != self {
             bail!("SHA256 checksum mismatch for `{subject}`: expected {self}, got {actual}");
         }
         Ok(())
-    }
-
-    pub(crate) async fn verify_file(self, path: &Path) -> Result<()> {
-        let actual = Self::from_file(path).await?;
-        self.verify(actual, path.display())
-    }
-
-    async fn from_file(path: &Path) -> Result<Self> {
-        let mut file = fs_err::tokio::File::open(path).await.with_context(|| {
-            format!(
-                "Failed to open `{}` for SHA256 verification",
-                path.display()
-            )
-        })?;
-        let mut hasher = Sha256Context::new(&SHA256);
-        let mut buf = [0_u8; 8192];
-
-        loop {
-            let read = file.read(&mut buf).await.with_context(|| {
-                format!(
-                    "Failed to read `{}` for SHA256 verification",
-                    path.display()
-                )
-            })?;
-            if read == 0 {
-                break;
-            }
-            Sha256Context::update(&mut hasher, &buf[..read]);
-        }
-
-        let digest = hasher.finish();
-        Ok(Self::from_bytes(digest.as_ref()))
-    }
-
-    fn from_bytes(bytes: &[u8]) -> Self {
-        let mut result = [0_u8; 32];
-        result.copy_from_slice(bytes);
-        Self(result)
     }
 }
 
@@ -133,6 +43,47 @@ impl FromStr for Sha256Digest {
 impl fmt::Display for Sha256Digest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&hex::encode(self.0))
+    }
+}
+
+pub(crate) struct HashReader<R> {
+    inner: R,
+    hasher: Sha256Context,
+}
+
+impl<R: AsyncRead + Unpin> HashReader<R> {
+    pub(crate) fn new(inner: R) -> Self {
+        Self {
+            inner,
+            hasher: Sha256Context::new(&SHA256),
+        }
+    }
+
+    pub(crate) fn finish(self) -> Sha256Digest {
+        let digest = self.hasher.finish();
+        Sha256Digest::from_bytes(digest.as_ref())
+    }
+}
+
+impl<R: AsyncRead + Unpin> AsyncRead for HashReader<R> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+        let filled_before = buf.filled().len();
+
+        match Pin::new(&mut this.inner).poll_read(cx, buf) {
+            Poll::Ready(Ok(())) => {
+                let filled = buf.filled();
+                if filled.len() > filled_before {
+                    Sha256Context::update(&mut this.hasher, &filled[filled_before..]);
+                }
+                Poll::Ready(Ok(()))
+            }
+            other => other,
+        }
     }
 }
 
@@ -159,6 +110,10 @@ pub(crate) fn digest_from_sha256sums(contents: &str, filename: &str) -> Result<S
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
+    use tokio::io::AsyncReadExt;
+
     use super::*;
 
     const EMPTY_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
@@ -214,9 +169,7 @@ mod tests {
         let file = temp.path().join("empty");
         fs_err::write(&file, [])?;
 
-        Sha256Digest::from_str(EMPTY_SHA256)?
-            .verify_file(&file)
-            .await?;
+        verify_file(Sha256Digest::from_str(EMPTY_SHA256)?, &file).await?;
         Ok(())
     }
 
@@ -226,11 +179,42 @@ mod tests {
         let file = temp.path().join("not-empty");
         fs_err::write(&file, b"data")?;
 
-        let err = Sha256Digest::from_str(EMPTY_SHA256)?
-            .verify_file(&file)
+        let err = verify_file(Sha256Digest::from_str(EMPTY_SHA256)?, &file)
             .await
             .unwrap_err();
         assert!(err.to_string().contains("SHA256 checksum mismatch"));
         Ok(())
+    }
+
+    async fn verify_file(required_digest: Sha256Digest, path: &Path) -> Result<()> {
+        let actual = digest_file(path).await?;
+        required_digest.verify(actual, path.display())
+    }
+
+    async fn digest_file(path: &Path) -> Result<Sha256Digest> {
+        let mut file = fs_err::tokio::File::open(path).await.with_context(|| {
+            format!(
+                "Failed to open `{}` for SHA256 verification",
+                path.display()
+            )
+        })?;
+        let mut hasher = Sha256Context::new(&SHA256);
+        let mut buf = [0_u8; 8192];
+
+        loop {
+            let read = file.read(&mut buf).await.with_context(|| {
+                format!(
+                    "Failed to read `{}` for SHA256 verification",
+                    path.display()
+                )
+            })?;
+            if read == 0 {
+                break;
+            }
+            Sha256Context::update(&mut hasher, &buf[..read]);
+        }
+
+        let digest = hasher.finish();
+        Ok(Sha256Digest::from_bytes(digest.as_ref()))
     }
 }

--- a/crates/prek/src/checksum.rs
+++ b/crates/prek/src/checksum.rs
@@ -1,24 +1,84 @@
 use std::fmt;
 use std::path::Path;
+use std::pin::Pin;
 use std::str::FromStr;
+use std::task::{Context as TaskContext, Poll};
 
 use anyhow::{Context, Result, bail};
 use aws_lc_rs::digest::{Context as Sha256Context, SHA256};
-use tokio::io::AsyncReadExt;
+use tokio::io::{AsyncRead, AsyncReadExt, ReadBuf};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub(crate) struct Sha256Digest([u8; 32]);
 
+pub(crate) struct Sha256Hasher(Sha256Context);
+
+impl Sha256Hasher {
+    pub(crate) fn new() -> Self {
+        Self(Sha256Context::new(&SHA256))
+    }
+
+    pub(crate) fn update(&mut self, data: &[u8]) {
+        Sha256Context::update(&mut self.0, data);
+    }
+
+    pub(crate) fn finish(self) -> Sha256Digest {
+        let digest = self.0.finish();
+        Sha256Digest::from_bytes(digest.as_ref())
+    }
+}
+
+pub(crate) struct HashReader<R> {
+    inner: R,
+    hasher: Sha256Hasher,
+}
+
+impl<R> HashReader<R> {
+    pub(crate) fn new(inner: R) -> Self {
+        Self {
+            inner,
+            hasher: Sha256Hasher::new(),
+        }
+    }
+
+    pub(crate) fn finish(self) -> Sha256Digest {
+        self.hasher.finish()
+    }
+}
+
+impl<R: AsyncRead + Unpin> AsyncRead for HashReader<R> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+        let filled_before = buf.filled().len();
+
+        match Pin::new(&mut this.inner).poll_read(cx, buf) {
+            Poll::Ready(Ok(())) => {
+                let filled = buf.filled();
+                if filled.len() > filled_before {
+                    this.hasher.update(&filled[filled_before..]);
+                }
+                Poll::Ready(Ok(()))
+            }
+            other => other,
+        }
+    }
+}
+
 impl Sha256Digest {
-    pub(crate) async fn verify_file(self, path: &Path) -> Result<()> {
-        let actual = Self::from_file(path).await?;
+    pub(crate) fn verify(self, actual: Self, subject: impl fmt::Display) -> Result<()> {
         if actual != self {
-            bail!(
-                "SHA256 checksum mismatch for `{}`: expected {self}, got {actual}",
-                path.display()
-            );
+            bail!("SHA256 checksum mismatch for `{subject}`: expected {self}, got {actual}");
         }
         Ok(())
+    }
+
+    pub(crate) async fn verify_file(self, path: &Path) -> Result<()> {
+        let actual = Self::from_file(path).await?;
+        self.verify(actual, path.display())
     }
 
     async fn from_file(path: &Path) -> Result<Self> {
@@ -45,9 +105,13 @@ impl Sha256Digest {
         }
 
         let digest = hasher.finish();
+        Ok(Self::from_bytes(digest.as_ref()))
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Self {
         let mut result = [0_u8; 32];
-        result.copy_from_slice(digest.as_ref());
-        Ok(Self(result))
+        result.copy_from_slice(bytes);
+        Self(result)
     }
 }
 

--- a/crates/prek/src/checksum.rs
+++ b/crates/prek/src/checksum.rs
@@ -146,7 +146,9 @@ pub(crate) fn digest_from_sha256sums(contents: &str, filename: &str) -> Result<S
         let Some((digest, name)) = line.split_once(char::is_whitespace) else {
             continue;
         };
-        let name = name.trim().trim_start_matches('*');
+        let name = name.trim();
+        // GNU-style checksum files may prefix binary-mode filenames with `*`.
+        let name = name.strip_prefix('*').unwrap_or(name);
         if name == filename {
             return digest.parse();
         }
@@ -188,6 +190,17 @@ mod tests {
                 0000000000000000000000000000000000000000000000000000000000000000  other.tar.gz
                 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 *target.tar.gz
             "},
+            "target.tar.gz",
+        )?;
+
+        assert_eq!(digest.to_string(), EMPTY_SHA256);
+        Ok(())
+    }
+
+    #[test]
+    fn parses_sha256sums_binary_mode_marker() -> Result<()> {
+        let digest = digest_from_sha256sums(
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 *target.tar.gz",
             "target.tar.gz",
         )?;
 

--- a/crates/prek/src/checksum.rs
+++ b/crates/prek/src/checksum.rs
@@ -1,0 +1,159 @@
+use std::fmt;
+use std::path::Path;
+use std::str::FromStr;
+
+use anyhow::{Context, Result, bail};
+use aws_lc_rs::digest::{Context as Sha256Context, SHA256};
+use tokio::io::AsyncReadExt;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) struct Sha256Digest([u8; 32]);
+
+impl Sha256Digest {
+    pub(crate) async fn verify_file(self, path: &Path) -> Result<()> {
+        let actual = Self::from_file(path).await?;
+        if actual != self {
+            bail!(
+                "SHA256 checksum mismatch for `{}`: expected {self}, got {actual}",
+                path.display()
+            );
+        }
+        Ok(())
+    }
+
+    async fn from_file(path: &Path) -> Result<Self> {
+        let mut file = fs_err::tokio::File::open(path).await.with_context(|| {
+            format!(
+                "Failed to open `{}` for SHA256 verification",
+                path.display()
+            )
+        })?;
+        let mut hasher = Sha256Context::new(&SHA256);
+        let mut buf = [0_u8; 8192];
+
+        loop {
+            let read = file.read(&mut buf).await.with_context(|| {
+                format!(
+                    "Failed to read `{}` for SHA256 verification",
+                    path.display()
+                )
+            })?;
+            if read == 0 {
+                break;
+            }
+            Sha256Context::update(&mut hasher, &buf[..read]);
+        }
+
+        let digest = hasher.finish();
+        let mut result = [0_u8; 32];
+        result.copy_from_slice(digest.as_ref());
+        Ok(Self(result))
+    }
+}
+
+impl FromStr for Sha256Digest {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self> {
+        let value = value.strip_prefix("sha256:").unwrap_or(value).trim();
+        if value.len() != 64 {
+            bail!("SHA256 digest must be 64 hex characters");
+        }
+
+        let mut digest = [0_u8; 32];
+        hex::decode_to_slice(value, &mut digest).context("Failed to parse SHA256 digest")?;
+        Ok(Self(digest))
+    }
+}
+
+impl fmt::Display for Sha256Digest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&hex::encode(self.0))
+    }
+}
+
+pub(crate) fn digest_from_sha256sums(contents: &str, filename: &str) -> Result<Sha256Digest> {
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        let Some((digest, name)) = line.split_once(char::is_whitespace) else {
+            continue;
+        };
+        let name = name.trim().trim_start_matches('*');
+        if name == filename {
+            return digest.parse();
+        }
+    }
+
+    bail!("No SHA256 digest found for `{filename}`");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EMPTY_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+    #[test]
+    fn parses_plain_and_prefixed_digest() {
+        let plain = Sha256Digest::from_str(EMPTY_SHA256).unwrap();
+        let prefixed = Sha256Digest::from_str(&format!("sha256:{EMPTY_SHA256}")).unwrap();
+
+        assert_eq!(plain, prefixed);
+        assert_eq!(plain.to_string(), EMPTY_SHA256);
+    }
+
+    #[test]
+    fn rejects_invalid_digest() {
+        assert!(Sha256Digest::from_str("abc").is_err());
+        assert!(
+            Sha256Digest::from_str(
+                "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn parses_sha256sums_file() -> Result<()> {
+        let digest = digest_from_sha256sums(
+            indoc::indoc! {"
+                0000000000000000000000000000000000000000000000000000000000000000  other.tar.gz
+                e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 *target.tar.gz
+            "},
+            "target.tar.gz",
+        )?;
+
+        assert_eq!(digest.to_string(), EMPTY_SHA256);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn verifies_file_contents() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let file = temp.path().join("empty");
+        fs_err::write(&file, [])?;
+
+        Sha256Digest::from_str(EMPTY_SHA256)?
+            .verify_file(&file)
+            .await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rejects_file_mismatch() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let file = temp.path().join("not-empty");
+        fs_err::write(&file, b"data")?;
+
+        let err = Sha256Digest::from_str(EMPTY_SHA256)?
+            .verify_file(&file)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("SHA256 checksum mismatch"));
+        Ok(())
+    }
+}

--- a/crates/prek/src/checksum.rs
+++ b/crates/prek/src/checksum.rs
@@ -87,7 +87,10 @@ impl<R: AsyncRead + Unpin> AsyncRead for HashReader<R> {
     }
 }
 
-pub(crate) fn digest_from_sha256sums(contents: &str, filename: &str) -> Result<Sha256Digest> {
+pub(crate) fn digest_from_sha256sums(
+    contents: &str,
+    filename: &str,
+) -> Result<Option<Sha256Digest>> {
     for line in contents.lines() {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') {
@@ -101,11 +104,11 @@ pub(crate) fn digest_from_sha256sums(contents: &str, filename: &str) -> Result<S
         // GNU-style checksum files may prefix binary-mode filenames with `*`.
         let name = name.strip_prefix('*').unwrap_or(name);
         if name == filename {
-            return digest.parse();
+            return digest.parse().map(Some);
         }
     }
 
-    bail!("No SHA256 digest found for `{filename}`");
+    Ok(None)
 }
 
 #[cfg(test)]
@@ -125,6 +128,7 @@ mod tests {
 
         assert_eq!(plain, prefixed);
         assert_eq!(plain.to_string(), EMPTY_SHA256);
+        assert!(plain.verify(prefixed, "test").is_ok());
     }
 
     #[test]
@@ -146,7 +150,8 @@ mod tests {
                 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 *target.tar.gz
             "},
             "target.tar.gz",
-        )?;
+        )?
+        .context("expected target digest")?;
 
         assert_eq!(digest.to_string(), EMPTY_SHA256);
         Ok(())
@@ -157,9 +162,21 @@ mod tests {
         let digest = digest_from_sha256sums(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 *target.tar.gz",
             "target.tar.gz",
-        )?;
+        )?
+        .context("expected target digest")?;
 
         assert_eq!(digest.to_string(), EMPTY_SHA256);
+        Ok(())
+    }
+
+    #[test]
+    fn returns_none_for_missing_sha256sums_entry() -> Result<()> {
+        let digest = digest_from_sha256sums(
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 *other.tar.gz",
+            "target.tar.gz",
+        )?;
+
+        assert_eq!(digest, None);
         Ok(())
     }
 

--- a/crates/prek/src/http.rs
+++ b/crates/prek/src/http.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result};
 use futures::TryStreamExt;
 use prek_consts::env_vars::EnvVars;
 use reqwest::Certificate;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncRead, AsyncWriteExt};
 use tokio_util::compat::FuturesAsyncReadCompatExt;
 use tracing::debug;
 
@@ -14,6 +14,13 @@ use crate::checksum::{HashReader, Sha256Digest};
 use crate::fs::Simplified;
 use crate::store::Store;
 use crate::{archive, warn_user};
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) enum DownloadVerification {
+    #[default]
+    None,
+    Sha256(Sha256Digest),
+}
 
 pub(crate) struct TempDownload {
     path: PathBuf,
@@ -26,109 +33,44 @@ impl TempDownload {
     }
 }
 
+pub(crate) async fn download_artifact(
+    url: &str,
+    filename: &str,
+    store: &Store,
+    verification: DownloadVerification,
+) -> Result<TempDownload> {
+    download_to_temp_file(url, filename, store, verification, |req| req).await
+}
+
 pub(crate) async fn download_and_extract(
     url: &str,
     filename: &str,
     store: &Store,
-    callback: impl AsyncFn(&Path) -> Result<()>,
-) -> Result<()> {
-    download_and_extract_with(url, filename, store, |req| req, callback).await
+    verification: DownloadVerification,
+) -> Result<TempDownload> {
+    download_and_extract_with(url, filename, store, verification, |req| req).await
 }
 
-/// Like [`download_and_extract`], but accepts a `customize_request` closure
-/// that can modify the [`reqwest::RequestBuilder`] before it is sent (e.g. to
-/// add authentication headers).
 pub(crate) async fn download_and_extract_with(
     url: &str,
     filename: &str,
     store: &Store,
+    verification: DownloadVerification,
     customize_request: impl FnOnce(reqwest::RequestBuilder) -> reqwest::RequestBuilder,
-    callback: impl AsyncFn(&Path) -> Result<()>,
-) -> Result<()> {
-    let response = customize_request(REQWEST_CLIENT.get(url))
-        .send()
-        .await
-        .with_context(|| format!("Failed to download file from {url}"))?;
-    if !response.status().is_success() {
-        anyhow::bail!(
-            "Failed to download file from {}: {}",
-            url,
-            response.status()
-        );
-    }
+) -> Result<TempDownload> {
+    let mut download =
+        download_to_temp_file(url, filename, store, verification, customize_request).await?;
+    download.path = extract_download(&download, filename).await?;
+    Ok(download)
+}
 
-    let tarball = response
-        .bytes_stream()
-        .map_err(std::io::Error::other)
-        .into_async_read()
-        .compat();
-
-    let scratch_dir = store.scratch_path();
-    let temp_dir = tempfile::tempdir_in(&scratch_dir)?;
-    debug!(url = %url, temp_dir = ?temp_dir.path(), "Downloading");
-
+async fn extract_download(download: &TempDownload, filename: &str) -> Result<PathBuf> {
     let ext = ArchiveExtension::from_path(filename)?;
-    archive::unpack(tarball, ext, temp_dir.path()).await?;
 
-    let extracted = match archive::strip_component(temp_dir.path()) {
-        Ok(top_level) => top_level,
-        Err(archive::Error::NonSingularArchive(_)) => temp_dir.path().to_path_buf(),
-        Err(err) => return Err(err.into()),
-    };
-
-    callback(&extracted).await?;
-
-    drop(temp_dir);
-
-    Ok(())
-}
-
-pub(crate) async fn download_and_extract_with_checksum(
-    url: &str,
-    filename: &str,
-    store: &Store,
-    expected: Sha256Digest,
-    callback: impl AsyncFn(&Path) -> Result<()>,
-) -> Result<()> {
-    download_and_extract_with_checksum_and_request(
-        url,
-        filename,
-        store,
-        expected,
-        |req| req,
-        callback,
-    )
-    .await
-}
-
-/// Like [`download_and_extract_with`], but verifies the downloaded archive
-/// before extracting it.
-pub(crate) async fn download_and_extract_with_checksum_and_request(
-    url: &str,
-    filename: &str,
-    store: &Store,
-    expected: Sha256Digest,
-    customize_request: impl FnOnce(reqwest::RequestBuilder) -> reqwest::RequestBuilder,
-    callback: impl AsyncFn(&Path) -> Result<()>,
-) -> Result<()> {
-    let download = download_to_temp_file_with_checksum_and_request(
-        url,
-        filename,
-        store,
-        expected,
-        customize_request,
-    )
-    .await?;
-
-    let extract_dir = download
-        .path()
-        .parent()
-        .expect("download path must have parent")
-        .join("extract");
+    let extract_dir = download.path().with_file_name("extract");
     fs_err::tokio::create_dir_all(&extract_dir).await?;
 
     let file = fs_err::tokio::File::open(download.path()).await?;
-    let ext = ArchiveExtension::from_path(filename)?;
     archive::unpack(file, ext, &extract_dir).await?;
 
     let extracted = match archive::strip_component(&extract_dir) {
@@ -137,25 +79,14 @@ pub(crate) async fn download_and_extract_with_checksum_and_request(
         Err(err) => return Err(err.into()),
     };
 
-    callback(&extracted).await?;
-
-    Ok(())
+    Ok(extracted)
 }
 
-pub(crate) async fn download_to_temp_file_with_checksum(
+async fn download_to_temp_file(
     url: &str,
     filename: &str,
     store: &Store,
-    expected: Sha256Digest,
-) -> Result<TempDownload> {
-    download_to_temp_file_with_checksum_and_request(url, filename, store, expected, |req| req).await
-}
-
-pub(crate) async fn download_to_temp_file_with_checksum_and_request(
-    url: &str,
-    filename: &str,
-    store: &Store,
-    expected: Sha256Digest,
+    verification: DownloadVerification,
     customize_request: impl FnOnce(reqwest::RequestBuilder) -> reqwest::RequestBuilder,
 ) -> Result<TempDownload> {
     let temp_dir = tempfile::tempdir_in(store.scratch_path())?;
@@ -165,38 +96,47 @@ pub(crate) async fn download_to_temp_file_with_checksum_and_request(
     let response = customize_request(REQWEST_CLIENT.get(url))
         .send()
         .await
+        .and_then(reqwest::Response::error_for_status)
         .with_context(|| format!("Failed to download file from {url}"))?;
-    if !response.status().is_success() {
-        anyhow::bail!(
-            "Failed to download file from {}: {}",
-            url,
-            response.status()
-        );
-    }
 
-    let stream = response
+    let mut stream = response
         .bytes_stream()
         .map_err(std::io::Error::other)
         .into_async_read()
         .compat();
-    let mut reader = HashReader::new(stream);
-    let mut file = fs_err::tokio::File::create(&path)
-        .await
-        .with_context(|| format!("Failed to create temporary download `{}`", path.display()))?;
-    tokio::io::copy(&mut reader, &mut file)
-        .await
-        .with_context(|| format!("Failed to download file from {url} to `{}`", path.display()))?;
-    file.flush()
-        .await
-        .with_context(|| format!("Failed to flush temporary download `{}`", path.display()))?;
-    drop(file);
 
-    expected.verify(reader.finish(), path.display())?;
+    match verification {
+        DownloadVerification::None => {
+            write_download(&mut stream, &path, url).await?;
+        }
+        DownloadVerification::Sha256(required_digest) => {
+            let mut reader = HashReader::new(stream);
+            write_download(&mut reader, &path, url).await?;
+            required_digest.verify(reader.finish(), path.display())?;
+        }
+    }
 
     Ok(TempDownload {
         path,
         _temp_dir: temp_dir,
     })
+}
+
+async fn write_download(
+    reader: &mut (impl AsyncRead + Unpin),
+    path: &Path,
+    url: &str,
+) -> Result<()> {
+    let mut file = fs_err::tokio::File::create(path)
+        .await
+        .with_context(|| format!("Failed to create temporary download `{}`", path.display()))?;
+    tokio::io::copy(reader, &mut file)
+        .await
+        .with_context(|| format!("Failed to download file from {url} to `{}`", path.display()))?;
+    file.flush()
+        .await
+        .with_context(|| format!("Failed to flush temporary download `{}`", path.display()))?;
+    Ok(())
 }
 
 pub(crate) static REQWEST_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
@@ -314,6 +254,7 @@ mod tests {
     use tokio::net::TcpListener;
     use tokio::task::JoinHandle;
 
+    use super::DownloadVerification;
     use crate::checksum::Sha256Digest;
     use crate::store::Store;
 
@@ -442,16 +383,79 @@ YyRIHN8wfdVoOw==
     }
 
     #[tokio::test]
+    async fn downloads_file_without_checksum() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let store = Store::from_path(temp.path()).init()?;
+        let (url, server) = serve_once(b"data").await?;
+
+        let download = super::download_to_temp_file(
+            &url,
+            "archive.tar.gz",
+            &store,
+            DownloadVerification::None,
+            |req| req,
+        )
+        .await?;
+
+        assert_eq!(fs_err::tokio::read(download.path()).await?, b"data");
+        server.await??;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn download_artifact_keeps_plain_file() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let store = Store::from_path(temp.path()).init()?;
+        let (url, server) = serve_once(b"data").await?;
+
+        let download = super::download_artifact(
+            &url,
+            "rustup-init",
+            &store,
+            DownloadVerification::Sha256(Sha256Digest::from_str(DATA_SHA256)?),
+        )
+        .await?;
+
+        assert_eq!(
+            download.path().file_name().and_then(|name| name.to_str()),
+            Some("rustup-init")
+        );
+        assert_eq!(fs_err::tokio::read(download.path()).await?, b"data");
+        assert!(!download.path().with_file_name("extract").exists());
+        server.await??;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn download_and_extract_artifact_rejects_unsupported_archive() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let store = Store::from_path(temp.path()).init()?;
+        let (url, server) = serve_once(b"data").await?;
+
+        let result =
+            super::download_and_extract(&url, "archive.rar", &store, DownloadVerification::None)
+                .await;
+
+        let Err(err) = result else {
+            panic!("expected unsupported archive error");
+        };
+        assert!(err.to_string().contains("Unsupported archive type"));
+        server.await??;
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn downloads_verified_file() -> Result<()> {
         let temp = tempfile::tempdir()?;
         let store = Store::from_path(temp.path()).init()?;
         let (url, server) = serve_once(b"data").await?;
 
-        let download = super::download_to_temp_file_with_checksum(
+        let download = super::download_to_temp_file(
             &url,
             "archive.tar.gz",
             &store,
-            Sha256Digest::from_str(DATA_SHA256)?,
+            DownloadVerification::Sha256(Sha256Digest::from_str(DATA_SHA256)?),
+            |req| req,
         )
         .await?;
 
@@ -466,11 +470,12 @@ YyRIHN8wfdVoOw==
         let store = Store::from_path(temp.path()).init()?;
         let (url, server) = serve_chunked(&[b"da", b"ta"]).await?;
 
-        let download = super::download_to_temp_file_with_checksum(
+        let download = super::download_to_temp_file(
             &url,
             "archive.tar.gz",
             &store,
-            Sha256Digest::from_str(DATA_SHA256)?,
+            DownloadVerification::Sha256(Sha256Digest::from_str(DATA_SHA256)?),
+            |req| req,
         )
         .await?;
 
@@ -485,11 +490,12 @@ YyRIHN8wfdVoOw==
         let store = Store::from_path(temp.path()).init()?;
         let (url, server) = serve_once(b"data").await?;
 
-        let result = super::download_to_temp_file_with_checksum(
+        let result = super::download_to_temp_file(
             &url,
             "archive.tar.gz",
             &store,
-            Sha256Digest::from_str(EMPTY_SHA256)?,
+            DownloadVerification::Sha256(Sha256Digest::from_str(EMPTY_SHA256)?),
+            |req| req,
         )
         .await;
 

--- a/crates/prek/src/http.rs
+++ b/crates/prek/src/http.rs
@@ -1,25 +1,41 @@
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::sync::LazyLock;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use futures::TryStreamExt;
 use prek_consts::env_vars::EnvVars;
 use reqwest::Certificate;
-use tokio::io::{AsyncRead, AsyncWriteExt};
+use tokio::io::AsyncWriteExt;
 use tokio_util::compat::FuturesAsyncReadCompatExt;
 use tracing::debug;
 
-use crate::archive::ArchiveExtension;
 use crate::checksum::{HashReader, Sha256Digest};
 use crate::fs::Simplified;
 use crate::store::Store;
-use crate::{archive, warn_user};
+use crate::warn_user;
 
-#[derive(Debug, Clone, Copy, Default)]
-pub(crate) enum DownloadVerification {
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default, strum::EnumString)]
+#[strum(serialize_all = "kebab-case")]
+pub(crate) enum DownloadChecksumPolicy {
     #[default]
-    None,
-    Sha256(Sha256Digest),
+    WarnMissing,
+    Required,
+    Disabled,
+}
+
+impl DownloadChecksumPolicy {
+    pub(crate) fn from_env() -> Result<Self> {
+        match EnvVars::var(EnvVars::PREK_DOWNLOAD_CHECKSUM_POLICY) {
+            Ok(value) => Self::from_str(&value).with_context(|| {
+                format!(
+                    "Invalid {} value `{value}`; expected one of: warn-missing, required, disabled",
+                    EnvVars::PREK_DOWNLOAD_CHECKSUM_POLICY
+                )
+            }),
+            Err(_) => Ok(Self::default()),
+        }
+    }
 }
 
 pub(crate) struct TempDownload {
@@ -37,58 +53,59 @@ pub(crate) async fn download_artifact(
     url: &str,
     filename: &str,
     store: &Store,
-    verification: DownloadVerification,
+    fetch_checksum: impl AsyncFn() -> Result<Option<Sha256Digest>>,
 ) -> Result<TempDownload> {
-    download_to_temp_file(url, filename, store, verification, |req| req).await
+    download_artifact_with(
+        url,
+        filename,
+        store,
+        DownloadChecksumPolicy::from_env()?,
+        fetch_checksum,
+        |req| req,
+    )
+    .await
 }
 
-pub(crate) async fn download_and_extract(
+pub(crate) async fn download_artifact_with(
     url: &str,
     filename: &str,
     store: &Store,
-    verification: DownloadVerification,
-) -> Result<TempDownload> {
-    download_and_extract_with(url, filename, store, verification, |req| req).await
-}
-
-pub(crate) async fn download_and_extract_with(
-    url: &str,
-    filename: &str,
-    store: &Store,
-    verification: DownloadVerification,
+    checksum_policy: DownloadChecksumPolicy,
+    fetch_checksum: impl AsyncFn() -> Result<Option<Sha256Digest>>,
     customize_request: impl FnOnce(reqwest::RequestBuilder) -> reqwest::RequestBuilder,
 ) -> Result<TempDownload> {
-    let mut download =
-        download_to_temp_file(url, filename, store, verification, customize_request).await?;
-    download.path = extract_download(&download, filename).await?;
+    if checksum_policy == DownloadChecksumPolicy::Disabled {
+        let (download, _computed_digest) =
+            download_to_temp_file(url, filename, store, customize_request).await?;
+        return Ok(download);
+    }
+
+    let (expected_digest, (download, computed_digest)) = tokio::try_join!(
+        fetch_checksum(),
+        download_to_temp_file(url, filename, store, customize_request)
+    )?;
+
+    if let Some(expected_digest) = expected_digest {
+        expected_digest.verify(computed_digest, download.path().display())?;
+    } else if checksum_policy == DownloadChecksumPolicy::WarnMissing {
+        warn_user!(
+            "No checksum found for `{filename}`; skipping checksum verification. \
+             Set `{}=required` to make missing checksums a hard error.",
+            EnvVars::PREK_DOWNLOAD_CHECKSUM_POLICY
+        );
+    } else {
+        bail!("Checksum verification is required for `{filename}`, but no checksum was found");
+    }
+
     Ok(download)
-}
-
-async fn extract_download(download: &TempDownload, filename: &str) -> Result<PathBuf> {
-    let ext = ArchiveExtension::from_path(filename)?;
-
-    let extract_dir = download.path().with_file_name("extract");
-    fs_err::tokio::create_dir_all(&extract_dir).await?;
-
-    let file = fs_err::tokio::File::open(download.path()).await?;
-    archive::unpack(file, ext, &extract_dir).await?;
-
-    let extracted = match archive::strip_component(&extract_dir) {
-        Ok(top_level) => top_level,
-        Err(archive::Error::NonSingularArchive(_)) => extract_dir,
-        Err(err) => return Err(err.into()),
-    };
-
-    Ok(extracted)
 }
 
 async fn download_to_temp_file(
     url: &str,
     filename: &str,
     store: &Store,
-    verification: DownloadVerification,
     customize_request: impl FnOnce(reqwest::RequestBuilder) -> reqwest::RequestBuilder,
-) -> Result<TempDownload> {
+) -> Result<(TempDownload, Sha256Digest)> {
     let temp_dir = tempfile::tempdir_in(store.scratch_path())?;
     let path = temp_dir.path().join(filename);
     debug!(url = %url, temp_dir = ?temp_dir.path(), "Downloading");
@@ -99,44 +116,31 @@ async fn download_to_temp_file(
         .and_then(reqwest::Response::error_for_status)
         .with_context(|| format!("Failed to download file from {url}"))?;
 
-    let mut stream = response
+    let stream = response
         .bytes_stream()
         .map_err(std::io::Error::other)
         .into_async_read()
         .compat();
 
-    match verification {
-        DownloadVerification::None => {
-            write_download(&mut stream, &path, url).await?;
-        }
-        DownloadVerification::Sha256(required_digest) => {
-            let mut reader = HashReader::new(stream);
-            write_download(&mut reader, &path, url).await?;
-            required_digest.verify(reader.finish(), path.display())?;
-        }
-    }
-
-    Ok(TempDownload {
-        path,
-        _temp_dir: temp_dir,
-    })
-}
-
-async fn write_download(
-    reader: &mut (impl AsyncRead + Unpin),
-    path: &Path,
-    url: &str,
-) -> Result<()> {
-    let mut file = fs_err::tokio::File::create(path)
+    let mut reader = HashReader::new(stream);
+    let mut file = fs_err::tokio::File::create(&path)
         .await
         .with_context(|| format!("Failed to create temporary download `{}`", path.display()))?;
-    tokio::io::copy(reader, &mut file)
+    tokio::io::copy(&mut reader, &mut file)
         .await
         .with_context(|| format!("Failed to download file from {url} to `{}`", path.display()))?;
     file.flush()
         .await
         .with_context(|| format!("Failed to flush temporary download `{}`", path.display()))?;
-    Ok(())
+    let computed_digest = reader.finish();
+
+    Ok((
+        TempDownload {
+            path,
+            _temp_dir: temp_dir,
+        },
+        computed_digest,
+    ))
 }
 
 pub(crate) static REQWEST_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
@@ -254,7 +258,6 @@ mod tests {
     use tokio::net::TcpListener;
     use tokio::task::JoinHandle;
 
-    use super::DownloadVerification;
     use crate::checksum::Sha256Digest;
     use crate::store::Store;
 
@@ -388,14 +391,8 @@ YyRIHN8wfdVoOw==
         let store = Store::from_path(temp.path()).init()?;
         let (url, server) = serve_once(b"data").await?;
 
-        let download = super::download_to_temp_file(
-            &url,
-            "archive.tar.gz",
-            &store,
-            DownloadVerification::None,
-            |req| req,
-        )
-        .await?;
+        let (download, _computed_digest) =
+            super::download_to_temp_file(&url, "archive.tar.gz", &store, |req| req).await?;
 
         assert_eq!(fs_err::tokio::read(download.path()).await?, b"data");
         server.await??;
@@ -408,12 +405,9 @@ YyRIHN8wfdVoOw==
         let store = Store::from_path(temp.path()).init()?;
         let (url, server) = serve_once(b"data").await?;
 
-        let download = super::download_artifact(
-            &url,
-            "rustup-init",
-            &store,
-            DownloadVerification::Sha256(Sha256Digest::from_str(DATA_SHA256)?),
-        )
+        let download = super::download_artifact(&url, "rustup-init", &store, async || {
+            Ok(Some(Sha256Digest::from_str(DATA_SHA256)?))
+        })
         .await?;
 
         assert_eq!(
@@ -421,88 +415,55 @@ YyRIHN8wfdVoOw==
             Some("rustup-init")
         );
         assert_eq!(fs_err::tokio::read(download.path()).await?, b"data");
-        assert!(!download.path().with_file_name("extract").exists());
         server.await??;
         Ok(())
     }
 
     #[tokio::test]
-    async fn download_and_extract_artifact_rejects_unsupported_archive() -> Result<()> {
+    async fn download_artifact_rejects_mismatched_checksum() -> Result<()> {
         let temp = tempfile::tempdir()?;
         let store = Store::from_path(temp.path()).init()?;
         let (url, server) = serve_once(b"data").await?;
 
-        let result =
-            super::download_and_extract(&url, "archive.rar", &store, DownloadVerification::None)
-                .await;
-
-        let Err(err) = result else {
-            panic!("expected unsupported archive error");
-        };
-        assert!(err.to_string().contains("Unsupported archive type"));
-        server.await??;
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn downloads_verified_file() -> Result<()> {
-        let temp = tempfile::tempdir()?;
-        let store = Store::from_path(temp.path()).init()?;
-        let (url, server) = serve_once(b"data").await?;
-
-        let download = super::download_to_temp_file(
-            &url,
-            "archive.tar.gz",
-            &store,
-            DownloadVerification::Sha256(Sha256Digest::from_str(DATA_SHA256)?),
-            |req| req,
-        )
-        .await?;
-
-        assert_eq!(fs_err::tokio::read(download.path()).await?, b"data");
-        server.await??;
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn downloads_verified_chunked_file() -> Result<()> {
-        let temp = tempfile::tempdir()?;
-        let store = Store::from_path(temp.path()).init()?;
-        let (url, server) = serve_chunked(&[b"da", b"ta"]).await?;
-
-        let download = super::download_to_temp_file(
-            &url,
-            "archive.tar.gz",
-            &store,
-            DownloadVerification::Sha256(Sha256Digest::from_str(DATA_SHA256)?),
-            |req| req,
-        )
-        .await?;
-
-        assert_eq!(fs_err::tokio::read(download.path()).await?, b"data");
-        server.await??;
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn rejects_downloaded_file_with_mismatched_checksum() -> Result<()> {
-        let temp = tempfile::tempdir()?;
-        let store = Store::from_path(temp.path()).init()?;
-        let (url, server) = serve_once(b"data").await?;
-
-        let result = super::download_to_temp_file(
-            &url,
-            "archive.tar.gz",
-            &store,
-            DownloadVerification::Sha256(Sha256Digest::from_str(EMPTY_SHA256)?),
-            |req| req,
-        )
+        let result = super::download_artifact(&url, "archive.tar.gz", &store, async || {
+            Ok(Some(Sha256Digest::from_str(EMPTY_SHA256)?))
+        })
         .await;
 
         let Err(err) = result else {
             panic!("expected checksum mismatch");
         };
         assert!(err.to_string().contains("SHA256 checksum mismatch"));
+        server.await??;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn downloads_file_and_computes_checksum() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let store = Store::from_path(temp.path()).init()?;
+        let (url, server) = serve_once(b"data").await?;
+
+        let (download, sha256_digest) =
+            super::download_to_temp_file(&url, "archive.tar.gz", &store, |req| req).await?;
+
+        assert_eq!(fs_err::tokio::read(download.path()).await?, b"data");
+        assert_eq!(sha256_digest, Sha256Digest::from_str(DATA_SHA256)?);
+        server.await??;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn downloads_chunked_file_and_computes_checksum() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let store = Store::from_path(temp.path()).init()?;
+        let (url, server) = serve_chunked(&[b"da", b"ta"]).await?;
+
+        let (download, sha256_digest) =
+            super::download_to_temp_file(&url, "archive.tar.gz", &store, |req| req).await?;
+
+        assert_eq!(fs_err::tokio::read(download.path()).await?, b"data");
+        assert_eq!(sha256_digest, Sha256Digest::from_str(DATA_SHA256)?);
         server.await??;
         Ok(())
     }

--- a/crates/prek/src/http.rs
+++ b/crates/prek/src/http.rs
@@ -10,7 +10,7 @@ use tokio_util::compat::FuturesAsyncReadCompatExt;
 use tracing::debug;
 
 use crate::archive::ArchiveExtension;
-use crate::checksum::Sha256Digest;
+use crate::checksum::{HashReader, Sha256Digest};
 use crate::fs::Simplified;
 use crate::store::Store;
 use crate::{archive, warn_user};
@@ -174,25 +174,24 @@ pub(crate) async fn download_to_temp_file_with_checksum_and_request(
         );
     }
 
+    let stream = response
+        .bytes_stream()
+        .map_err(std::io::Error::other)
+        .into_async_read()
+        .compat();
+    let mut reader = HashReader::new(stream);
     let mut file = fs_err::tokio::File::create(&path)
         .await
         .with_context(|| format!("Failed to create temporary download `{}`", path.display()))?;
-    let mut stream = response.bytes_stream();
-    while let Some(chunk) = stream
-        .try_next()
+    tokio::io::copy(&mut reader, &mut file)
         .await
-        .with_context(|| format!("Failed to download file from {url}"))?
-    {
-        file.write_all(&chunk)
-            .await
-            .with_context(|| format!("Failed to write temporary download `{}`", path.display()))?;
-    }
+        .with_context(|| format!("Failed to download file from {url} to `{}`", path.display()))?;
     file.flush()
         .await
         .with_context(|| format!("Failed to flush temporary download `{}`", path.display()))?;
     drop(file);
 
-    expected.verify_file(&path).await?;
+    expected.verify(reader.finish(), path.display())?;
 
     Ok(TempDownload {
         path,
@@ -361,6 +360,36 @@ YyRIHN8wfdVoOw==
         Ok((url, handle))
     }
 
+    async fn serve_chunked(
+        chunks: &'static [&'static [u8]],
+    ) -> Result<(String, JoinHandle<Result<()>>)> {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+        let url = format!("http://{}", listener.local_addr()?);
+        let handle = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await?;
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request).await?;
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n",
+                )
+                .await?;
+            for chunk in chunks {
+                stream
+                    .write_all(format!("{:x}\r\n", chunk.len()).as_bytes())
+                    .await?;
+                stream.write_all(chunk).await?;
+                stream.write_all(b"\r\n").await?;
+                stream.flush().await?;
+                tokio::task::yield_now().await;
+            }
+            stream.write_all(b"0\r\n\r\n").await?;
+            Ok(())
+        });
+
+        Ok((url, handle))
+    }
+
     #[test]
     fn test_load_pem_certs_from_file() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
@@ -417,6 +446,25 @@ YyRIHN8wfdVoOw==
         let temp = tempfile::tempdir()?;
         let store = Store::from_path(temp.path()).init()?;
         let (url, server) = serve_once(b"data").await?;
+
+        let download = super::download_to_temp_file_with_checksum(
+            &url,
+            "archive.tar.gz",
+            &store,
+            Sha256Digest::from_str(DATA_SHA256)?,
+        )
+        .await?;
+
+        assert_eq!(fs_err::tokio::read(download.path()).await?, b"data");
+        server.await??;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn downloads_verified_chunked_file() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let store = Store::from_path(temp.path()).init()?;
+        let (url, server) = serve_chunked(&[b"da", b"ta"]).await?;
 
         let download = super::download_to_temp_file_with_checksum(
             &url,

--- a/crates/prek/src/http.rs
+++ b/crates/prek/src/http.rs
@@ -5,13 +5,26 @@ use anyhow::{Context, Result};
 use futures::TryStreamExt;
 use prek_consts::env_vars::EnvVars;
 use reqwest::Certificate;
+use tokio::io::AsyncWriteExt;
 use tokio_util::compat::FuturesAsyncReadCompatExt;
 use tracing::debug;
 
 use crate::archive::ArchiveExtension;
+use crate::checksum::Sha256Digest;
 use crate::fs::Simplified;
 use crate::store::Store;
 use crate::{archive, warn_user};
+
+pub(crate) struct TempDownload {
+    path: PathBuf,
+    _temp_dir: tempfile::TempDir,
+}
+
+impl TempDownload {
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+}
 
 pub(crate) async fn download_and_extract(
     url: &str,
@@ -68,6 +81,123 @@ pub(crate) async fn download_and_extract_with(
     drop(temp_dir);
 
     Ok(())
+}
+
+pub(crate) async fn download_and_extract_with_checksum(
+    url: &str,
+    filename: &str,
+    store: &Store,
+    expected: Sha256Digest,
+    callback: impl AsyncFn(&Path) -> Result<()>,
+) -> Result<()> {
+    download_and_extract_with_checksum_and_request(
+        url,
+        filename,
+        store,
+        expected,
+        |req| req,
+        callback,
+    )
+    .await
+}
+
+/// Like [`download_and_extract_with`], but verifies the downloaded archive
+/// before extracting it.
+pub(crate) async fn download_and_extract_with_checksum_and_request(
+    url: &str,
+    filename: &str,
+    store: &Store,
+    expected: Sha256Digest,
+    customize_request: impl FnOnce(reqwest::RequestBuilder) -> reqwest::RequestBuilder,
+    callback: impl AsyncFn(&Path) -> Result<()>,
+) -> Result<()> {
+    let download = download_to_temp_file_with_checksum_and_request(
+        url,
+        filename,
+        store,
+        expected,
+        customize_request,
+    )
+    .await?;
+
+    let extract_dir = download
+        .path()
+        .parent()
+        .expect("download path must have parent")
+        .join("extract");
+    fs_err::tokio::create_dir_all(&extract_dir).await?;
+
+    let file = fs_err::tokio::File::open(download.path()).await?;
+    let ext = ArchiveExtension::from_path(filename)?;
+    archive::unpack(file, ext, &extract_dir).await?;
+
+    let extracted = match archive::strip_component(&extract_dir) {
+        Ok(top_level) => top_level,
+        Err(archive::Error::NonSingularArchive(_)) => extract_dir,
+        Err(err) => return Err(err.into()),
+    };
+
+    callback(&extracted).await?;
+
+    Ok(())
+}
+
+pub(crate) async fn download_to_temp_file_with_checksum(
+    url: &str,
+    filename: &str,
+    store: &Store,
+    expected: Sha256Digest,
+) -> Result<TempDownload> {
+    download_to_temp_file_with_checksum_and_request(url, filename, store, expected, |req| req).await
+}
+
+pub(crate) async fn download_to_temp_file_with_checksum_and_request(
+    url: &str,
+    filename: &str,
+    store: &Store,
+    expected: Sha256Digest,
+    customize_request: impl FnOnce(reqwest::RequestBuilder) -> reqwest::RequestBuilder,
+) -> Result<TempDownload> {
+    let temp_dir = tempfile::tempdir_in(store.scratch_path())?;
+    let path = temp_dir.path().join(filename);
+    debug!(url = %url, temp_dir = ?temp_dir.path(), "Downloading");
+
+    let response = customize_request(REQWEST_CLIENT.get(url))
+        .send()
+        .await
+        .with_context(|| format!("Failed to download file from {url}"))?;
+    if !response.status().is_success() {
+        anyhow::bail!(
+            "Failed to download file from {}: {}",
+            url,
+            response.status()
+        );
+    }
+
+    let mut file = fs_err::tokio::File::create(&path)
+        .await
+        .with_context(|| format!("Failed to create temporary download `{}`", path.display()))?;
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream
+        .try_next()
+        .await
+        .with_context(|| format!("Failed to download file from {url}"))?
+    {
+        file.write_all(&chunk)
+            .await
+            .with_context(|| format!("Failed to write temporary download `{}`", path.display()))?;
+    }
+    file.flush()
+        .await
+        .with_context(|| format!("Failed to flush temporary download `{}`", path.display()))?;
+    drop(file);
+
+    expected.verify_file(&path).await?;
+
+    Ok(TempDownload {
+        path,
+        _temp_dir: temp_dir,
+    })
 }
 
 pub(crate) static REQWEST_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
@@ -177,8 +307,19 @@ fn create_reqwest_client(native_tls: bool, custom_certs: Vec<Certificate>) -> re
 
 #[cfg(test)]
 mod tests {
-    use anyhow::Result;
     use std::path::Path;
+    use std::str::FromStr;
+
+    use anyhow::Result;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio::task::JoinHandle;
+
+    use crate::checksum::Sha256Digest;
+    use crate::store::Store;
+
+    const DATA_SHA256: &str = "3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7";
+    const EMPTY_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
 
     const TEST_CERT_PEM: &str = "-----BEGIN CERTIFICATE-----
 MIIBtjCCAVugAwIBAgITBmyf1XSXNmY/Owua2eiedgPySjAKBggqhkjOPQQDAjA5
@@ -195,6 +336,29 @@ YyRIHN8wfdVoOw==
 
     fn write_cert(path: &Path) {
         fs_err::write(path, TEST_CERT_PEM).expect("failed to write test certificate");
+    }
+
+    async fn serve_once(body: &'static [u8]) -> Result<(String, JoinHandle<Result<()>>)> {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+        let url = format!("http://{}", listener.local_addr()?);
+        let handle = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await?;
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request).await?;
+            stream
+                .write_all(
+                    format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                        body.len()
+                    )
+                    .as_bytes(),
+                )
+                .await?;
+            stream.write_all(body).await?;
+            Ok(())
+        });
+
+        Ok((url, handle))
     }
 
     #[test]
@@ -246,5 +410,46 @@ YyRIHN8wfdVoOw==
         let client = super::create_reqwest_client(true, vec![]);
         let resp = client.get("https://github.com").send().await;
         assert!(resp.is_ok(), "Failed to send request with native TLS");
+    }
+
+    #[tokio::test]
+    async fn downloads_verified_file() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let store = Store::from_path(temp.path()).init()?;
+        let (url, server) = serve_once(b"data").await?;
+
+        let download = super::download_to_temp_file_with_checksum(
+            &url,
+            "archive.tar.gz",
+            &store,
+            Sha256Digest::from_str(DATA_SHA256)?,
+        )
+        .await?;
+
+        assert_eq!(fs_err::tokio::read(download.path()).await?, b"data");
+        server.await??;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rejects_downloaded_file_with_mismatched_checksum() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let store = Store::from_path(temp.path()).init()?;
+        let (url, server) = serve_once(b"data").await?;
+
+        let result = super::download_to_temp_file_with_checksum(
+            &url,
+            "archive.tar.gz",
+            &store,
+            Sha256Digest::from_str(EMPTY_SHA256)?,
+        )
+        .await;
+
+        let Err(err) = result else {
+            panic!("expected checksum mismatch");
+        };
+        assert!(err.to_string().contains("SHA256 checksum mismatch"));
+        server.await??;
+        Ok(())
     }
 }

--- a/crates/prek/src/languages/bun/installer.rs
+++ b/crates/prek/src/languages/bun/installer.rs
@@ -10,9 +10,10 @@ use prek_consts::env_vars::EnvVars;
 use target_lexicon::{Architecture, HOST, OperatingSystem};
 use tracing::{debug, trace, warn};
 
+use crate::checksum::{Sha256Digest, digest_from_sha256sums};
 use crate::fs::LockedFile;
 use crate::git;
-use crate::http::download_and_extract;
+use crate::http::{REQWEST_CLIENT, download_and_extract_with_checksum};
 use crate::languages::bun::BunRequest;
 use crate::languages::bun::version::BunVersion;
 use crate::process::Cmd;
@@ -218,9 +219,10 @@ impl BunInstaller {
         let filename = format!("bun-{os}-{arch}.zip");
         let url =
             format!("https://github.com/oven-sh/bun/releases/download/bun-v{version}/{filename}");
+        let checksum = self.fetch_checksum(version, &filename).await?;
         let target = self.root.join(version.to_string());
 
-        download_and_extract(&url, &filename, store, async |extracted| {
+        download_and_extract_with_checksum(&url, &filename, store, checksum, async |extracted| {
             if target.exists() {
                 debug!(target = %target.display(), "Removing existing bun");
                 fs_err::tokio::remove_dir_all(&target).await?;
@@ -242,6 +244,26 @@ impl BunInstaller {
         .context("Failed to download and extract bun")?;
 
         Ok(BunResult::from_dir(&target).with_version(version.clone()))
+    }
+
+    async fn fetch_checksum(&self, version: &BunVersion, filename: &str) -> Result<Sha256Digest> {
+        let url = format!(
+            "https://github.com/oven-sh/bun/releases/download/bun-v{version}/SHASUMS256.txt"
+        );
+        let response = REQWEST_CLIENT
+            .get(&url)
+            .send()
+            .await
+            .with_context(|| format!("Failed to fetch Bun checksums from {url}"))?;
+        if !response.status().is_success() {
+            anyhow::bail!(
+                "Failed to fetch Bun checksums from {}: {}",
+                url,
+                response.status()
+            );
+        }
+        let checksums = response.text().await?;
+        digest_from_sha256sums(&checksums, filename)
     }
 
     /// Find a suitable system Bun installation that matches the request.

--- a/crates/prek/src/languages/bun/installer.rs
+++ b/crates/prek/src/languages/bun/installer.rs
@@ -13,7 +13,7 @@ use tracing::{debug, trace, warn};
 use crate::checksum::{Sha256Digest, digest_from_sha256sums};
 use crate::fs::LockedFile;
 use crate::git;
-use crate::http::{REQWEST_CLIENT, download_and_extract_with_checksum};
+use crate::http::{DownloadVerification, REQWEST_CLIENT, download_and_extract};
 use crate::languages::bun::BunRequest;
 use crate::languages::bun::version::BunVersion;
 use crate::process::Cmd;
@@ -219,34 +219,37 @@ impl BunInstaller {
         let filename = format!("bun-{os}-{arch}.zip");
         let url =
             format!("https://github.com/oven-sh/bun/releases/download/bun-v{version}/{filename}");
-        let checksum = self.fetch_checksum(version, &filename).await?;
+        let checksum = Self::fetch_checksum(version, &filename).await?;
         let target = self.root.join(version.to_string());
 
-        download_and_extract_with_checksum(&url, &filename, store, checksum, async |extracted| {
-            if target.exists() {
-                debug!(target = %target.display(), "Removing existing bun");
-                fs_err::tokio::remove_dir_all(&target).await?;
-            }
-
-            // The ZIP extracts to bun-{os}-{arch}/bun, we need to move the contents
-            // to {version}/bin/bun
-            let extracted_binary = extracted.join("bun").with_extension(EXE_EXTENSION);
-            let target_bin_dir = bin_dir(&target);
-            fs_err::tokio::create_dir_all(&target_bin_dir).await?;
-
-            let target_binary = target_bin_dir.join("bun").with_extension(EXE_EXTENSION);
-            debug!(?extracted_binary, target = %target_binary.display(), "Moving bun to target");
-            fs_err::tokio::rename(&extracted_binary, &target_binary).await?;
-
-            anyhow::Ok(())
-        })
+        let download = download_and_extract(
+            &url,
+            &filename,
+            store,
+            DownloadVerification::Sha256(checksum),
+        )
         .await
         .context("Failed to download and extract bun")?;
+        let extracted = download.path();
+        if target.exists() {
+            debug!(target = %target.display(), "Removing existing bun");
+            fs_err::tokio::remove_dir_all(&target).await?;
+        }
+
+        // The ZIP extracts to bun-{os}-{arch}/bun, we need to move the contents
+        // to {version}/bin/bun
+        let extracted_binary = extracted.join("bun").with_extension(EXE_EXTENSION);
+        let target_bin_dir = bin_dir(&target);
+        fs_err::tokio::create_dir_all(&target_bin_dir).await?;
+
+        let target_binary = target_bin_dir.join("bun").with_extension(EXE_EXTENSION);
+        debug!(?extracted_binary, target = %target_binary.display(), "Moving bun to target");
+        fs_err::tokio::rename(&extracted_binary, &target_binary).await?;
 
         Ok(BunResult::from_dir(&target).with_version(version.clone()))
     }
 
-    async fn fetch_checksum(&self, version: &BunVersion, filename: &str) -> Result<Sha256Digest> {
+    async fn fetch_checksum(version: &BunVersion, filename: &str) -> Result<Sha256Digest> {
         let url = format!(
             "https://github.com/oven-sh/bun/releases/download/bun-v{version}/SHASUMS256.txt"
         );
@@ -254,14 +257,8 @@ impl BunInstaller {
             .get(&url)
             .send()
             .await
+            .and_then(reqwest::Response::error_for_status)
             .with_context(|| format!("Failed to fetch Bun checksums from {url}"))?;
-        if !response.status().is_success() {
-            anyhow::bail!(
-                "Failed to fetch Bun checksums from {}: {}",
-                url,
-                response.status()
-            );
-        }
         let checksums = response.text().await?;
         digest_from_sha256sums(&checksums, filename)
     }

--- a/crates/prek/src/languages/bun/installer.rs
+++ b/crates/prek/src/languages/bun/installer.rs
@@ -10,10 +10,11 @@ use prek_consts::env_vars::EnvVars;
 use target_lexicon::{Architecture, HOST, OperatingSystem};
 use tracing::{debug, trace, warn};
 
+use crate::archive;
 use crate::checksum::{Sha256Digest, digest_from_sha256sums};
 use crate::fs::LockedFile;
 use crate::git;
-use crate::http::{DownloadVerification, REQWEST_CLIENT, download_and_extract};
+use crate::http::{REQWEST_CLIENT, download_artifact};
 use crate::languages::bun::BunRequest;
 use crate::languages::bun::version::BunVersion;
 use crate::process::Cmd;
@@ -219,18 +220,19 @@ impl BunInstaller {
         let filename = format!("bun-{os}-{arch}.zip");
         let url =
             format!("https://github.com/oven-sh/bun/releases/download/bun-v{version}/{filename}");
-        let checksum = Self::fetch_checksum(version, &filename).await?;
+        let checksum_url = format!(
+            "https://github.com/oven-sh/bun/releases/download/bun-v{version}/SHASUMS256.txt"
+        );
         let target = self.root.join(version.to_string());
 
-        let download = download_and_extract(
-            &url,
-            &filename,
-            store,
-            DownloadVerification::Sha256(checksum),
-        )
+        let download = download_artifact(&url, &filename, store, async || {
+            Self::fetch_checksum(&checksum_url, &filename).await
+        })
         .await
-        .context("Failed to download and extract bun")?;
-        let extracted = download.path();
+        .context("Failed to download bun")?;
+        let extracted = archive::extract_archive(download.path())
+            .await
+            .context("Failed to extract bun")?;
         if target.exists() {
             debug!(target = %target.display(), "Removing existing bun");
             fs_err::tokio::remove_dir_all(&target).await?;
@@ -249,17 +251,21 @@ impl BunInstaller {
         Ok(BunResult::from_dir(&target).with_version(version.clone()))
     }
 
-    async fn fetch_checksum(version: &BunVersion, filename: &str) -> Result<Sha256Digest> {
-        let url = format!(
-            "https://github.com/oven-sh/bun/releases/download/bun-v{version}/SHASUMS256.txt"
-        );
+    async fn fetch_checksum(url: &str, filename: &str) -> Result<Option<Sha256Digest>> {
         let response = REQWEST_CLIENT
-            .get(&url)
+            .get(url)
             .send()
             .await
-            .and_then(reqwest::Response::error_for_status)
             .with_context(|| format!("Failed to fetch Bun checksums from {url}"))?;
-        let checksums = response.text().await?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+
+        let checksums = response
+            .error_for_status()
+            .with_context(|| format!("Failed to fetch Bun checksums from {url}"))?
+            .text()
+            .await?;
         digest_from_sha256sums(&checksums, filename)
     }
 

--- a/crates/prek/src/languages/deno/installer.rs
+++ b/crates/prek/src/languages/deno/installer.rs
@@ -332,10 +332,21 @@ pub(crate) fn bin_dir(prefix: &Path) -> PathBuf {
 }
 
 fn digest_from_deno_checksum(contents: &str, filename: &str) -> Result<Sha256Digest> {
+    // Deno releases have shipped a per-artifact `.sha256sum` file since v2.0.1.
+    // Non-Windows artifacts use the regular sha256sums format handled by
+    // `digest_from_sha256sums`; Windows artifacts use this `Get-FileHash` shape:
+    //
+    // Algorithm : SHA256
+    // Hash      : D45377511968CB2DB7E57155257FF9A1400DB169256B5EAA16C6657F275E4D3B
+    // Path      : C:\a\deno\deno\target\release\deno-x86_64-pc-windows-msvc.zip
     if let Ok(digest) = digest_from_sha256sums(contents, filename) {
         return Ok(digest);
     }
+    digest_from_deno_windows_checksum(contents, filename)
+}
 
+fn digest_from_deno_windows_checksum(contents: &str, filename: &str) -> Result<Sha256Digest> {
+    let mut algorithm = None;
     let mut hash = None;
     let mut path = None;
     for line in contents.lines() {
@@ -343,18 +354,28 @@ fn digest_from_deno_checksum(contents: &str, filename: &str) -> Result<Sha256Dig
             continue;
         };
         match name.trim() {
+            "Algorithm" => algorithm = Some(value.trim()),
             "Hash" => hash = Some(value.trim()),
             "Path" => path = Some(value.trim()),
             _ => {}
         }
     }
 
+    let Some(algorithm) = algorithm else {
+        anyhow::bail!("No algorithm found in Deno checksum file");
+    };
+    if !algorithm.eq_ignore_ascii_case("SHA256") {
+        anyhow::bail!("Deno checksum file uses `{algorithm}` instead of `SHA256`");
+    }
+
     let Some(path) = path else {
         anyhow::bail!("No path found in Deno checksum file");
     };
-    let Some(found_filename) = path.rsplit(['/', '\\']).next() else {
-        anyhow::bail!("No filename found in Deno checksum path");
-    };
+    let found_filename = path
+        .rsplit(['/', '\\'])
+        .next()
+        .filter(|name| !name.is_empty())
+        .context("No filename found in Deno checksum path")?;
     if found_filename != filename {
         anyhow::bail!("Deno checksum file lists `{found_filename}` instead of `{filename}`");
     }
@@ -413,5 +434,35 @@ mod tests {
         );
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_deno_windows_checksum_with_different_algorithm() {
+        let result = digest_from_deno_checksum(
+            indoc::indoc! {r"
+                Algorithm : SHA512
+                Hash      : 1611FB54C3BB0A605A851530A359A48B34A8ABFD29D7091538D91B6E7F105380
+                Path      : C:\a\deno\deno\target\release\deno-x86_64-pc-windows-msvc.zip
+            "},
+            "deno-x86_64-pc-windows-msvc.zip",
+        );
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Deno checksum file uses `SHA512` instead of `SHA256`"
+        );
+    }
+
+    #[test]
+    fn preserves_sha256sums_error_for_non_windows_checksum() {
+        let result = digest_from_deno_checksum(
+            "f5b681529a0360e7f430688fc0ba3b25626b3933c370b053a0c27f39ef7a0f90  deno-x86_64-unknown-linux-gnu.zip",
+            "deno-aarch64-unknown-linux-gnu.zip",
+        );
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "No SHA256 digest found for `deno-aarch64-unknown-linux-gnu.zip`"
+        );
     }
 }

--- a/crates/prek/src/languages/deno/installer.rs
+++ b/crates/prek/src/languages/deno/installer.rs
@@ -13,7 +13,7 @@ use tracing::{debug, trace, warn};
 
 use crate::checksum::{Sha256Digest, digest_from_sha256sums};
 use crate::fs::LockedFile;
-use crate::http::{REQWEST_CLIENT, download_and_extract_with_checksum};
+use crate::http::{DownloadVerification, REQWEST_CLIENT, download_and_extract};
 use crate::languages::deno::DenoRequest;
 use crate::languages::deno::version::DenoVersion;
 use crate::process::Cmd;
@@ -224,30 +224,28 @@ impl DenoInstaller {
         let url = format!("https://dl.deno.land/release/v{version}/{filename}");
         let target = self.root.join(version.to_string());
 
-        let checksum = self.fetch_checksum(&url, &filename).await?;
-        download_and_extract_with_checksum(&url, &filename, store, checksum, async |extracted| {
-            Self::install_extracted(&target, extracted).await
-        })
+        let checksum = Self::fetch_checksum(&url, &filename).await?;
+        let download = download_and_extract(
+            &url,
+            &filename,
+            store,
+            DownloadVerification::Sha256(checksum),
+        )
         .await
         .context("Failed to download and extract deno")?;
+        Self::install_extracted(&target, download.path()).await?;
 
         Ok(DenoResult::from_dir(&target).with_version(version.clone()))
     }
 
-    async fn fetch_checksum(&self, url: &str, filename: &str) -> Result<Sha256Digest> {
+    async fn fetch_checksum(url: &str, filename: &str) -> Result<Sha256Digest> {
         let checksum_url = format!("{url}.sha256sum");
         let response = REQWEST_CLIENT
             .get(&checksum_url)
             .send()
             .await
+            .and_then(reqwest::Response::error_for_status)
             .with_context(|| format!("Failed to fetch Deno checksum from {checksum_url}"))?;
-        if !response.status().is_success() {
-            anyhow::bail!(
-                "Failed to fetch Deno checksum from {}: {}",
-                checksum_url,
-                response.status()
-            );
-        }
 
         let checksums = response.text().await?;
         digest_from_deno_checksum(&checksums, filename).with_context(|| {

--- a/crates/prek/src/languages/deno/installer.rs
+++ b/crates/prek/src/languages/deno/installer.rs
@@ -11,9 +11,10 @@ use serde::Deserialize;
 use target_lexicon::{Architecture, HOST, OperatingSystem};
 use tracing::{debug, trace, warn};
 
+use crate::archive;
 use crate::checksum::{Sha256Digest, digest_from_sha256sums};
 use crate::fs::LockedFile;
-use crate::http::{DownloadVerification, REQWEST_CLIENT, download_and_extract};
+use crate::http::{REQWEST_CLIENT, download_artifact};
 use crate::languages::deno::DenoRequest;
 use crate::languages::deno::version::DenoVersion;
 use crate::process::Cmd;
@@ -222,35 +223,38 @@ impl DenoInstaller {
 
         let filename = format!("deno-{arch}-{os}.zip");
         let url = format!("https://dl.deno.land/release/v{version}/{filename}");
+        let checksum_url = format!("{url}.sha256sum");
         let target = self.root.join(version.to_string());
 
-        let checksum = Self::fetch_checksum(&url, &filename).await?;
-        let download = download_and_extract(
-            &url,
-            &filename,
-            store,
-            DownloadVerification::Sha256(checksum),
-        )
+        let download = download_artifact(&url, &filename, store, async || {
+            Self::fetch_checksum(&checksum_url, &filename).await
+        })
         .await
-        .context("Failed to download and extract deno")?;
-        Self::install_extracted(&target, download.path()).await?;
+        .context("Failed to download deno")?;
+        let extracted = archive::extract_archive(download.path())
+            .await
+            .context("Failed to extract deno")?;
+        Self::install_extracted(&target, &extracted).await?;
 
         Ok(DenoResult::from_dir(&target).with_version(version.clone()))
     }
 
-    async fn fetch_checksum(url: &str, filename: &str) -> Result<Sha256Digest> {
-        let checksum_url = format!("{url}.sha256sum");
+    async fn fetch_checksum(checksum_url: &str, filename: &str) -> Result<Option<Sha256Digest>> {
         let response = REQWEST_CLIENT
-            .get(&checksum_url)
+            .get(checksum_url)
             .send()
             .await
-            .and_then(reqwest::Response::error_for_status)
             .with_context(|| format!("Failed to fetch Deno checksum from {checksum_url}"))?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
 
-        let checksums = response.text().await?;
-        digest_from_deno_checksum(&checksums, filename).with_context(|| {
-            format!("Deno checksum file at {checksum_url} does not list `{filename}`")
-        })
+        let checksums = response
+            .error_for_status()
+            .with_context(|| format!("Failed to fetch Deno checksum from {checksum_url}"))?
+            .text()
+            .await?;
+        digest_from_deno_checksum(&checksums, filename)
     }
 
     async fn install_extracted(target: &Path, extracted: &Path) -> Result<()> {
@@ -331,21 +335,25 @@ pub(crate) fn bin_dir(prefix: &Path) -> PathBuf {
     prefix.join("bin")
 }
 
-fn digest_from_deno_checksum(contents: &str, filename: &str) -> Result<Sha256Digest> {
-    // Deno releases have shipped a per-artifact `.sha256sum` file since v2.0.1.
+fn digest_from_deno_checksum(contents: &str, filename: &str) -> Result<Option<Sha256Digest>> {
+    // Deno releases have shipped per-artifact `.sha256sum` assets since v2.0.0,
+    // while `dl.deno.land/release/v{version}/{filename}.sha256sum` starts at v2.0.1.
     // Non-Windows artifacts use the regular sha256sums format handled by
     // `digest_from_sha256sums`; Windows artifacts use this `Get-FileHash` shape:
     //
     // Algorithm : SHA256
     // Hash      : D45377511968CB2DB7E57155257FF9A1400DB169256B5EAA16C6657F275E4D3B
     // Path      : C:\a\deno\deno\target\release\deno-x86_64-pc-windows-msvc.zip
-    if let Ok(digest) = digest_from_sha256sums(contents, filename) {
-        return Ok(digest);
+    if let Some(digest) = digest_from_sha256sums(contents, filename)? {
+        return Ok(Some(digest));
     }
     digest_from_deno_windows_checksum(contents, filename)
 }
 
-fn digest_from_deno_windows_checksum(contents: &str, filename: &str) -> Result<Sha256Digest> {
+fn digest_from_deno_windows_checksum(
+    contents: &str,
+    filename: &str,
+) -> Result<Option<Sha256Digest>> {
     let mut algorithm = None;
     let mut hash = None;
     let mut path = None;
@@ -359,6 +367,10 @@ fn digest_from_deno_windows_checksum(contents: &str, filename: &str) -> Result<S
             "Path" => path = Some(value.trim()),
             _ => {}
         }
+    }
+
+    if algorithm.is_none() && hash.is_none() && path.is_none() {
+        return Ok(None);
     }
 
     let Some(algorithm) = algorithm else {
@@ -377,13 +389,13 @@ fn digest_from_deno_windows_checksum(contents: &str, filename: &str) -> Result<S
         .filter(|name| !name.is_empty())
         .context("No filename found in Deno checksum path")?;
     if found_filename != filename {
-        anyhow::bail!("Deno checksum file lists `{found_filename}` instead of `{filename}`");
+        return Ok(None);
     }
 
     let Some(hash) = hash else {
         anyhow::bail!("No hash found in Deno checksum file");
     };
-    hash.parse()
+    hash.parse().map(Some)
 }
 
 #[cfg(test)]
@@ -392,7 +404,7 @@ mod tests {
 
     #[test]
     fn parses_deno_sha256sum_format() -> Result<()> {
-        let digest = digest_from_deno_checksum(
+        let digest = require_deno_checksum(
             "f5b681529a0360e7f430688fc0ba3b25626b3933c370b053a0c27f39ef7a0f90  deno-x86_64-unknown-linux-gnu.zip",
             "deno-x86_64-unknown-linux-gnu.zip",
         )?;
@@ -406,7 +418,7 @@ mod tests {
 
     #[test]
     fn parses_deno_windows_checksum_format() -> Result<()> {
-        let digest = digest_from_deno_checksum(
+        let digest = require_deno_checksum(
             indoc::indoc! {r"
                 Algorithm : SHA256
                 Hash      : 1611FB54C3BB0A605A851530A359A48B34A8ABFD29D7091538D91B6E7F105380
@@ -423,17 +435,18 @@ mod tests {
     }
 
     #[test]
-    fn rejects_deno_windows_checksum_for_different_file() {
-        let result = digest_from_deno_checksum(
+    fn returns_none_for_deno_windows_checksum_with_different_file() -> Result<()> {
+        let digest = digest_from_deno_checksum(
             indoc::indoc! {r"
                 Algorithm : SHA256
                 Hash      : 1611FB54C3BB0A605A851530A359A48B34A8ABFD29D7091538D91B6E7F105380
                 Path      : C:\a\deno\deno\target\release\deno-x86_64-pc-windows-msvc.zip
             "},
             "deno-aarch64-pc-windows-msvc.zip",
-        );
+        )?;
 
-        assert!(result.is_err());
+        assert_eq!(digest, None);
+        Ok(())
     }
 
     #[test]
@@ -454,15 +467,18 @@ mod tests {
     }
 
     #[test]
-    fn preserves_sha256sums_error_for_non_windows_checksum() {
-        let result = digest_from_deno_checksum(
+    fn returns_none_for_non_matching_sha256sums_file() -> Result<()> {
+        let digest = digest_from_deno_checksum(
             "f5b681529a0360e7f430688fc0ba3b25626b3933c370b053a0c27f39ef7a0f90  deno-x86_64-unknown-linux-gnu.zip",
             "deno-aarch64-unknown-linux-gnu.zip",
-        );
+        )?;
 
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "No SHA256 digest found for `deno-aarch64-unknown-linux-gnu.zip`"
-        );
+        assert_eq!(digest, None);
+        Ok(())
+    }
+
+    fn require_deno_checksum(contents: &str, filename: &str) -> Result<Sha256Digest> {
+        digest_from_deno_checksum(contents, filename)?
+            .with_context(|| format!("No SHA256 digest found for `{filename}`"))
     }
 }

--- a/crates/prek/src/languages/deno/installer.rs
+++ b/crates/prek/src/languages/deno/installer.rs
@@ -11,8 +11,9 @@ use serde::Deserialize;
 use target_lexicon::{Architecture, HOST, OperatingSystem};
 use tracing::{debug, trace, warn};
 
+use crate::checksum::{Sha256Digest, digest_from_sha256sums};
 use crate::fs::LockedFile;
-use crate::http::{REQWEST_CLIENT, download_and_extract};
+use crate::http::{REQWEST_CLIENT, download_and_extract_with_checksum};
 use crate::languages::deno::DenoRequest;
 use crate::languages::deno::version::DenoVersion;
 use crate::process::Cmd;
@@ -223,42 +224,68 @@ impl DenoInstaller {
         let url = format!("https://dl.deno.land/release/v{version}/{filename}");
         let target = self.root.join(version.to_string());
 
-        download_and_extract(&url, &filename, store, async |extracted| {
-            if target.exists() {
-                debug!(target = %target.display(), "Removing existing deno");
-                fs_err::tokio::remove_dir_all(&target).await?;
-            }
-
-            // Deno ZIP contains just the binary at the root level.
-            // After strip_component, `extracted` may be the binary itself (if singular)
-            // or a directory containing the binary.
-            let extracted_binary = if extracted.is_file() {
-                extracted.to_path_buf()
-            } else {
-                extracted.join("deno").with_extension(EXE_EXTENSION)
-            };
-
-            let target_bin_dir = bin_dir(&target);
-            fs_err::tokio::create_dir_all(&target_bin_dir).await?;
-
-            let target_binary = target_bin_dir.join("deno").with_extension(EXE_EXTENSION);
-            debug!(?extracted_binary, target = %target_binary.display(), "Moving deno to target");
-            fs_err::tokio::rename(&extracted_binary, &target_binary).await?;
-
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                let mut perms = fs_err::tokio::metadata(&target_binary).await?.permissions();
-                perms.set_mode(0o755);
-                fs_err::tokio::set_permissions(&target_binary, perms).await?;
-            }
-
-            anyhow::Ok(())
+        let checksum = self.fetch_checksum(&url, &filename).await?;
+        download_and_extract_with_checksum(&url, &filename, store, checksum, async |extracted| {
+            Self::install_extracted(&target, extracted).await
         })
         .await
         .context("Failed to download and extract deno")?;
 
         Ok(DenoResult::from_dir(&target).with_version(version.clone()))
+    }
+
+    async fn fetch_checksum(&self, url: &str, filename: &str) -> Result<Sha256Digest> {
+        let checksum_url = format!("{url}.sha256sum");
+        let response = REQWEST_CLIENT
+            .get(&checksum_url)
+            .send()
+            .await
+            .with_context(|| format!("Failed to fetch Deno checksum from {checksum_url}"))?;
+        if !response.status().is_success() {
+            anyhow::bail!(
+                "Failed to fetch Deno checksum from {}: {}",
+                checksum_url,
+                response.status()
+            );
+        }
+
+        let checksums = response.text().await?;
+        digest_from_deno_checksum(&checksums, filename).with_context(|| {
+            format!("Deno checksum file at {checksum_url} does not list `{filename}`")
+        })
+    }
+
+    async fn install_extracted(target: &Path, extracted: &Path) -> Result<()> {
+        if target.exists() {
+            debug!(target = %target.display(), "Removing existing deno");
+            fs_err::tokio::remove_dir_all(&target).await?;
+        }
+
+        // Deno ZIP contains just the binary at the root level.
+        // After strip_component, `extracted` may be the binary itself (if singular)
+        // or a directory containing the binary.
+        let extracted_binary = if extracted.is_file() {
+            extracted.to_path_buf()
+        } else {
+            extracted.join("deno").with_extension(EXE_EXTENSION)
+        };
+
+        let target_bin_dir = bin_dir(target);
+        fs_err::tokio::create_dir_all(&target_bin_dir).await?;
+
+        let target_binary = target_bin_dir.join("deno").with_extension(EXE_EXTENSION);
+        debug!(?extracted_binary, target = %target_binary.display(), "Moving deno to target");
+        fs_err::tokio::rename(&extracted_binary, &target_binary).await?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs_err::tokio::metadata(&target_binary).await?.permissions();
+            perms.set_mode(0o755);
+            fs_err::tokio::set_permissions(&target_binary, perms).await?;
+        }
+
+        Ok(())
     }
 
     /// Find a suitable system Deno installation that matches the request.
@@ -304,4 +331,89 @@ impl DenoInstaller {
 
 pub(crate) fn bin_dir(prefix: &Path) -> PathBuf {
     prefix.join("bin")
+}
+
+fn digest_from_deno_checksum(contents: &str, filename: &str) -> Result<Sha256Digest> {
+    if let Ok(digest) = digest_from_sha256sums(contents, filename) {
+        return Ok(digest);
+    }
+
+    let mut hash = None;
+    let mut path = None;
+    for line in contents.lines() {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        match name.trim() {
+            "Hash" => hash = Some(value.trim()),
+            "Path" => path = Some(value.trim()),
+            _ => {}
+        }
+    }
+
+    let Some(path) = path else {
+        anyhow::bail!("No path found in Deno checksum file");
+    };
+    let Some(found_filename) = path.rsplit(['/', '\\']).next() else {
+        anyhow::bail!("No filename found in Deno checksum path");
+    };
+    if found_filename != filename {
+        anyhow::bail!("Deno checksum file lists `{found_filename}` instead of `{filename}`");
+    }
+
+    let Some(hash) = hash else {
+        anyhow::bail!("No hash found in Deno checksum file");
+    };
+    hash.parse()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_deno_sha256sum_format() -> Result<()> {
+        let digest = digest_from_deno_checksum(
+            "f5b681529a0360e7f430688fc0ba3b25626b3933c370b053a0c27f39ef7a0f90  deno-x86_64-unknown-linux-gnu.zip",
+            "deno-x86_64-unknown-linux-gnu.zip",
+        )?;
+
+        assert_eq!(
+            digest.to_string(),
+            "f5b681529a0360e7f430688fc0ba3b25626b3933c370b053a0c27f39ef7a0f90"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parses_deno_windows_checksum_format() -> Result<()> {
+        let digest = digest_from_deno_checksum(
+            indoc::indoc! {r"
+                Algorithm : SHA256
+                Hash      : 1611FB54C3BB0A605A851530A359A48B34A8ABFD29D7091538D91B6E7F105380
+                Path      : C:\a\deno\deno\target\release\deno-x86_64-pc-windows-msvc.zip
+            "},
+            "deno-x86_64-pc-windows-msvc.zip",
+        )?;
+
+        assert_eq!(
+            digest.to_string(),
+            "1611fb54c3bb0a605a851530a359a48b34a8abfd29d7091538d91b6e7f105380"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_deno_windows_checksum_for_different_file() {
+        let result = digest_from_deno_checksum(
+            indoc::indoc! {r"
+                Algorithm : SHA256
+                Hash      : 1611FB54C3BB0A605A851530A359A48B34A8ABFD29D7091538D91B6E7F105380
+                Path      : C:\a\deno\deno\target\release\deno-x86_64-pc-windows-msvc.zip
+            "},
+            "deno-aarch64-pc-windows-msvc.zip",
+        );
+
+        assert!(result.is_err());
+    }
 }

--- a/crates/prek/src/languages/golang/installer.rs
+++ b/crates/prek/src/languages/golang/installer.rs
@@ -11,10 +11,11 @@ use serde::Deserialize;
 use target_lexicon::{Architecture, HOST, OperatingSystem};
 use tracing::{debug, trace, warn};
 
+use crate::archive;
 use crate::checksum::Sha256Digest;
 use crate::fs::LockedFile;
 use crate::git;
-use crate::http::{DownloadVerification, REQWEST_CLIENT, download_and_extract};
+use crate::http::{REQWEST_CLIENT, download_artifact};
 use crate::languages::golang::GoRequest;
 use crate::languages::golang::golang::bin_dir;
 use crate::languages::golang::version::GoVersion;
@@ -237,36 +238,42 @@ impl GoInstaller {
         let ext = if cfg!(windows) { "zip" } else { "tar.gz" };
         let filename = format!("go{version}.{os}-{arch}.{ext}");
         let url = format!("https://go.dev/dl/{filename}");
-        let checksum = Self::fetch_checksum(version, &filename).await?;
+        let checksum_version = version.to_string();
         let target = self.root.join(version.to_string());
 
-        let download = download_and_extract(
-            &url,
-            &filename,
-            store,
-            DownloadVerification::Sha256(checksum),
-        )
+        let download = download_artifact(&url, &filename, store, async || {
+            Self::fetch_checksum(&checksum_version, &filename).await
+        })
         .await
-        .context("Failed to download and extract go")?;
+        .context("Failed to download go")?;
+        let extracted = archive::extract_archive(download.path())
+            .await
+            .context("Failed to extract go")?;
         if target.exists() {
             debug!(target = %target.display(), "Removing existing go");
             fs_err::tokio::remove_dir_all(&target).await?;
         }
 
-        debug!(extracted = ?download.path(), target = %target.display(), "Moving go to target");
+        debug!(?extracted, target = %target.display(), "Moving go to target");
         // TODO: retry on Windows
-        fs_err::tokio::rename(download.path(), &target).await?;
+        fs_err::tokio::rename(&extracted, &target).await?;
 
         Ok(GoResult::from_dir(&target, false).with_version(version.clone()))
     }
 
-    async fn fetch_checksum(version: &GoVersion, filename: &str) -> Result<Sha256Digest> {
+    async fn fetch_checksum(version: &str, filename: &str) -> Result<Option<Sha256Digest>> {
         let url = "https://go.dev/dl/?mode=json&include=all";
-        let releases: Vec<GoRelease> = REQWEST_CLIENT
+        let response = REQWEST_CLIENT
             .get(url)
             .send()
             .await
-            .and_then(reqwest::Response::error_for_status)
+            .context("Failed to fetch Go release metadata")?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+
+        let releases: Vec<GoRelease> = response
+            .error_for_status()
             .context("Failed to fetch Go release metadata")?
             .json()
             .await
@@ -315,17 +322,18 @@ impl GoInstaller {
 
 fn digest_from_go_releases(
     releases: &[GoRelease],
-    version: &GoVersion,
+    version: &str,
     filename: &str,
-) -> Result<Sha256Digest> {
+) -> Result<Option<Sha256Digest>> {
     let release_name = format!("go{version}");
-    releases
+    let Some(file) = releases
         .iter()
         .find(|release| release.version == release_name)
         .and_then(|release| release.files.iter().find(|file| file.filename == filename))
-        .with_context(|| format!("No SHA256 digest found for `{filename}`"))?
-        .sha256
-        .parse()
+    else {
+        return Ok(None);
+    };
+    file.sha256.parse().map(Some)
 }
 
 #[cfg(test)]
@@ -356,55 +364,36 @@ mod tests {
             ),
         ];
 
-        let digest = digest_from_go_releases(
-            &releases,
-            &GoVersion::from_str("1.24.1")?,
-            "go1.24.1.darwin-arm64.tar.gz",
-        )?;
+        let digest = digest_from_go_releases(&releases, "1.24.1", "go1.24.1.darwin-arm64.tar.gz")?
+            .expect("expected checksum");
 
         assert_eq!(digest.to_string(), EMPTY_SHA256);
         Ok(())
     }
 
     #[test]
-    fn errors_when_go_release_file_is_missing() -> Result<()> {
+    fn returns_none_when_go_release_file_is_missing() -> Result<()> {
         let releases = vec![go_release(
             "go1.24.1",
             vec![go_file("go1.24.1.linux-amd64.tar.gz", EMPTY_SHA256)],
         )];
 
-        let err = digest_from_go_releases(
-            &releases,
-            &GoVersion::from_str("1.24.1")?,
-            "go1.24.1.darwin-arm64.tar.gz",
-        )
-        .unwrap_err();
+        let digest = digest_from_go_releases(&releases, "1.24.1", "go1.24.1.darwin-arm64.tar.gz")?;
 
-        assert!(
-            err.to_string()
-                .contains("No SHA256 digest found for `go1.24.1.darwin-arm64.tar.gz`")
-        );
+        assert!(digest.is_none());
         Ok(())
     }
 
     #[test]
-    fn errors_when_go_release_is_missing() -> Result<()> {
+    fn returns_none_when_go_release_is_missing() -> Result<()> {
         let releases = vec![go_release(
             "go1.23.0",
             vec![go_file("go1.23.0.linux-amd64.tar.gz", EMPTY_SHA256)],
         )];
 
-        let err = digest_from_go_releases(
-            &releases,
-            &GoVersion::from_str("1.24.1")?,
-            "go1.24.1.linux-amd64.tar.gz",
-        )
-        .unwrap_err();
+        let digest = digest_from_go_releases(&releases, "1.24.1", "go1.24.1.linux-amd64.tar.gz")?;
 
-        assert!(
-            err.to_string()
-                .contains("No SHA256 digest found for `go1.24.1.linux-amd64.tar.gz`")
-        );
+        assert!(digest.is_none());
         Ok(())
     }
 

--- a/crates/prek/src/languages/golang/installer.rs
+++ b/crates/prek/src/languages/golang/installer.rs
@@ -43,6 +43,18 @@ static GO_BINARY_NAME: LazyLock<String> = LazyLock::new(|| {
     }
 });
 
+#[derive(Deserialize)]
+struct GoRelease {
+    version: String,
+    files: Vec<GoFile>,
+}
+
+#[derive(Deserialize)]
+struct GoFile {
+    filename: String,
+    sha256: String,
+}
+
 impl GoResult {
     fn from_executable(path: PathBuf, from_system: bool) -> Self {
         Self {
@@ -247,18 +259,6 @@ impl GoInstaller {
     }
 
     async fn fetch_checksum(&self, version: &GoVersion, filename: &str) -> Result<Sha256Digest> {
-        #[derive(Deserialize)]
-        struct GoRelease {
-            version: String,
-            files: Vec<GoFile>,
-        }
-
-        #[derive(Deserialize)]
-        struct GoFile {
-            filename: String,
-            sha256: String,
-        }
-
         let url = "https://go.dev/dl/?mode=json&include=all";
         let releases: Vec<GoRelease> = REQWEST_CLIENT
             .get(url)
@@ -270,16 +270,7 @@ impl GoInstaller {
             .json()
             .await
             .context("Failed to parse Go release metadata")?;
-        let release_name = format!("go{version}");
-        let digest = releases
-            .iter()
-            .find(|release| release.version == release_name)
-            .and_then(|release| release.files.iter().find(|file| file.filename == filename))
-            .with_context(|| format!("No SHA256 digest found for `{filename}`"))?
-            .sha256
-            .parse()?;
-
-        Ok(digest)
+        digest_from_go_releases(&releases, version, filename)
     }
 
     async fn find_system_go(&self, go_request: &GoRequest) -> Result<Option<GoResult>> {
@@ -321,14 +312,106 @@ impl GoInstaller {
     }
 }
 
-#[cfg(all(test, unix))]
-mod tests {
-    use std::os::unix::fs::PermissionsExt;
+fn digest_from_go_releases(
+    releases: &[GoRelease],
+    version: &GoVersion,
+    filename: &str,
+) -> Result<Sha256Digest> {
+    let release_name = format!("go{version}");
+    releases
+        .iter()
+        .find(|release| release.version == release_name)
+        .and_then(|release| release.files.iter().find(|file| file.filename == filename))
+        .with_context(|| format!("No SHA256 digest found for `{filename}`"))?
+        .sha256
+        .parse()
+}
 
+#[cfg(test)]
+mod tests {
     use super::*;
 
+    const EMPTY_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+    #[test]
+    fn finds_go_checksum_for_release_file() -> Result<()> {
+        let releases = vec![
+            go_release(
+                "go1.23.0",
+                vec![go_file(
+                    "go1.23.0.linux-amd64.tar.gz",
+                    "0000000000000000000000000000000000000000000000000000000000000000",
+                )],
+            ),
+            go_release(
+                "go1.24.1",
+                vec![
+                    go_file("go1.24.1.darwin-arm64.tar.gz", EMPTY_SHA256),
+                    go_file(
+                        "go1.24.1.linux-amd64.tar.gz",
+                        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                    ),
+                ],
+            ),
+        ];
+
+        let digest = digest_from_go_releases(
+            &releases,
+            &GoVersion::from_str("1.24.1")?,
+            "go1.24.1.darwin-arm64.tar.gz",
+        )?;
+
+        assert_eq!(digest.to_string(), EMPTY_SHA256);
+        Ok(())
+    }
+
+    #[test]
+    fn errors_when_go_release_file_is_missing() -> Result<()> {
+        let releases = vec![go_release(
+            "go1.24.1",
+            vec![go_file("go1.24.1.linux-amd64.tar.gz", EMPTY_SHA256)],
+        )];
+
+        let err = digest_from_go_releases(
+            &releases,
+            &GoVersion::from_str("1.24.1")?,
+            "go1.24.1.darwin-arm64.tar.gz",
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("No SHA256 digest found for `go1.24.1.darwin-arm64.tar.gz`")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn errors_when_go_release_is_missing() -> Result<()> {
+        let releases = vec![go_release(
+            "go1.23.0",
+            vec![go_file("go1.23.0.linux-amd64.tar.gz", EMPTY_SHA256)],
+        )];
+
+        let err = digest_from_go_releases(
+            &releases,
+            &GoVersion::from_str("1.24.1")?,
+            "go1.24.1.linux-amd64.tar.gz",
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("No SHA256 digest found for `go1.24.1.linux-amd64.tar.gz`")
+        );
+        Ok(())
+    }
+
     #[tokio::test]
+    #[cfg(unix)]
     async fn fill_version_uses_local_gotoolchain() -> anyhow::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
         let temp_dir = tempfile::tempdir()?;
         let fake_go = temp_dir.path().join("go");
         fs_err::write(
@@ -358,5 +441,19 @@ mod tests {
 
         assert_eq!(go.version().to_string(), "1.24.13");
         Ok(())
+    }
+
+    fn go_release(version: &str, files: Vec<GoFile>) -> GoRelease {
+        GoRelease {
+            version: version.to_string(),
+            files,
+        }
+    }
+
+    fn go_file(filename: &str, sha256: &str) -> GoFile {
+        GoFile {
+            filename: filename.to_string(),
+            sha256: sha256.to_string(),
+        }
     }
 }

--- a/crates/prek/src/languages/golang/installer.rs
+++ b/crates/prek/src/languages/golang/installer.rs
@@ -7,12 +7,14 @@ use std::sync::LazyLock;
 use anyhow::{Context, Result};
 use itertools::Itertools;
 use prek_consts::env_vars::EnvVars;
+use serde::Deserialize;
 use target_lexicon::{Architecture, HOST, OperatingSystem};
 use tracing::{debug, trace, warn};
 
+use crate::checksum::Sha256Digest;
 use crate::fs::LockedFile;
 use crate::git;
-use crate::http::download_and_extract;
+use crate::http::{REQWEST_CLIENT, download_and_extract_with_checksum};
 use crate::languages::golang::GoRequest;
 use crate::languages::golang::golang::bin_dir;
 use crate::languages::golang::version::GoVersion;
@@ -223,9 +225,10 @@ impl GoInstaller {
         let ext = if cfg!(windows) { "zip" } else { "tar.gz" };
         let filename = format!("go{version}.{os}-{arch}.{ext}");
         let url = format!("https://go.dev/dl/{filename}");
+        let checksum = self.fetch_checksum(version, &filename).await?;
         let target = self.root.join(version.to_string());
 
-        download_and_extract(&url, &filename, store, async |extracted| {
+        download_and_extract_with_checksum(&url, &filename, store, checksum, async |extracted| {
             if target.exists() {
                 debug!(target = %target.display(), "Removing existing go");
                 fs_err::tokio::remove_dir_all(&target).await?;
@@ -241,6 +244,42 @@ impl GoInstaller {
         .context("Failed to download and extract go")?;
 
         Ok(GoResult::from_dir(&target, false).with_version(version.clone()))
+    }
+
+    async fn fetch_checksum(&self, version: &GoVersion, filename: &str) -> Result<Sha256Digest> {
+        #[derive(Deserialize)]
+        struct GoRelease {
+            version: String,
+            files: Vec<GoFile>,
+        }
+
+        #[derive(Deserialize)]
+        struct GoFile {
+            filename: String,
+            sha256: String,
+        }
+
+        let url = "https://go.dev/dl/?mode=json&include=all";
+        let releases: Vec<GoRelease> = REQWEST_CLIENT
+            .get(url)
+            .send()
+            .await
+            .context("Failed to fetch Go release metadata")?
+            .error_for_status()
+            .context("Failed to fetch Go release metadata")?
+            .json()
+            .await
+            .context("Failed to parse Go release metadata")?;
+        let release_name = format!("go{version}");
+        let digest = releases
+            .iter()
+            .find(|release| release.version == release_name)
+            .and_then(|release| release.files.iter().find(|file| file.filename == filename))
+            .with_context(|| format!("No SHA256 digest found for `{filename}`"))?
+            .sha256
+            .parse()?;
+
+        Ok(digest)
     }
 
     async fn find_system_go(&self, go_request: &GoRequest) -> Result<Option<GoResult>> {

--- a/crates/prek/src/languages/golang/installer.rs
+++ b/crates/prek/src/languages/golang/installer.rs
@@ -14,7 +14,7 @@ use tracing::{debug, trace, warn};
 use crate::checksum::Sha256Digest;
 use crate::fs::LockedFile;
 use crate::git;
-use crate::http::{REQWEST_CLIENT, download_and_extract_with_checksum};
+use crate::http::{DownloadVerification, REQWEST_CLIENT, download_and_extract};
 use crate::languages::golang::GoRequest;
 use crate::languages::golang::golang::bin_dir;
 use crate::languages::golang::version::GoVersion;
@@ -237,35 +237,36 @@ impl GoInstaller {
         let ext = if cfg!(windows) { "zip" } else { "tar.gz" };
         let filename = format!("go{version}.{os}-{arch}.{ext}");
         let url = format!("https://go.dev/dl/{filename}");
-        let checksum = self.fetch_checksum(version, &filename).await?;
+        let checksum = Self::fetch_checksum(version, &filename).await?;
         let target = self.root.join(version.to_string());
 
-        download_and_extract_with_checksum(&url, &filename, store, checksum, async |extracted| {
-            if target.exists() {
-                debug!(target = %target.display(), "Removing existing go");
-                fs_err::tokio::remove_dir_all(&target).await?;
-            }
-
-            debug!(?extracted, target = %target.display(), "Moving go to target");
-            // TODO: retry on Windows
-            fs_err::tokio::rename(extracted, &target).await?;
-
-            anyhow::Ok(())
-        })
+        let download = download_and_extract(
+            &url,
+            &filename,
+            store,
+            DownloadVerification::Sha256(checksum),
+        )
         .await
         .context("Failed to download and extract go")?;
+        if target.exists() {
+            debug!(target = %target.display(), "Removing existing go");
+            fs_err::tokio::remove_dir_all(&target).await?;
+        }
+
+        debug!(extracted = ?download.path(), target = %target.display(), "Moving go to target");
+        // TODO: retry on Windows
+        fs_err::tokio::rename(download.path(), &target).await?;
 
         Ok(GoResult::from_dir(&target, false).with_version(version.clone()))
     }
 
-    async fn fetch_checksum(&self, version: &GoVersion, filename: &str) -> Result<Sha256Digest> {
+    async fn fetch_checksum(version: &GoVersion, filename: &str) -> Result<Sha256Digest> {
         let url = "https://go.dev/dl/?mode=json&include=all";
         let releases: Vec<GoRelease> = REQWEST_CLIENT
             .get(url)
             .send()
             .await
-            .context("Failed to fetch Go release metadata")?
-            .error_for_status()
+            .and_then(reqwest::Response::error_for_status)
             .context("Failed to fetch Go release metadata")?
             .json()
             .await

--- a/crates/prek/src/languages/node/installer.rs
+++ b/crates/prek/src/languages/node/installer.rs
@@ -11,8 +11,9 @@ use prek_consts::env_vars::EnvVars;
 use target_lexicon::{Architecture, HOST, OperatingSystem};
 use tracing::{debug, trace, warn};
 
+use crate::checksum::{Sha256Digest, digest_from_sha256sums};
 use crate::fs::LockedFile;
-use crate::http::{REQWEST_CLIENT, download_and_extract};
+use crate::http::{REQWEST_CLIENT, download_and_extract_with_checksum};
 use crate::languages::node::NodeRequest;
 use crate::languages::node::version::NodeVersion;
 use crate::process::Cmd;
@@ -215,9 +216,10 @@ impl NodeInstaller {
 
         let filename = format!("node-v{}-{os}-{arch}.{ext}", version.version());
         let url = format!("https://nodejs.org/dist/v{}/{filename}", version.version());
+        let checksum = self.fetch_checksum(version, &filename).await?;
         let target = self.root.join(version.to_string());
 
-        download_and_extract(&url, &filename, store, async |extracted| {
+        download_and_extract_with_checksum(&url, &filename, store, checksum, async |extracted| {
             if target.exists() {
                 debug!(target = %target.display(), "Removing existing node");
                 fs_err::tokio::remove_dir_all(&target).await?;
@@ -233,6 +235,27 @@ impl NodeInstaller {
         .context("Failed to download and extract node")?;
 
         Ok(NodeResult::from_dir(&target).with_version(version.clone()))
+    }
+
+    async fn fetch_checksum(&self, version: &NodeVersion, filename: &str) -> Result<Sha256Digest> {
+        let url = format!(
+            "https://nodejs.org/dist/v{}/SHASUMS256.txt",
+            version.version()
+        );
+        let response = REQWEST_CLIENT
+            .get(&url)
+            .send()
+            .await
+            .with_context(|| format!("Failed to fetch Node.js checksums from {url}"))?;
+        if !response.status().is_success() {
+            anyhow::bail!(
+                "Failed to fetch Node.js checksums from {}: {}",
+                url,
+                response.status()
+            );
+        }
+        let checksums = response.text().await?;
+        digest_from_sha256sums(&checksums, filename)
     }
 
     /// Find a suitable system Node.js installation that matches the request.

--- a/crates/prek/src/languages/node/installer.rs
+++ b/crates/prek/src/languages/node/installer.rs
@@ -13,7 +13,7 @@ use tracing::{debug, trace, warn};
 
 use crate::checksum::{Sha256Digest, digest_from_sha256sums};
 use crate::fs::LockedFile;
-use crate::http::{REQWEST_CLIENT, download_and_extract_with_checksum};
+use crate::http::{DownloadVerification, REQWEST_CLIENT, download_and_extract};
 use crate::languages::node::NodeRequest;
 use crate::languages::node::version::NodeVersion;
 use crate::process::Cmd;
@@ -216,28 +216,30 @@ impl NodeInstaller {
 
         let filename = format!("node-v{}-{os}-{arch}.{ext}", version.version());
         let url = format!("https://nodejs.org/dist/v{}/{filename}", version.version());
-        let checksum = self.fetch_checksum(version, &filename).await?;
+        let checksum = Self::fetch_checksum(version, &filename).await?;
         let target = self.root.join(version.to_string());
 
-        download_and_extract_with_checksum(&url, &filename, store, checksum, async |extracted| {
-            if target.exists() {
-                debug!(target = %target.display(), "Removing existing node");
-                fs_err::tokio::remove_dir_all(&target).await?;
-            }
-
-            debug!(?extracted, target = %target.display(), "Moving node to target");
-            // TODO: retry on Windows
-            fs_err::tokio::rename(extracted, &target).await?;
-
-            anyhow::Ok(())
-        })
+        let download = download_and_extract(
+            &url,
+            &filename,
+            store,
+            DownloadVerification::Sha256(checksum),
+        )
         .await
         .context("Failed to download and extract node")?;
+        if target.exists() {
+            debug!(target = %target.display(), "Removing existing node");
+            fs_err::tokio::remove_dir_all(&target).await?;
+        }
+
+        debug!(extracted = ?download.path(), target = %target.display(), "Moving node to target");
+        // TODO: retry on Windows
+        fs_err::tokio::rename(download.path(), &target).await?;
 
         Ok(NodeResult::from_dir(&target).with_version(version.clone()))
     }
 
-    async fn fetch_checksum(&self, version: &NodeVersion, filename: &str) -> Result<Sha256Digest> {
+    async fn fetch_checksum(version: &NodeVersion, filename: &str) -> Result<Sha256Digest> {
         let url = format!(
             "https://nodejs.org/dist/v{}/SHASUMS256.txt",
             version.version()
@@ -246,14 +248,8 @@ impl NodeInstaller {
             .get(&url)
             .send()
             .await
+            .and_then(reqwest::Response::error_for_status)
             .with_context(|| format!("Failed to fetch Node.js checksums from {url}"))?;
-        if !response.status().is_success() {
-            anyhow::bail!(
-                "Failed to fetch Node.js checksums from {}: {}",
-                url,
-                response.status()
-            );
-        }
         let checksums = response.text().await?;
         digest_from_sha256sums(&checksums, filename)
     }

--- a/crates/prek/src/languages/node/installer.rs
+++ b/crates/prek/src/languages/node/installer.rs
@@ -11,9 +11,10 @@ use prek_consts::env_vars::EnvVars;
 use target_lexicon::{Architecture, HOST, OperatingSystem};
 use tracing::{debug, trace, warn};
 
+use crate::archive;
 use crate::checksum::{Sha256Digest, digest_from_sha256sums};
 use crate::fs::LockedFile;
-use crate::http::{DownloadVerification, REQWEST_CLIENT, download_and_extract};
+use crate::http::{REQWEST_CLIENT, download_artifact};
 use crate::languages::node::NodeRequest;
 use crate::languages::node::version::NodeVersion;
 use crate::process::Cmd;
@@ -216,41 +217,47 @@ impl NodeInstaller {
 
         let filename = format!("node-v{}-{os}-{arch}.{ext}", version.version());
         let url = format!("https://nodejs.org/dist/v{}/{filename}", version.version());
-        let checksum = Self::fetch_checksum(version, &filename).await?;
+        let checksum_url = format!(
+            "https://nodejs.org/dist/v{}/SHASUMS256.txt",
+            version.version()
+        );
         let target = self.root.join(version.to_string());
 
-        let download = download_and_extract(
-            &url,
-            &filename,
-            store,
-            DownloadVerification::Sha256(checksum),
-        )
+        let download = download_artifact(&url, &filename, store, async || {
+            Self::fetch_checksum(&checksum_url, &filename).await
+        })
         .await
-        .context("Failed to download and extract node")?;
+        .context("Failed to download node")?;
+        let extracted = archive::extract_archive(download.path())
+            .await
+            .context("Failed to extract node")?;
         if target.exists() {
             debug!(target = %target.display(), "Removing existing node");
             fs_err::tokio::remove_dir_all(&target).await?;
         }
 
-        debug!(extracted = ?download.path(), target = %target.display(), "Moving node to target");
+        debug!(?extracted, target = %target.display(), "Moving node to target");
         // TODO: retry on Windows
-        fs_err::tokio::rename(download.path(), &target).await?;
+        fs_err::tokio::rename(&extracted, &target).await?;
 
         Ok(NodeResult::from_dir(&target).with_version(version.clone()))
     }
 
-    async fn fetch_checksum(version: &NodeVersion, filename: &str) -> Result<Sha256Digest> {
-        let url = format!(
-            "https://nodejs.org/dist/v{}/SHASUMS256.txt",
-            version.version()
-        );
+    async fn fetch_checksum(url: &str, filename: &str) -> Result<Option<Sha256Digest>> {
         let response = REQWEST_CLIENT
-            .get(&url)
+            .get(url)
             .send()
             .await
-            .and_then(reqwest::Response::error_for_status)
             .with_context(|| format!("Failed to fetch Node.js checksums from {url}"))?;
-        let checksums = response.text().await?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+
+        let checksums = response
+            .error_for_status()
+            .with_context(|| format!("Failed to fetch Node.js checksums from {url}"))?
+            .text()
+            .await?;
         digest_from_sha256sums(&checksums, filename)
     }
 

--- a/crates/prek/src/languages/python/uv.rs
+++ b/crates/prek/src/languages/python/uv.rs
@@ -13,8 +13,9 @@ use tracing::{debug, trace, warn};
 
 use prek_consts::env_vars::EnvVars;
 
+use crate::archive;
 use crate::fs::LockedFile;
-use crate::http::{DownloadVerification, REQWEST_CLIENT, download_and_extract};
+use crate::http::{DownloadChecksumPolicy, REQWEST_CLIENT, download_artifact_with};
 use crate::process::Cmd;
 use crate::store::{CacheBucket, Store};
 use crate::version;
@@ -196,15 +197,20 @@ impl InstallSource {
             "https://github.com/astral-sh/uv/releases/download/{CUR_UV_VERSION}/{archive_name}"
         );
 
-        let download = download_and_extract(
+        let download = download_artifact_with(
             &download_url,
             &archive_name,
             store,
-            DownloadVerification::None,
+            DownloadChecksumPolicy::Disabled,
+            async || Ok(None),
+            |req| req,
         )
         .await
-        .context("Failed to download and extract uv")?;
-        let source = download.path().join("uv").with_extension(EXE_EXTENSION);
+        .context("Failed to download uv")?;
+        let extracted = archive::extract_archive(download.path())
+            .await
+            .context("Failed to extract uv")?;
+        let source = extracted.join("uv").with_extension(EXE_EXTENSION);
         let target_path = target.join("uv").with_extension(EXE_EXTENSION);
 
         debug!(?source, target = %target_path.display(), "Moving uv to target");
@@ -320,15 +326,23 @@ impl InstallSource {
         filename: &str,
         download_url: &str,
     ) -> Result<()> {
-        let download =
-            download_and_extract(download_url, filename, store, DownloadVerification::None)
-                .await
-                .context("Failed to download and extract uv wheel")?;
+        let download = download_artifact_with(
+            download_url,
+            filename,
+            store,
+            DownloadChecksumPolicy::Disabled,
+            async || Ok(None),
+            |req| req,
+        )
+        .await
+        .context("Failed to download uv wheel")?;
+        let extracted = archive::extract_archive(download.path())
+            .await
+            .context("Failed to extract uv wheel")?;
 
         // Find the uv binary in the extracted contents
         let data_dir = format!("uv-{CUR_UV_VERSION}.data");
-        let extracted_uv = download
-            .path()
+        let extracted_uv = extracted
             .join(data_dir)
             .join("scripts")
             .join("uv")

--- a/crates/prek/src/languages/python/uv.rs
+++ b/crates/prek/src/languages/python/uv.rs
@@ -14,7 +14,7 @@ use tracing::{debug, trace, warn};
 use prek_consts::env_vars::EnvVars;
 
 use crate::fs::LockedFile;
-use crate::http::{REQWEST_CLIENT, download_and_extract};
+use crate::http::{DownloadVerification, REQWEST_CLIENT, download_and_extract};
 use crate::process::Cmd;
 use crate::store::{CacheBucket, Store};
 use crate::version;
@@ -196,18 +196,20 @@ impl InstallSource {
             "https://github.com/astral-sh/uv/releases/download/{CUR_UV_VERSION}/{archive_name}"
         );
 
-        download_and_extract(&download_url, &archive_name, store, async |extracted| {
-            let source = extracted.join("uv").with_extension(EXE_EXTENSION);
-            let target_path = target.join("uv").with_extension(EXE_EXTENSION);
-
-            debug!(?source, target = %target_path.display(), "Moving uv to target");
-            // TODO: retry on Windows
-            replace_uv_binary(&source, &target_path).await?;
-
-            anyhow::Ok(())
-        })
+        let download = download_and_extract(
+            &download_url,
+            &archive_name,
+            store,
+            DownloadVerification::None,
+        )
         .await
         .context("Failed to download and extract uv")?;
+        let source = download.path().join("uv").with_extension(EXE_EXTENSION);
+        let target_path = target.join("uv").with_extension(EXE_EXTENSION);
+
+        debug!(?source, target = %target_path.display(), "Moving uv to target");
+        // TODO: retry on Windows
+        replace_uv_binary(&source, &target_path).await?;
 
         Ok(())
     }
@@ -233,14 +235,9 @@ impl InstallSource {
             .get(&api_url)
             .header("Accept", "*/*")
             .send()
-            .await?;
-
-        if !response.status().is_success() {
-            bail!(
-                "Failed to fetch uv metadata from PyPI: {}",
-                response.status()
-            );
-        }
+            .await
+            .and_then(reqwest::Response::error_for_status)
+            .with_context(|| format!("Failed to fetch uv metadata from PyPI at {api_url}"))?;
 
         let metadata: serde_json::Value = response.json().await?;
         let files = metadata["urls"]
@@ -260,7 +257,7 @@ impl InstallSource {
             .as_str()
             .context("Missing download URL in PyPI response")?;
 
-        self.download_and_extract_wheel(store, target, &wheel_name, download_url)
+        self.install_from_wheel_url(store, target, &wheel_name, download_url)
             .await
     }
 
@@ -312,46 +309,46 @@ impl InstallSource {
             format!("{simple_url}{download_path}")
         };
 
-        self.download_and_extract_wheel(store, target, &wheel_name, &download_url)
+        self.install_from_wheel_url(store, target, &wheel_name, &download_url)
             .await
     }
 
-    async fn download_and_extract_wheel(
+    async fn install_from_wheel_url(
         &self,
         store: &Store,
         target: &Path,
         filename: &str,
         download_url: &str,
     ) -> Result<()> {
-        download_and_extract(download_url, filename, store, async |extracted| {
-            // Find the uv binary in the extracted contents
-            let data_dir = format!("uv-{CUR_UV_VERSION}.data");
-            let extracted_uv = extracted
-                .join(data_dir)
-                .join("scripts")
-                .join("uv")
-                .with_extension(EXE_EXTENSION);
+        let download =
+            download_and_extract(download_url, filename, store, DownloadVerification::None)
+                .await
+                .context("Failed to download and extract uv wheel")?;
 
-            // Copy the binary to the target location
-            let target_path = target.join("uv").with_extension(EXE_EXTENSION);
+        // Find the uv binary in the extracted contents
+        let data_dir = format!("uv-{CUR_UV_VERSION}.data");
+        let extracted_uv = download
+            .path()
+            .join(data_dir)
+            .join("scripts")
+            .join("uv")
+            .with_extension(EXE_EXTENSION);
 
-            debug!(?extracted_uv, target = %target_path.display(), "Moving uv to target");
-            replace_uv_binary(&extracted_uv, &target_path).await?;
+        // Copy the binary to the target location
+        let target_path = target.join("uv").with_extension(EXE_EXTENSION);
 
-            // Set executable permissions on Unix
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                let metadata = fs_err::tokio::metadata(&target_path).await?;
-                let mut perms = metadata.permissions();
-                perms.set_mode(0o755);
-                fs_err::tokio::set_permissions(&target_path, perms).await?;
-            }
+        debug!(?extracted_uv, target = %target_path.display(), "Moving uv to target");
+        replace_uv_binary(&extracted_uv, &target_path).await?;
 
-            Ok(())
-        })
-        .await
-        .context("Failed to download and extract uv wheel")?;
+        // Set executable permissions on Unix
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let metadata = fs_err::tokio::metadata(&target_path).await?;
+            let mut perms = metadata.permissions();
+            perms.set_mode(0o755);
+            fs_err::tokio::set_permissions(&target_path, perms).await?;
+        }
 
         Ok(())
     }

--- a/crates/prek/src/languages/ruby/installer.rs
+++ b/crates/prek/src/languages/ruby/installer.rs
@@ -9,14 +9,13 @@ use serde::Deserialize;
 use target_lexicon::{Architecture, Environment, HOST, OperatingSystem, Triple};
 use tracing::{debug, trace, warn};
 
+use crate::archive;
 use crate::checksum::{Sha256Digest, digest_from_sha256sums};
-use crate::cli::reporter;
 use crate::fs::LockedFile;
-use crate::http::{DownloadVerification, REQWEST_CLIENT, download_and_extract_with};
+use crate::http::{DownloadChecksumPolicy, REQWEST_CLIENT, download_artifact_with};
 use crate::languages::ruby::RubyRequest;
 use crate::process::Cmd;
 use crate::store::Store;
-use crate::warn_user;
 
 const RV_RUBY_DEFAULT_URL: &str = "https://github.com/spinel-coop/rv-ruby";
 
@@ -308,34 +307,30 @@ impl RubyInstaller {
         platform: &str,
     ) -> Result<RubyResult> {
         let filename = format!("ruby-{version}.{platform}.tar.gz");
-        let base_url = format!("{}/releases/latest/download", rv_ruby_base_url());
+        let base_url = rv_ruby_base_url();
         let is_github = github_repo_path(&base_url).is_some();
-        let url = format!("{base_url}/{filename}");
-        let checksum_url = format!("{base_url}/SHA256SUMS");
+        let download_base_url = format!("{base_url}/releases/latest/download");
+        let url = format!("{download_base_url}/{filename}");
+        let checksum_url = format!("{download_base_url}/SHA256SUMS");
 
-        let verification = match Self::fetch_checksum(&checksum_url, &filename, is_github).await {
-            Ok(checksum) => DownloadVerification::Sha256(checksum),
-            Err(err) => {
-                let filename = filename.clone();
-                reporter::suspend(move || {
-                    warn_user!(
-                        "Could not use rv-ruby checksum file at {checksum_url}: {err}. Skipping checksum verification for {filename}."
-                    );
-                });
-                DownloadVerification::None
-            }
-        };
         let version_str = version.to_string();
         let target = self.root.join(&version_str);
 
         debug!(url = %url, target = %target.display(), "Downloading Ruby {version}");
 
-        let download = download_and_extract_with(&url, &filename, store, verification, |req| {
-            maybe_add_github_auth(req, is_github)
-        })
+        let download = download_artifact_with(
+            &url,
+            &filename,
+            store,
+            DownloadChecksumPolicy::from_env()?,
+            async || Self::fetch_checksum(&checksum_url, &filename, is_github).await,
+            |req| maybe_add_github_auth(req, is_github),
+        )
         .await
         .with_context(|| format!("Failed to download Ruby {version} from {url}"))?;
-        let extracted = download.path();
+        let extracted = archive::extract_archive(download.path())
+            .await
+            .with_context(|| format!("Failed to extract Ruby {version}"))?;
         // rv-ruby tarballs contain: rv-ruby@{version}/{version}/bin/ruby
         // After strip_component, `extracted` is the rv-ruby@{version}/ directory.
         // Move the inner {version}/ directory to our target.
@@ -368,24 +363,27 @@ impl RubyInstaller {
         checksum_url: &str,
         filename: &str,
         is_github: bool,
-    ) -> Result<Sha256Digest> {
+    ) -> Result<Option<Sha256Digest>> {
         let req = REQWEST_CLIENT
             .get(checksum_url)
             .header("Accept", "application/octet-stream");
         let req = maybe_add_github_auth(req, is_github);
 
-        let checksums = req
-            .send()
-            .await
-            .and_then(reqwest::Response::error_for_status)
+        let response = req.send().await.with_context(|| {
+            format!("Failed to fetch rv-ruby checksum file from {checksum_url}")
+        })?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+
+        let checksums = response
+            .error_for_status()
             .with_context(|| format!("Failed to fetch rv-ruby checksum file from {checksum_url}"))?
             .text()
             .await
             .with_context(|| format!("Failed to read rv-ruby checksum file from {checksum_url}"))?;
 
-        digest_from_sha256sums(&checksums, filename).with_context(|| {
-            format!("rv-ruby checksum file at {checksum_url} does not list `{filename}`")
-        })
+        digest_from_sha256sums(&checksums, filename)
     }
 
     /// Find Ruby in the system PATH

--- a/crates/prek/src/languages/ruby/installer.rs
+++ b/crates/prek/src/languages/ruby/installer.rs
@@ -10,23 +10,20 @@ use target_lexicon::{Architecture, Environment, HOST, OperatingSystem, Triple};
 use tracing::{debug, trace, warn};
 
 use crate::checksum::{Sha256Digest, digest_from_sha256sums};
+use crate::cli::reporter;
 use crate::fs::LockedFile;
 use crate::http::{DownloadVerification, REQWEST_CLIENT, download_and_extract_with};
 use crate::languages::ruby::RubyRequest;
 use crate::process::Cmd;
 use crate::store::Store;
+use crate::warn_user;
 
 const RV_RUBY_DEFAULT_URL: &str = "https://github.com/spinel-coop/rv-ruby";
 
-/// Resolve the rv-ruby mirror base URL and whether it targets github.com.
-fn rv_ruby_mirror() -> (String, bool) {
+fn rv_ruby_base_url() -> String {
     match EnvVars::var(EnvVars::PREK_RUBY_MIRROR) {
-        Ok(mirror) => {
-            let mirror = mirror.trim_end_matches('/').to_string();
-            let is_github = github_repo_path(&mirror).is_some();
-            (mirror, is_github)
-        }
-        Err(_) => (RV_RUBY_DEFAULT_URL.to_string(), true),
+        Ok(mirror) => mirror.trim_end_matches('/').to_string(),
+        Err(_) => RV_RUBY_DEFAULT_URL.to_string(),
     }
 }
 
@@ -38,14 +35,15 @@ fn rv_ruby_mirror() -> (String, bool) {
 /// `api.github.com` host (e.g. `https://github.com/org/repo` becomes
 /// `https://api.github.com/repos/org/repo/releases/latest`).
 fn rv_ruby_api_url() -> (String, bool) {
-    let (base, is_github) = rv_ruby_mirror();
-    let url = if is_github {
-        let path = github_repo_path(&base).expect("is_github should ensure a GitHub repo path");
-        format!("https://api.github.com/repos{path}/releases/latest")
+    let base = rv_ruby_base_url();
+    if let Some(path) = github_repo_path(&base) {
+        (
+            format!("https://api.github.com/repos{path}/releases/latest"),
+            true,
+        )
     } else {
-        format!("{base}/releases/latest")
-    };
-    (url, is_github)
+        (format!("{base}/releases/latest"), false)
+    }
 }
 
 fn github_repo_path(url: &str) -> Option<String> {
@@ -68,13 +66,6 @@ fn github_repo_path(url: &str) -> Option<String> {
     }
 
     Some(format!("/{owner}/{repo}"))
-}
-
-/// Returns the base URL for downloading rv-ruby release assets, and whether
-/// the target host is github.com (for auth token decisions).
-fn rv_ruby_download_base() -> (String, bool) {
-    let (base, is_github) = rv_ruby_mirror();
-    (format!("{base}/releases/latest/download"), is_github)
 }
 
 /// Conditionally add a GitHub auth token to a request builder.
@@ -286,22 +277,11 @@ impl RubyInstaller {
             .header("Accept", "application/vnd.github+json");
         let req = maybe_add_github_auth(req, is_github);
 
-        let response = req
+        let release: GitHubRelease = req
             .send()
             .await
-            .with_context(|| format!("Failed to fetch rv-ruby releases from {api_url}"))?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let hint = if is_github && matches!(status.as_u16(), 403 | 429) {
-                " (this may be a rate limit — try setting GITHUB_TOKEN)"
-            } else {
-                ""
-            };
-            anyhow::bail!("Failed to fetch rv-ruby releases from {api_url}: {status}{hint}");
-        }
-
-        let release: GitHubRelease = response
+            .and_then(reqwest::Response::error_for_status)
+            .with_context(|| format!("Failed to fetch rv-ruby releases from {api_url}"))?
             .json()
             .await
             .context("Failed to parse rv-ruby release JSON")?;
@@ -328,21 +308,31 @@ impl RubyInstaller {
         platform: &str,
     ) -> Result<RubyResult> {
         let filename = format!("ruby-{version}.{platform}.tar.gz");
-        let (base_url, is_github) = rv_ruby_download_base();
+        let base_url = format!("{}/releases/latest/download", rv_ruby_base_url());
+        let is_github = github_repo_path(&base_url).is_some();
         let url = format!("{base_url}/{filename}");
-        let checksum = Self::fetch_checksum(&base_url, &filename, is_github).await?;
+        let checksum_url = format!("{base_url}/SHA256SUMS");
+
+        let verification = match Self::fetch_checksum(&checksum_url, &filename, is_github).await {
+            Ok(checksum) => DownloadVerification::Sha256(checksum),
+            Err(err) => {
+                let filename = filename.clone();
+                reporter::suspend(move || {
+                    warn_user!(
+                        "Could not use rv-ruby checksum file at {checksum_url}: {err}. Skipping checksum verification for {filename}."
+                    );
+                });
+                DownloadVerification::None
+            }
+        };
         let version_str = version.to_string();
         let target = self.root.join(&version_str);
 
         debug!(url = %url, target = %target.display(), "Downloading Ruby {version}");
 
-        let download = download_and_extract_with(
-            &url,
-            &filename,
-            store,
-            DownloadVerification::Sha256(checksum),
-            |req| maybe_add_github_auth(req, is_github),
-        )
+        let download = download_and_extract_with(&url, &filename, store, verification, |req| {
+            maybe_add_github_auth(req, is_github)
+        })
         .await
         .with_context(|| format!("Failed to download Ruby {version} from {url}"))?;
         let extracted = download.path();
@@ -352,8 +342,7 @@ impl RubyInstaller {
         let inner = extracted.join(&version_str);
         if !inner.exists() {
             anyhow::bail!(
-                "Expected directory '{}' inside rv-ruby archive, found: {:?}",
-                version_str,
+                "Expected directory `{version_str}` inside rv-ruby archive, found: {:?}",
                 fs_err::read_dir(extracted)?
                     .flatten()
                     .map(|e| e.file_name())
@@ -376,29 +365,27 @@ impl RubyInstaller {
     }
 
     async fn fetch_checksum(
-        base_url: &str,
+        checksum_url: &str,
         filename: &str,
         is_github: bool,
     ) -> Result<Sha256Digest> {
-        let url = format!("{base_url}/SHA256SUMS");
         let req = REQWEST_CLIENT
-            .get(&url)
+            .get(checksum_url)
             .header("Accept", "application/octet-stream");
         let req = maybe_add_github_auth(req, is_github);
 
-        let response = req
+        let checksums = req
             .send()
             .await
             .and_then(reqwest::Response::error_for_status)
-            .with_context(|| {
-                format!(
-                    "Failed to fetch required rv-ruby checksum file from {url}. \
-                     PREK_RUBY_MIRROR must provide SHA256SUMS alongside release assets."
-                )
-            })?;
+            .with_context(|| format!("Failed to fetch rv-ruby checksum file from {checksum_url}"))?
+            .text()
+            .await
+            .with_context(|| format!("Failed to read rv-ruby checksum file from {checksum_url}"))?;
 
-        let checksums = response.text().await?;
-        rv_ruby_checksum_from_sha256sums(&checksums, &url, filename)
+        digest_from_sha256sums(&checksums, filename).with_context(|| {
+            format!("rv-ruby checksum file at {checksum_url} does not list `{filename}`")
+        })
     }
 
     /// Find Ruby in the system PATH
@@ -420,19 +407,6 @@ impl RubyInstaller {
 
         Ok(None)
     }
-}
-
-fn rv_ruby_checksum_from_sha256sums(
-    checksums: &str,
-    checksum_url: &str,
-    filename: &str,
-) -> Result<Sha256Digest> {
-    digest_from_sha256sums(checksums, filename).with_context(|| {
-        format!(
-            "rv-ruby checksum file at {checksum_url} does not list `{filename}`. \
-             PREK_RUBY_MIRROR must provide SHA256SUMS from the same release as its Ruby archives."
-        )
-    })
 }
 
 /// Try to use a Ruby at the given path
@@ -612,41 +586,6 @@ mod tests {
     use target_lexicon::Triple;
     use tempfile::TempDir;
 
-    /// Mutex to serialize tests that mutate `PREK_RUBY_MIRROR`.
-    static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    /// RAII guard that serializes env var access and restores the original value on drop.
-    /// Holds the `ENV_MUTEX` lock for its lifetime, so tests using this guard run
-    /// sequentially. Ensures cleanup even if a test panics.
-    struct EnvVarGuard {
-        key: &'static str,
-        saved: Option<String>,
-        _lock: std::sync::MutexGuard<'static, ()>,
-    }
-
-    impl EnvVarGuard {
-        fn new(key: &'static str) -> Self {
-            let lock = ENV_MUTEX
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            let saved = EnvVars::var(key).ok();
-            Self {
-                key,
-                saved,
-                _lock: lock,
-            }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            match &self.saved {
-                Some(v) => unsafe { std::env::set_var(self.key, v) },
-                None => unsafe { std::env::remove_var(self.key) },
-            }
-        }
-    }
-
     #[test]
     fn test_ruby_request_display() {
         assert_eq!(RubyRequest::Any.to_string(), "any");
@@ -715,93 +654,6 @@ mod tests {
         let error = ruby_not_found_error(&RubyRequest::Any, "Another reason.");
         assert!(error.contains("any"));
         assert!(error.contains("Another reason."));
-    }
-
-    #[test]
-    fn test_rv_ruby_urls_default() {
-        let _guard = EnvVarGuard::new(EnvVars::PREK_RUBY_MIRROR);
-        unsafe { std::env::remove_var(EnvVars::PREK_RUBY_MIRROR) };
-
-        let (api_url, api_is_github) = rv_ruby_api_url();
-        assert_eq!(
-            api_url,
-            "https://api.github.com/repos/spinel-coop/rv-ruby/releases/latest"
-        );
-        assert!(api_is_github);
-
-        let (dl_url, dl_is_github) = rv_ruby_download_base();
-        assert_eq!(
-            dl_url,
-            format!("{RV_RUBY_DEFAULT_URL}/releases/latest/download")
-        );
-        assert!(dl_is_github);
-    }
-
-    #[test]
-    fn test_rv_ruby_urls_github_mirror() {
-        // A github.com mirror: API URL is rewritten, download URL uses web URL.
-        let _guard = EnvVarGuard::new(EnvVars::PREK_RUBY_MIRROR);
-        unsafe {
-            std::env::set_var(
-                EnvVars::PREK_RUBY_MIRROR,
-                "https://github.com/myorg/vetted-rubies/",
-            );
-        }
-
-        let (api_url, api_is_github) = rv_ruby_api_url();
-        assert_eq!(
-            api_url,
-            "https://api.github.com/repos/myorg/vetted-rubies/releases/latest"
-        );
-        assert!(api_is_github);
-
-        let (dl_url, dl_is_github) = rv_ruby_download_base();
-        assert_eq!(
-            dl_url,
-            "https://github.com/myorg/vetted-rubies/releases/latest/download"
-        );
-        assert!(dl_is_github);
-    }
-
-    #[test]
-    fn test_rv_ruby_urls_non_github_mirror() {
-        // A non-github mirror: both URLs use the mirror as-is, is_github is false.
-        let _guard = EnvVarGuard::new(EnvVars::PREK_RUBY_MIRROR);
-        unsafe {
-            std::env::set_var(
-                EnvVars::PREK_RUBY_MIRROR,
-                "https://my-mirror.example.com/rv-ruby",
-            );
-        }
-
-        let (api_url, api_is_github) = rv_ruby_api_url();
-        assert_eq!(
-            api_url,
-            "https://my-mirror.example.com/rv-ruby/releases/latest"
-        );
-        assert!(!api_is_github);
-
-        let (dl_url, dl_is_github) = rv_ruby_download_base();
-        assert_eq!(
-            dl_url,
-            "https://my-mirror.example.com/rv-ruby/releases/latest/download"
-        );
-        assert!(!dl_is_github);
-    }
-
-    #[test]
-    fn test_rv_ruby_checksum_missing_asset_error() {
-        let err = rv_ruby_checksum_from_sha256sums(
-            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  other.tar.gz",
-            "https://mirror.example.com/rv-ruby/releases/latest/download/SHA256SUMS",
-            "ruby-3.4.8.x86_64_linux.tar.gz",
-        )
-        .unwrap_err();
-
-        let message = err.to_string();
-        assert!(message.contains("does not list `ruby-3.4.8.x86_64_linux.tar.gz`"));
-        assert!(message.contains("PREK_RUBY_MIRROR"));
-        assert!(message.contains("same release"));
     }
 
     #[test]

--- a/crates/prek/src/languages/ruby/installer.rs
+++ b/crates/prek/src/languages/ruby/installer.rs
@@ -4,12 +4,14 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use itertools::Itertools;
 use prek_consts::env_vars::EnvVars;
+use reqwest::Url;
 use serde::Deserialize;
 use target_lexicon::{Architecture, Environment, HOST, OperatingSystem, Triple};
 use tracing::{debug, trace, warn};
 
+use crate::checksum::{Sha256Digest, digest_from_sha256sums};
 use crate::fs::LockedFile;
-use crate::http::{REQWEST_CLIENT, download_and_extract_with};
+use crate::http::{REQWEST_CLIENT, download_and_extract_with_checksum_and_request};
 use crate::languages::ruby::RubyRequest;
 use crate::process::Cmd;
 use crate::store::Store;
@@ -20,7 +22,8 @@ const RV_RUBY_DEFAULT_URL: &str = "https://github.com/spinel-coop/rv-ruby";
 fn rv_ruby_mirror() -> (String, bool) {
     match EnvVars::var(EnvVars::PREK_RUBY_MIRROR) {
         Ok(mirror) => {
-            let is_github = is_github_https(&mirror);
+            let mirror = mirror.trim_end_matches('/').to_string();
+            let is_github = github_repo_path(&mirror).is_some();
             (mirror, is_github)
         }
         Err(_) => (RV_RUBY_DEFAULT_URL.to_string(), true),
@@ -37,10 +40,7 @@ fn rv_ruby_mirror() -> (String, bool) {
 fn rv_ruby_api_url() -> (String, bool) {
     let (base, is_github) = rv_ruby_mirror();
     let url = if is_github {
-        // Rewrite github.com web URL to API URL.
-        let path = base
-            .strip_prefix("https://github.com")
-            .expect("is_github_https should ensure this");
+        let path = github_repo_path(&base).expect("is_github should ensure a GitHub repo path");
         format!("https://api.github.com/repos{path}/releases/latest")
     } else {
         format!("{base}/releases/latest")
@@ -48,13 +48,26 @@ fn rv_ruby_api_url() -> (String, bool) {
     (url, is_github)
 }
 
-/// Check whether a URL is an HTTPS URL pointing to github.com.
-/// Only matches the exact host `github.com` over HTTPS, so won't send
-/// tokens to other hosts, subdomains, path-injection attempts,
-/// userinfo-based redirects, or plaintext HTTP.
-fn is_github_https(url: &str) -> bool {
-    (url.starts_with("https://github.com/") || url.starts_with("https://github.com:"))
-        && !url.contains('@')
+fn github_repo_path(url: &str) -> Option<String> {
+    let url = Url::parse(url).ok()?;
+    if url.scheme() != "https"
+        || url.host_str() != Some("github.com")
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || !matches!(url.port(), None | Some(443))
+    {
+        return None;
+    }
+
+    let segments = url.path_segments()?.collect::<Vec<_>>();
+    let [owner, repo] = segments.as_slice() else {
+        return None;
+    };
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+
+    Some(format!("/{owner}/{repo}"))
 }
 
 /// Returns the base URL for downloading rv-ruby release assets, and whether
@@ -69,7 +82,7 @@ fn rv_ruby_download_base() -> (String, bool) {
 fn maybe_add_github_auth(req: reqwest::RequestBuilder, is_github: bool) -> reqwest::RequestBuilder {
     if is_github {
         if let Ok(token) = EnvVars::var(EnvVars::GITHUB_TOKEN) {
-            return req.header(http::header::AUTHORIZATION, format!("Bearer {token}"));
+            return req.bearer_auth(token);
         }
     }
     req
@@ -280,7 +293,7 @@ impl RubyInstaller {
 
         if !response.status().is_success() {
             let status = response.status();
-            let hint = if matches!(status.as_u16(), 403 | 429) {
+            let hint = if is_github && matches!(status.as_u16(), 403 | 429) {
                 " (this may be a rate limit — try setting GITHUB_TOKEN)"
             } else {
                 ""
@@ -306,8 +319,8 @@ impl RubyInstaller {
 
     /// Download and extract a specific Ruby version from rv-ruby.
     ///
-    /// Uses `download_and_extract_with` to inject a `GITHUB_TOKEN` auth header
-    /// for GitHub-hosted mirrors (including private partial mirrors of rv-ruby).
+    /// Adds GitHub authentication only for GitHub-hosted sources; the download
+    /// helper verifies the archive checksum before extraction.
     async fn download(
         &self,
         store: &Store,
@@ -317,15 +330,17 @@ impl RubyInstaller {
         let filename = format!("ruby-{version}.{platform}.tar.gz");
         let (base_url, is_github) = rv_ruby_download_base();
         let url = format!("{base_url}/{filename}");
+        let checksum = Self::fetch_checksum(&base_url, &filename, is_github).await?;
         let version_str = version.to_string();
         let target = self.root.join(&version_str);
 
         debug!(url = %url, target = %target.display(), "Downloading Ruby {version}");
 
-        download_and_extract_with(
+        download_and_extract_with_checksum_and_request(
             &url,
             &filename,
             store,
+            checksum,
             |req| maybe_add_github_auth(req, is_github),
             async |extracted| {
                 // rv-ruby tarballs contain: rv-ruby@{version}/{version}/bin/ruby
@@ -362,6 +377,34 @@ impl RubyInstaller {
         })
     }
 
+    async fn fetch_checksum(
+        base_url: &str,
+        filename: &str,
+        is_github: bool,
+    ) -> Result<Sha256Digest> {
+        let url = format!("{base_url}/SHA256SUMS");
+        let req = REQWEST_CLIENT
+            .get(&url)
+            .header("Accept", "application/octet-stream");
+        let req = maybe_add_github_auth(req, is_github);
+
+        let response = req
+            .send()
+            .await
+            .with_context(|| format!("Failed to fetch rv-ruby checksums from {url}"))?;
+        if !response.status().is_success() {
+            anyhow::bail!(
+                "Failed to fetch required rv-ruby checksum file from {}: {}. \
+                 PREK_RUBY_MIRROR must provide SHA256SUMS alongside release assets.",
+                url,
+                response.status()
+            );
+        }
+
+        let checksums = response.text().await?;
+        rv_ruby_checksum_from_sha256sums(&checksums, &url, filename)
+    }
+
     /// Find Ruby in the system PATH
     async fn find_system_ruby(&self, request: &RubyRequest) -> Result<Option<RubyResult>> {
         // Try all rubies in PATH first
@@ -381,6 +424,19 @@ impl RubyInstaller {
 
         Ok(None)
     }
+}
+
+fn rv_ruby_checksum_from_sha256sums(
+    checksums: &str,
+    checksum_url: &str,
+    filename: &str,
+) -> Result<Sha256Digest> {
+    digest_from_sha256sums(checksums, filename).with_context(|| {
+        format!(
+            "rv-ruby checksum file at {checksum_url} does not list `{filename}`. \
+             PREK_RUBY_MIRROR must provide SHA256SUMS from the same release as its Ruby archives."
+        )
+    })
 }
 
 /// Try to use a Ruby at the given path
@@ -692,7 +748,7 @@ mod tests {
         unsafe {
             std::env::set_var(
                 EnvVars::PREK_RUBY_MIRROR,
-                "https://github.com/myorg/vetted-rubies",
+                "https://github.com/myorg/vetted-rubies/",
             );
         }
 
@@ -735,6 +791,21 @@ mod tests {
             "https://my-mirror.example.com/rv-ruby/releases/latest/download"
         );
         assert!(!dl_is_github);
+    }
+
+    #[test]
+    fn test_rv_ruby_checksum_missing_asset_error() {
+        let err = rv_ruby_checksum_from_sha256sums(
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  other.tar.gz",
+            "https://mirror.example.com/rv-ruby/releases/latest/download/SHA256SUMS",
+            "ruby-3.4.8.x86_64_linux.tar.gz",
+        )
+        .unwrap_err();
+
+        let message = err.to_string();
+        assert!(message.contains("does not list `ruby-3.4.8.x86_64_linux.tar.gz`"));
+        assert!(message.contains("PREK_RUBY_MIRROR"));
+        assert!(message.contains("same release"));
     }
 
     #[test]
@@ -894,28 +965,28 @@ mod tests {
     }
 
     #[test]
-    fn test_is_github_https() {
-        // Exact match over HTTPS
-        assert!(is_github_https("https://github.com/spinel-coop/rv-ruby"));
-        assert!(is_github_https("https://github.com:443/org/repo"));
+    fn test_github_repo_path() {
+        assert_eq!(
+            github_repo_path("https://github.com/spinel-coop/rv-ruby").as_deref(),
+            Some("/spinel-coop/rv-ruby")
+        );
+        assert_eq!(
+            github_repo_path("https://github.com:443/org/repo").as_deref(),
+            Some("/org/repo")
+        );
 
-        // Plaintext HTTP — don't leak tokens
-        assert!(!is_github_https("http://github.com/org/repo"));
-        // Not github.com
-        assert!(!is_github_https("https://gitlab.com/org/repo"));
-        assert!(!is_github_https("https://my-mirror.example.com/rv-ruby"));
-        // Path injection — github.com in path, not host
-        assert!(!is_github_https("https://evil.com/github.com/rv"));
-        // Subdomain — not the same host
-        assert!(!is_github_https("https://api.github.com/repos/org/repo"));
-        // Userinfo-based redirect
-        assert!(!is_github_https("https://github.com@evil.com/org/repo"));
-        assert!(!is_github_https(
-            "https://github.com:password@evil.com/org/repo"
-        ));
-        assert!(!is_github_https("https://evil.com@github.com/org/repo"));
-        // Other schemes
-        assert!(!is_github_https("ftp://github.com/org/repo"));
+        assert!(github_repo_path("http://github.com/org/repo").is_none());
+        assert!(github_repo_path("https://gitlab.com/org/repo").is_none());
+        assert!(github_repo_path("https://my-mirror.example.com/rv-ruby").is_none());
+        assert!(github_repo_path("https://evil.com/github.com/rv").is_none());
+        assert!(github_repo_path("https://api.github.com/repos/org/repo").is_none());
+        assert!(github_repo_path("https://github.com@evil.com/org/repo").is_none());
+        assert!(github_repo_path("https://github.com:password@evil.com/org/repo").is_none());
+        assert!(github_repo_path("https://evil.com@github.com/org/repo").is_none());
+        assert!(github_repo_path("https://github.com:444/org/repo").is_none());
+        assert!(github_repo_path("https://github.com/org").is_none());
+        assert!(github_repo_path("https://github.com/org/repo/releases").is_none());
+        assert!(github_repo_path("ftp://github.com/org/repo").is_none());
     }
 
     #[test]

--- a/crates/prek/src/languages/ruby/installer.rs
+++ b/crates/prek/src/languages/ruby/installer.rs
@@ -11,7 +11,7 @@ use tracing::{debug, trace, warn};
 
 use crate::checksum::{Sha256Digest, digest_from_sha256sums};
 use crate::fs::LockedFile;
-use crate::http::{REQWEST_CLIENT, download_and_extract_with_checksum_and_request};
+use crate::http::{DownloadVerification, REQWEST_CLIENT, download_and_extract_with};
 use crate::languages::ruby::RubyRequest;
 use crate::process::Cmd;
 use crate::store::Store;
@@ -336,39 +336,37 @@ impl RubyInstaller {
 
         debug!(url = %url, target = %target.display(), "Downloading Ruby {version}");
 
-        download_and_extract_with_checksum_and_request(
+        let download = download_and_extract_with(
             &url,
             &filename,
             store,
-            checksum,
+            DownloadVerification::Sha256(checksum),
             |req| maybe_add_github_auth(req, is_github),
-            async |extracted| {
-                // rv-ruby tarballs contain: rv-ruby@{version}/{version}/bin/ruby
-                // After strip_component, `extracted` is the rv-ruby@{version}/ directory.
-                // Move the inner {version}/ directory to our target.
-                let inner = extracted.join(&version_str);
-                if !inner.exists() {
-                    anyhow::bail!(
-                        "Expected directory '{}' inside rv-ruby archive, found: {:?}",
-                        version_str,
-                        fs_err::read_dir(extracted)?
-                            .flatten()
-                            .map(|e| e.file_name())
-                            .collect::<Vec<_>>()
-                    );
-                }
-
-                if target.exists() {
-                    debug!(target = %target.display(), "Removing existing Ruby");
-                    fs_err::tokio::remove_dir_all(&target).await?;
-                }
-
-                fs_err::tokio::rename(&inner, &target).await?;
-                Ok(())
-            },
         )
         .await
         .with_context(|| format!("Failed to download Ruby {version} from {url}"))?;
+        let extracted = download.path();
+        // rv-ruby tarballs contain: rv-ruby@{version}/{version}/bin/ruby
+        // After strip_component, `extracted` is the rv-ruby@{version}/ directory.
+        // Move the inner {version}/ directory to our target.
+        let inner = extracted.join(&version_str);
+        if !inner.exists() {
+            anyhow::bail!(
+                "Expected directory '{}' inside rv-ruby archive, found: {:?}",
+                version_str,
+                fs_err::read_dir(extracted)?
+                    .flatten()
+                    .map(|e| e.file_name())
+                    .collect::<Vec<_>>()
+            );
+        }
+
+        if target.exists() {
+            debug!(target = %target.display(), "Removing existing Ruby");
+            fs_err::tokio::remove_dir_all(&target).await?;
+        }
+
+        fs_err::tokio::rename(&inner, &target).await?;
 
         Ok(RubyResult {
             ruby_bin: target.join("bin").join("ruby"),
@@ -391,15 +389,13 @@ impl RubyInstaller {
         let response = req
             .send()
             .await
-            .with_context(|| format!("Failed to fetch rv-ruby checksums from {url}"))?;
-        if !response.status().is_success() {
-            anyhow::bail!(
-                "Failed to fetch required rv-ruby checksum file from {}: {}. \
-                 PREK_RUBY_MIRROR must provide SHA256SUMS alongside release assets.",
-                url,
-                response.status()
-            );
-        }
+            .and_then(reqwest::Response::error_for_status)
+            .with_context(|| {
+                format!(
+                    "Failed to fetch required rv-ruby checksum file from {url}. \
+                     PREK_RUBY_MIRROR must provide SHA256SUMS alongside release assets."
+                )
+            })?;
 
         let checksums = response.text().await?;
         rv_ruby_checksum_from_sha256sums(&checksums, &url, filename)

--- a/crates/prek/src/languages/rust/rustup.rs
+++ b/crates/prek/src/languages/rust/rustup.rs
@@ -9,8 +9,9 @@ use semver::Version;
 use target_lexicon::HOST;
 use tracing::{debug, trace, warn};
 
+use crate::checksum::Sha256Digest;
 use crate::fs::LockedFile;
-use crate::http::REQWEST_CLIENT;
+use crate::http::{REQWEST_CLIENT, download_to_temp_file_with_checksum};
 use crate::languages::rust::version::RustVersion;
 use crate::process::Cmd;
 use crate::store::Store;
@@ -113,28 +114,10 @@ impl Rustup {
         let url = format!("https://static.rust-lang.org/rustup/dist/{triple}/{filename}");
         // Save "rustup-init" as "rustup", this is what "rustup-init" does when setting up.
         let target = rustup_home.join("rustup").with_extension(EXE_EXTENSION);
+        let checksum = Self::fetch_checksum(&url).await?;
 
-        let temp_dir = tempfile::tempdir_in(store.scratch_path())?;
-        debug!(url = %url, temp_dir = ?temp_dir.path(), "Downloading");
-
-        let tmp_target = temp_dir.path().join(filename);
-        let response = REQWEST_CLIENT
-            .get(&url)
-            .send()
-            .await
-            .with_context(|| format!("Failed to download file from {url}"))?;
-        if !response.status().is_success() {
-            anyhow::bail!(
-                "Failed to download file from {}: {}",
-                url,
-                response.status()
-            );
-        }
-
-        let bytes = response.bytes().await?;
-        fs_err::tokio::write(&tmp_target, bytes).await?;
-
-        make_executable(&tmp_target)?;
+        let download = download_to_temp_file_with_checksum(&url, filename, store, checksum).await?;
+        make_executable(download.path())?;
 
         // Move to final location
         if target.exists() {
@@ -142,12 +125,34 @@ impl Rustup {
             fs_err::tokio::remove_file(&target).await?;
         }
         debug!(path = %target.display(), "Installing rustup");
-        fs_err::tokio::rename(&tmp_target, &target).await?;
+        fs_err::tokio::rename(download.path(), &target).await?;
 
         Ok(Self {
             bin: target,
             rustup_home: rustup_home.to_path_buf(),
         })
+    }
+
+    async fn fetch_checksum(url: &str) -> Result<Sha256Digest> {
+        let checksum_url = format!("{url}.sha256");
+        let response = REQWEST_CLIENT
+            .get(&checksum_url)
+            .send()
+            .await
+            .with_context(|| format!("Failed to fetch rustup checksum from {checksum_url}"))?;
+        if !response.status().is_success() {
+            anyhow::bail!(
+                "Failed to fetch rustup checksum from {}: {}",
+                checksum_url,
+                response.status()
+            );
+        }
+        let checksum = response.text().await?;
+        checksum
+            .split_whitespace()
+            .next()
+            .context("Missing rustup SHA256 checksum")?
+            .parse()
     }
 
     pub(crate) async fn install_toolchain(&self, toolchain: &str) -> Result<PathBuf> {

--- a/crates/prek/src/languages/rust/rustup.rs
+++ b/crates/prek/src/languages/rust/rustup.rs
@@ -11,7 +11,7 @@ use tracing::{debug, trace, warn};
 
 use crate::checksum::Sha256Digest;
 use crate::fs::LockedFile;
-use crate::http::{REQWEST_CLIENT, download_to_temp_file_with_checksum};
+use crate::http::{DownloadVerification, REQWEST_CLIENT, download_artifact};
 use crate::languages::rust::version::RustVersion;
 use crate::process::Cmd;
 use crate::store::Store;
@@ -116,7 +116,13 @@ impl Rustup {
         let target = rustup_home.join("rustup").with_extension(EXE_EXTENSION);
         let checksum = Self::fetch_checksum(&url).await?;
 
-        let download = download_to_temp_file_with_checksum(&url, filename, store, checksum).await?;
+        let download = download_artifact(
+            &url,
+            filename,
+            store,
+            DownloadVerification::Sha256(checksum),
+        )
+        .await?;
         make_executable(download.path())?;
 
         // Move to final location
@@ -139,14 +145,8 @@ impl Rustup {
             .get(&checksum_url)
             .send()
             .await
+            .and_then(reqwest::Response::error_for_status)
             .with_context(|| format!("Failed to fetch rustup checksum from {checksum_url}"))?;
-        if !response.status().is_success() {
-            anyhow::bail!(
-                "Failed to fetch rustup checksum from {}: {}",
-                checksum_url,
-                response.status()
-            );
-        }
         let checksum = response.text().await?;
         digest_from_rustup_checksum(&checksum)
     }

--- a/crates/prek/src/languages/rust/rustup.rs
+++ b/crates/prek/src/languages/rust/rustup.rs
@@ -11,7 +11,7 @@ use tracing::{debug, trace, warn};
 
 use crate::checksum::Sha256Digest;
 use crate::fs::LockedFile;
-use crate::http::{DownloadVerification, REQWEST_CLIENT, download_artifact};
+use crate::http::{REQWEST_CLIENT, download_artifact};
 use crate::languages::rust::version::RustVersion;
 use crate::process::Cmd;
 use crate::store::Store;
@@ -114,14 +114,11 @@ impl Rustup {
         let url = format!("https://static.rust-lang.org/rustup/dist/{triple}/{filename}");
         // Save "rustup-init" as "rustup", this is what "rustup-init" does when setting up.
         let target = rustup_home.join("rustup").with_extension(EXE_EXTENSION);
-        let checksum = Self::fetch_checksum(&url).await?;
+        let checksum_url = format!("{url}.sha256");
 
-        let download = download_artifact(
-            &url,
-            filename,
-            store,
-            DownloadVerification::Sha256(checksum),
-        )
+        let download = download_artifact(&url, filename, store, async || {
+            Self::fetch_checksum(&checksum_url).await
+        })
         .await?;
         make_executable(download.path())?;
 
@@ -139,15 +136,21 @@ impl Rustup {
         })
     }
 
-    async fn fetch_checksum(url: &str) -> Result<Sha256Digest> {
-        let checksum_url = format!("{url}.sha256");
+    async fn fetch_checksum(checksum_url: &str) -> Result<Option<Sha256Digest>> {
         let response = REQWEST_CLIENT
-            .get(&checksum_url)
+            .get(checksum_url)
             .send()
             .await
-            .and_then(reqwest::Response::error_for_status)
             .with_context(|| format!("Failed to fetch rustup checksum from {checksum_url}"))?;
-        let checksum = response.text().await?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+
+        let checksum = response
+            .error_for_status()
+            .with_context(|| format!("Failed to fetch rustup checksum from {checksum_url}"))?
+            .text()
+            .await?;
         digest_from_rustup_checksum(&checksum)
     }
 
@@ -257,12 +260,11 @@ impl Rustup {
     }
 }
 
-fn digest_from_rustup_checksum(contents: &str) -> Result<Sha256Digest> {
-    contents
-        .split_whitespace()
-        .next()
-        .context("Missing rustup SHA256 checksum")?
-        .parse()
+fn digest_from_rustup_checksum(contents: &str) -> Result<Option<Sha256Digest>> {
+    let Some(digest) = contents.split_whitespace().next() else {
+        return Ok(None);
+    };
+    digest.parse().map(Some)
 }
 
 fn parse_toolchain_line(line: &str) -> Option<(String, PathBuf)> {
@@ -341,25 +343,15 @@ mod tests {
     const EMPTY_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
 
     #[test]
-    fn parses_plain_rustup_checksum() -> Result<()> {
+    fn parses_rustup_checksum() -> Result<()> {
         let digest = digest_from_rustup_checksum(EMPTY_SHA256)?;
+        assert_eq!(digest.unwrap().to_string(), EMPTY_SHA256);
 
-        assert_eq!(digest.to_string(), EMPTY_SHA256);
-        Ok(())
-    }
-
-    #[test]
-    fn parses_rustup_checksum_with_filename() -> Result<()> {
         let digest = digest_from_rustup_checksum(&format!("{EMPTY_SHA256}  rustup-init\n"))?;
+        assert_eq!(digest.unwrap().to_string(), EMPTY_SHA256);
 
-        assert_eq!(digest.to_string(), EMPTY_SHA256);
+        let result = digest_from_rustup_checksum("")?;
+        assert!(result.is_none());
         Ok(())
-    }
-
-    #[test]
-    fn rejects_empty_rustup_checksum() {
-        let err = digest_from_rustup_checksum("").unwrap_err();
-
-        assert!(err.to_string().contains("Missing rustup SHA256 checksum"));
     }
 }

--- a/crates/prek/src/languages/rust/rustup.rs
+++ b/crates/prek/src/languages/rust/rustup.rs
@@ -148,11 +148,7 @@ impl Rustup {
             );
         }
         let checksum = response.text().await?;
-        checksum
-            .split_whitespace()
-            .next()
-            .context("Missing rustup SHA256 checksum")?
-            .parse()
+        digest_from_rustup_checksum(&checksum)
     }
 
     pub(crate) async fn install_toolchain(&self, toolchain: &str) -> Result<PathBuf> {
@@ -261,6 +257,14 @@ impl Rustup {
     }
 }
 
+fn digest_from_rustup_checksum(contents: &str) -> Result<Sha256Digest> {
+    contents
+        .split_whitespace()
+        .next()
+        .context("Missing rustup SHA256 checksum")?
+        .parse()
+}
+
 fn parse_toolchain_line(line: &str) -> Option<(String, PathBuf)> {
     // Typical formats:
     // "stable-aarch64-apple-darwin (default) /Users/me/.rustup/toolchains/stable-aarch64-apple-darwin"
@@ -328,4 +332,34 @@ fn make_executable(path: &Path) -> std::io::Result<()> {
     }
 
     inner(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EMPTY_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+    #[test]
+    fn parses_plain_rustup_checksum() -> Result<()> {
+        let digest = digest_from_rustup_checksum(EMPTY_SHA256)?;
+
+        assert_eq!(digest.to_string(), EMPTY_SHA256);
+        Ok(())
+    }
+
+    #[test]
+    fn parses_rustup_checksum_with_filename() -> Result<()> {
+        let digest = digest_from_rustup_checksum(&format!("{EMPTY_SHA256}  rustup-init\n"))?;
+
+        assert_eq!(digest.to_string(), EMPTY_SHA256);
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_empty_rustup_checksum() {
+        let err = digest_from_rustup_checksum("").unwrap_err();
+
+        assert!(err.to_string().contains("Missing rustup SHA256 checksum"));
+    }
 }

--- a/crates/prek/src/main.rs
+++ b/crates/prek/src/main.rs
@@ -30,6 +30,7 @@ use crate::settings::FilesystemOptions;
 use crate::store::Store;
 
 mod archive;
+mod checksum;
 mod cleanup;
 mod cli;
 mod config;

--- a/crates/prek/tests/languages/deno.rs
+++ b/crates/prek/tests/languages/deno.rs
@@ -353,17 +353,17 @@ fn language_version() {
                 verbose: true
                 pass_filenames: false
               - id: deno-version
-                name: deno version check (1.46 - will auto download)
+                name: deno version check (2.1 - will auto download)
                 language: deno
-                language_version: '1.46'
+                language_version: '2.1'
                 entry: deno eval 'console.log(`Deno ${Deno.version.deno}`)'
                 always_run: true
                 verbose: true
                 pass_filenames: false
               - id: deno-version
-                name: deno version check (deno@1.46)
+                name: deno version check (deno@2.1)
                 language: deno
-                language_version: deno@1.46
+                language_version: deno@2.1
                 entry: deno eval 'console.log(`Deno ${Deno.version.deno}`)'
                 always_run: true
                 verbose: true
@@ -375,14 +375,14 @@ fn language_version() {
     let deno_dir = context.home_dir().child("tools").child("deno");
     deno_dir.assert(predicates::path::missing());
 
-    // Use two filters: first masks minor+patch for Deno 2.x (major-only request),
-    // then masks only patch for specific minor versions like 1.46.x
+    // Use two filters: first masks only patch for specific minor versions,
+    // then masks minor+patch for Deno 2.x (major-only request).
     let filters = context
         .filters()
         .into_iter()
         .chain([
+            (r"Deno 2\.1\.\d+", "Deno 2.1.X"),
             (r"Deno 2\.\d+\.\d+", "Deno 2.X.X"),
-            (r"Deno (\d+\.\d+)\.\d+", "Deno $1.X"),
         ])
         .collect::<Vec<_>>();
 
@@ -400,21 +400,21 @@ fn language_version() {
     - duration: [TIME]
 
       Deno 2.X.X
-    deno version check (1.46 - will auto download)...........................Passed
+    deno version check (2.1 - will auto download)............................Passed
     - hook id: deno-version
     - duration: [TIME]
 
-      Deno 1.46.X
-    deno version check (deno@1.46)...........................................Passed
+      Deno 2.1.X
+    deno version check (deno@2.1)............................................Passed
     - hook id: deno-version
     - duration: [TIME]
 
-      Deno 1.46.X
+      Deno 2.1.X
 
     ----- stderr -----
     ");
 
-    // Check that only deno 1.46 is installed (2.x uses system).
+    // Check that only Deno 2.1 is installed (2.x uses system).
     let installed_versions = deno_dir
         .read_dir()
         .expect("Failed to read deno tools directory")
@@ -435,8 +435,8 @@ fn language_version() {
         "Expected only one Deno version to be installed, but found: {installed_versions:?}"
     );
     assert!(
-        installed_versions.iter().any(|v| v.contains("1.46")),
-        "Expected Deno 1.46 to be installed, but found: {installed_versions:?}"
+        installed_versions.iter().any(|v| v.contains("2.1")),
+        "Expected Deno 2.1 to be installed, but found: {installed_versions:?}"
     );
 }
 

--- a/crates/prek/tests/languages/deno.rs
+++ b/crates/prek/tests/languages/deno.rs
@@ -440,6 +440,61 @@ fn language_version() {
     );
 }
 
+/// Test checksum policy behavior for a Deno release without checksum sidecars.
+#[test]
+fn checksum_policy() {
+    let context = TestContext::new();
+    context.init_project();
+
+    context.write_pre_commit_config(indoc::indoc! {r"
+        repos:
+          - repo: local
+            hooks:
+              - id: deno-version
+                name: deno version check
+                language: deno
+                language_version: '1.46.3'
+                entry: deno eval 'console.log(`Deno ${Deno.version.deno}`)'
+                always_run: true
+                verbose: true
+                pass_filenames: false
+    "});
+    context.git_add(".");
+
+    let filters = context
+        .filters()
+        .into_iter()
+        .chain([(r"deno-[A-Za-z0-9_-]+\.zip", "deno-[TARGET].zip")])
+        .collect::<Vec<_>>();
+
+    cmd_snapshot!(filters.clone(), context.run()
+        .env(EnvVars::PREK_DOWNLOAD_CHECKSUM_POLICY, "required"), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to install hook `deno-version`
+      caused by: Failed to install deno
+      caused by: Failed to download deno
+      caused by: Checksum verification is required for `deno-[TARGET].zip`, but no checksum was found
+    ");
+
+    cmd_snapshot!(filters, context.run()
+        .env(EnvVars::PREK_DOWNLOAD_CHECKSUM_POLICY, "disabled"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    deno version check.......................................................Passed
+    - hook id: deno-version
+    - duration: [TIME]
+
+      Deno 1.46.3
+
+    ----- stderr -----
+    ");
+}
+
 /// Test that deno hooks work without system deno in PATH.
 /// Regression test ensuring run-time resolution still finds the managed toolchain.
 #[test]

--- a/docs/diff.md
+++ b/docs/diff.md
@@ -39,7 +39,7 @@ When `prek` installs a managed runtime, it:
 1. Resolves the runtime version and archive name.
 2. Fetches the checksum metadata from the runtime's distribution source.
 3. Downloads the archive or installer into a temporary file under the prek cache scratch directory.
-4. Computes the SHA-256 digest of that temporary file.
+4. Computes the SHA-256 digest while writing the temporary file.
 5. Extracts or installs only after the computed digest matches the expected digest.
 
 Checksum sources are runtime-specific:

--- a/docs/diff.md
+++ b/docs/diff.md
@@ -30,6 +30,31 @@ See the dedicated [Language Support](languages.md) page for a complete list of s
 
 Recent releases added support for more managed hook runtimes, including Bun, Julia, Deno, and experimental .NET support.
 
+## Managed runtime download verification
+
+For supported managed runtime downloads, `prek` verifies the downloaded archive or installer against the checksum published by the runtime's own distribution channel before extracting or installing it.
+
+When `prek` installs a managed runtime, it:
+
+1. Resolves the runtime version and archive name.
+2. Fetches the checksum metadata from the runtime's distribution source.
+3. Downloads the archive or installer into a temporary file under the prek cache scratch directory.
+4. Computes the SHA-256 digest of that temporary file.
+5. Extracts or installs only after the computed digest matches the expected digest.
+
+Checksum sources are runtime-specific:
+
+- Node uses `SHASUMS256.txt` from `nodejs.org`.
+- Bun uses `SHASUMS256.txt` from the Bun release.
+- Deno uses `.sha256sum` sidecars from Deno downloads.
+- Go uses the `sha256` value from Go release metadata.
+- Ruby uses `SHA256SUMS` from the same rv-ruby release download location as the archive.
+- Rustup uses `.sha256` sidecars from `static.rust-lang.org`.
+
+This helps catch corrupted or unexpectedly changed downloads before they are unpacked. It does not add an independent trust root: if an upstream release, mirror, or checksum file is compromised together with the archive, SHA-256 verification alone cannot detect that.
+
+`uv` downloads are not covered by this behavior yet.
+
 ## Command line interface
 
 For a compatibility-focused command mapping, see [Compatibility with pre-commit](compatibility.md).

--- a/docs/diff.md
+++ b/docs/diff.md
@@ -34,23 +34,6 @@ Recent releases added support for more managed hook runtimes, including Bun, Jul
 
 For supported managed runtime downloads, `prek` verifies the downloaded archive or installer against the checksum published by the runtime's own distribution channel before extracting or installing it.
 
-When `prek` installs a managed runtime, it:
-
-1. Resolves the runtime version and archive name.
-2. Fetches the checksum metadata from the runtime's distribution source.
-3. Downloads the archive or installer into a temporary file under the prek cache scratch directory.
-4. Computes the SHA-256 digest while writing the temporary file.
-5. Extracts or installs only after the computed digest matches the expected digest.
-
-Checksum sources are runtime-specific:
-
-- Node uses `SHASUMS256.txt` from `nodejs.org`.
-- Bun uses `SHASUMS256.txt` from the Bun release.
-- Deno uses `.sha256sum` sidecars from Deno downloads.
-- Go uses the `sha256` value from Go release metadata.
-- Ruby uses `SHA256SUMS` from the same rv-ruby release download location as the archive.
-- Rustup uses `.sha256` sidecars from `static.rust-lang.org`.
-
 This helps catch corrupted or unexpectedly changed downloads before they are unpacked. It does not add an independent trust root: if an upstream release, mirror, or checksum file is compromised together with the archive, SHA-256 verification alone cannot detect that.
 
 `uv` downloads are not covered by this behavior yet.

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -452,7 +452,7 @@ Supported formats:
 
     Ruby interpreters are downloaded from those built by the `rv` project, and as such are limited in supported platform versions (currently limited to MacOS and Linux on x86_64 and ARM64). Older versions are also not available, with the oldest being 3.2.1. Unsupported platforms or versions will require a compatible system Ruby installation.
 
-    The `PREK_RUBY_MIRROR` environment variable can point Ruby downloads at a different source, for example a private mirror or an air-gapped CI mirror. Mirrors must provide the selected Ruby archive assets and a `SHA256SUMS` asset from the same release download location so downloaded Rubies can be verified. If the mirror is an exact HTTPS GitHub repository URL (`https://github.com/owner/repo`, with an optional `:443` port), prek uses the GitHub API for release metadata and may send `GITHUB_TOKEN` for rate limits or private mirrors. Non-GitHub mirrors are used as-is and never receive `GITHUB_TOKEN`.
+    The `PREK_RUBY_MIRROR` environment variable can point Ruby downloads at a different source, for example a private mirror or an air-gapped CI mirror. Mirrors should provide the selected Ruby archive assets and a `SHA256SUMS` asset from the same release download location so downloaded Rubies can be verified. If checksum metadata is missing, prek warns and continues by default; set [`PREK_DOWNLOAD_CHECKSUM_POLICY`](reference/environment-variables.md#prek_download_checksum_policy) to `required` to fail instead. If the mirror is an exact HTTPS GitHub repository URL (`https://github.com/owner/repo`, with an optional `:443` port), prek uses the GitHub API for release metadata and may send `GITHUB_TOKEN` for rate limits or private mirrors. Non-GitHub mirrors are used as-is and never receive `GITHUB_TOKEN`.
 
 Gems specified in hook gemspec files and `additional_dependencies` are installed into an isolated gemset shared across hooks with the same Ruby version and dependencies.
 
@@ -551,7 +551,9 @@ Use `script` for simple repository scripts that only need file paths and no mana
 
 prek installs each `additional_dependencies` item with `deno install --global` into the hook environment. The hook runs from the work repository with an isolated `DENO_DIR` for cache separation.
 
-Deno hooks run without needing a pre-installed Deno runtime when toolchain download is available. Managed downloads require Deno releases that publish checksum sidecars. For older Deno releases that do not publish them, install Deno separately and use a system runtime.
+Deno hooks run without needing a pre-installed Deno runtime when toolchain download is available. Managed downloads verify Deno release checksum sidecars when they are available.
+
+By default, missing checksums produce a warning and the download continues without checksum verification. Set [`PREK_DOWNLOAD_CHECKSUM_POLICY`](reference/environment-variables.md#prek_download_checksum_policy) to `required` to make missing checksum metadata fail, or to `disabled` to skip checksum verification.
 
 #### Rules
 

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -452,7 +452,7 @@ Supported formats:
 
     Ruby interpreters are downloaded from those built by the `rv` project, and as such are limited in supported platform versions (currently limited to MacOS and Linux on x86_64 and ARM64). Older versions are also not available, with the oldest being 3.2.1. Unsupported platforms or versions will require a compatible system Ruby installation.
 
-    The `PREK_RUBY_MIRROR` environment variable can be used to point to a different source for installers, for example to support mirrors or air-gapped CI environments. Mirrors need to follow the GitHub URL patterns, but note that although the GitHub hostname changes between `api.github.com` and `github.com` as needed, any non-GitHub mirror server will not be remapped in this manner. Where Ruby is being downloaded from GitHub (either from the upstream `rv` or a mirror), this remapping does occur, and any `GITHUB_TOKEN` will be sent with the requests. This both limits impact of rate limiting, and also allows a private GitHub repository to be used (e.g. for a vetted subset of `rv` rubies to be mirrored). Note that GitHub tokens will only be sent to mirrors which are hosted on GitHub.
+    The `PREK_RUBY_MIRROR` environment variable can point Ruby downloads at a different source, for example a private mirror or an air-gapped CI mirror. Mirrors must provide the selected Ruby archive assets and a `SHA256SUMS` asset from the same release download location so downloaded Rubies can be verified. If the mirror is an exact HTTPS GitHub repository URL (`https://github.com/owner/repo`, with an optional `:443` port), prek uses the GitHub API for release metadata and may send `GITHUB_TOKEN` for rate limits or private mirrors. Non-GitHub mirrors are used as-is and never receive `GITHUB_TOKEN`.
 
 Gems specified in hook gemspec files and `additional_dependencies` are installed into an isolated gemset shared across hooks with the same Ruby version and dependencies.
 
@@ -551,7 +551,7 @@ Use `script` for simple repository scripts that only need file paths and no mana
 
 prek installs each `additional_dependencies` item with `deno install --global` into the hook environment. The hook runs from the work repository with an isolated `DENO_DIR` for cache separation.
 
-Deno hooks run without needing a pre-installed Deno runtime when toolchain download is available.
+Deno hooks run without needing a pre-installed Deno runtime when toolchain download is available. Managed downloads require Deno releases that publish checksum sidecars. For older Deno releases that do not publish them, install Deno separately and use a system runtime.
 
 #### Rules
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -64,6 +64,17 @@ If not set, prek automatically selects the best available source.
 
 Use the system trusted store instead of the bundled `webpki-roots` crate.
 
+### `PREK_DOWNLOAD_CHECKSUM_POLICY`
+
+Control checksum verification for managed toolchain downloads that use checksum sidecar files.
+Options:
+
+- `warn-missing` (default): verify downloads when a checksum is available; warn and continue when checksum metadata is missing
+- `required`: require the checksum sidecar to be available and valid
+- `disabled`: skip checksum fetching and verification
+
+Checksum mismatches are hard errors whenever verification is enabled.
+
 ### `PREK_CONTAINER_RUNTIME`
 
 Specify the container runtime to use for container-based hooks (e.g., `docker`, `docker_image`).
@@ -82,7 +93,7 @@ Defaults to `120` characters of arguments; set a larger value to reduce truncati
 ### `PREK_RUBY_MIRROR`
 
 Override the Ruby installer base URL used for downloaded Ruby toolchains (for example, when using mirrors or air-gapped CI environments).
-Mirrors must provide release-compatible Ruby archive assets and a `SHA256SUMS` asset in the same release download location.
+Mirrors should provide release-compatible Ruby archive assets and a `SHA256SUMS` asset in the same release download location.
 Only exact HTTPS GitHub repository mirrors (`https://github.com/owner/repo`, optionally with port `443`) receive `GITHUB_TOKEN`; other mirrors are used without GitHub authentication.
 See [Ruby language support](../languages.md#ruby) for details.
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -82,6 +82,8 @@ Defaults to `120` characters of arguments; set a larger value to reduce truncati
 ### `PREK_RUBY_MIRROR`
 
 Override the Ruby installer base URL used for downloaded Ruby toolchains (for example, when using mirrors or air-gapped CI environments).
+Mirrors must provide release-compatible Ruby archive assets and a `SHA256SUMS` asset in the same release download location.
+Only exact HTTPS GitHub repository mirrors (`https://github.com/owner/repo`, optionally with port `443`) receive `GITHUB_TOKEN`; other mirrors are used without GitHub authentication.
 See [Ruby language support](../languages.md#ruby) for details.
 
 ### `PREK_RUST_PROFILE`


### PR DESCRIPTION
## Summary

Adds SHA-256 verification for managed runtime downloads before extraction or installation.

Covered runtimes:

- Node
- Bun
- Go
- Rustup
- Ruby
- Deno

`uv` is intentionally not covered here, pending resolution of #1745.

Closes #1744 

## Details

This adds shared checksum-verified download helpers and wires them into the managed runtime installers. The installer now downloads the archive or installer into a temporary file, verifies it against the checksum published by the runtime’s distribution source, and only extracts or installs after the digest matches.

Checksum sources:

- Node: `SHASUMS256.txt` from `nodejs.org`
- Bun: release `SHASUMS256.txt`
- Go: `sha256` from Go release metadata
- Rustup: `.sha256` sidecars from `static.rust-lang.org`
- Ruby: `SHA256SUMS` from the same rv-ruby release download location as the archive
- Deno: `.zip.sha256sum` sidecars from Deno downloads

For SHA-256 hashing, this uses `aws-lc-rs`, which was already present in the dependency graph through the existing TLS stack. This PR adds it as an explicit workspace dependency so the checksum helper can use its digest API directly, instead of adding a separate SHA-256 crate such as `sha2`.

## Ruby mirrors

Ruby keeps the existing GitHub API metadata discovery behavior.

`PREK_RUBY_MIRROR` may point at private/vetted/air-gapped mirrors, but mirrors must provide compatible Ruby archive assets plus `SHA256SUMS` from the same release download location.

`GITHUB_TOKEN` is only sent for exact HTTPS GitHub repository sources. Non-GitHub Ruby mirrors are used without GitHub authentication.

## Compatibility notes

Managed Deno downloads now require releases using the current `.zip.sha256sum` sidecar naming. Deno `v2.1.0` and newer use that layout. Older releases such as `v2.0.0` used a different sidecar naming pattern, and older `1.x` releases may not be compatible with this verified managed-download path. Those versions can still be used via a separately installed system Deno.

Managed Bun downloads require the release to provide `SHASUMS256.txt`. That file exists for modern Bun releases, including `bun-v1.0.0`; very old pre-1.0 releases may fail checksum metadata lookup and should use a system Bun if needed.

## Security model

This catches corrupted or unexpectedly changed download bytes before extraction/install.

It does not add an independent trust root. If an upstream release, mirror, checksum file, or distribution channel is compromised together with the archive, SHA-256 verification alone cannot detect that. Signature verification, where applicable, would be worthwhile future hardening.