### PR TITLE
Multiple small optimizations

### DIFF
--- a/crates/prek/src/cli/auto_update/repository.rs
+++ b/crates/prek/src/cli/auto_update/repository.rs
@@ -311,7 +311,7 @@ pub(super) fn select_best_tag<'a>(
     allow_non_version_like: bool,
 ) -> Option<&'a str> {
     let has_version_like = tags.iter().any(|tag| tag.contains('.'));
-    let mut candidates = if has_version_like {
+    let candidates = if has_version_like {
         tags.iter()
             .filter(|tag| tag.contains('.'))
             .copied()
@@ -322,14 +322,16 @@ pub(super) fn select_best_tag<'a>(
         return None;
     };
 
-    candidates.sort_by(|tag_a, tag_b| {
-        levenshtein_distance(tag_a, current_ref)
-            .cmp(&levenshtein_distance(tag_b, current_ref))
-            .then_with(|| compare_tag_versions_desc(tag_a, tag_b))
-            .then_with(|| tag_a.cmp(tag_b))
-    });
-
-    candidates.into_iter().next()
+    candidates
+        .into_iter()
+        .map(|tag| (levenshtein_distance(tag, current_ref), tag))
+        .min_by(|(distance_a, tag_a), (distance_b, tag_b)| {
+            distance_a
+                .cmp(distance_b)
+                .then_with(|| compare_tag_versions_desc(tag_a, tag_b))
+                .then_with(|| tag_a.cmp(tag_b))
+        })
+        .map(|(_, tag)| tag)
 }
 
 fn levenshtein_distance(a: &str, b: &str) -> usize {

--- a/crates/prek/src/cli/auto_update/source.rs
+++ b/crates/prek/src/cli/auto_update/source.rs
@@ -154,9 +154,11 @@ async fn collect_frozen_mismatches<'a>(
         .iter()
         .filter_map(|usage| {
             let current_frozen = usage.current_frozen.as_deref()?;
-            let frozen_commit = resolved_frozen_refs.get(current_frozen).cloned().flatten();
+            let frozen_commit = resolved_frozen_refs
+                .get(current_frozen)
+                .and_then(|commit| commit.as_deref());
 
-            let reason = match frozen_commit.as_deref() {
+            let reason = match frozen_commit {
                 Some(frozen_commit) if frozen_commit.eq_ignore_ascii_case(target.current_rev) => {
                     return None;
                 }

--- a/crates/prek/src/cli/auto_update/source.rs
+++ b/crates/prek/src/cli/auto_update/source.rs
@@ -1,3 +1,4 @@
+use std::collections::hash_map::Entry;
 use std::path::Path;
 
 use anyhow::{Context, Result};
@@ -80,21 +81,21 @@ pub(super) fn collect_repo_sources<'a>(
             required_hook_ids.sort_unstable();
             required_hook_ids.dedup();
 
-            let target = repo_sources
-                .entry(remote_repo.repo.as_str())
-                .or_default()
-                .entry((
-                    remote_repo.rev.as_str(),
-                    required_hook_ids.clone(),
-                    cooldown_days,
-                ))
-                .or_insert_with(|| RepoTarget {
-                    repo: remote_repo.repo.as_str(),
-                    current_rev: remote_repo.rev.as_str(),
-                    cooldown_days,
-                    required_hook_ids,
-                    usages: Vec::new(),
-                });
+            let targets = repo_sources.entry(remote_repo.repo.as_str()).or_default();
+            let target_key = (remote_repo.rev.as_str(), required_hook_ids, cooldown_days);
+            let target = match targets.entry(target_key) {
+                Entry::Occupied(entry) => entry.into_mut(),
+                Entry::Vacant(entry) => {
+                    let required_hook_ids = entry.key().1.clone();
+                    entry.insert(RepoTarget {
+                        repo: remote_repo.repo.as_str(),
+                        current_rev: remote_repo.rev.as_str(),
+                        cooldown_days,
+                        required_hook_ids,
+                        usages: Vec::new(),
+                    })
+                }
+            };
             target.usages.push(RepoUsage {
                 project,
                 remote_count,

--- a/crates/prek/src/hooks/pre_commit_hooks/check_added_large_files.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_added_large_files.rs
@@ -41,6 +41,10 @@ pub(crate) async fn check_added_large_files(
         candidate_filenames.as_slice()
     };
 
+    if filenames.is_empty() {
+        return Ok((0, Vec::new()));
+    }
+
     // Builtin hooks receive project-relative filenames, so git attribute lookups need to run
     // from the project root for nested `.gitattributes` files to apply.
     let lfs_files = get_lfs_files(hook.work_dir(), filenames).await?;


### PR DESCRIPTION
- **Skip empty large file checks**
- **Avoid repeated tag distance calculations**
- **Borrow frozen refs during auto-update checks**
- **Avoid repeated auto-update hook key clones**
