### PR TITLE
Use futures-util directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,28 +894,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
-name = "futures"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -923,17 +907,6 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -983,7 +956,6 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -2039,7 +2011,7 @@ dependencies = [
  "etcetera",
  "fancy-regex",
  "fs-err",
- "futures",
+ "futures-util",
  "globset",
  "hex",
  "http",
@@ -2084,6 +2056,7 @@ dependencies = [
  "textwrap",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "toml",
  "toml_edit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,9 @@ dunce = { version = "1.0.5" }
 etcetera = { version = "0.11.0" }
 fancy-regex = { version = "0.18.0" }
 fs-err = { version = "3.3.0", features = ["tokio"] }
-futures = { version = "0.3.31" }
+futures-util = { version = "0.3.31", default-features = false, features = [
+  "alloc",
+] }
 hex = { version = "0.4.3" }
 http = { version = "1.1.0" }
 ignore = { version = "0.4.23" }
@@ -101,14 +103,17 @@ thiserror = { version = "2.0.11" }
 tokio = { version = "1.47.1", features = [
   "fs",
   "io-std",
+  "io-util",
   "process",
   "rt",
   "sync",
   "macros",
   "net",
+  "time",
 ] }
 tokio-tar = { version = "0.6.0", package = "astral-tokio-tar" }
-tokio-util = { version = "0.7.13" }
+tokio-stream = { version = "0.1.18", default-features = false }
+tokio-util = { version = "0.7.13", features = ["compat", "io"] }
 toml = { version = "1.0.1", default-features = false, features = [
   "fast_hash",
   "parse",

--- a/crates/prek/Cargo.toml
+++ b/crates/prek/Cargo.toml
@@ -44,7 +44,7 @@ dunce = { workspace = true }
 etcetera = { workspace = true }
 fancy-regex = { workspace = true }
 fs-err = { workspace = true }
-futures = { workspace = true }
+futures-util = { workspace = true }
 hex = { workspace = true }
 http = { workspace = true }
 ignore = { workspace = true }
@@ -81,6 +81,7 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-tar = { workspace = true }
+tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
 toml = { workspace = true }
 toml_edit = { workspace = true }

--- a/crates/prek/src/archive.rs
+++ b/crates/prek/src/archive.rs
@@ -170,7 +170,7 @@ pub async fn unzip<R: AsyncRead + Unpin>(reader: R, target: impl AsRef<Path>) ->
     }
 
     let target = target.as_ref();
-    let mut reader = futures::io::BufReader::with_capacity(DEFAULT_BUF_SIZE, reader.compat());
+    let mut reader = BufReader::with_capacity(DEFAULT_BUF_SIZE, reader).compat();
     let mut zip = ZipFileReader::new(&mut reader);
 
     let mut directories = FxHashSet::default();

--- a/crates/prek/src/cli/auto_update/mod.rs
+++ b/crates/prek/src/cli/auto_update/mod.rs
@@ -2,7 +2,7 @@ use std::ops::Range;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use futures::{StreamExt, TryStreamExt};
+use futures_util::{StreamExt, TryStreamExt};
 use rustc_hash::FxHashMap;
 use semver::Version;
 
@@ -401,7 +401,7 @@ pub(crate) async fn auto_update(
         (filter_repos.is_empty() || filter_repos.iter().any(|repo| repo == repo_source.repo))
             && !exclude_repos.iter().any(|repo| repo == repo_source.repo)
     });
-    let outcomes: Vec<RepoUpdate<'_>> = futures::stream::iter(sources)
+    let outcomes: Vec<RepoUpdate<'_>> = futures_util::stream::iter(sources)
         .map(async |repo_source| {
             let progress = reporter.on_update_start(repo_source.repo);
             let result =

--- a/crates/prek/src/cli/run/install.rs
+++ b/crates/prek/src/cli/run/install.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use futures::stream::{FuturesUnordered, StreamExt};
+use futures_util::stream::{FuturesUnordered, StreamExt};
 use mea::once::OnceCell;
 use mea::semaphore::Semaphore;
 use rustc_hash::FxHashMap;
@@ -266,7 +266,7 @@ impl InstallCache {
     async fn load_store_installed_hooks(store: &Store) -> Vec<CachedInstallInfo> {
         match fs_err::read_dir(store.hooks_dir()) {
             Ok(dirs) => {
-                let mut tasks = futures::stream::iter(dirs)
+                let mut tasks = futures_util::stream::iter(dirs)
                     .map(async |entry| {
                         let path = match entry {
                             Ok(entry) => entry.path(),

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 use std::sync::{Arc, LazyLock};
 
 use anyhow::{Context, Result};
-use futures::stream::{FuturesUnordered, StreamExt};
+use futures_util::stream::{FuturesUnordered, StreamExt};
 use mea::semaphore::Semaphore;
 use owo_colors::OwoColorize;
 use prek_consts::env_vars::EnvVars;

--- a/crates/prek/src/hooks/mod.rs
+++ b/crates/prek/src/hooks/mod.rs
@@ -83,9 +83,9 @@ where
     F: Fn(&'a Path) -> Fut,
     Fut: Future<Output = anyhow::Result<(i32, Vec<u8>)>>,
 {
-    use futures::StreamExt;
+    use futures_util::StreamExt;
 
-    let mut tasks = futures::stream::iter(filenames)
+    let mut tasks = futures_util::stream::iter(filenames)
         .map(check)
         .buffered(concurrency);
 

--- a/crates/prek/src/http.rs
+++ b/crates/prek/src/http.rs
@@ -3,11 +3,11 @@ use std::str::FromStr;
 use std::sync::LazyLock;
 
 use anyhow::{Context, Result, bail};
-use futures::TryStreamExt;
 use prek_consts::env_vars::EnvVars;
 use reqwest::Certificate;
 use tokio::io::AsyncWriteExt;
-use tokio_util::compat::FuturesAsyncReadCompatExt;
+use tokio_stream::StreamExt;
+use tokio_util::io::StreamReader;
 use tracing::debug;
 
 use crate::checksum::{HashReader, Sha256Digest};
@@ -118,11 +118,9 @@ async fn download_to_temp_file(
 
     let stream = response
         .bytes_stream()
-        .map_err(std::io::Error::other)
-        .into_async_read()
-        .compat();
+        .map(|result| result.map_err(std::io::Error::other));
 
-    let mut reader = HashReader::new(stream);
+    let mut reader = HashReader::new(StreamReader::new(stream));
     let mut file = fs_err::tokio::File::create(&path)
         .await
         .with_context(|| format!("Failed to create temporary download `{}`", path.display()))?;

--- a/crates/prek/src/languages/ruby/gem.rs
+++ b/crates/prek/src/languages/ruby/gem.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use futures::{StreamExt, TryStreamExt};
+use futures_util::{StreamExt, TryStreamExt};
 use prek_consts::env_vars::EnvVars;
 use prek_consts::prepend_paths;
 use rand::RngExt;
@@ -325,7 +325,7 @@ pub(crate) async fn install_gems(
         Ok(gems) if !gems.is_empty() => {
             debug!("Installing {} gems in parallel", gems.len());
 
-            let result = futures::stream::iter(gems)
+            let result = futures_util::stream::iter(gems)
                 .map(|gem| {
                     let key = gem.key();
                     let local_path = local_gem_map.get(key.as_str()).copied();

--- a/crates/prek/src/languages/rust/rustup.rs
+++ b/crates/prek/src/languages/rust/rustup.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
 use anyhow::{Context, Result};
-use futures::StreamExt;
+use futures_util::StreamExt;
 use prek_consts::env_vars::EnvVars;
 use semver::Version;
 use target_lexicon::HOST;
@@ -210,7 +210,7 @@ impl Rustup {
             .filter_map(parse_toolchain_line)
             .collect();
 
-        let infos: Vec<ToolchainInfo> = futures::stream::iter(entries)
+        let infos: Vec<ToolchainInfo> = futures_util::stream::iter(entries)
             .map(async move |(name, path)| toolchain_info(name, path).await)
             .buffer_unordered(8)
             .filter_map(async move |result| match result {
@@ -243,7 +243,7 @@ impl Rustup {
             .filter_map(parse_toolchain_line)
             .collect();
 
-        let infos: Vec<ToolchainInfo> = futures::stream::iter(entries)
+        let infos: Vec<ToolchainInfo> = futures_util::stream::iter(entries)
             .map(async move |(name, path)| toolchain_info(name, path).await)
             .buffer_unordered(8)
             .filter_map(async move |result| match result {

--- a/crates/prek/src/run.rs
+++ b/crates/prek/src/run.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::sync::LazyLock;
 
 use anstream::ColorChoice;
-use futures::{StreamExt, TryStreamExt};
+use futures_util::{StreamExt, TryStreamExt};
 use prek_consts::env_vars::EnvVars;
 use rustc_hash::FxHashMap;
 use tracing::trace;
@@ -278,7 +278,7 @@ where
     );
 
     #[allow(clippy::redundant_closure)]
-    let results: Vec<_> = futures::stream::iter(partitions)
+    let results: Vec<_> = futures_util::stream::iter(partitions)
         .map(|batch| run(batch))
         .buffered(concurrency)
         .try_collect()

--- a/crates/prek/src/store.rs
+++ b/crates/prek/src/store.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use etcetera::BaseStrategy;
-use futures::StreamExt;
+use futures_util::StreamExt;
 use prek_consts::env_vars::EnvVars;
 use rustc_hash::{FxHashMap, FxHashSet};
 use seahash::SeaHasher;
@@ -161,7 +161,7 @@ impl Store {
         }
 
         let mut auth_failed = Vec::new();
-        let mut tasks = futures::stream::iter(pending)
+        let mut tasks = futures_util::stream::iter(pending)
             .map(async |pending| {
                 let progress =
                     reporter.map(|reporter| reporter.on_clone_start(&format!("{}", pending.repo)));


### PR DESCRIPTION
## Summary

- depend on `futures-util` directly instead of the `futures` meta crate
- narrow direct `futures-util` usage to the `alloc` feature for stream concurrency helpers
- adapt HTTP response streams with `tokio_stream` and `tokio_util::io::StreamReader`
- keep `tokio-util/compat` only for async-zip interop and declare Tokio async features explicitly