### PR TITLE
Use fastrand instead of rand

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -90,12 +90,6 @@
     }
   ],
   packageRules: [
-    // Keep deterministic filename shuffling on rand 0.9.
-    {
-      matchManagers: ['cargo'],
-      matchPackageNames: ['rand'],
-      allowedVersions: '<0.10',
-    },
     // Group all GitHub Actions updates together
     {
       groupName: 'GitHub Actions',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -90,6 +90,12 @@
     }
   ],
   packageRules: [
+    // Keep deterministic filename shuffling on rand 0.9.
+    {
+      matchManagers: ['cargo'],
+      matchPackageNames: ['rand'],
+      allowedVersions: '<0.10',
+    },
     // Group all GitHub Actions updates together
     {
       groupName: 'GitHub Actions',

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2004,7 +2004,6 @@ dependencies = [
  "prek-pty",
  "pretty_assertions",
  "quick-xml 0.40.1",
- "rand",
  "regex",
  "reqwest",
  "rustc-hash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2025,7 +2025,6 @@ dependencies = [
  "textwrap",
  "thiserror",
  "tokio",
- "tokio-stream",
  "tokio-util",
  "toml",
  "toml_edit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,17 +453,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chacha20"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,15 +593,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -988,21 +968,9 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi 5.3.0",
+ "r-efi",
  "wasip2",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
- "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2010,6 +1978,7 @@ dependencies = [
  "dunce",
  "etcetera",
  "fancy-regex",
+ "fastrand",
  "fs-err",
  "futures-util",
  "globset",
@@ -2035,7 +2004,6 @@ dependencies = [
  "prek-pty",
  "pretty_assertions",
  "quick-xml 0.40.1",
- "rand 0.10.1",
  "regex",
  "reqwest",
  "rustc-hash",
@@ -2183,7 +2151,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.4",
+ "rand",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2225,30 +2193,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
 name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
-dependencies = [
- "chacha20",
- "getrandom 0.4.3",
- "rand_core 0.10.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -2258,7 +2209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -2269,12 +2220,6 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ref-cast"
@@ -2963,7 +2908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2004,6 +2004,7 @@ dependencies = [
  "prek-pty",
  "pretty_assertions",
  "quick-xml 0.40.1",
+ "rand",
  "regex",
  "reqwest",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ ctrlc = { version = "3.4.5" }
 dunce = { version = "1.0.5" }
 etcetera = { version = "0.11.0" }
 fancy-regex = { version = "0.18.0" }
-fastrand = { version = "2.4.1" }
+fastrand = { version = "2.4.1", default-features = false }
 fs-err = { version = "3.3.0", features = ["tokio"] }
 futures-util = { version = "0.3.31", default-features = false, features = [
   "alloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ owo-colors = { version = "4.1.0" }
 phf = { version = "0.13.1", default-features = false, features = ["macros"] }
 pprof = { version = "0.15.0" }
 quick-xml = { version = "0.40" }
+rand = { version = "0.9.4", default-features = false, features = ["std_rng"] }
 reqwest = { version = "0.13.2", default-features = false, features = [
   "http2",
   "stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ ctrlc = { version = "3.4.5" }
 dunce = { version = "1.0.5" }
 etcetera = { version = "0.11.0" }
 fancy-regex = { version = "0.18.0" }
+fastrand = { version = "2.4.1" }
 fs-err = { version = "3.3.0", features = ["tokio"] }
 futures-util = { version = "0.3.31", default-features = false, features = [
   "alloc",
@@ -66,7 +67,6 @@ owo-colors = { version = "4.1.0" }
 phf = { version = "0.13.1", default-features = false, features = ["macros"] }
 pprof = { version = "0.15.0" }
 quick-xml = { version = "0.40" }
-rand = { version = "0.10.0" }
 reqwest = { version = "0.13.2", default-features = false, features = [
   "http2",
   "stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,6 @@ tokio = { version = "1.47.1", features = [
   "time",
 ] }
 tokio-tar = { version = "0.6.0", package = "astral-tokio-tar" }
-tokio-stream = { version = "0.1.18", default-features = false }
 tokio-util = { version = "0.7.13", features = ["compat", "io"] }
 toml = { version = "1.0.1", default-features = false, features = [
   "fast_hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ owo-colors = { version = "4.1.0" }
 phf = { version = "0.13.1", default-features = false, features = ["macros"] }
 pprof = { version = "0.15.0" }
 quick-xml = { version = "0.40" }
-rand = { version = "0.9.4", default-features = false, features = ["std_rng"] }
+rand = { version = "0.9", default-features = false, features = ["std_rng"] }
 reqwest = { version = "0.13.2", default-features = false, features = [
   "http2",
   "stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,6 @@ owo-colors = { version = "4.1.0" }
 phf = { version = "0.13.1", default-features = false, features = ["macros"] }
 pprof = { version = "0.15.0" }
 quick-xml = { version = "0.40" }
-rand = { version = "0.9", default-features = false, features = ["std_rng"] }
 reqwest = { version = "0.13.2", default-features = false, features = [
   "http2",
   "stream",

--- a/crates/prek/Cargo.toml
+++ b/crates/prek/Cargo.toml
@@ -43,6 +43,7 @@ ctrlc = { workspace = true }
 dunce = { workspace = true }
 etcetera = { workspace = true }
 fancy-regex = { workspace = true }
+fastrand = { workspace = true }
 fs-err = { workspace = true }
 futures-util = { workspace = true }
 hex = { workspace = true }
@@ -60,7 +61,6 @@ mea = { workspace = true }
 memchr = { workspace = true }
 owo-colors = { workspace = true }
 quick-xml = { workspace = true }
-rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
 aws-lc-rs = { workspace = true }

--- a/crates/prek/Cargo.toml
+++ b/crates/prek/Cargo.toml
@@ -61,6 +61,7 @@ mea = { workspace = true }
 memchr = { workspace = true }
 owo-colors = { workspace = true }
 quick-xml = { workspace = true }
+rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
 aws-lc-rs = { workspace = true }

--- a/crates/prek/Cargo.toml
+++ b/crates/prek/Cargo.toml
@@ -82,7 +82,6 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-tar = { workspace = true }
-tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
 toml = { workspace = true }
 toml_edit = { workspace = true }

--- a/crates/prek/Cargo.toml
+++ b/crates/prek/Cargo.toml
@@ -61,7 +61,6 @@ mea = { workspace = true }
 memchr = { workspace = true }
 owo-colors = { workspace = true }
 quick-xml = { workspace = true }
-rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
 aws-lc-rs = { workspace = true }

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -12,8 +12,6 @@ use owo_colors::OwoColorize;
 use prek_consts::env_vars::EnvVars;
 use prek_consts::{PRE_COMMIT_CONFIG_YAML, PREK_TOML};
 use prek_identify::{TagSet, tags_from_path};
-use rand::SeedableRng;
-use rand::prelude::{SliceRandom, StdRng};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use tracing::{debug, error, trace};
 use unicode_width::UnicodeWidthStr;
@@ -1276,8 +1274,8 @@ impl<'a> HookRunInput<'a> {
         // partitions, but do it deterministically in case a hook cares about ordering.
         const SEED: u64 = 1_542_676_187;
         if let Self::Filenames(filenames) = self {
-            let mut rng = StdRng::seed_from_u64(SEED);
-            filenames.shuffle(&mut rng);
+            let mut rng = fastrand::Rng::with_seed(SEED);
+            rng.shuffle(filenames);
         }
     }
 }

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -12,6 +12,8 @@ use owo_colors::OwoColorize;
 use prek_consts::env_vars::EnvVars;
 use prek_consts::{PRE_COMMIT_CONFIG_YAML, PREK_TOML};
 use prek_identify::{TagSet, tags_from_path};
+use rand::SeedableRng;
+use rand::prelude::{SliceRandom, StdRng};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use tracing::{debug, error, trace};
 use unicode_width::UnicodeWidthStr;
@@ -1274,8 +1276,8 @@ impl<'a> HookRunInput<'a> {
         // partitions, but do it deterministically in case a hook cares about ordering.
         const SEED: u64 = 1_542_676_187;
         if let Self::Filenames(filenames) = self {
-            let mut rng = fastrand::Rng::with_seed(SEED);
-            rng.shuffle(filenames);
+            let mut rng = StdRng::seed_from_u64(SEED);
+            filenames.shuffle(&mut rng);
         }
     }
 }

--- a/crates/prek/src/languages/ruby/gem.rs
+++ b/crates/prek/src/languages/ruby/gem.rs
@@ -6,7 +6,6 @@ use anyhow::{Context, Result};
 use futures_util::{StreamExt, TryStreamExt};
 use prek_consts::env_vars::EnvVars;
 use prek_consts::prepend_paths;
-use rand::RngExt;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::debug;
 
@@ -337,7 +336,7 @@ pub(crate) async fn install_gems(
                                 // each other's partially-written gemspec files, causing
                                 // transient failures (especially on Windows/NTFS). Retry
                                 // once after a random delay to let the other process finish.
-                                let delay = rand::rng().random_range(50..=500);
+                                let delay = fastrand::u64(50..=500);
                                 debug!(
                                     "gem install {} failed, retrying in {delay}ms: {first_err:#}",
                                     gem.name

--- a/crates/prek/src/profiler.rs
+++ b/crates/prek/src/profiler.rs
@@ -23,7 +23,7 @@ pub(crate) fn finish_profiling(profiler_guard: Option<pprof::ProfilerGuard>) {
         .build()
     {
         Ok(report) => {
-            let random = rand::random::<u64>();
+            let random = fastrand::u64(..);
             let file = fs_err::File::create(format!(
                 "{}.{random}.flamegraph.svg",
                 env!("CARGO_PKG_NAME"),

--- a/crates/prek/tests/builtin_hooks.rs
+++ b/crates/prek/tests/builtin_hooks.rs
@@ -107,7 +107,7 @@ fn end_of_file_fixer_hook() -> Result<()> {
     context.git_add(".");
 
     // First run: hooks should fail and fix the files
-    cmd_snapshot!(context.filters(), context.run(), @r"
+    cmd_snapshot!(context.filters(), context.run(), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -116,14 +116,14 @@ fn end_of_file_fixer_hook() -> Result<()> {
     - exit code: 1
     - files were modified by this hook
 
+      Fixing only_win_newlines.txt
+      Fixing multiple_lf.txt
+      Fixing no_newline.txt
       Fixing multiple_crlf.txt
       Fixing only_newlines.txt
-      Fixing only_win_newlines.txt
-      Fixing no_newline.txt
-      Fixing multiple_lf.txt
 
     ----- stderr -----
-    ");
+    "#);
 
     // Assert that the files have been corrected
     assert_snapshot!(context.read("correct_lf.txt"), @"Hello World");
@@ -608,7 +608,7 @@ fn mixed_line_ending_hook() -> Result<()> {
         .child("mixed.txt")
         .write_str("line1\nline2\r\n")?;
     context.git_add(".");
-    cmd_snapshot!(context.filters(), context.run(), @r"
+    cmd_snapshot!(context.filters(), context.run(), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -618,11 +618,11 @@ fn mixed_line_ending_hook() -> Result<()> {
     - files were modified by this hook
 
       Fixing .pre-commit-config.yaml
-      Fixing mixed.txt
       Fixing only_lf.txt
+      Fixing mixed.txt
 
     ----- stderr -----
-    ");
+    "#);
     assert_snapshot!(context.read("mixed.txt"), @r"
     line1
     line2
@@ -713,7 +713,7 @@ fn check_added_large_files_hook() -> Result<()> {
     "});
 
     // Second run: the hook should check all files even if not staged
-    cmd_snapshot!(context.filters(), context.run().arg("--all-files"), @r"
+    cmd_snapshot!(context.filters(), context.run().arg("--all-files"), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -721,11 +721,11 @@ fn check_added_large_files_hook() -> Result<()> {
     - hook id: check-added-large-files
     - exit code: 1
 
-      unstaged_large_file.txt (2 KB) exceeds 1 KB
       large_file.txt (2 KB) exceeds 1 KB
+      unstaged_large_file.txt (2 KB) exceeds 1 KB
 
     ----- stderr -----
-    ");
+    "#);
 
     context.git_rm("unstaged_large_file.txt");
     context.git_clean();
@@ -938,30 +938,30 @@ fn builtin_hooks_workspace_mode() -> Result<()> {
       - hook id: identity
       - duration: [TIME]
 
-        correct.txt
-        invalid.yaml
-        empty.json
-        duplicate.json
-        trailing_ws.txt
-        large.bin
-        eof_multiple_lf.txt
-        duplicate.yaml
-        empty.yaml
-        mixed.txt
         invalid.json
+        empty.yaml
+        eof_multiple_lf.txt
+        duplicate.json
+        empty.json
+        mixed.txt
+        duplicate.yaml
         .pre-commit-config.yaml
         eof_no_newline.txt
+        correct.txt
+        invalid.yaml
+        trailing_ws.txt
+        large.bin
       fix end of files.......................................................Failed
       - hook id: end-of-file-fixer
       - exit code: 1
       - files were modified by this hook
 
-        Fixing invalid.yaml
-        Fixing duplicate.json
-        Fixing eof_no_newline.txt
-        Fixing eof_multiple_lf.txt
-        Fixing duplicate.yaml
         Fixing invalid.json
+        Fixing eof_multiple_lf.txt
+        Fixing duplicate.json
+        Fixing duplicate.yaml
+        Fixing eof_no_newline.txt
+        Fixing invalid.yaml
       check yaml.............................................................Failed
       - hook id: check-yaml
       - exit code: 1
@@ -1005,19 +1005,19 @@ fn builtin_hooks_workspace_mode() -> Result<()> {
       - hook id: identity
       - duration: [TIME]
 
-        app/.pre-commit-config.yaml
-        app/invalid.json
-        app/duplicate.yaml
-        app/correct.txt
-        app/mixed.txt
-        app/invalid.yaml
-        app/empty.yaml
-        app/duplicate.json
-        app/empty.json
-        app/large.bin
         app/eof_no_newline.txt
+        app/empty.json
+        app/empty.yaml
+        app/correct.txt
+        app/duplicate.yaml
+        app/large.bin
+        app/duplicate.json
         .pre-commit-config.yaml
         app/eof_multiple_lf.txt
+        app/.pre-commit-config.yaml
+        app/invalid.json
+        app/mixed.txt
+        app/invalid.yaml
         app/trailing_ws.txt
 
     ----- stderr -----
@@ -1043,19 +1043,19 @@ fn builtin_hooks_workspace_mode() -> Result<()> {
       - hook id: identity
       - duration: [TIME]
 
-        correct.txt
-        invalid.yaml
-        empty.json
-        duplicate.json
-        trailing_ws.txt
-        large.bin
-        eof_multiple_lf.txt
-        duplicate.yaml
-        empty.yaml
-        mixed.txt
         invalid.json
+        empty.yaml
+        eof_multiple_lf.txt
+        duplicate.json
+        empty.json
+        mixed.txt
+        duplicate.yaml
         .pre-commit-config.yaml
         eof_no_newline.txt
+        correct.txt
+        invalid.yaml
+        trailing_ws.txt
+        large.bin
       fix end of files.......................................................Passed
       check yaml.............................................................Passed
       check json.............................................................Passed
@@ -1067,19 +1067,19 @@ fn builtin_hooks_workspace_mode() -> Result<()> {
       - hook id: identity
       - duration: [TIME]
 
-        app/.pre-commit-config.yaml
-        app/invalid.json
-        app/duplicate.yaml
-        app/correct.txt
-        app/mixed.txt
-        app/invalid.yaml
-        app/empty.yaml
-        app/duplicate.json
-        app/empty.json
-        app/large.bin
         app/eof_no_newline.txt
+        app/empty.json
+        app/empty.yaml
+        app/correct.txt
+        app/duplicate.yaml
+        app/large.bin
+        app/duplicate.json
         .pre-commit-config.yaml
         app/eof_multiple_lf.txt
+        app/.pre-commit-config.yaml
+        app/invalid.json
+        app/mixed.txt
+        app/invalid.yaml
         app/trailing_ws.txt
 
     ----- stderr -----
@@ -1210,11 +1210,11 @@ fn pretty_format_json_hook() -> Result<()> {
     - exit code: 1
     - files were modified by this hook
 
-      empty.json: invalid JSON (EOF while parsing a value at line 1 column 0). Consider using the `check-json` hook.
       Fixing file compact.json
-      Fixing file uppercase_unicode.json
-      invalid.json: invalid JSON (trailing comma at line 1 column 9). Consider using the `check-json` hook.
       Fixing file unsorted.json
+      invalid.json: invalid JSON (trailing comma at line 1 column 9). Consider using the `check-json` hook.
+      Fixing file uppercase_unicode.json
+      empty.json: invalid JSON (EOF while parsing a value at line 1 column 0). Consider using the `check-json` hook.
 
     ----- stderr -----
     "#);
@@ -1824,7 +1824,7 @@ fn detect_private_key_hook() -> Result<()> {
     context.git_add(".");
 
     // First run: hooks should fail due to private keys
-    cmd_snapshot!(context.filters(), context.run(), @r"
+    cmd_snapshot!(context.filters(), context.run(), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1832,17 +1832,17 @@ fn detect_private_key_hook() -> Result<()> {
     - hook id: detect-private-key
     - exit code: 1
 
-      Private key found: doc.txt
-      Private key found: id_ecdsa
-      Private key found: key.ppk
-      Private key found: id_rsa
-      Private key found: id_dsa
-      Private key found: id_ed25519
-      Private key found: ta.key
       Private key found: private.asc
+      Private key found: id_ed25519
+      Private key found: id_rsa
+      Private key found: id_ecdsa
+      Private key found: ta.key
+      Private key found: id_dsa
+      Private key found: key.ppk
+      Private key found: doc.txt
 
     ----- stderr -----
-    ");
+    "#);
 
     // Remove all private keys
     context.git_rm("id_rsa");
@@ -1924,12 +1924,12 @@ fn check_merge_conflict_hook() -> Result<()> {
     - hook id: check-merge-conflict
     - exit code: 1
 
-      partial_separator_conflict.txt:2: Merge conflict string "<<<<<<< " found
-      partial_separator_conflict.txt:4: Merge conflict string "=======" found
+      partial_conflict.txt:2: Merge conflict string "<<<<<<< " found
       conflict.txt:2: Merge conflict string "<<<<<<< " found
       conflict.txt:4: Merge conflict string "=======" found
       conflict.txt:6: Merge conflict string ">>>>>>> " found
-      partial_conflict.txt:2: Merge conflict string "<<<<<<< " found
+      partial_separator_conflict.txt:2: Merge conflict string "<<<<<<< " found
+      partial_separator_conflict.txt:4: Merge conflict string "=======" found
 
     ----- stderr -----
     "#);
@@ -2124,7 +2124,7 @@ fn check_xml_hook() -> Result<()> {
     context.git_add(".");
 
     // First run: hooks should fail
-    cmd_snapshot!(context.filters(), context.run(), @r"
+    cmd_snapshot!(context.filters(), context.run(), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -2132,13 +2132,13 @@ fn check_xml_hook() -> Result<()> {
     - hook id: check-xml
     - exit code: 1
 
-      invalid_mismatched.xml: Failed to xml parse (ill-formed document: expected `</element>`, but `</different>` was found)
       empty.xml: Failed to xml parse (no element found)
-      invalid_unclosed.xml: Failed to xml parse (ill-formed document: expected `</element>`, but `</root>` was found)
+      invalid_mismatched.xml: Failed to xml parse (ill-formed document: expected `</element>`, but `</different>` was found)
       multiple_roots.xml: Failed to xml parse (junk after document element)
+      invalid_unclosed.xml: Failed to xml parse (ill-formed document: expected `</element>`, but `</root>` was found)
 
     ----- stderr -----
-    ");
+    "#);
 
     // Fix the files
     cwd.child("invalid_unclosed.xml").write_str(
@@ -2703,7 +2703,7 @@ fn check_executables_have_shebangs_various_cases() -> Result<()> {
     context.git_add(".");
 
     // Run: should fail for partial_shebang.sh, whitespace.sh, invalid_shebang.sh
-    cmd_snapshot!(context.filters(), context.run(), @r"
+    cmd_snapshot!(context.filters(), context.run(), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -2711,13 +2711,13 @@ fn check_executables_have_shebangs_various_cases() -> Result<()> {
     - hook id: check-executables-have-shebangs
     - exit code: 1
 
-      partial_shebang.sh marked executable but has no (or invalid) shebang!
-        If it isn't supposed to be executable, try: 'chmod -x partial_shebang.sh'
-        If on Windows, you may also need to: 'git add --chmod=-x partial_shebang.sh'
-        If it is supposed to be executable, double-check its shebang.
       invalid_shebang.sh marked executable but has no (or invalid) shebang!
         If it isn't supposed to be executable, try: 'chmod -x invalid_shebang.sh'
         If on Windows, you may also need to: 'git add --chmod=-x invalid_shebang.sh'
+        If it is supposed to be executable, double-check its shebang.
+      partial_shebang.sh marked executable but has no (or invalid) shebang!
+        If it isn't supposed to be executable, try: 'chmod -x partial_shebang.sh'
+        If on Windows, you may also need to: 'git add --chmod=-x partial_shebang.sh'
         If it is supposed to be executable, double-check its shebang.
       whitespace.sh marked executable but has no (or invalid) shebang!
         If it isn't supposed to be executable, try: 'chmod -x whitespace.sh'
@@ -2725,7 +2725,7 @@ fn check_executables_have_shebangs_various_cases() -> Result<()> {
         If it is supposed to be executable, double-check its shebang.
 
     ----- stderr -----
-    ");
+    "#);
 
     // Fix the files: add valid shebangs or remove executable bit
     cwd.child("partial_shebang.sh")

--- a/crates/prek/tests/cache.rs
+++ b/crates/prek/tests/cache.rs
@@ -232,14 +232,14 @@ fn cache_gc_removes_unreferenced_entries() -> anyhow::Result<()> {
               - id: check-yaml
     "});
 
-    cmd_snapshot!(context.filters(), context.command().arg("cache").arg("gc"), @r"
+    cmd_snapshot!(context.filters(), context.command().arg("cache").arg("gc"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
     Removed 1 repo, 2 hook envs, 1 tool, 1 cache entry ([SIZE])
 
     ----- stderr -----
-    ");
+    "#);
 
     home.child("repos/unused-repo")
         .assert(predicates::path::missing());
@@ -356,7 +356,7 @@ fn cache_gc_prunes_unused_tool_versions() -> anyhow::Result<()> {
         .child(".prek-hook.json")
         .write_str(&serde_json::to_string_pretty(&marker_go)?)?;
 
-    cmd_snapshot!(context.filters(), context.command().args(["cache", "gc", "--dry-run", "-v"]), @r"
+    cmd_snapshot!(context.filters(), context.command().args(["cache", "gc", "--dry-run", "-v"]), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -377,9 +377,9 @@ fn cache_gc_prunes_unused_tool_versions() -> anyhow::Result<()> {
       path: [HOME]/tools/python/3.11.0
 
     ----- stderr -----
-    ");
+    "#);
 
-    cmd_snapshot!(context.filters(), context.command().args(["cache", "gc", "-v"]), @r"
+    cmd_snapshot!(context.filters(), context.command().args(["cache", "gc", "-v"]), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -400,7 +400,7 @@ fn cache_gc_prunes_unused_tool_versions() -> anyhow::Result<()> {
       path: [HOME]/tools/python/3.11.0
 
     ----- stderr -----
-    ");
+    "#);
 
     Ok(())
 }
@@ -541,14 +541,14 @@ fn cache_gc_keeps_local_hook_env() -> anyhow::Result<()> {
     // Add an obviously-unused entry to ensure GC does work.
     home.child("hooks/unused-hook-env").create_dir_all()?;
 
-    cmd_snapshot!(context.filters(), context.command().args(["cache", "gc"]), @r"
+    cmd_snapshot!(context.filters(), context.command().args(["cache", "gc"]), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
     Removed 1 hook env ([SIZE])
 
     ----- stderr -----
-    ");
+    "#);
 
     // The local hook env(s) should remain.
     for env in local_envs {
@@ -696,14 +696,14 @@ fn cache_gc_bootstraps_tracking_from_workspace_cache() -> anyhow::Result<()> {
     home.child("repos/deadbeef").create_dir_all()?;
     home.child("hooks/hook-env-dead").create_dir_all()?;
 
-    cmd_snapshot!(context.filters(), context.command().arg("cache").arg("gc"), @r"
+    cmd_snapshot!(context.filters(), context.command().arg("cache").arg("gc"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
     Removed 1 repo, 1 hook env ([SIZE])
 
     ----- stderr -----
-    ");
+    "#);
 
     home.child("repos/deadbeef")
         .assert(predicates::path::missing());
@@ -737,14 +737,14 @@ fn cache_gc_drops_missing_tracked_config() -> anyhow::Result<()> {
     home.child("scratch/some-temp").create_dir_all()?;
     home.child("patches/some-patch").create_dir_all()?;
 
-    cmd_snapshot!(context.filters(), context.command().arg("cache").arg("gc"), @r"
+    cmd_snapshot!(context.filters(), context.command().arg("cache").arg("gc"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
     Removed 1 repo, 1 hook env, 1 tool, 1 cache entry ([SIZE])
 
     ----- stderr -----
-    ");
+    "#);
 
     // Tracking file should be updated to drop the missing config.
     let content = fs_err::read_to_string(home.child("config-tracking.json").path())?;
@@ -778,14 +778,14 @@ fn cache_gc_keeps_tracked_config_on_parse_error() -> anyhow::Result<()> {
     home.child("tools/node").create_dir_all()?;
     home.child("cache/go").create_dir_all()?;
 
-    cmd_snapshot!(context.filters(), context.command().arg("cache").arg("gc"), @r"
+    cmd_snapshot!(context.filters(), context.command().arg("cache").arg("gc"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
     Removed 1 repo, 1 hook env, 1 tool, 1 cache entry ([SIZE])
 
     ----- stderr -----
-    ");
+    "#);
 
     // Parse errors should not drop the config from tracking.
     let content = fs_err::read_to_string(home.child("config-tracking.json").path())?;
@@ -815,14 +815,14 @@ fn cache_gc_dry_run_does_not_remove_entries() -> anyhow::Result<()> {
     home.child("cache/go").create_dir_all()?;
     home.child("scratch/some-temp").create_dir_all()?;
 
-    cmd_snapshot!(context.filters(), context.command().arg("cache").arg("gc").arg("--dry-run"), @r"
+    cmd_snapshot!(context.filters(), context.command().arg("cache").arg("gc").arg("--dry-run"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
     Would remove 1 repo, 1 hook env, 1 tool, 1 cache entry ([SIZE])
 
     ----- stderr -----
-    ");
+    "#);
 
     // Nothing should be removed in dry-run mode.
     home.child("repos/unused-repo")

--- a/crates/prek/tests/common/mod.rs
+++ b/crates/prek/tests/common/mod.rs
@@ -169,6 +169,7 @@ impl TestContext {
             cmd.current_dir(self.work_dir());
             cmd.env(EnvVars::PREK_HOME, &**self.home_dir());
             cmd.env(EnvVars::PREK_INTERNAL__SORT_FILENAMES, "1");
+            cmd.env_remove("RUST_LOG");
             cmd
         };
 

--- a/crates/prek/tests/languages/dart.rs
+++ b/crates/prek/tests/languages/dart.rs
@@ -126,8 +126,8 @@ fn script_with_files() -> anyhow::Result<()> {
     - hook id: dart
     - duration: [TIME]
 
-      Processing file: script.dart
       Processing file: .pre-commit-config.yaml
+      Processing file: script.dart
       Processing file: test2.dart
       Processing file: test1.dart
 

--- a/crates/prek/tests/languages/docker.rs
+++ b/crates/prek/tests/languages/docker.rs
@@ -68,20 +68,20 @@ fn workspace_docker() -> anyhow::Result<()> {
       - hook id: hello-world
       - duration: [TIME]
 
-        project1.txt .pre-commit-config.yaml
+        .pre-commit-config.yaml project1.txt
     ✓ project2
       Hello World............................................................Passed
       - hook id: hello-world
       - duration: [TIME]
 
-        project2.txt .pre-commit-config.yaml
+        .pre-commit-config.yaml project2.txt
     ✓ <workspace>
       Hello World............................................................Passed
       - hook id: hello-world
       - duration: [TIME]
 
-        project1/.pre-commit-config.yaml .pre-commit-config.yaml project2/project2.txt project1/project1.txt
-        project2/.pre-commit-config.yaml
+        .pre-commit-config.yaml project1/.pre-commit-config.yaml project2/.pre-commit-config.yaml project1/project1.txt
+        project2/project2.txt
 
     ----- stderr -----
     "#);

--- a/crates/prek/tests/languages/lua.rs
+++ b/crates/prek/tests/languages/lua.rs
@@ -160,7 +160,7 @@ fn script_with_files() -> anyhow::Result<()> {
 
     context.git_add(".");
 
-    cmd_snapshot!(context.filters(), context.run(), @r"
+    cmd_snapshot!(context.filters(), context.run(), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -168,13 +168,13 @@ fn script_with_files() -> anyhow::Result<()> {
     - hook id: lua
     - duration: [TIME]
 
-      Processing file:	script.lua
       Processing file:	.pre-commit-config.yaml
+      Processing file:	script.lua
       Processing file:	test2.lua
       Processing file:	test1.lua
 
     ----- stderr -----
-    ");
+    "#);
 
     Ok(())
 }

--- a/crates/prek/tests/languages/unsupported.rs
+++ b/crates/prek/tests/languages/unsupported.rs
@@ -31,7 +31,7 @@ fn unsupported_language() -> anyhow::Result<()> {
         "#})?;
     context.git_add(".");
 
-    cmd_snapshot!(context.filters(), context.run(), @r"
+    cmd_snapshot!(context.filters(), context.run(), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -39,7 +39,7 @@ fn unsupported_language() -> anyhow::Result<()> {
     - hook id: unsupported
     - duration: [TIME]
 
-      script.sh .pre-commit-config.yaml
+      .pre-commit-config.yaml script.sh
     unsupported-script.......................................................Passed
     - hook id: unsupported-script
     - duration: [TIME]
@@ -47,7 +47,7 @@ fn unsupported_language() -> anyhow::Result<()> {
       Hello, World!
 
     ----- stderr -----
-    ");
+    "#);
 
     Ok(())
 }

--- a/crates/prek/tests/meta_hooks.rs
+++ b/crates/prek/tests/meta_hooks.rs
@@ -38,7 +38,7 @@ fn meta_hooks() -> anyhow::Result<()> {
     "});
     context.git_add(".");
 
-    cmd_snapshot!(context.filters(), context.run(), @r"
+    cmd_snapshot!(context.filters(), context.run(), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -56,16 +56,16 @@ fn meta_hooks() -> anyhow::Result<()> {
     - hook id: identity
     - duration: [TIME]
 
-      file.txt
       .pre-commit-config.yaml
-      valid.json
-      invalid.json
+      file.txt
       main.py
+      invalid.json
+      valid.json
     match no files.......................................(no files to check)Skipped
     useless exclude..........................................................Passed
 
     ----- stderr -----
-    ");
+    "#);
 
     Ok(())
 }
@@ -208,11 +208,11 @@ fn meta_hooks_workspace() -> anyhow::Result<()> {
       - hook id: identity
       - duration: [TIME]
 
-        file.txt
         .pre-commit-config.yaml
-        valid.json
-        invalid.json
+        file.txt
         main.py
+        invalid.json
+        valid.json
       match no files.....................................(no files to check)Skipped
       useless exclude........................................................Passed
 

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -39,7 +39,7 @@ fn run_basic() -> Result<()> {
 
     context.git_add(".");
 
-    cmd_snapshot!(context.filters(), context.run(), @r"
+    cmd_snapshot!(context.filters(), context.run(), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -54,13 +54,13 @@ fn run_basic() -> Result<()> {
     - exit code: 1
     - files were modified by this hook
 
-      Fixing valid.json
-      Fixing invalid.json
       Fixing main.py
+      Fixing invalid.json
+      Fixing valid.json
     check json...............................................................Passed
 
     ----- stderr -----
-    ");
+    "#);
 
     context.git_add(".");
 
@@ -1387,7 +1387,7 @@ fn file_types() -> Result<()> {
     "#});
     context.git_add(".");
 
-    cmd_snapshot!(context.filters(), context.run(), @r"
+    cmd_snapshot!(context.filters(), context.run(), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1400,16 +1400,16 @@ fn file_types() -> Result<()> {
     - hook id: trailing-whitespace
     - exit code: 1
 
-      ['main.py', 'json.json']
+      ['json.json', 'main.py']
     trailing-whitespace......................................................Failed
     - hook id: trailing-whitespace
     - exit code: 1
 
-      ['file.txt', '.pre-commit-config.yaml', 'main.py']
+      ['.pre-commit-config.yaml', 'file.txt', 'main.py']
     trailing-whitespace..................................(no files to check)Skipped
 
     ----- stderr -----
-    ");
+    "#);
 
     Ok(())
 }
@@ -1855,7 +1855,7 @@ fn intent_to_add_file_survives_conflicted_stash_restore() -> Result<()> {
         .chain([(r"/\d+-\d+.patch", "/[TIME]-[PID].patch")])
         .collect();
 
-    cmd_snapshot!(filters, context.run(), @r"
+    cmd_snapshot!(filters, context.run(), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1867,7 +1867,7 @@ fn intent_to_add_file_survives_conflicted_stash_restore() -> Result<()> {
     Unstaged changes detected, stashing unstaged changes to `[HOME]/patches/[TIME]-[PID].patch`
     Stashed changes conflicted with changes made by hook, rolling back the hook changes
     Restored working tree changes from `[HOME]/patches/[TIME]-[PID].patch`
-    ");
+    "#);
 
     assert_eq!(context.read("intent.txt"), "preserve me\n");
     assert_eq!(context.read("test.py"), "a=1\nb = 2\n");
@@ -2102,7 +2102,7 @@ fn init_nonexistent_repo() {
         ])
         .collect::<Vec<_>>();
 
-    cmd_snapshot!(filters, context.run(), @"
+    cmd_snapshot!(filters, context.run(), @r#"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -2117,7 +2117,7 @@ fn init_nonexistent_repo() {
 
     [stderr]
     fatal: unable to access 'https://notexistentatallnevergonnahappen.com/nonexistent/repo/': [error]
-    ");
+    "#);
 }
 
 #[test]
@@ -2279,7 +2279,7 @@ fn unmatched_skip_does_not_suppress_remote_clone() {
     cmd_snapshot!(
         filters,
         context.run().arg("--all-files").arg("--skip").arg("other-hook"),
-        @"
+        @r#"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -2294,7 +2294,7 @@ fn unmatched_skip_does_not_suppress_remote_clone() {
 
     [stderr]
     fatal: unable to access 'https://notexistentatallnevergonnahappen.com/nonexistent/repo/': [error]
-    "
+    "#
     );
 }
 
@@ -2461,7 +2461,7 @@ fn run_multiple_files() -> Result<()> {
     cwd.child("file2.txt").write_str("Hello, world!")?;
     context.git_add(".");
     // `--files` with multiple files
-    cmd_snapshot!(context.filters(), context.run().arg("--files").arg("file1.txt").arg("file2.txt"), @r"
+    cmd_snapshot!(context.filters(), context.run().arg("--files").arg("file1.txt").arg("file2.txt"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -2469,10 +2469,10 @@ fn run_multiple_files() -> Result<()> {
     - hook id: multiple-files
     - duration: [TIME]
 
-      file2.txt file1.txt
+      file1.txt file2.txt
 
     ----- stderr -----
-    ");
+    "#);
     Ok(())
 }
 
@@ -2559,7 +2559,7 @@ fn run_directory() -> Result<()> {
     ");
 
     // multiple `--directory`
-    cmd_snapshot!(context.filters(), context.run().arg("--directory").arg("dir1").arg("--directory").arg("dir2"), @r"
+    cmd_snapshot!(context.filters(), context.run().arg("--directory").arg("dir1").arg("--directory").arg("dir2"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -2567,10 +2567,10 @@ fn run_directory() -> Result<()> {
     - hook id: directory
     - duration: [TIME]
 
-      dir2/file.txt dir1/file.txt
+      dir1/file.txt dir2/file.txt
 
     ----- stderr -----
-    ");
+    "#);
 
     // non-existing directory
     cmd_snapshot!(context.filters(), context.run().arg("--directory").arg("non-existing-dir"), @r"
@@ -2595,7 +2595,7 @@ fn run_directory() -> Result<()> {
 
     ----- stderr -----
     ");
-    cmd_snapshot!(context.filters(), context.run().arg("--directory").arg("dir1").arg("--files").arg("dir2/file.txt"), @r"
+    cmd_snapshot!(context.filters(), context.run().arg("--directory").arg("dir1").arg("--files").arg("dir2/file.txt"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -2603,10 +2603,10 @@ fn run_directory() -> Result<()> {
     - hook id: directory
     - duration: [TIME]
 
-      dir2/file.txt dir1/file.txt
+      dir1/file.txt dir2/file.txt
 
     ----- stderr -----
-    ");
+    "#);
 
     // run `--directory` inside a subdirectory
     cmd_snapshot!(context.filters(), context.run().current_dir(cwd.join("dir1")).arg("--directory").arg("."), @r"

--- a/crates/prek/tests/workspace.rs
+++ b/crates/prek/tests/workspace.rs
@@ -755,14 +755,14 @@ fn skips() -> Result<()> {
       - duration: [TIME]
 
         [TEMP_DIR]/project3
-        ['project4/.pre-commit-config.yaml', '.pre-commit-config.yaml']
+        ['.pre-commit-config.yaml', 'project4/.pre-commit-config.yaml']
     ✓ <workspace>
       Show CWD...............................................................Passed
       - hook id: show-cwd
       - duration: [TIME]
 
         [TEMP_DIR]/
-        ['project2/.pre-commit-config.yaml', '.pre-commit-config.yaml', 'project3/project4/.pre-commit-config.yaml', 'project3/.pre-commit-config.yaml']
+        ['.pre-commit-config.yaml', 'project2/.pre-commit-config.yaml', 'project3/project4/.pre-commit-config.yaml', 'project3/.pre-commit-config.yaml']
 
     ----- stderr -----
     "#);
@@ -785,14 +785,14 @@ fn skips() -> Result<()> {
       - duration: [TIME]
 
         [TEMP_DIR]/project3
-        ['project4/.pre-commit-config.yaml', '.pre-commit-config.yaml']
+        ['.pre-commit-config.yaml', 'project4/.pre-commit-config.yaml']
     ✓ <workspace>
       Show CWD...............................................................Passed
       - hook id: show-cwd
       - duration: [TIME]
 
         [TEMP_DIR]/
-        ['project2/.pre-commit-config.yaml', '.pre-commit-config.yaml', 'project3/project4/.pre-commit-config.yaml', 'project3/.pre-commit-config.yaml']
+        ['.pre-commit-config.yaml', 'project2/.pre-commit-config.yaml', 'project3/project4/.pre-commit-config.yaml', 'project3/.pre-commit-config.yaml']
 
     ----- stderr -----
     "#);
@@ -815,14 +815,14 @@ fn skips() -> Result<()> {
       - duration: [TIME]
 
         [TEMP_DIR]/project3
-        ['project4/.pre-commit-config.yaml', '.pre-commit-config.yaml']
+        ['.pre-commit-config.yaml', 'project4/.pre-commit-config.yaml']
     ✓ <workspace>
       Show CWD...............................................................Passed
       - hook id: show-cwd
       - duration: [TIME]
 
         [TEMP_DIR]/
-        ['project2/.pre-commit-config.yaml', '.pre-commit-config.yaml', 'project3/project4/.pre-commit-config.yaml', 'project3/.pre-commit-config.yaml']
+        ['.pre-commit-config.yaml', 'project2/.pre-commit-config.yaml', 'project3/project4/.pre-commit-config.yaml', 'project3/.pre-commit-config.yaml']
 
     ----- stderr -----
     "#);
@@ -845,14 +845,14 @@ fn skips() -> Result<()> {
       - duration: [TIME]
 
         [TEMP_DIR]/project3
-        ['project4/.pre-commit-config.yaml', '.pre-commit-config.yaml']
+        ['.pre-commit-config.yaml', 'project4/.pre-commit-config.yaml']
     ✓ <workspace>
       Show CWD...............................................................Passed
       - hook id: show-cwd
       - duration: [TIME]
 
         [TEMP_DIR]/
-        ['project2/.pre-commit-config.yaml', '.pre-commit-config.yaml', 'project3/project4/.pre-commit-config.yaml', 'project3/.pre-commit-config.yaml']
+        ['.pre-commit-config.yaml', 'project2/.pre-commit-config.yaml', 'project3/project4/.pre-commit-config.yaml', 'project3/.pre-commit-config.yaml']
 
     ----- stderr -----
     "#);
@@ -875,14 +875,14 @@ fn skips() -> Result<()> {
       - duration: [TIME]
 
         [TEMP_DIR]/project3
-        ['project4/.pre-commit-config.yaml', '.pre-commit-config.yaml']
+        ['.pre-commit-config.yaml', 'project4/.pre-commit-config.yaml']
     ✓ <workspace>
       Show CWD...............................................................Passed
       - hook id: show-cwd
       - duration: [TIME]
 
         [TEMP_DIR]/
-        ['project2/.pre-commit-config.yaml', '.pre-commit-config.yaml', 'project3/project4/.pre-commit-config.yaml', 'project3/.pre-commit-config.yaml']
+        ['.pre-commit-config.yaml', 'project2/.pre-commit-config.yaml', 'project3/project4/.pre-commit-config.yaml', 'project3/.pre-commit-config.yaml']
 
     ----- stderr -----
     "#);
@@ -897,7 +897,7 @@ fn skips() -> Result<()> {
     - duration: [TIME]
 
       [TEMP_DIR]/
-      ['project2/.pre-commit-config.yaml', '.pre-commit-config.yaml', 'project3/project4/.pre-commit-config.yaml', 'project3/.pre-commit-config.yaml']
+      ['.pre-commit-config.yaml', 'project2/.pre-commit-config.yaml', 'project3/project4/.pre-commit-config.yaml', 'project3/.pre-commit-config.yaml']
 
     ----- stderr -----
     warning: selector `PREK_SKIP=non-exist-hook` did not match any hooks
@@ -926,7 +926,9 @@ fn skips() -> Result<()> {
     ");
 
     // Should skip the invalid config
-    cmd_snapshot!(context.filters(), context.run().arg("--skip").arg("project3/"), @r#"
+    let mut filters = context.filters();
+    filters.push((r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z", "[TIMESTAMP]"));
+    cmd_snapshot!(filters, context.run().arg("--skip").arg("project3/"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -943,9 +945,10 @@ fn skips() -> Result<()> {
       - duration: [TIME]
 
         [TEMP_DIR]/
-        ['project2/.pre-commit-config.yaml', '.pre-commit-config.yaml', 'project3/project4/.pre-commit-config.yaml', 'project3/.pre-commit-config.yaml']
+        ['.pre-commit-config.yaml', 'project2/.pre-commit-config.yaml', 'project3/project4/.pre-commit-config.yaml', 'project3/.pre-commit-config.yaml']
 
     ----- stderr -----
+    [TIMESTAMP] ERROR Skipping project due to error: Failed to parse `project3/.pre-commit-config.yaml` path=project3
     "#);
 
     Ok(())

--- a/crates/prek/tests/workspace.rs
+++ b/crates/prek/tests/workspace.rs
@@ -68,16 +68,16 @@ fn basic_discovery() -> Result<()> {
       - duration: [TIME]
 
         [TEMP_DIR]/project3
-        ['project5/.pre-commit-config.yaml', '.pre-commit-config.yaml']
+        ['.pre-commit-config.yaml', 'project5/.pre-commit-config.yaml']
     ✓ <workspace>
       Show CWD...............................................................Passed
       - hook id: show-cwd
       - duration: [TIME]
 
         [TEMP_DIR]/
-        ['nested/project4/.pre-commit-config.yaml', '.pre-commit-config.yaml', 'project3/project5/.pre-commit-config.yaml', 'project2/.pre-commit-config.yaml']
+        ['.pre-commit-config.yaml', 'nested/project4/.pre-commit-config.yaml', 'project3/.pre-commit-config.yaml', 'project2/.pre-commit-config.yaml']
         [TEMP_DIR]/
-        ['project3/.pre-commit-config.yaml']
+        ['project3/project5/.pre-commit-config.yaml']
 
     ----- stderr -----
     "#);
@@ -128,7 +128,7 @@ fn basic_discovery() -> Result<()> {
       - duration: [TIME]
 
         [TEMP_DIR]/project3
-        ['project5/.pre-commit-config.yaml', '.pre-commit-config.yaml']
+        ['.pre-commit-config.yaml', 'project5/.pre-commit-config.yaml']
 
     ----- stderr -----
     "#);
@@ -150,7 +150,7 @@ fn basic_discovery() -> Result<()> {
       - duration: [TIME]
 
         [TEMP_DIR]/project3
-        ['project5/.pre-commit-config.yaml', '.pre-commit-config.yaml']
+        ['.pre-commit-config.yaml', 'project5/.pre-commit-config.yaml']
 
     ----- stderr -----
     "#);
@@ -162,7 +162,7 @@ fn basic_discovery() -> Result<()> {
         .write_str("project5/\n")?;
     context.git_add(".");
 
-    cmd_snapshot!(context.filters(), context.run().arg("--refresh").arg("--cd").arg(cwd.join("project3")), @r"
+    cmd_snapshot!(context.filters(), context.run().arg("--refresh").arg("--cd").arg(cwd.join("project3")), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -171,10 +171,10 @@ fn basic_discovery() -> Result<()> {
     - duration: [TIME]
 
       [TEMP_DIR]/project3
-      ['.prekignore', '.pre-commit-config.yaml', 'project5/.pre-commit-config.yaml']
+      ['.pre-commit-config.yaml', '.prekignore', 'project5/.pre-commit-config.yaml']
 
     ----- stderr -----
-    ");
+    "#);
 
     // Ignoring everything under project3, but when runs from project3, it’s still getting picked up.
     context
@@ -182,7 +182,7 @@ fn basic_discovery() -> Result<()> {
         .child("project3/.prekignore")
         .write_str("*\n")?;
     context.git_add(".");
-    cmd_snapshot!(context.filters(), context.run().arg("--refresh").arg("--cd").arg(cwd.join("project3")), @r"
+    cmd_snapshot!(context.filters(), context.run().arg("--refresh").arg("--cd").arg(cwd.join("project3")), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -191,10 +191,10 @@ fn basic_discovery() -> Result<()> {
     - duration: [TIME]
 
       [TEMP_DIR]/project3
-      ['.prekignore', '.pre-commit-config.yaml', 'project5/.pre-commit-config.yaml']
+      ['.pre-commit-config.yaml', '.prekignore', 'project5/.pre-commit-config.yaml']
 
     ----- stderr -----
-    ");
+    "#);
 
     Ok(())
 }
@@ -482,16 +482,16 @@ fn run_with_selectors() -> Result<()> {
       - duration: [TIME]
 
         [TEMP_DIR]/project3
-        ['project5/.pre-commit-config.yaml', '.pre-commit-config.yaml']
+        ['.pre-commit-config.yaml', 'project5/.pre-commit-config.yaml']
     ✓ <workspace>
       Show CWD...............................................................Passed
       - hook id: show-cwd
       - duration: [TIME]
 
         [TEMP_DIR]/
-        ['nested/project4/.pre-commit-config.yaml', '.pre-commit-config.yaml', 'project3/project5/.pre-commit-config.yaml', 'project2/.pre-commit-config.yaml']
+        ['.pre-commit-config.yaml', 'nested/project4/.pre-commit-config.yaml', 'project3/.pre-commit-config.yaml', 'project2/.pre-commit-config.yaml']
         [TEMP_DIR]/
-        ['project3/.pre-commit-config.yaml']
+        ['project3/project5/.pre-commit-config.yaml']
 
     ----- stderr -----
     "#);
@@ -513,9 +513,9 @@ fn run_with_selectors() -> Result<()> {
       - duration: [TIME]
 
         [TEMP_DIR]/
-        ['nested/project4/.pre-commit-config.yaml', '.pre-commit-config.yaml', 'project3/project5/.pre-commit-config.yaml', 'project2/.pre-commit-config.yaml']
+        ['.pre-commit-config.yaml', 'nested/project4/.pre-commit-config.yaml', 'project3/.pre-commit-config.yaml', 'project2/.pre-commit-config.yaml']
         [TEMP_DIR]/
-        ['project3/.pre-commit-config.yaml']
+        ['project3/project5/.pre-commit-config.yaml']
 
     ----- stderr -----
     "#);
@@ -551,16 +551,16 @@ fn run_with_selectors() -> Result<()> {
       - duration: [TIME]
 
         [TEMP_DIR]/project3
-        ['project5/.pre-commit-config.yaml', '.pre-commit-config.yaml']
+        ['.pre-commit-config.yaml', 'project5/.pre-commit-config.yaml']
     ✓ <workspace>
       Show CWD...............................................................Passed
       - hook id: show-cwd
       - duration: [TIME]
 
         [TEMP_DIR]/
-        ['nested/project4/.pre-commit-config.yaml', '.pre-commit-config.yaml', 'project3/project5/.pre-commit-config.yaml', 'project2/.pre-commit-config.yaml']
+        ['.pre-commit-config.yaml', 'nested/project4/.pre-commit-config.yaml', 'project3/.pre-commit-config.yaml', 'project2/.pre-commit-config.yaml']
         [TEMP_DIR]/
-        ['project3/.pre-commit-config.yaml']
+        ['project3/project5/.pre-commit-config.yaml']
 
     ----- stderr -----
     "#);
@@ -580,7 +580,7 @@ fn run_with_selectors() -> Result<()> {
     ----- stderr -----
     "#);
 
-    cmd_snapshot!(context.filters(), context.run().arg(".:show-cwd"), @r"
+    cmd_snapshot!(context.filters(), context.run().arg(".:show-cwd"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -589,12 +589,12 @@ fn run_with_selectors() -> Result<()> {
     - duration: [TIME]
 
       [TEMP_DIR]/
-      ['nested/project4/.pre-commit-config.yaml', '.pre-commit-config.yaml', 'project3/project5/.pre-commit-config.yaml', 'project2/.pre-commit-config.yaml']
+      ['.pre-commit-config.yaml', 'nested/project4/.pre-commit-config.yaml', 'project3/.pre-commit-config.yaml', 'project2/.pre-commit-config.yaml']
       [TEMP_DIR]/
-      ['project3/.pre-commit-config.yaml']
+      ['project3/project5/.pre-commit-config.yaml']
 
     ----- stderr -----
-    ");
+    "#);
 
     cmd_snapshot!(context.filters(), context.run().arg("--skip").arg("show-cwd"), @r"
     success: false
@@ -629,16 +629,16 @@ fn run_with_selectors() -> Result<()> {
       - duration: [TIME]
 
         [TEMP_DIR]/project3
-        ['project5/.pre-commit-config.yaml', '.pre-commit-config.yaml']
+        ['.pre-commit-config.yaml', 'project5/.pre-commit-config.yaml']
     ✓ <workspace>
       Show CWD...............................................................Passed
       - hook id: show-cwd
       - duration: [TIME]
 
         [TEMP_DIR]/
-        ['nested/project4/.pre-commit-config.yaml', '.pre-commit-config.yaml', 'project3/project5/.pre-commit-config.yaml', 'project2/.pre-commit-config.yaml']
+        ['.pre-commit-config.yaml', 'nested/project4/.pre-commit-config.yaml', 'project3/.pre-commit-config.yaml', 'project2/.pre-commit-config.yaml']
         [TEMP_DIR]/
-        ['project3/.pre-commit-config.yaml']
+        ['project3/project5/.pre-commit-config.yaml']
 
     ----- stderr -----
     warning: selector `--skip=nested:show-cwd` did not match any hooks
@@ -675,16 +675,16 @@ fn run_with_selectors() -> Result<()> {
       - duration: [TIME]
 
         [TEMP_DIR]/project3
-        ['project5/.pre-commit-config.yaml', '.pre-commit-config.yaml']
+        ['.pre-commit-config.yaml', 'project5/.pre-commit-config.yaml']
     ✓ <workspace>
       Show CWD...............................................................Passed
       - hook id: show-cwd
       - duration: [TIME]
 
         [TEMP_DIR]/
-        ['nested/project4/.pre-commit-config.yaml', '.pre-commit-config.yaml', 'project3/project5/.pre-commit-config.yaml', 'project2/.pre-commit-config.yaml']
+        ['.pre-commit-config.yaml', 'nested/project4/.pre-commit-config.yaml', 'project3/.pre-commit-config.yaml', 'project2/.pre-commit-config.yaml']
         [TEMP_DIR]/
-        ['project3/.pre-commit-config.yaml']
+        ['project3/project5/.pre-commit-config.yaml']
 
     ----- stderr -----
     warning: selector `--skip=non-exist` did not match any hooks
@@ -926,9 +926,7 @@ fn skips() -> Result<()> {
     ");
 
     // Should skip the invalid config
-    let mut filters = context.filters();
-    filters.push((r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z", "[TIMESTAMP]"));
-    cmd_snapshot!(filters, context.run().arg("--skip").arg("project3/"), @r#"
+    cmd_snapshot!(context.filters(), context.run().arg("--skip").arg("project3/"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -948,7 +946,6 @@ fn skips() -> Result<()> {
         ['.pre-commit-config.yaml', 'project2/.pre-commit-config.yaml', 'project3/project4/.pre-commit-config.yaml', 'project3/.pre-commit-config.yaml']
 
     ----- stderr -----
-    [TIMESTAMP] ERROR Skipping project due to error: Failed to parse `project3/.pre-commit-config.yaml` path=project3
     "#);
 
     Ok(())
@@ -1098,8 +1095,8 @@ fn nested_project_exclude_is_relative() -> Result<()> {
       - duration: [TIME]
 
         Processing 2 files
-          - nested/include
           - nested/excluded_by_project
+          - nested/include
 
     ----- stderr -----
     "#);
@@ -1198,7 +1195,7 @@ fn submodule_discovery() -> Result<()> {
       - duration: [TIME]
 
         [TEMP_DIR]/
-        ['.pre-commit-config.yaml', '.gitmodules', 'project2/.pre-commit-config.yaml']
+        ['.gitmodules', '.pre-commit-config.yaml', 'project2/.pre-commit-config.yaml']
 
     ----- stderr -----
     "#);
@@ -1278,7 +1275,7 @@ fn cookiecutter_template_directories_are_skipped() -> Result<()> {
       - duration: [TIME]
 
         [TEMP_DIR]/
-        ['project2/.pre-commit-config.yaml', '.pre-commit-config.yaml']
+        ['.pre-commit-config.yaml', 'project2/.pre-commit-config.yaml']
 
     ----- stderr -----
     "#);
@@ -1346,16 +1343,16 @@ fn orphan_projects() -> Result<()> {
       - duration: [TIME]
 
         Processing 2 files
-          - test.py
           - backend/test.py
+          - test.py
     ✓ <workspace>
       Show Files.............................................................Passed
       - hook id: show-files
       - duration: [TIME]
 
         Processing 3 files
-          - src/test.py
           - src/backend/test.py
+          - src/test.py
           - test.py
 
     ----- stderr -----


### PR DESCRIPTION
Switch non-cryptographic random usage for the profiler suffix, Ruby retry jitter, and filename shuffling from `rand` to `fastrand`.

The direct `fastrand` dependency has default features disabled, and `prek` no longer pulls in the extra `rand 0.10`, `rand_core 0.10`, `getrandom 0.4`, and related transitive packages.