### PR TITLE
Prefilter VCS permalink lines

### DIFF
--- a/crates/prek/src/hooks/pre_commit_hooks/check_vcs_permalinks.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_vcs_permalinks.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 
 use anyhow::Result;
 use clap::Parser;
-use fancy_regex::{Regex, escape};
 use memchr::memmem;
+use regex::bytes::{Match, Regex};
 use tokio::io::{AsyncBufReadExt, BufReader};
 
 use crate::hook::Hook;
@@ -22,23 +22,17 @@ struct Args {
 }
 
 #[derive(Debug)]
-struct GithubPermalinkMatcher {
-    checks: Vec<GithubPermalinkCheck>,
+struct GithubNonPermalinkMatcher {
+    checks: Vec<GithubNonPermalinkCheck>,
 }
 
 #[derive(Debug)]
-struct GithubPermalinkCheck {
+struct GithubNonPermalinkCheck {
     needle: Vec<u8>,
     pattern: Regex,
 }
 
-impl GithubPermalinkMatcher {
-    fn from_hook(hook: &Hook) -> Result<Self> {
-        let args =
-            Args::try_parse_from(hook.entry.expect_direct().split()?.iter().chain(&hook.args))?;
-        Ok(Self::new(args.additional_github_domains))
-    }
-
+impl GithubNonPermalinkMatcher {
     fn new(additional_domains: Vec<String>) -> Self {
         let mut domains = BTreeSet::from([String::from("github.com")]);
         domains.extend(additional_domains);
@@ -47,11 +41,9 @@ impl GithubPermalinkMatcher {
             .into_iter()
             .map(|domain| {
                 let needle = format!("https://{domain}/").into_bytes();
-                let domain = escape(&domain);
-                let pattern = format!(
-                    r"https://{domain}/[^/ ]+/[^/ ]+/blob/(?![a-fA-F0-9]{{4,64}}/)([^/. ]+)/[^# ]+#L\d+"
-                );
-                GithubPermalinkCheck {
+                let domain = regex::escape(&domain);
+                let pattern = format!(r"https://{domain}/[^/ ]+/[^/ ]+/blob/([^/. ]+)/[^# ]+#L\d+");
+                GithubNonPermalinkCheck {
                     needle,
                     pattern: Regex::new(&pattern).expect("vcs permalink regex must be valid"),
                 }
@@ -61,26 +53,39 @@ impl GithubPermalinkMatcher {
         Self { checks }
     }
 
-    fn is_non_permalink(&self, line: &[u8]) -> bool {
-        let mut line_text = None;
-        self.checks.iter().any(|check| {
-            if memmem::find(line, &check.needle).is_none() {
-                return false;
-            }
-
-            let line = line_text.get_or_insert_with(|| String::from_utf8_lossy(line));
-            check.pattern.is_match(line).unwrap_or(false)
-        })
+    fn find_non_permalink<'a>(&self, line: &'a [u8]) -> impl Iterator<Item = Match<'a>> {
+        let mut matches = self
+            .checks
+            .iter()
+            .filter(|check| memmem::find(line, &check.needle).is_some())
+            .flat_map(|check| {
+                check.pattern.captures_iter(line).filter_map(|captures| {
+                    let reference = captures.get(1)?;
+                    if is_probable_commit_hash(reference.as_bytes()) {
+                        None
+                    } else {
+                        captures.get(0)
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+        matches.sort_unstable_by_key(Match::start);
+        matches.into_iter()
     }
+}
+
+fn is_probable_commit_hash(reference: &[u8]) -> bool {
+    (4..=64).contains(&reference.len()) && reference.iter().all(u8::is_ascii_hexdigit)
 }
 
 pub(crate) async fn check_vcs_permalinks(
     hook: &Hook,
     filenames: &[&Path],
 ) -> Result<(i32, Vec<u8>)> {
-    let file_base = hook.project().relative_path();
-    let matcher = GithubPermalinkMatcher::from_hook(hook)?;
+    let args = Args::try_parse_from(hook.entry.expect_direct().split()?.iter().chain(&hook.args))?;
+    let matcher = GithubNonPermalinkMatcher::new(args.additional_github_domains);
 
+    let file_base = hook.project().relative_path();
     run_concurrent_file_checks(filenames.iter().copied(), *CONCURRENCY, |filename| {
         check_file(file_base, filename, &matcher)
     })
@@ -90,7 +95,7 @@ pub(crate) async fn check_vcs_permalinks(
 async fn check_file(
     file_base: &Path,
     filename: &Path,
-    matcher: &GithubPermalinkMatcher,
+    matcher: &GithubNonPermalinkMatcher,
 ) -> Result<(i32, Vec<u8>)> {
     let path = file_base.join(filename);
     let file = fs_err::tokio::File::open(&path).await?;
@@ -103,24 +108,14 @@ async fn check_file(
 
     while reader.read_until(b'\n', &mut line).await? != 0 {
         line_number += 1;
-        if matcher.is_non_permalink(&line) {
+        for m in matcher.find_non_permalink(&line) {
             retval = 1;
+            write!(output, "Non-permanent github link detected: ")?;
             write!(output, "{}:{}:", filename.display(), line_number)?;
-            output.write_all(&line)?;
-            if !line.ends_with(b"\n") {
-                writeln!(output)?;
-            }
+            output.write_all(m.as_bytes())?;
+            writeln!(output)?;
         }
         line.clear();
-    }
-
-    if retval != 0 {
-        writeln!(output)?;
-        writeln!(output, "Non-permanent github link detected.")?;
-        writeln!(
-            output,
-            "On any page on github press [y] to load a permalink."
-        )?;
     }
 
     Ok((retval, output))
@@ -132,38 +127,61 @@ mod tests {
     use std::path::PathBuf;
     use tempfile::tempdir;
 
-    fn matcher(domains: &[&str]) -> GithubPermalinkMatcher {
-        GithubPermalinkMatcher::new(domains.iter().map(ToString::to_string).collect())
+    fn matcher(domains: &[&str]) -> GithubNonPermalinkMatcher {
+        GithubNonPermalinkMatcher::new(domains.iter().map(ToString::to_string).collect())
     }
 
     #[test]
     fn test_permalink_not_flagged() {
         let matcher = matcher(&[]);
         assert!(
-            !matcher
-                .is_non_permalink(b"https://github.com/owner/repo/blob/abc123def456/file.py#L10")
+            matcher
+                .find_non_permalink(b"https://github.com/owner/repo/blob/abc123def456/file.py#L10")
+                .next()
+                .is_none()
         );
-        assert!(!matcher.is_non_permalink(
-            b"https://github.com/owner/repo/blob/abcdef1234567890abcdef1234567890abcdef12/src/main.rs#L42",
-        ));
+        assert!(
+            matcher
+                .find_non_permalink(
+                    b"https://github.com/owner/repo/blob/abcdef1234567890abcdef1234567890abcdef12/src/main.rs#L42",
+                )
+                .next()
+                .is_none()
+        );
     }
 
     #[test]
     fn test_branch_link_flagged() {
         let matcher = matcher(&[]);
-        assert!(matcher.is_non_permalink(b"https://github.com/owner/repo/blob/main/file.py#L10"));
         assert!(
-            matcher.is_non_permalink(b"https://github.com/owner/repo/blob/master/src/lib.rs#L5")
+            matcher
+                .find_non_permalink(b"https://github.com/owner/repo/blob/main/file.py#L10")
+                .next()
+                .is_some()
         );
         assert!(
-            matcher.is_non_permalink(b"https://github.com/owner/repo/blob/develop/README.md#L1")
+            matcher
+                .find_non_permalink(b"https://github.com/owner/repo/blob/master/src/lib.rs#L5")
+                .next()
+                .is_some()
+        );
+        assert!(
+            matcher
+                .find_non_permalink(b"https://github.com/owner/repo/blob/develop/README.md#L1")
+                .next()
+                .is_some()
         );
     }
 
     #[test]
     fn test_no_line_number_not_flagged() {
         let matcher = matcher(&[]);
-        assert!(!matcher.is_non_permalink(b"https://github.com/owner/repo/blob/main/file.py"));
+        assert!(
+            matcher
+                .find_non_permalink(b"https://github.com/owner/repo/blob/main/file.py")
+                .next()
+                .is_none()
+        );
     }
 
     #[test]
@@ -171,18 +189,29 @@ mod tests {
         let matcher = matcher(&["github.example.com"]);
         assert!(
             matcher
-                .is_non_permalink(b"https://github.example.com/owner/repo/blob/main/file.py#L10",)
+                .find_non_permalink(b"https://github.example.com/owner/repo/blob/main/file.py#L10",)
+                .next()
+                .is_some()
         );
     }
 
     #[test]
-    fn test_github_domains_are_deduplicated() {
-        let matcher = GithubPermalinkMatcher::new(vec![
-            "github.example.com".to_string(),
-            "github.com".to_string(),
-            "github.example.com".to_string(),
-        ]);
-        assert_eq!(matcher.checks.len(), 2);
+    fn test_find_non_permalink_returns_all_url_matches_in_order() {
+        let matcher = matcher(&["github.example.com"]);
+        let line = b"See https://github.example.com/owner/repo/blob/main/file.py#L10 and https://github.com/owner/repo/blob/master/src/lib.rs#L5";
+
+        let urls = matcher
+            .find_non_permalink(line)
+            .map(|m| m.as_bytes())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            urls,
+            vec![
+                b"https://github.example.com/owner/repo/blob/main/file.py#L10".as_slice(),
+                b"https://github.com/owner/repo/blob/master/src/lib.rs#L5".as_slice(),
+            ],
+        );
     }
 
     #[tokio::test]
@@ -191,7 +220,7 @@ mod tests {
         let file_path = dir.path().join("links.md");
         fs_err::tokio::write(
             &file_path,
-            b"https://github.example.com/owner/repo/blob/main/file.py#L10\n",
+            b"https://github.example.com/owner/repo/blob/main/file.py#L10 and https://github.com/owner/repo/blob/master/src/lib.rs#L5\n",
         )
         .await?;
 
@@ -202,7 +231,7 @@ mod tests {
         assert_eq!(code, 1);
         assert_eq!(
             String::from_utf8(output)?,
-            "links.md:1:https://github.example.com/owner/repo/blob/main/file.py#L10\n\nNon-permanent github link detected.\nOn any page on github press [y] to load a permalink.\n",
+            "Non-permanent github link detected: links.md:1:https://github.example.com/owner/repo/blob/main/file.py#L10\nNon-permanent github link detected: links.md:1:https://github.com/owner/repo/blob/master/src/lib.rs#L5\n",
         );
 
         Ok(())

--- a/crates/prek/src/hooks/pre_commit_hooks/check_vcs_permalinks.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_vcs_permalinks.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use anyhow::Result;
 use clap::Parser;
 use fancy_regex::{Regex, escape};
+use memchr::memmem;
 use tokio::io::{AsyncBufReadExt, BufReader};
 
 use crate::hook::Hook;
@@ -22,7 +23,13 @@ struct Args {
 
 #[derive(Debug)]
 struct GithubPermalinkMatcher {
-    patterns: Vec<Regex>,
+    checks: Vec<GithubPermalinkCheck>,
+}
+
+#[derive(Debug)]
+struct GithubPermalinkCheck {
+    needle: Vec<u8>,
+    pattern: Regex,
 }
 
 impl GithubPermalinkMatcher {
@@ -36,25 +43,34 @@ impl GithubPermalinkMatcher {
         let mut domains = BTreeSet::from([String::from("github.com")]);
         domains.extend(additional_domains);
 
-        let patterns = domains
+        let checks = domains
             .into_iter()
             .map(|domain| {
+                let needle = format!("https://{domain}/").into_bytes();
                 let domain = escape(&domain);
                 let pattern = format!(
                     r"https://{domain}/[^/ ]+/[^/ ]+/blob/(?![a-fA-F0-9]{{4,64}}/)([^/. ]+)/[^# ]+#L\d+"
                 );
-                Regex::new(&pattern).expect("vcs permalink regex must be valid")
+                GithubPermalinkCheck {
+                    needle,
+                    pattern: Regex::new(&pattern).expect("vcs permalink regex must be valid"),
+                }
             })
             .collect();
 
-        Self { patterns }
+        Self { checks }
     }
 
     fn is_non_permalink(&self, line: &[u8]) -> bool {
-        let line = String::from_utf8_lossy(line);
-        self.patterns
-            .iter()
-            .any(|pattern| pattern.is_match(&line).unwrap_or(false))
+        let mut line_text = None;
+        self.checks.iter().any(|check| {
+            if memmem::find(line, &check.needle).is_none() {
+                return false;
+            }
+
+            let line = line_text.get_or_insert_with(|| String::from_utf8_lossy(line));
+            check.pattern.is_match(line).unwrap_or(false)
+        })
     }
 }
 
@@ -166,7 +182,7 @@ mod tests {
             "github.com".to_string(),
             "github.example.com".to_string(),
         ]);
-        assert_eq!(matcher.patterns.len(), 2);
+        assert_eq!(matcher.checks.len(), 2);
     }
 
     #[tokio::test]

--- a/crates/prek/tests/builtin_hooks.rs
+++ b/crates/prek/tests/builtin_hooks.rs
@@ -414,8 +414,7 @@ fn check_vcs_permalinks_builtin() -> Result<()> {
         .work_dir()
         .child("links.md")
         .write_str(indoc::indoc! {r"
-        https://github.com/owner/repo/blob/main/file.py#L10
-        https://github.example.com/owner/repo/blob/master/src/lib.rs#L5
+        See https://github.com/owner/repo/blob/main/file.py#L10 and https://github.example.com/owner/repo/blob/master/src/lib.rs#L5 for context.
         https://github.com/owner/repo/blob/abcdef1234567890abcdef1234567890abcdef12/file.py#L10
     "})?;
 
@@ -429,11 +428,8 @@ fn check_vcs_permalinks_builtin() -> Result<()> {
     - hook id: check-vcs-permalinks
     - exit code: 1
 
-      links.md:1:https://github.com/owner/repo/blob/main/file.py#L10
-      links.md:2:https://github.example.com/owner/repo/blob/master/src/lib.rs#L5
-
-      Non-permanent github link detected.
-      On any page on github press [y] to load a permalink.
+      Non-permanent github link detected: links.md:1:https://github.com/owner/repo/blob/main/file.py#L10
+      Non-permanent github link detected: links.md:1:https://github.example.com/owner/repo/blob/master/src/lib.rs#L5
 
     ----- stderr -----
     ");


### PR DESCRIPTION
```
❯ hyperfine --warmup 5 --runs 30  "prek run check-vcs-permalinks --all-files" "./target/profiling/prek run check-vcs-permalinks --all-files" -i                                                                                                                                                                           
Benchmark 1: prek run check-vcs-permalinks --all-files
  Time (mean ± σ):     107.5 ms ±   8.3 ms    [User: 81.3 ms, System: 29.2 ms]
  Range (min … max):    97.6 ms … 134.6 ms    30 runs
 
  Warning: Ignoring non-zero exit code.
 
Benchmark 2: ./target/profiling/prek run check-vcs-permalinks --all-files
  Time (mean ± σ):      39.3 ms ±   1.1 ms    [User: 20.4 ms, System: 27.5 ms]
  Range (min … max):    36.9 ms …  41.8 ms    30 runs
 
  Warning: Ignoring non-zero exit code.
 
Summary
  ./target/profiling/prek run check-vcs-permalinks --all-files ran
    2.74 ± 0.23 times faster than prek run check-vcs-permalinks --all-files
```