### PR TITLE
Reduce binary size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,12 +837,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,25 +1008,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,7 +1092,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -2279,7 +2253,6 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,6 @@ dependencies = [
  "rustc-hash",
  "tokio",
  "tokio-stream",
- "xattr",
 ]
 
 [[package]]
@@ -3785,16 +3784,6 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "xattr"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
-dependencies = [
- "libc",
- "rustix",
-]
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3156,18 +3156,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
 ]
 
 [[package]]
@@ -3181,11 +3169,9 @@ dependencies = [
  "once_cell",
  "regex-automata",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -3275,12 +3261,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,7 +470,6 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "terminal_size",
 ]
 
 [[package]]
@@ -2874,16 +2873,6 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
-dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1990,7 +1990,7 @@ dependencies = [
  "serde-saphyr",
  "serde_json",
  "serde_stacker",
- "shlex 2.0.1",
+ "shlex 1.3.0",
  "similar 3.1.1",
  "strum",
  "target-lexicon",
@@ -2027,7 +2027,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "shlex 2.0.1",
+ "shlex 1.3.0",
  "tempfile",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,7 +470,6 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
  "terminal_size",
 ]
 
@@ -2757,12 +2756,6 @@ checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
 dependencies = [
  "vte",
 ]
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,6 +223,8 @@ codegen-units = 16
 
 [profile.minimal-size]
 inherits = "release"
+# Optimize for binary size rather than release-profile throughput.
+opt-level = "z"
 # Enable Full LTO for the best optimizations
 lto = "fat"
 # Reduce codegen units to 1 for better optimizations

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ tokio = { version = "1.47.1", features = [
   "net",
   "time",
 ] }
-tokio-tar = { version = "0.6.0", package = "astral-tokio-tar" }
+tokio-tar = { version = "0.6.0", package = "astral-tokio-tar", default-features = false }
 tokio-util = { version = "0.7.13", features = ["compat", "io"] }
 toml = { version = "1.0.1", default-features = false, features = [
   "fast_hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ serde-saphyr = { version = "0.0.28", default-features = false, features = [
   "deserialize",
   "serialize",
 ] }
-shlex = { version = "2.0.0" }
+shlex = { version = "1.3.0" }
 globset = { version = "0.4.18" }
 similar = { version = "3.0.0" }
 strum = { version = "0.28.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ clap = { version = "4.6.0", default-features = false, features = [
   "std",
   "string",
   "usage",
-  "wrap_help",
 ] }
 clap_complete = { version = "4.6.0", features = ["unstable-dynamic"] }
 console = { version = "0.16", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,11 @@ toml = { version = "1.0.1", default-features = false, features = [
 ] }
 toml_edit = { version = "0.25.1" }
 tracing = { version = "0.1.40" }
-tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.20", default-features = false, features = [
+  "ansi",
+  "env-filter",
+  "fmt",
+] }
 unicode-width = { version = "0.2.0", default-features = false }
 walkdir = { version = "2.5.0" }
 webpki-root-certs = { version = "1.0.6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,8 +67,9 @@ owo-colors = { version = "4.1.0" }
 phf = { version = "0.13.1", default-features = false, features = ["macros"] }
 pprof = { version = "0.15.0" }
 quick-xml = { version = "0.40" }
+# Downloads and update checks work over HTTP/1.1; keep HTTP/2 disabled to avoid
+# pulling in h2 and Hyper HTTP/2 code.
 reqwest = { version = "0.13.2", default-features = false, features = [
-  "http2",
   "stream",
   "json",
   "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,15 @@ axoupdater = { version = "0.10.0", default-features = false, features = [
 ] }
 bstr = { version = "1.11.0" }
 cargo_metadata = { version = "0.23.1" }
-clap = { version = "4.6.0", features = [
+clap = { version = "4.6.0", default-features = false, features = [
+  "color",
   "derive",
   "env",
+  "error-context",
+  "help",
+  "std",
   "string",
+  "usage",
   "wrap_help",
 ] }
 clap_complete = { version = "4.6.0", features = ["unstable-dynamic"] }

--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ prek self update
 
 ### prek includes security-focused safeguards
 
+- For supported managed toolchain downloads, `prek` verifies the downloaded archive or installer checksum before extracting or installing it, helping ensure the integrity of downloaded toolchains.
 - [`prek auto-update`](https://prek.j178.dev/reference/cli/#prek-auto-update) supports `--cooldown-days`, so you can keep newly published releases on hold for a cooling-off period before adopting them.
 - [`prek auto-update`](https://prek.j178.dev/reference/cli/#prek-auto-update) validates pinned SHA revisions against the fetched upstream refs, including impostor-commit detection, and keeps `# frozen:` comments in sync with the configured commit.
 - [`prek auto-update --check`](https://prek.j178.dev/reference/cli/#prek-auto-update--check) is useful in CI when you want updates or frozen-reference mismatches to fail the job without rewriting the config.

--- a/crates/prek/src/languages/mod.rs
+++ b/crates/prek/src/languages/mod.rs
@@ -1,5 +1,7 @@
 use std::ffi::OsStr;
+use std::future::Future;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -82,6 +84,109 @@ trait LanguageImpl {
         store: &Store,
         reporter: &HookRunReporter,
     ) -> Result<(i32, Vec<u8>)>;
+}
+
+type InstallFuture<'a> = Pin<Box<dyn Future<Output = Result<InstalledHook>> + 'a>>;
+type CheckHealthFuture<'a> = Pin<Box<dyn Future<Output = Result<()>> + 'a>>;
+type RunFuture<'a> = Pin<Box<dyn Future<Output = Result<(i32, Vec<u8>)>> + 'a>>;
+
+macro_rules! language_impl_match {
+    ($language:expr, $impl:ident => $body:expr) => {
+        match $language {
+            Self::Bun => {
+                let $impl = &BUN;
+                $body
+            }
+            Self::Conda => {
+                let $impl = &CONDA;
+                $body
+            }
+            Self::Coursier => {
+                let $impl = &COURSIER;
+                $body
+            }
+            Self::Dart => {
+                let $impl = &DART;
+                $body
+            }
+            Self::Deno => {
+                let $impl = &DENO;
+                $body
+            }
+            Self::Docker => {
+                let $impl = &DOCKER;
+                $body
+            }
+            Self::DockerImage => {
+                let $impl = &DOCKER_IMAGE;
+                $body
+            }
+            Self::Dotnet => {
+                let $impl = &DOTNET;
+                $body
+            }
+            Self::Fail => {
+                let $impl = &FAIL;
+                $body
+            }
+            Self::Golang => {
+                let $impl = &GOLANG;
+                $body
+            }
+            Self::Haskell => {
+                let $impl = &HASKELL;
+                $body
+            }
+            Self::Julia => {
+                let $impl = &JULIA;
+                $body
+            }
+            Self::Lua => {
+                let $impl = &LUA;
+                $body
+            }
+            Self::Node => {
+                let $impl = &NODE;
+                $body
+            }
+            Self::Perl => {
+                let $impl = &PERL;
+                $body
+            }
+            Self::Pygrep => {
+                let $impl = &PYGREP;
+                $body
+            }
+            Self::Python => {
+                let $impl = &PYTHON;
+                $body
+            }
+            Self::R => {
+                let $impl = &R;
+                $body
+            }
+            Self::Ruby => {
+                let $impl = &RUBY;
+                $body
+            }
+            Self::Rust => {
+                let $impl = &RUST;
+                $body
+            }
+            Self::Script => {
+                let $impl = &SCRIPT;
+                $body
+            }
+            Self::Swift => {
+                let $impl = &SWIFT;
+                $body
+            }
+            Self::System => {
+                let $impl = &SYSTEM;
+                $body
+            }
+        }
+    };
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -296,59 +401,24 @@ impl Language {
         store: &Store,
         reporter: &HookInstallReporter,
     ) -> Result<InstalledHook> {
-        match self {
-            Self::Dart => DART.install(hook, store, reporter).await,
-            Self::Bun => BUN.install(hook, store, reporter).await,
-            Self::Coursier => COURSIER.install(hook, store, reporter).await,
-            Self::Deno => DENO.install(hook, store, reporter).await,
-            Self::Docker => DOCKER.install(hook, store, reporter).await,
-            Self::DockerImage => DOCKER_IMAGE.install(hook, store, reporter).await,
-            Self::Dotnet => DOTNET.install(hook, store, reporter).await,
-            Self::Fail => FAIL.install(hook, store, reporter).await,
-            Self::Golang => GOLANG.install(hook, store, reporter).await,
-            Self::Haskell => HASKELL.install(hook, store, reporter).await,
-            Self::Julia => JULIA.install(hook, store, reporter).await,
-            Self::Lua => LUA.install(hook, store, reporter).await,
-            Self::Node => NODE.install(hook, store, reporter).await,
-            Self::Perl => PERL.install(hook, store, reporter).await,
-            Self::Pygrep => PYGREP.install(hook, store, reporter).await,
-            Self::Python => PYTHON.install(hook, store, reporter).await,
-            Self::R => R.install(hook, store, reporter).await,
-            Self::Ruby => RUBY.install(hook, store, reporter).await,
-            Self::Rust => RUST.install(hook, store, reporter).await,
-            Self::Script => SCRIPT.install(hook, store, reporter).await,
-            Self::Swift => SWIFT.install(hook, store, reporter).await,
-            Self::System => SYSTEM.install(hook, store, reporter).await,
-            Self::Conda => CONDA.install(hook, store, reporter).await,
-        }
+        self.install_future(hook, store, reporter).await
+    }
+
+    fn install_future<'a>(
+        &'a self,
+        hook: Arc<Hook>,
+        store: &'a Store,
+        reporter: &'a HookInstallReporter,
+    ) -> InstallFuture<'a> {
+        language_impl_match!(self, language => Box::pin(language.install(hook, store, reporter)))
     }
 
     pub(crate) async fn check_health(&self, info: &InstallInfo) -> Result<()> {
-        match self {
-            Self::Dart => DART.check_health(info).await,
-            Self::Bun => BUN.check_health(info).await,
-            Self::Coursier => COURSIER.check_health(info).await,
-            Self::Deno => DENO.check_health(info).await,
-            Self::Docker => DOCKER.check_health(info).await,
-            Self::DockerImage => DOCKER_IMAGE.check_health(info).await,
-            Self::Dotnet => DOTNET.check_health(info).await,
-            Self::Fail => FAIL.check_health(info).await,
-            Self::Golang => GOLANG.check_health(info).await,
-            Self::Haskell => HASKELL.check_health(info).await,
-            Self::Julia => JULIA.check_health(info).await,
-            Self::Lua => LUA.check_health(info).await,
-            Self::Node => NODE.check_health(info).await,
-            Self::Perl => PERL.check_health(info).await,
-            Self::Pygrep => PYGREP.check_health(info).await,
-            Self::Python => PYTHON.check_health(info).await,
-            Self::R => R.check_health(info).await,
-            Self::Ruby => RUBY.check_health(info).await,
-            Self::Rust => RUST.check_health(info).await,
-            Self::Script => SCRIPT.check_health(info).await,
-            Self::Swift => SWIFT.check_health(info).await,
-            Self::System => SYSTEM.check_health(info).await,
-            Self::Conda => CONDA.check_health(info).await,
-        }
+        self.check_health_future(info).await
+    }
+
+    fn check_health_future<'a>(&'a self, info: &'a InstallInfo) -> CheckHealthFuture<'a> {
+        language_impl_match!(self, language => Box::pin(language.check_health(info)))
     }
 
     #[instrument(level = "trace", skip_all, fields(hook_id = %hook.id, language = %hook.language))]
@@ -359,53 +429,47 @@ impl Language {
         store: &Store,
         reporter: &HookRunReporter,
     ) -> Result<(i32, Vec<u8>)> {
+        self.run_future(hook, filenames, store, reporter).await
+    }
+
+    fn run_future<'a, 'p>(
+        &'a self,
+        hook: &'a InstalledHook,
+        filenames: &'a [&'p Path],
+        store: &'a Store,
+        reporter: &'a HookRunReporter,
+    ) -> RunFuture<'a>
+    where
+        'p: 'a,
+    {
         match hook.repo() {
             Repo::Meta { .. } => {
-                return hooks::MetaHooks::from_str(&hook.id)
-                    .unwrap()
-                    .run(store, hook, filenames, reporter)
-                    .await;
+                return Box::pin(
+                    hooks::MetaHooks::from_str(&hook.id)
+                        .unwrap()
+                        .run(store, hook, filenames, reporter),
+                );
             }
             Repo::Builtin { .. } => {
-                return hooks::BuiltinHooks::from_str(&hook.id)
-                    .unwrap()
-                    .run(store, hook, filenames, reporter)
-                    .await;
+                return Box::pin(
+                    hooks::BuiltinHooks::from_str(&hook.id)
+                        .unwrap()
+                        .run(store, hook, filenames, reporter),
+                );
             }
             Repo::Remote { .. } => {
                 // Fast path for hooks implemented in Rust
                 if hooks::check_fast_path(hook) {
-                    return hooks::run_fast_path(store, hook, filenames, reporter).await;
+                    return Box::pin(hooks::run_fast_path(store, hook, filenames, reporter));
                 }
             }
             Repo::Local { .. } => {}
         }
 
-        match self {
-            Self::Dart => DART.run(hook, filenames, store, reporter).await,
-            Self::Bun => BUN.run(hook, filenames, store, reporter).await,
-            Self::Coursier => COURSIER.run(hook, filenames, store, reporter).await,
-            Self::Deno => DENO.run(hook, filenames, store, reporter).await,
-            Self::Docker => DOCKER.run(hook, filenames, store, reporter).await,
-            Self::DockerImage => DOCKER_IMAGE.run(hook, filenames, store, reporter).await,
-            Self::Dotnet => DOTNET.run(hook, filenames, store, reporter).await,
-            Self::Fail => FAIL.run(hook, filenames, store, reporter).await,
-            Self::Golang => GOLANG.run(hook, filenames, store, reporter).await,
-            Self::Haskell => HASKELL.run(hook, filenames, store, reporter).await,
-            Self::Julia => JULIA.run(hook, filenames, store, reporter).await,
-            Self::Lua => LUA.run(hook, filenames, store, reporter).await,
-            Self::Node => NODE.run(hook, filenames, store, reporter).await,
-            Self::Perl => PERL.run(hook, filenames, store, reporter).await,
-            Self::Pygrep => PYGREP.run(hook, filenames, store, reporter).await,
-            Self::Python => PYTHON.run(hook, filenames, store, reporter).await,
-            Self::R => R.run(hook, filenames, store, reporter).await,
-            Self::Ruby => RUBY.run(hook, filenames, store, reporter).await,
-            Self::Rust => RUST.run(hook, filenames, store, reporter).await,
-            Self::Script => SCRIPT.run(hook, filenames, store, reporter).await,
-            Self::Swift => SWIFT.run(hook, filenames, store, reporter).await,
-            Self::System => SYSTEM.run(hook, filenames, store, reporter).await,
-            Self::Conda => CONDA.run(hook, filenames, store, reporter).await,
-        }
+        language_impl_match!(
+            self,
+            language => Box::pin(language.run(hook, filenames, store, reporter))
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- trim unused feature paths from reqwest, tracing-subscriber, tar, and clap
- tune the dist profile for size
- box language dispatch futures to keep async dispatch state smaller