### PR TITLE
Split run concurrency knobs

### DIFF
--- a/crates/prek-consts/Cargo.toml
+++ b/crates/prek-consts/Cargo.toml
@@ -10,5 +10,8 @@ license = { workspace = true }
 [dependencies]
 tracing = { workspace = true }
 
+[features]
+test-utils = []
+
 [lints]
 workspace = true

--- a/crates/prek-consts/src/env_vars.rs
+++ b/crates/prek-consts/src/env_vars.rs
@@ -4,6 +4,54 @@ use tracing::info;
 
 pub struct EnvVars;
 
+pub trait EnvVarsRead {
+    fn var_os(&self, name: &str) -> Option<OsString>;
+
+    fn is_set(&self, name: &str) -> bool {
+        self.var_os(name).is_some()
+    }
+
+    fn var(&self, name: &str) -> Result<String, std::env::VarError> {
+        match self.var_os(name) {
+            Some(s) => s.into_string().map_err(std::env::VarError::NotUnicode),
+            None => Err(std::env::VarError::NotPresent),
+        }
+    }
+}
+
+impl EnvVarsRead for EnvVars {
+    fn var_os(&self, name: &str) -> Option<OsString> {
+        Self::var_os(name)
+    }
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+#[derive(Debug, Clone, Copy)]
+pub struct EnvVarsMap<'a> {
+    values: &'a [(&'a str, &'a str)],
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+impl EnvVarsMap<'_> {
+    fn direct_var_os(&self, name: &str) -> Option<OsString> {
+        self.values
+            .iter()
+            .find_map(|(key, value)| (*key == name).then(|| OsString::from(value)))
+    }
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+impl EnvVarsRead for EnvVarsMap<'_> {
+    fn var_os(&self, name: &str) -> Option<OsString> {
+        self.direct_var_os(name).or_else(|| {
+            let name = EnvVars::pre_commit_name(name)?;
+            let val = self.direct_var_os(name)?;
+            info!("Falling back to pre-commit environment variable for {name}");
+            Some(val)
+        })
+    }
+}
+
 impl EnvVars {
     pub const PATH: &'static str = "PATH";
     pub const HOME: &'static str = "HOME";
@@ -23,6 +71,8 @@ impl EnvVars {
     pub const PREK_SKIP: &'static str = "PREK_SKIP";
     pub const PREK_ALLOW_NO_CONFIG: &'static str = "PREK_ALLOW_NO_CONFIG";
     pub const PREK_NO_CONCURRENCY: &'static str = "PREK_NO_CONCURRENCY";
+    pub const PREK_CONCURRENT_HOOKS: &'static str = "PREK_CONCURRENT_HOOKS";
+    pub const PREK_CONCURRENT_BATCHES: &'static str = "PREK_CONCURRENT_BATCHES";
     pub const PREK_MAX_CONCURRENCY: &'static str = "PREK_MAX_CONCURRENCY";
     pub const PREK_NO_FAST_PATH: &'static str = "PREK_NO_FAST_PATH";
     pub const PREK_UV_SOURCE: &'static str = "PREK_UV_SOURCE";
@@ -124,6 +174,13 @@ impl EnvVars {
     pub const DOTNET_ROOT: &'static str = "DOTNET_ROOT";
 }
 
+#[cfg(any(test, feature = "test-utils"))]
+impl EnvVars {
+    pub const fn from_map<'a>(values: &'a [(&'a str, &'a str)]) -> EnvVarsMap<'a> {
+        EnvVarsMap { values }
+    }
+}
+
 impl EnvVars {
     // Pre-commit environment variables that we support for compatibility
     pub const PRE_COMMIT_HOME: &'static str = "PRE_COMMIT_HOME";
@@ -205,7 +262,7 @@ impl EnvVars {
 
 #[cfg(test)]
 mod tests {
-    use super::EnvVars;
+    use super::{EnvVars, EnvVarsRead};
 
     #[test]
     fn test_parse_boolish() {
@@ -222,5 +279,29 @@ mod tests {
         assert_eq!(EnvVars::parse_boolish("maybe"), None);
         assert_eq!(EnvVars::parse_boolish(""), None);
         assert_eq!(EnvVars::parse_boolish("123"), None);
+    }
+
+    #[test]
+    fn test_env_vars_map_reads_values() {
+        let env_vars = EnvVars::from_map(&[(EnvVars::PREK_COLOR, "never")]);
+
+        assert_eq!(env_vars.var(EnvVars::PREK_COLOR).unwrap(), "never");
+    }
+
+    #[test]
+    fn test_env_vars_map_falls_back_to_pre_commit_name() {
+        let env_vars = EnvVars::from_map(&[(EnvVars::PRE_COMMIT_NO_CONCURRENCY, "1")]);
+
+        assert_eq!(env_vars.var(EnvVars::PREK_NO_CONCURRENCY).unwrap(), "1");
+    }
+
+    #[test]
+    fn test_env_vars_map_prefers_prek_name_over_pre_commit_name() {
+        let env_vars = EnvVars::from_map(&[
+            (EnvVars::PREK_NO_CONCURRENCY, "prek"),
+            (EnvVars::PRE_COMMIT_NO_CONCURRENCY, "pre-commit"),
+        ]);
+
+        assert_eq!(env_vars.var(EnvVars::PREK_NO_CONCURRENCY).unwrap(), "prek");
     }
 }

--- a/crates/prek/Cargo.toml
+++ b/crates/prek/Cargo.toml
@@ -108,6 +108,7 @@ etcetera = { workspace = true }
 insta = { workspace = true }
 insta-cmd = { workspace = true }
 markdown = { workspace = true }
+prek-consts = { workspace = true, features = ["test-utils"] }
 predicates = { workspace = true }
 pretty_assertions = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/prek/src/cli/auto_update/mod.rs
+++ b/crates/prek/src/cli/auto_update/mod.rs
@@ -15,7 +15,7 @@ use crate::cli::run::Selectors;
 use crate::config::GlobPatterns;
 use crate::fs::CWD;
 use crate::printer::Printer;
-use crate::run::CONCURRENCY;
+use crate::run::INTERNAL_CONCURRENCY;
 use crate::settings::FilesystemOptions;
 use crate::store::Store;
 use crate::workspace::{Project, Workspace};
@@ -393,7 +393,11 @@ pub(crate) async fn auto_update(
 
     let tag_filters =
         TagFilters::new(include_tag, exclude_tag, repo_include_tag, repo_exclude_tag)?;
-    let jobs = if jobs == 0 { *CONCURRENCY } else { jobs };
+    let jobs = if jobs == 0 {
+        *INTERNAL_CONCURRENCY
+    } else {
+        jobs
+    };
     let reporter = AutoUpdateReporter::new(printer);
 
     let repo_sources = collect_repo_sources(&workspace, cooldown_days, filesystem.as_ref())?;

--- a/crates/prek/src/cli/run/install.rs
+++ b/crates/prek/src/cli/run/install.rs
@@ -11,7 +11,7 @@ use tracing::{debug, warn};
 use crate::cli::reporter::HookInstallReporter;
 use crate::config::Language;
 use crate::hook::{Hook, InstallInfo, InstalledHook};
-use crate::run::CONCURRENCY;
+use crate::run::INTERNAL_CONCURRENCY;
 use crate::store::Store;
 
 /// Resolve already-installed hook environments and install the missing ones.
@@ -41,7 +41,7 @@ pub(crate) async fn install_hooks(
         }
     }
 
-    let semaphore = Rc::new(Semaphore::new(*CONCURRENCY));
+    let semaphore = Rc::new(Semaphore::new(*INTERNAL_CONCURRENCY));
     let mut futures = FuturesUnordered::new();
 
     for partition in partition_hooks(hooks_to_install) {
@@ -284,7 +284,7 @@ impl InstallCache {
                         };
                         Some(CachedInstallInfo::new(Arc::new(info)))
                     })
-                    .buffer_unordered(*CONCURRENCY);
+                    .buffer_unordered(*INTERNAL_CONCURRENCY);
 
                 let mut hooks = Vec::new();
                 while let Some(hook) = tasks.next().await {

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -31,7 +31,7 @@ use crate::fs::CWD;
 use crate::git::GIT_ROOT;
 use crate::hook::{Hook, InstalledHook};
 use crate::printer::Printer;
-use crate::run::{CONCURRENCY, USE_COLOR};
+use crate::run::{HOOK_CONCURRENCY, USE_COLOR};
 use crate::store::Store;
 use crate::workspace::{HookInitFilters, Project, Workspace};
 use crate::{fs, git, hooks, warn_user};
@@ -729,7 +729,7 @@ impl<'a> HookRunSession<'a> {
         tag_cache: &FileTagCache<'paths>,
         clean_baseline: bool,
     ) -> Result<Vec<ProjectRunResult<'project, 'paths>>> {
-        let semaphore = Rc::new(Semaphore::new(*CONCURRENCY));
+        let semaphore = Rc::new(Semaphore::new(*HOOK_CONCURRENCY));
         let mut runs = FuturesUnordered::new();
         for (idx, project_run) in project_runs.into_iter().enumerate() {
             let semaphore = Rc::clone(&semaphore);
@@ -846,9 +846,8 @@ impl<'a> HookRunSession<'a> {
         semaphore: Rc<Semaphore>,
     ) -> Result<Vec<RunResult>> {
         debug!(
-            "Running priority group with priority {} with concurrency {}: {:?}",
+            "Running priority group with priority {}: {:?}",
             group_hooks[0].priority,
-            *CONCURRENCY,
             group_hooks.iter().map(|hook| &hook.id).collect::<Vec<_>>()
         );
 

--- a/crates/prek/src/hooks/builtin_hooks/check_json5.rs
+++ b/crates/prek/src/hooks/builtin_hooks/check_json5.rs
@@ -3,15 +3,17 @@ use std::path::Path;
 use crate::hook::Hook;
 use crate::hooks::pre_commit_hooks::check_json::JsonDuplicateKeyChecker;
 use crate::hooks::run_concurrent_file_checks;
-use crate::run::CONCURRENCY;
+use crate::run::INTERNAL_CONCURRENCY;
 
 pub(crate) async fn check_json5(
     hook: &Hook,
     filenames: &[&Path],
 ) -> anyhow::Result<(i32, Vec<u8>)> {
-    run_concurrent_file_checks(filenames.iter().copied(), *CONCURRENCY, |filename| {
-        check_file(hook.project().relative_path(), filename)
-    })
+    run_concurrent_file_checks(
+        filenames.iter().copied(),
+        *INTERNAL_CONCURRENCY,
+        |filename| check_file(hook.project().relative_path(), filename),
+    )
     .await
 }
 

--- a/crates/prek/src/hooks/pre_commit_hooks/check_added_large_files.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_added_large_files.rs
@@ -6,7 +6,7 @@ use rustc_hash::FxHashSet;
 use crate::git::{get_added_files, get_lfs_files};
 use crate::hook::Hook;
 use crate::hooks::run_concurrent_file_checks;
-use crate::run::CONCURRENCY;
+use crate::run::INTERNAL_CONCURRENCY;
 
 #[derive(Parser)]
 #[command(disable_help_subcommand = true)]
@@ -54,7 +54,7 @@ pub(crate) async fn check_added_large_files(
         .copied()
         .filter(|f| !lfs_files.contains(*f));
 
-    run_concurrent_file_checks(filenames, *CONCURRENCY, |filename| async move {
+    run_concurrent_file_checks(filenames, *INTERNAL_CONCURRENCY, |filename| async move {
         let file_path = hook.project().relative_path().join(filename);
         let size = fs_err::tokio::metadata(file_path).await?.len() / 1024;
         if size > args.max_kb {

--- a/crates/prek/src/hooks/pre_commit_hooks/check_executables_have_shebangs.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_executables_have_shebangs.rs
@@ -9,7 +9,7 @@ use crate::hooks::pre_commit_hooks::shebangs::{
     file_has_shebang, git_index_stage_output, matching_git_index_paths_by_executable_bit,
 };
 use crate::hooks::run_concurrent_file_checks;
-use crate::run::CONCURRENCY;
+use crate::run::INTERNAL_CONCURRENCY;
 use rustc_hash::FxHashSet;
 
 pub(crate) async fn check_executables_have_shebangs(
@@ -47,16 +47,20 @@ async fn os_check_shebangs(
     file_base: &Path,
     paths: &[&Path],
 ) -> Result<(i32, Vec<u8>), anyhow::Error> {
-    run_concurrent_file_checks(paths.iter().copied(), *CONCURRENCY, |file| async move {
-        let file_path = file_base.join(file);
-        let has_shebang = file_has_shebang(&file_path).await?;
-        if has_shebang {
-            anyhow::Ok((0, Vec::new()))
-        } else {
-            let msg = build_missing_shebang_warning(file)?;
-            Ok((1, msg.into_bytes()))
-        }
-    })
+    run_concurrent_file_checks(
+        paths.iter().copied(),
+        *INTERNAL_CONCURRENCY,
+        |file| async move {
+            let file_path = file_base.join(file);
+            let has_shebang = file_has_shebang(&file_path).await?;
+            if has_shebang {
+                anyhow::Ok((0, Vec::new()))
+            } else {
+                let msg = build_missing_shebang_warning(file)?;
+                Ok((1, msg.into_bytes()))
+            }
+        },
+    )
     .await
 }
 
@@ -98,7 +102,7 @@ async fn git_check_shebangs(
     let filenames: FxHashSet<_> = filenames.iter().copied().collect();
     let entries = matching_git_index_paths_by_executable_bit(&stdout, file_base, &filenames, true);
 
-    run_concurrent_file_checks(entries, *CONCURRENCY, |file| async move {
+    run_concurrent_file_checks(entries, *INTERNAL_CONCURRENCY, |file| async move {
         let file_path = file_base.join(file);
         if file_has_shebang(&file_path).await? {
             Ok((0, Vec::new()))

--- a/crates/prek/src/hooks/pre_commit_hooks/check_json.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_json.rs
@@ -7,12 +7,14 @@ use serde::{Deserialize, Deserializer};
 
 use crate::hook::Hook;
 use crate::hooks::run_concurrent_file_checks;
-use crate::run::CONCURRENCY;
+use crate::run::INTERNAL_CONCURRENCY;
 
 pub(crate) async fn check_json(hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
-    run_concurrent_file_checks(filenames.iter().copied(), *CONCURRENCY, |filename| {
-        check_file(hook.project().relative_path(), filename)
-    })
+    run_concurrent_file_checks(
+        filenames.iter().copied(),
+        *INTERNAL_CONCURRENCY,
+        |filename| check_file(hook.project().relative_path(), filename),
+    )
     .await
 }
 

--- a/crates/prek/src/hooks/pre_commit_hooks/check_merge_conflict.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_merge_conflict.rs
@@ -8,7 +8,7 @@ use tokio::io::AsyncBufReadExt;
 use crate::git::get_git_dir;
 use crate::hook::Hook;
 use crate::hooks::run_concurrent_file_checks;
-use crate::run::CONCURRENCY;
+use crate::run::INTERNAL_CONCURRENCY;
 
 const START_PATTERN: &[u8] = b"<<<<<<< ";
 const ANCESTOR_PATTERN: &[u8] = b"||||||| ";
@@ -35,9 +35,11 @@ pub(crate) async fn check_merge_conflict(
         return Ok((0, Vec::new()));
     }
 
-    run_concurrent_file_checks(filenames.iter().copied(), *CONCURRENCY, |filename| {
-        check_file(hook.project().relative_path(), filename)
-    })
+    run_concurrent_file_checks(
+        filenames.iter().copied(),
+        *INTERNAL_CONCURRENCY,
+        |filename| check_file(hook.project().relative_path(), filename),
+    )
     .await
 }
 

--- a/crates/prek/src/hooks/pre_commit_hooks/check_shebang_scripts_are_executable.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_shebang_scripts_are_executable.rs
@@ -8,7 +8,7 @@ use crate::hooks::pre_commit_hooks::shebangs::{
     file_has_shebang, git_index_stage_output, matching_git_index_paths_by_executable_bit,
 };
 use crate::hooks::run_concurrent_file_checks;
-use crate::run::CONCURRENCY;
+use crate::run::INTERNAL_CONCURRENCY;
 use rustc_hash::FxHashSet;
 
 pub(crate) async fn check_shebang_scripts_are_executable(
@@ -24,7 +24,7 @@ pub(crate) async fn check_shebang_scripts_are_executable(
     let filenames: FxHashSet<_> = filenames.iter().copied().collect();
     let entries = matching_git_index_paths_by_executable_bit(&stdout, file_base, &filenames, false);
 
-    run_concurrent_file_checks(entries, *CONCURRENCY, |file| async move {
+    run_concurrent_file_checks(entries, *INTERNAL_CONCURRENCY, |file| async move {
         let file_path = file_base.join(file);
         if file_has_shebang(&file_path).await? {
             Ok((1, build_non_executable_shebang_warning(file)?.into_bytes()))

--- a/crates/prek/src/hooks/pre_commit_hooks/check_symlinks.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_symlinks.rs
@@ -4,12 +4,14 @@ use anyhow::Result;
 
 use crate::hook::Hook;
 use crate::hooks::run_concurrent_file_checks;
-use crate::run::CONCURRENCY;
+use crate::run::INTERNAL_CONCURRENCY;
 
 pub(crate) async fn check_symlinks(hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
-    run_concurrent_file_checks(filenames.iter().copied(), *CONCURRENCY, |filename| {
-        check_file(hook.project().relative_path(), filename)
-    })
+    run_concurrent_file_checks(
+        filenames.iter().copied(),
+        *INTERNAL_CONCURRENCY,
+        |filename| check_file(hook.project().relative_path(), filename),
+    )
     .await
 }
 

--- a/crates/prek/src/hooks/pre_commit_hooks/check_toml.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_toml.rs
@@ -5,12 +5,14 @@ use anyhow::Result;
 
 use crate::hook::Hook;
 use crate::hooks::run_concurrent_file_checks;
-use crate::run::CONCURRENCY;
+use crate::run::INTERNAL_CONCURRENCY;
 
 pub(crate) async fn check_toml(hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
-    run_concurrent_file_checks(filenames.iter().copied(), *CONCURRENCY, |filename| {
-        check_file(hook.project().relative_path(), filename)
-    })
+    run_concurrent_file_checks(
+        filenames.iter().copied(),
+        *INTERNAL_CONCURRENCY,
+        |filename| check_file(hook.project().relative_path(), filename),
+    )
     .await
 }
 

--- a/crates/prek/src/hooks/pre_commit_hooks/check_vcs_permalinks.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_vcs_permalinks.rs
@@ -10,7 +10,7 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 
 use crate::hook::Hook;
 use crate::hooks::run_concurrent_file_checks;
-use crate::run::CONCURRENCY;
+use crate::run::INTERNAL_CONCURRENCY;
 
 #[derive(Parser)]
 #[command(disable_help_subcommand = true)]
@@ -86,9 +86,11 @@ pub(crate) async fn check_vcs_permalinks(
     let matcher = GithubNonPermalinkMatcher::new(args.additional_github_domains);
 
     let file_base = hook.project().relative_path();
-    run_concurrent_file_checks(filenames.iter().copied(), *CONCURRENCY, |filename| {
-        check_file(file_base, filename, &matcher)
-    })
+    run_concurrent_file_checks(
+        filenames.iter().copied(),
+        *INTERNAL_CONCURRENCY,
+        |filename| check_file(file_base, filename, &matcher),
+    )
     .await
 }
 

--- a/crates/prek/src/hooks/pre_commit_hooks/check_xml.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_xml.rs
@@ -4,12 +4,14 @@ use anyhow::Result;
 
 use crate::hook::Hook;
 use crate::hooks::run_concurrent_file_checks;
-use crate::run::CONCURRENCY;
+use crate::run::INTERNAL_CONCURRENCY;
 
 pub(crate) async fn check_xml(hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
-    run_concurrent_file_checks(filenames.iter().copied(), *CONCURRENCY, |filename| {
-        check_file(hook.project().relative_path(), filename)
-    })
+    run_concurrent_file_checks(
+        filenames.iter().copied(),
+        *INTERNAL_CONCURRENCY,
+        |filename| check_file(hook.project().relative_path(), filename),
+    )
     .await
 }
 

--- a/crates/prek/src/hooks/pre_commit_hooks/check_yaml.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_yaml.rs
@@ -6,7 +6,7 @@ use serde::de::IgnoredAny;
 
 use crate::hook::Hook;
 use crate::hooks::run_concurrent_file_checks;
-use crate::run::CONCURRENCY;
+use crate::run::INTERNAL_CONCURRENCY;
 
 #[derive(Parser)]
 #[command(disable_help_subcommand = true)]
@@ -23,13 +23,17 @@ struct Args {
 pub(crate) async fn check_yaml(hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
     let args = Args::try_parse_from(hook.entry.expect_direct().split()?.iter().chain(&hook.args))?;
 
-    run_concurrent_file_checks(filenames.iter().copied(), *CONCURRENCY, |filename| {
-        check_file(
-            hook.project().relative_path(),
-            filename,
-            args.allow_multiple_documents,
-        )
-    })
+    run_concurrent_file_checks(
+        filenames.iter().copied(),
+        *INTERNAL_CONCURRENCY,
+        |filename| {
+            check_file(
+                hook.project().relative_path(),
+                filename,
+                args.allow_multiple_documents,
+            )
+        },
+    )
     .await
 }
 

--- a/crates/prek/src/hooks/pre_commit_hooks/detect_private_key.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/detect_private_key.rs
@@ -7,7 +7,7 @@ use tokio::io::AsyncReadExt;
 
 use crate::hook::Hook;
 use crate::hooks::run_concurrent_file_checks;
-use crate::run::CONCURRENCY;
+use crate::run::INTERNAL_CONCURRENCY;
 
 const BLACKLIST: &[&[u8]] = &[
     b"BEGIN RSA PRIVATE KEY",
@@ -42,9 +42,11 @@ static PRIVATE_KEY_MATCHER: LazyLock<AhoCorasick> = LazyLock::new(|| {
 });
 
 pub(crate) async fn detect_private_key(hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
-    run_concurrent_file_checks(filenames.iter().copied(), *CONCURRENCY, |filename| {
-        check_file(hook.project().relative_path(), filename)
-    })
+    run_concurrent_file_checks(
+        filenames.iter().copied(),
+        *INTERNAL_CONCURRENCY,
+        |filename| check_file(hook.project().relative_path(), filename),
+    )
     .await
 }
 

--- a/crates/prek/src/hooks/pre_commit_hooks/file_contents_sorter.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/file_contents_sorter.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 
 use crate::hook::Hook;
 use crate::hooks::run_concurrent_file_checks;
-use crate::run::CONCURRENCY;
+use crate::run::INTERNAL_CONCURRENCY;
 
 #[derive(Parser)]
 #[command(disable_help_subcommand = true)]
@@ -26,9 +26,11 @@ pub(crate) async fn file_contents_sorter(
     let args = Args::try_parse_from(hook.entry.expect_direct().split()?.iter().chain(&hook.args))?;
     let file_base = hook.project().relative_path();
 
-    run_concurrent_file_checks(filenames.iter().copied(), *CONCURRENCY, |filename| {
-        sort_file(file_base, filename, args.ignore_case, args.unique)
-    })
+    run_concurrent_file_checks(
+        filenames.iter().copied(),
+        *INTERNAL_CONCURRENCY,
+        |filename| sort_file(file_base, filename, args.ignore_case, args.unique),
+    )
     .await
 }
 

--- a/crates/prek/src/hooks/pre_commit_hooks/fix_byte_order_marker.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/fix_byte_order_marker.rs
@@ -5,7 +5,7 @@ use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt, SeekFrom};
 
 use crate::hook::Hook;
 use crate::hooks::run_concurrent_file_checks;
-use crate::run::CONCURRENCY;
+use crate::run::INTERNAL_CONCURRENCY;
 
 const UTF8_BOM: &[u8] = b"\xef\xbb\xbf";
 const BUFFER_SIZE: usize = 8192; // 8KB buffer for streaming
@@ -14,9 +14,11 @@ pub(crate) async fn fix_byte_order_marker(
     hook: &Hook,
     filenames: &[&Path],
 ) -> Result<(i32, Vec<u8>)> {
-    run_concurrent_file_checks(filenames.iter().copied(), *CONCURRENCY, |filename| {
-        fix_file(hook.project().relative_path(), filename)
-    })
+    run_concurrent_file_checks(
+        filenames.iter().copied(),
+        *INTERNAL_CONCURRENCY,
+        |filename| fix_file(hook.project().relative_path(), filename),
+    )
     .await
 }
 

--- a/crates/prek/src/hooks/pre_commit_hooks/fix_end_of_file.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/fix_end_of_file.rs
@@ -5,12 +5,14 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, AsyncWriteExt,
 
 use crate::hook::Hook;
 use crate::hooks::run_concurrent_file_checks;
-use crate::run::CONCURRENCY;
+use crate::run::INTERNAL_CONCURRENCY;
 
 pub(crate) async fn fix_end_of_file(hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
-    run_concurrent_file_checks(filenames.iter().copied(), *CONCURRENCY, |filename| {
-        fix_file(hook.project().relative_path(), filename)
-    })
+    run_concurrent_file_checks(
+        filenames.iter().copied(),
+        *INTERNAL_CONCURRENCY,
+        |filename| fix_file(hook.project().relative_path(), filename),
+    )
     .await
 }
 

--- a/crates/prek/src/hooks/pre_commit_hooks/fix_trailing_whitespace.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/fix_trailing_whitespace.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 
 use crate::hook::Hook;
 use crate::hooks::run_concurrent_file_checks;
-use crate::run::CONCURRENCY;
+use crate::run::INTERNAL_CONCURRENCY;
 
 const MARKDOWN_LINE_BREAK: &[u8] = b"  ";
 
@@ -71,15 +71,19 @@ pub(crate) async fn fix_trailing_whitespace(
         .as_ref()
         .map_or(&[][..], |chars| chars.0.as_slice());
 
-    run_concurrent_file_checks(filenames.iter().copied(), *CONCURRENCY, |filename| {
-        fix_file(
-            hook.project().relative_path(),
-            filename,
-            chars,
-            force_markdown,
-            &markdown_exts,
-        )
-    })
+    run_concurrent_file_checks(
+        filenames.iter().copied(),
+        *INTERNAL_CONCURRENCY,
+        |filename| {
+            fix_file(
+                hook.project().relative_path(),
+                filename,
+                chars,
+                force_markdown,
+                &markdown_exts,
+            )
+        },
+    )
     .await
 }
 

--- a/crates/prek/src/hooks/pre_commit_hooks/mixed_line_ending.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/mixed_line_ending.rs
@@ -6,7 +6,7 @@ use clap::{Parser, ValueEnum};
 
 use crate::hook::Hook;
 use crate::hooks::run_concurrent_file_checks;
-use crate::run::CONCURRENCY;
+use crate::run::INTERNAL_CONCURRENCY;
 
 const CRLF: &[u8] = b"\r\n";
 const LF: &[u8] = b"\n";
@@ -61,9 +61,11 @@ impl LineEndingCounts {
 pub(crate) async fn mixed_line_ending(hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
     let args = Args::try_parse_from(hook.entry.expect_direct().split()?.iter().chain(&hook.args))?;
 
-    run_concurrent_file_checks(filenames.iter().copied(), *CONCURRENCY, |filename| {
-        fix_file(hook.project().relative_path(), filename, args.fix)
-    })
+    run_concurrent_file_checks(
+        filenames.iter().copied(),
+        *INTERNAL_CONCURRENCY,
+        |filename| fix_file(hook.project().relative_path(), filename, args.fix),
+    )
     .await
 }
 

--- a/crates/prek/src/hooks/pre_commit_hooks/pretty_format_json.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/pretty_format_json.rs
@@ -11,7 +11,7 @@ use similar::TextDiff;
 
 use crate::hook::Hook;
 use crate::hooks::run_concurrent_file_checks;
-use crate::run::CONCURRENCY;
+use crate::run::INTERNAL_CONCURRENCY;
 
 #[derive(Parser, Debug)]
 #[command(disable_help_subcommand = true)]
@@ -72,9 +72,11 @@ pub(crate) async fn pretty_format_json(hook: &Hook, filenames: &[&Path]) -> Resu
     let args = Args::try_parse_from(hook.entry.expect_direct().split()?.iter().chain(&hook.args))?;
     let prepared = PreparedArgs::from(&args);
 
-    run_concurrent_file_checks(filenames.iter().copied(), *CONCURRENCY, |filename| {
-        check_file(hook.project().relative_path(), filename, &prepared)
-    })
+    run_concurrent_file_checks(
+        filenames.iter().copied(),
+        *INTERNAL_CONCURRENCY,
+        |filename| check_file(hook.project().relative_path(), filename, &prepared),
+    )
     .await
 }
 

--- a/crates/prek/src/languages/pygrep/pygrep.rs
+++ b/crates/prek/src/languages/pygrep/pygrep.rs
@@ -13,7 +13,7 @@ use crate::hook::{Hook, InstallInfo, InstalledHook};
 use crate::languages::LanguageImpl;
 use crate::languages::python::{Uv, python_exec, query_python_info_cached};
 use crate::process::Cmd;
-use crate::run::CONCURRENCY;
+use crate::run::INTERNAL_CONCURRENCY;
 use crate::store::{CacheBucket, Store, ToolBucket};
 
 #[derive(Debug, Default)]
@@ -207,7 +207,7 @@ impl LanguageImpl for Pygrep {
             .arg("-B") // Don't write bytecode.
             .arg(py_script.path())
             .args(args.to_args())
-            .arg(CONCURRENCY.to_string())
+            .arg(INTERNAL_CONCURRENCY.to_string())
             .arg(hook.entry.expect_direct().raw())
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())

--- a/crates/prek/src/languages/ruby/gem.rs
+++ b/crates/prek/src/languages/ruby/gem.rs
@@ -11,7 +11,7 @@ use tracing::debug;
 
 use crate::languages::ruby::installer::RubyResult;
 use crate::process::Cmd;
-use crate::run::CONCURRENCY;
+use crate::run::INTERNAL_CONCURRENCY;
 
 /// Build a `PATH` value with the resolved Ruby's bin directory prepended.
 ///
@@ -115,7 +115,7 @@ fn gem_env<'a>(cmd: &'a mut Cmd, ruby: &RubyResult, gem_home: &Path) -> Result<&
     // Respect existing MAKEFLAGS if set (user may need to limit parallelism
     // in memory-constrained environments like Docker).
     if EnvVars::var_os("MAKEFLAGS").is_none() {
-        cmd.env("MAKEFLAGS", format!("-j{}", *CONCURRENCY));
+        cmd.env("MAKEFLAGS", format!("-j{}", *INTERNAL_CONCURRENCY));
     }
 
     Ok(cmd)
@@ -351,7 +351,7 @@ pub(crate) async fn install_gems(
                         }
                     }
                 })
-                .buffer_unordered(*CONCURRENCY)
+                .buffer_unordered(*INTERNAL_CONCURRENCY)
                 .try_collect::<Vec<()>>()
                 .await;
 

--- a/crates/prek/src/run.rs
+++ b/crates/prek/src/run.rs
@@ -5,7 +5,7 @@ use std::sync::LazyLock;
 
 use anstream::ColorChoice;
 use futures_util::{StreamExt, TryStreamExt};
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use rustc_hash::FxHashMap;
 use tracing::trace;
 
@@ -21,39 +21,43 @@ pub(crate) static USE_COLOR: LazyLock<bool> =
         ColorChoice::Auto => unreachable!(),
     });
 
-fn resolve_concurrency(no_concurrency: bool, max_concurrency: Option<&str>, cpu: usize) -> usize {
-    if no_concurrency {
+fn cpu_count() -> usize {
+    std::thread::available_parallelism()
+        .map(std::num::NonZero::get)
+        .unwrap_or(1)
+}
+
+fn resolve_concurrency(env_vars: &impl EnvVarsRead, primary_env_var: &str) -> usize {
+    if env_vars.is_set(EnvVars::PREK_NO_CONCURRENCY) {
         return 1;
     }
 
-    if let Some(v) = max_concurrency {
-        if let Ok(cap) = v.parse::<usize>() {
+    let primary = env_vars.var(primary_env_var).ok();
+    let legacy_max = env_vars.var(EnvVars::PREK_MAX_CONCURRENCY).ok();
+    let (name, value) = if let Some(primary) = primary.as_deref() {
+        (primary_env_var, Some(primary))
+    } else {
+        (EnvVars::PREK_MAX_CONCURRENCY, legacy_max.as_deref())
+    };
+
+    let cpu = cpu_count();
+    if let Some(value) = value {
+        if let Ok(cap) = value.parse::<usize>() {
             return cap.max(1);
         }
-        warn_user!(
-            "Invalid value for {}: {v:?}, using default ({cpu})",
-            EnvVars::PREK_MAX_CONCURRENCY,
-        );
+        warn_user!("Invalid value for {name}: {value:?}, using default ({cpu})");
     }
 
     cpu
 }
 
-pub(crate) static CONCURRENCY: LazyLock<usize> = LazyLock::new(|| {
-    let cpu = std::thread::available_parallelism()
-        .map(std::num::NonZero::get)
-        .unwrap_or(1);
+pub(crate) static INTERNAL_CONCURRENCY: LazyLock<usize> = LazyLock::new(cpu_count);
 
-    resolve_concurrency(
-        EnvVars::is_set(EnvVars::PREK_NO_CONCURRENCY),
-        EnvVars::var(EnvVars::PREK_MAX_CONCURRENCY).ok().as_deref(),
-        cpu,
-    )
-});
+pub(crate) static HOOK_CONCURRENCY: LazyLock<usize> =
+    LazyLock::new(|| resolve_concurrency(&EnvVars, EnvVars::PREK_CONCURRENT_HOOKS));
 
-fn target_concurrency(serial: bool) -> usize {
-    if serial { 1 } else { *CONCURRENCY }
-}
+pub(crate) static BATCH_CONCURRENCY: LazyLock<usize> =
+    LazyLock::new(|| resolve_concurrency(&EnvVars, EnvVars::PREK_CONCURRENT_BATCHES));
 
 /// Iterator that yields partitions of filenames that fit within the maximum command line length.
 struct Partitions<'a> {
@@ -266,7 +270,11 @@ where
     F: for<'a> AsyncFn(&'a [&'a Path]) -> anyhow::Result<T>,
     T: Send + 'static,
 {
-    let concurrency = target_concurrency(hook.require_serial);
+    let concurrency = if hook.require_serial {
+        1
+    } else {
+        *BATCH_CONCURRENCY
+    };
 
     // Split files into batches
     let partitions = Partitions::split(hook, entry, filenames, concurrency)?;
@@ -291,6 +299,10 @@ where
 mod tests {
     use super::*;
     use std::path::{Path, PathBuf};
+
+    fn resolve_concurrency_from_map(values: &[(&str, &str)], primary_env_var: &str) -> usize {
+        resolve_concurrency(&EnvVars::from_map(values), primary_env_var)
+    }
 
     /// Helper to create a Partitions iterator for testing.
     /// This bypasses the Hook requirement by directly constructing the struct.
@@ -379,42 +391,94 @@ mod tests {
 
     #[test]
     fn test_resolve_concurrency_defaults_to_cpu() {
-        assert_eq!(resolve_concurrency(false, None, 16), 16);
+        assert_eq!(
+            resolve_concurrency_from_map(&[], EnvVars::PREK_CONCURRENT_HOOKS),
+            cpu_count()
+        );
     }
 
     #[test]
-    fn test_resolve_concurrency_max_caps_value() {
-        assert_eq!(resolve_concurrency(false, Some("4"), 16), 4);
+    fn test_resolve_concurrency_uses_configured_limit() {
+        assert_eq!(
+            resolve_concurrency_from_map(
+                &[(EnvVars::PREK_CONCURRENT_HOOKS, "4")],
+                EnvVars::PREK_CONCURRENT_HOOKS,
+            ),
+            4
+        );
     }
 
     #[test]
-    fn test_resolve_concurrency_max_above_cpu() {
-        assert_eq!(resolve_concurrency(false, Some("32"), 8), 32);
+    fn test_resolve_concurrency_allows_above_cpu_limit() {
+        assert_eq!(
+            resolve_concurrency_from_map(
+                &[(EnvVars::PREK_CONCURRENT_HOOKS, "9999")],
+                EnvVars::PREK_CONCURRENT_HOOKS,
+            ),
+            9999
+        );
     }
 
     #[test]
-    fn test_resolve_concurrency_max_zero_floors_to_one() {
-        assert_eq!(resolve_concurrency(false, Some("0"), 16), 1);
+    fn test_resolve_concurrency_zero_floors_to_one() {
+        assert_eq!(
+            resolve_concurrency_from_map(
+                &[(EnvVars::PREK_CONCURRENT_HOOKS, "0")],
+                EnvVars::PREK_CONCURRENT_HOOKS,
+            ),
+            1
+        );
     }
 
     #[test]
-    fn test_resolve_concurrency_max_invalid_falls_back() {
-        assert_eq!(resolve_concurrency(false, Some("abc"), 16), 16);
+    fn test_resolve_concurrency_invalid_falls_back() {
+        assert_eq!(
+            resolve_concurrency_from_map(
+                &[(EnvVars::PREK_CONCURRENT_HOOKS, "abc")],
+                EnvVars::PREK_CONCURRENT_HOOKS,
+            ),
+            cpu_count()
+        );
     }
 
     #[test]
-    fn test_resolve_concurrency_max_empty_falls_back() {
-        assert_eq!(resolve_concurrency(false, Some(""), 16), 16);
+    fn test_resolve_concurrency_no_concurrency_overrides_limits() {
+        assert_eq!(
+            resolve_concurrency_from_map(
+                &[
+                    (EnvVars::PREK_NO_CONCURRENCY, "1"),
+                    (EnvVars::PREK_CONCURRENT_HOOKS, "8"),
+                    (EnvVars::PREK_MAX_CONCURRENCY, "4"),
+                ],
+                EnvVars::PREK_CONCURRENT_HOOKS,
+            ),
+            1
+        );
     }
 
     #[test]
-    fn test_resolve_concurrency_no_concurrency() {
-        assert_eq!(resolve_concurrency(true, None, 16), 1);
+    fn test_resolve_concurrency_uses_legacy_max() {
+        assert_eq!(
+            resolve_concurrency_from_map(
+                &[(EnvVars::PREK_MAX_CONCURRENCY, "4")],
+                EnvVars::PREK_CONCURRENT_HOOKS,
+            ),
+            4
+        );
     }
 
     #[test]
-    fn test_resolve_concurrency_no_concurrency_overrides_max() {
-        assert_eq!(resolve_concurrency(true, Some("8"), 16), 1);
+    fn test_resolve_concurrency_prefers_new_env_over_legacy_max() {
+        assert_eq!(
+            resolve_concurrency_from_map(
+                &[
+                    (EnvVars::PREK_CONCURRENT_BATCHES, "2"),
+                    (EnvVars::PREK_MAX_CONCURRENCY, "4"),
+                ],
+                EnvVars::PREK_CONCURRENT_BATCHES,
+            ),
+            2
+        );
     }
 
     #[test]

--- a/crates/prek/src/store.rs
+++ b/crates/prek/src/store.rs
@@ -14,7 +14,7 @@ use tracing::{debug, warn};
 use crate::config::{RemoteRepo, RemoteRepoKey};
 use crate::fs::{LockedFile, expand_tilde};
 use crate::git::{self, TerminalPrompt};
-use crate::run::CONCURRENCY;
+use crate::run::INTERNAL_CONCURRENCY;
 use crate::warn_user;
 use crate::workspace::{HookInitReporter, WorkspaceCache};
 
@@ -192,7 +192,7 @@ impl Store {
                     }),
                 }
             })
-            .buffer_unordered(*CONCURRENCY);
+            .buffer_unordered(*INTERNAL_CONCURRENCY);
 
         while let Some(result) = tasks.next().await {
             match result? {

--- a/crates/prek/tests/workspace.rs
+++ b/crates/prek/tests/workspace.rs
@@ -200,7 +200,7 @@ fn basic_discovery() -> Result<()> {
 }
 
 #[test]
-fn same_depth_projects_run_concurrently_with_stable_output() -> Result<()> {
+fn same_depth_project_concurrency_has_stable_output() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -230,7 +230,7 @@ fn same_depth_projects_run_concurrently_with_stable_output() -> Result<()> {
 
     let mut run = context.run();
     run.arg("--all-files")
-        .env(EnvVars::PREK_MAX_CONCURRENCY, "2");
+        .env(EnvVars::PREK_CONCURRENT_HOOKS, "2");
     cmd_snapshot!(context.filters(), run, @r#"
     success: true
     exit_code: 0
@@ -311,7 +311,7 @@ fn fail_fast_stops_after_current_project_level() -> Result<()> {
 
     let mut run = context.run();
     run.arg("--all-files")
-        .env(EnvVars::PREK_MAX_CONCURRENCY, "2");
+        .env(EnvVars::PREK_CONCURRENT_HOOKS, "2");
     cmd_snapshot!(context.filters(), run, @r#"
     success: false
     exit_code: 1

--- a/docs/proposals/concurrency.md
+++ b/docs/proposals/concurrency.md
@@ -33,7 +33,7 @@ Execution is driven purely by priority numbers:
 `priority` does **not** apply across *different* `.pre-commit-config.yaml` files (or separate `prek` runs with different configs). Each config file is scheduled independently.
 
 1. **Ordering**: Hooks run from the lowest priority value to the highest.
-2. **Concurrency**: Hooks that share the same priority execute concurrently, subject to the global concurrency limit (default: number of CPUs).
+2. **Concurrency**: Hooks that share the same priority execute concurrently, subject to `PREK_CONCURRENT_HOOKS` (default: number of CPUs).
 3. **Defaults**: Without explicit priorities, each hook receives a unique priority derived from its position, so execution remains sequential and backwards-compatible.
 4. **Conflicts**: If two hooks intentionally share a priority, they will be run in parallel. Users are responsible for assigning priorities that match their desired grouping.
 
@@ -41,7 +41,7 @@ Execution is driven purely by priority numbers:
 
 The existing `require_serial` configuration key often causes confusion. In this design, its meaning is strictly scoped:
 
-- **`require_serial: true`**: Controls **invocation concurrency for that hook**. When running a hook against files, `prek` limits that hook to a single in-flight invocation at a time. This effectively disables running multiple batches of the *same hook* concurrently.
+- **`require_serial: true`**: Controls **batch concurrency for that hook**. A batch is one hook command invocation over a subset of the matched filenames. When running a hook against files, `prek` limits that hook to a single in-flight batch at a time. This effectively disables running multiple batches of the *same hook* concurrently.
     - `prek` will still try to pass all files in one invocation, but may split into multiple invocations if the OS command-line length limit would be exceeded.
 - **It does NOT imply exclusive execution**. A hook with `require_serial: true` can still run in parallel with other hooks that share its `priority`.
 - If a hook *must* run alone (e.g., it modifies global state), it should be assigned a unique priority value that no other hook uses.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1002,7 +1002,7 @@ Controls whether `prek` appends the matching filenames to the command line.
 
 Set `pass_filenames: false` for hooks that don’t accept file arguments (or that discover files themselves).
 
-Set `pass_filenames: n` (a positive integer) to limit each invocation to at most `n` filenames. When there are more matching files than `n`, `prek` splits them across multiple invocations. Those invocations may run concurrently unless [`require_serial`](#require_serial) is `true`. This is useful for tools that can only process a limited number of files at once.
+Set `pass_filenames: n` (a positive integer) to limit each invocation to at most `n` filenames. When there are more matching files than `n`, `prek` splits them across multiple batches. A batch is one hook command invocation over a subset of the matched filenames. Batches may run concurrently up to `PREK_CONCURRENT_BATCHES` unless [`require_serial`](#require_serial) is `true`. This is useful for tools that can only process a limited number of files at once.
 
 Prek will automatically limit the number of filenames to ensure command lines don’t exceed the OS limit, even when `pass_filenames: true`.
 
@@ -1121,7 +1121,7 @@ fails.
 
 ### `require_serial`
 
-Force a hook to run without parallel invocations (one in-flight process for that hook at a time).
+Force a hook to run without parallel batches (one in-flight process for that hook at a time).
 
 - Type: boolean
 - Default: `false`
@@ -1143,7 +1143,7 @@ Scope:
 - `priority` is evaluated **within a single configuration file** and is compared across **all hooks in that file**, even if they appear under different `repos:` entries.
 - `priority` does **not** coordinate across different config files. In workspace mode, each project’s config file is scheduled independently.
 
-Hooks run in ascending priority order: **lower `priority` values run earlier**. Hooks that share the same `priority` value run concurrently, subject to the global concurrency limit.
+Hooks run in ascending priority order: **lower `priority` values run earlier**. Hooks that share the same `priority` value run concurrently, subject to `PREK_CONCURRENT_HOOKS`.
 
 When `priority` is omitted, `prek` assigns an implicit value based on hook order to preserve sequential behavior.
 
@@ -1223,7 +1223,7 @@ Example:
 
 !!! note "`require_serial` is different"
 
-    [`require_serial`](#require_serial) set to `true` prevents concurrent invocations of the *same hook*.
+    [`require_serial`](#require_serial) set to `true` prevents concurrent batches of the *same hook*.
     It does not prevent other hooks from running alongside it; use a unique `priority` if you need exclusivity.
 
 ### `fail_fast`

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -30,15 +30,21 @@ Allow running without a configuration file (useful for ad-hoc runs).
 
 ### `PREK_NO_CONCURRENCY`
 
-Disable parallelism for installs and runs.
-If set, force concurrency to 1.
+Disable hook and batch parallelism during `prek run`.
+If set, force `PREK_CONCURRENT_HOOKS` and `PREK_CONCURRENT_BATCHES` to 1.
 
-### `PREK_MAX_CONCURRENCY`
+### `PREK_CONCURRENT_HOOKS`
 
-Set the maximum number of concurrent hooks (minimum 1).
+Set the maximum number of hooks that can run at once during `prek run` (minimum 1).
 Defaults to the number of CPU cores when unset.
 Ignored when `PREK_NO_CONCURRENCY` is set.
-If you encounter "Too many open files" errors, lowering this value or raising the file descriptor limit with `ulimit -n` can help.
+
+### `PREK_CONCURRENT_BATCHES`
+
+Set the maximum number of batches that each hook can run at once during `prek run` (minimum 1).
+A batch is one hook command invocation over a subset of the matched filenames.
+Defaults to the number of CPU cores when unset.
+Ignored when `PREK_NO_CONCURRENCY` is set.
 
 ### `PREK_NO_FAST_PATH`
 

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -102,7 +102,7 @@ Projects are executed from **deepest to shallowest**:
 
 This ensures that more specific configurations (deeper projects) take precedence over general ones.
 
-Projects at the same depth can run concurrently because the file sets passed to their hooks do not overlap. Concurrency is still bounded by prek's global concurrency limit.
+Projects at the same depth can run concurrently because the file sets passed to their hooks do not overlap. Concurrency is still bounded by `PREK_CONCURRENT_HOOKS`.
 
 This concurrency assumes hooks only operate on their own project state and the files passed to them. Hooks that read from or write to shared resources outside their project directory (for example, sibling project files, shared caches, lockfiles, or other global state) may still contend and should be designed to avoid that.
 


### PR DESCRIPTION
## Summary

- Add explicit `PREK_CONCURRENT_HOOKS` and `PREK_CONCURRENT_BATCHES` controls for `prek run`
- Keep `PREK_MAX_CONCURRENCY` as a legacy alias for batch concurrency
- Keep internal implementation concurrency separate from user-facing run concurrency

Closes #2272