### PR TITLE
Refactor env var handling

### DIFF
--- a/crates/prek-consts/src/env_vars.rs
+++ b/crates/prek-consts/src/env_vars.rs
@@ -17,11 +17,27 @@ pub trait EnvVarsRead {
             None => Err(std::env::VarError::NotPresent),
         }
     }
+
+    fn var_as_bool(&self, name: &str) -> Result<Option<bool>, String> {
+        let Some(val) = self.var_os(name) else {
+            return Ok(None);
+        };
+        let val = val.to_string_lossy();
+        parse_boolish(&val)
+            .map(Some)
+            .ok_or_else(|| val.into_owned())
+    }
 }
 
 impl EnvVarsRead for EnvVars {
     fn var_os(&self, name: &str) -> Option<OsString> {
-        Self::var_os(name)
+        #[allow(clippy::disallowed_methods)]
+        std::env::var_os(name).or_else(|| {
+            let name = EnvVars::pre_commit_name(name)?;
+            let val = std::env::var_os(name)?;
+            info!("Falling back to pre-commit environment variable for {name}");
+            Some(val)
+        })
     }
 }
 
@@ -189,66 +205,9 @@ impl EnvVars {
 }
 
 impl EnvVars {
-    /// Read an environment variable, falling back to pre-commit corresponding variable if not found.
-    pub fn var_os(name: &str) -> Option<OsString> {
-        #[allow(clippy::disallowed_methods)]
-        std::env::var_os(name).or_else(|| {
-            let name = Self::pre_commit_name(name)?;
-            let val = std::env::var_os(name)?;
-            info!("Falling back to pre-commit environment variable for {name}");
-            Some(val)
-        })
-    }
-
-    pub fn is_set(name: &str) -> bool {
-        Self::var_os(name).is_some()
-    }
-
     /// Return whether the current process is running under CI.
     pub fn is_under_ci() -> bool {
-        Self::is_set(Self::CI)
-    }
-
-    /// Read an environment variable, falling back to pre-commit corresponding variable if not found.
-    pub fn var(name: &str) -> Result<String, std::env::VarError> {
-        match Self::var_os(name) {
-            Some(s) => s.into_string().map_err(std::env::VarError::NotUnicode),
-            None => Err(std::env::VarError::NotPresent),
-        }
-    }
-
-    /// Read an environment var and parse as bool.
-    pub fn var_as_bool(name: &str) -> Option<bool> {
-        if let Some(val) = EnvVars::var_os(name)
-            && let Some(val) = val.to_str()
-            && let Some(val) = EnvVars::parse_boolish(val)
-        {
-            Some(val)
-        } else {
-            None
-        }
-    }
-
-    /// Parse a boolean from a string.
-    ///
-    /// Adapted from Clap's `BoolishValueParser` which is dual licensed under the MIT and Apache-2.0.
-    /// See `clap_builder/src/util/str_to_bool.rs`
-    fn parse_boolish(val: &str) -> Option<bool> {
-        // True values are `y`, `yes`, `t`, `true`, `on`, and `1`.
-        const TRUE_LITERALS: [&str; 6] = ["y", "yes", "t", "true", "on", "1"];
-
-        // False values are `n`, `no`, `f`, `false`, `off`, and `0`.
-        const FALSE_LITERALS: [&str; 6] = ["n", "no", "f", "false", "off", "0"];
-
-        let val = val.to_lowercase();
-        let pat = val.as_str();
-        if TRUE_LITERALS.contains(&pat) {
-            Some(true)
-        } else if FALSE_LITERALS.contains(&pat) {
-            Some(false)
-        } else {
-            None
-        }
+        EnvVars.is_set(Self::CI)
     }
 
     fn pre_commit_name(name: &str) -> Option<&str> {
@@ -260,48 +219,87 @@ impl EnvVars {
     }
 }
 
+/// Parse a boolean from a string.
+///
+/// Adapted from Clap's `BoolishValueParser` which is dual licensed under the MIT and Apache-2.0.
+/// See `clap_builder/src/util/str_to_bool.rs`
+fn parse_boolish(val: &str) -> Option<bool> {
+    // True values are `y`, `yes`, `t`, `true`, `on`, and `1`.
+    const TRUE_LITERALS: [&str; 6] = ["y", "yes", "t", "true", "on", "1"];
+
+    // False values are `n`, `no`, `f`, `false`, `off`, and `0`.
+    const FALSE_LITERALS: [&str; 6] = ["n", "no", "f", "false", "off", "0"];
+
+    let val = val.to_lowercase();
+    let pat = val.as_str();
+    if TRUE_LITERALS.contains(&pat) {
+        Some(true)
+    } else if FALSE_LITERALS.contains(&pat) {
+        Some(false)
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{EnvVars, EnvVarsRead};
+    use super::{EnvVars, EnvVarsRead, parse_boolish};
 
     #[test]
     fn test_parse_boolish() {
         let true_values = ["y", "yes", "t", "true", "on", "1"];
         let false_values = ["n", "no", "f", "false", "off", "0"];
         for val in true_values {
-            assert_eq!(EnvVars::parse_boolish(val), Some(true),);
-            assert_eq!(EnvVars::parse_boolish(&val.to_uppercase()), Some(true),);
+            assert_eq!(parse_boolish(val), Some(true),);
+            assert_eq!(parse_boolish(&val.to_uppercase()), Some(true),);
         }
         for val in false_values {
-            assert_eq!(EnvVars::parse_boolish(val), Some(false),);
-            assert_eq!(EnvVars::parse_boolish(&val.to_uppercase()), Some(false),);
+            assert_eq!(parse_boolish(val), Some(false),);
+            assert_eq!(parse_boolish(&val.to_uppercase()), Some(false),);
         }
-        assert_eq!(EnvVars::parse_boolish("maybe"), None);
-        assert_eq!(EnvVars::parse_boolish(""), None);
-        assert_eq!(EnvVars::parse_boolish("123"), None);
+        assert_eq!(parse_boolish("maybe"), None);
+        assert_eq!(parse_boolish(""), None);
+        assert_eq!(parse_boolish("123"), None);
     }
 
     #[test]
-    fn test_env_vars_map_reads_values() {
+    fn test_env_vars_read_helpers() {
         let env_vars = EnvVars::from_map(&[(EnvVars::PREK_COLOR, "never")]);
-
         assert_eq!(env_vars.var(EnvVars::PREK_COLOR).unwrap(), "never");
-    }
+        assert!(env_vars.is_set(EnvVars::PREK_COLOR));
 
-    #[test]
-    fn test_env_vars_map_falls_back_to_pre_commit_name() {
+        let env_vars = EnvVars::from_map(&[]);
+        assert!(matches!(
+            env_vars.var(EnvVars::PREK_COLOR),
+            Err(std::env::VarError::NotPresent)
+        ));
+        assert!(!env_vars.is_set(EnvVars::PREK_COLOR));
+
         let env_vars = EnvVars::from_map(&[(EnvVars::PRE_COMMIT_NO_CONCURRENCY, "1")]);
-
         assert_eq!(env_vars.var(EnvVars::PREK_NO_CONCURRENCY).unwrap(), "1");
-    }
 
-    #[test]
-    fn test_env_vars_map_prefers_prek_name_over_pre_commit_name() {
         let env_vars = EnvVars::from_map(&[
             (EnvVars::PREK_NO_CONCURRENCY, "prek"),
             (EnvVars::PRE_COMMIT_NO_CONCURRENCY, "pre-commit"),
         ]);
-
         assert_eq!(env_vars.var(EnvVars::PREK_NO_CONCURRENCY).unwrap(), "prek");
+
+        let env_vars = EnvVars::from_map(&[
+            (EnvVars::PREK_DOCKER_NO_INIT, "yes"),
+            (EnvVars::PREK_NATIVE_TLS, "0"),
+            (EnvVars::PREK_ALLOW_NO_CONFIG, "maybe"),
+        ]);
+        assert_eq!(
+            env_vars.var_as_bool(EnvVars::PREK_DOCKER_NO_INIT),
+            Ok(Some(true))
+        );
+        assert_eq!(
+            env_vars.var_as_bool(EnvVars::PREK_NATIVE_TLS),
+            Ok(Some(false))
+        );
+        assert_eq!(
+            env_vars.var_as_bool(EnvVars::PREK_ALLOW_NO_CONFIG),
+            Err("maybe".to_string())
+        );
     }
 }

--- a/crates/prek-consts/src/lib.rs
+++ b/crates/prek-consts/src/lib.rs
@@ -3,7 +3,7 @@ pub mod env_vars;
 use std::ffi::OsString;
 use std::path::Path;
 
-use env_vars::EnvVars;
+use env_vars::{EnvVars, EnvVarsRead};
 
 pub const PRE_COMMIT_CONFIG_YAML: &str = ".pre-commit-config.yaml";
 pub const PRE_COMMIT_CONFIG_YML: &str = ".pre-commit-config.yml";
@@ -18,7 +18,8 @@ pub const CONFIG_FILENAMES: &[&str] = &[PREK_TOML, PRE_COMMIT_CONFIG_YAML, PRE_C
 pub fn prepend_paths(paths: &[&Path]) -> Result<OsString, std::env::JoinPathsError> {
     std::env::join_paths(
         paths.iter().map(|p| p.to_path_buf()).chain(
-            EnvVars::var_os(EnvVars::PATH)
+            EnvVars
+                .var_os(EnvVars::PATH)
                 .as_ref()
                 .iter()
                 .flat_map(std::env::split_paths),

--- a/crates/prek/src/cli/hook_impl.rs
+++ b/crates/prek/src/cli/hook_impl.rs
@@ -8,7 +8,7 @@ use anstream::eprintln;
 use anyhow::Result;
 use itertools::Itertools;
 use owo_colors::OwoColorize;
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::cli::{self, ExitStatus, RunOptions, flag};
@@ -48,7 +48,7 @@ pub(crate) async fn hook_impl(
     }
 
     let allow_missing_config =
-        skip_on_missing_config || EnvVars::is_set(EnvVars::PREK_ALLOW_NO_CONFIG);
+        skip_on_missing_config || EnvVars.is_set(EnvVars::PREK_ALLOW_NO_CONFIG);
     let warn_for_no_config = || {
         eprintln!(
             "- To temporarily silence this, run `{}`",
@@ -182,7 +182,7 @@ async fn run_legacy(
     args: &[OsString],
     stdin: &[u8],
 ) -> Result<u8> {
-    if EnvVars::is_set(EnvVars::PREK_RUNNING_LEGACY) {
+    if EnvVars.is_set(EnvVars::PREK_RUNNING_LEGACY) {
         anyhow::bail!(
             "prek's Git shim is installed in migration mode\n\
             run `prek install -f --hook-type {hook_type}` to reinstall the shim"

--- a/crates/prek/src/cli/mod.rs
+++ b/crates/prek/src/cli/mod.rs
@@ -1005,7 +1005,7 @@ mod _gen {
     use anyhow::{Result, bail};
     use clap::{Command, CommandFactory};
     use itertools::Itertools;
-    use prek_consts::env_vars::EnvVars;
+    use prek_consts::env_vars::{EnvVars, EnvVarsRead};
     use pretty_assertions::StrComparison;
     use std::cmp::max;
     use std::path::PathBuf;
@@ -1283,7 +1283,7 @@ mod _gen {
 
     #[test]
     fn generate_cli_reference() -> Result<()> {
-        let mode = if EnvVars::is_set(EnvVars::PREK_GENERATE) {
+        let mode = if EnvVars.is_set(EnvVars::PREK_GENERATE) {
             Mode::Write
         } else {
             Mode::Check

--- a/crates/prek/src/cli/run/filter.rs
+++ b/crates/prek/src/cli/run/filter.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use itertools::{Either, Itertools};
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use prek_identify::{TagSet, tags_from_path};
 use rustc_hash::FxHashSet;
 use tracing::{debug, error, instrument};
@@ -458,7 +458,7 @@ pub(crate) async fn collect_run_input(root: &Path, opts: CollectOptions) -> Resu
         .collect::<Vec<_>>();
 
     // Sort filenames if in tests to make the order consistent.
-    if EnvVars::is_set(EnvVars::PREK_INTERNAL__SORT_FILENAMES) {
+    if EnvVars.is_set(EnvVars::PREK_INTERNAL__SORT_FILENAMES) {
         filenames.sort_unstable();
     }
 

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Result};
 use futures_util::stream::{FuturesUnordered, StreamExt};
 use mea::semaphore::Semaphore;
 use owo_colors::OwoColorize;
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use prek_consts::{PRE_COMMIT_CONFIG_YAML, PREK_TOML};
 use prek_identify::{TagSet, tags_from_path};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
@@ -68,7 +68,7 @@ pub(crate) async fn run(
 
     // Prevent recursive post-checkout hooks.
     if hook_stage == Some(Stage::PostCheckout)
-        && EnvVars::is_set(EnvVars::PREK_INTERNAL__SKIP_POST_CHECKOUT)
+        && EnvVars.is_set(EnvVars::PREK_INTERNAL__SKIP_POST_CHECKOUT)
     {
         return Ok(ExitStatus::Success);
     }

--- a/crates/prek/src/cli/run/selector.rs
+++ b/crates/prek/src/cli/run/selector.rs
@@ -9,7 +9,8 @@ use crate::warn_user;
 
 use anyhow::anyhow;
 use itertools::Itertools;
-use prek_consts::env_vars::EnvVars;
+use owo_colors::OwoColorize;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use rustc_hash::FxHashSet;
 use tracing::trace;
 
@@ -724,8 +725,8 @@ pub(crate) fn load_skips<FS: FileSystem>(
     workspace_root: &Path,
     fs: FS,
 ) -> Result<Vec<Selector>, Error> {
-    let prek_skip = EnvVars::var(EnvVars::PREK_SKIP);
-    let skip = EnvVars::var(EnvVars::SKIP);
+    let prek_skip = EnvVars.var(EnvVars::PREK_SKIP);
+    let skip = EnvVars.var(EnvVars::SKIP);
 
     let (skips, source) = if !cli_skips.is_empty() {
         (

--- a/crates/prek/src/config.rs
+++ b/crates/prek/src/config.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use fancy_regex::Regex;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use itertools::Itertools;
+use owo_colors::OwoColorize;
 use prek_identify::TagSet;
 use rustc_hash::FxHashMap;
 use serde::de::{DeserializeSeed, Error as DeError, MapAccess, Visitor};

--- a/crates/prek/src/fs.rs
+++ b/crates/prek/src/fs.rs
@@ -32,8 +32,6 @@ use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 use tracing::{debug, error, info, trace};
 
-use crate::cli::reporter;
-
 pub static CWD: LazyLock<PathBuf> = LazyLock::new(|| {
     std::env::current_dir()
         .map(|cwd| dunce::canonicalize(&cwd).unwrap_or(cwd))
@@ -156,20 +154,18 @@ impl LockedFile {
                 };
 
                 if !held_by_this_process {
-                    reporter::suspend(move || {
-                        #[cfg(test)]
-                        {
-                            LOCK_WARNING_PATHS.lock().unwrap().insert(warning_path);
-                        }
+                    #[cfg(test)]
+                    {
+                        LOCK_WARNING_PATHS.lock().unwrap().insert(warning_path);
+                    }
 
-                        #[cfg(not(test))]
-                        {
-                            crate::warn_user!(
-                                "Waiting to acquire lock at `{}`. Another prek process may still be running",
-                                warning_path.display()
-                            );
-                        }
-                    });
+                    #[cfg(not(test))]
+                    {
+                        crate::warn_user!(
+                            "Waiting to acquire lock at `{}`. Another prek process may still be running",
+                            warning_path.display()
+                        );
+                    }
                 }
 
                 task.await??

--- a/crates/prek/src/hooks/mod.rs
+++ b/crates/prek/src/hooks/mod.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::str::FromStr;
 use std::sync::LazyLock;
 
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 
 use crate::cli::run::HookRunReporter;
 use crate::hook::{Hook, Repo};
@@ -16,7 +16,7 @@ mod builtin_hooks;
 mod meta_hooks;
 mod pre_commit_hooks;
 
-static NO_FAST_PATH: LazyLock<bool> = LazyLock::new(|| EnvVars::is_set(EnvVars::PREK_NO_FAST_PATH));
+static NO_FAST_PATH: LazyLock<bool> = LazyLock::new(|| EnvVars.is_set(EnvVars::PREK_NO_FAST_PATH));
 
 /// Returns true if the hook has a builtin Rust implementation.
 pub fn check_fast_path(hook: &Hook) -> bool {

--- a/crates/prek/src/hooks/pre_commit_hooks/forbid_new_submodules.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/forbid_new_submodules.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::fmt::Write;
 use std::path::Path;
 
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 
 use crate::git;
 use crate::hook::Hook;
@@ -12,8 +12,8 @@ pub(crate) async fn forbid_new_submodules(
     filenames: &[&Path],
 ) -> Result<(i32, Vec<u8>), anyhow::Error> {
     let diff_arg = if let (Ok(from_ref), Ok(to_ref)) = (
-        EnvVars::var("PRE_COMMIT_FROM_REF"),
-        EnvVars::var("PRE_COMMIT_TO_REF"),
+        EnvVars.var("PRE_COMMIT_FROM_REF"),
+        EnvVars.var("PRE_COMMIT_TO_REF"),
     ) {
         Cow::Owned(format!("{from_ref}...{to_ref}"))
     } else {

--- a/crates/prek/src/http.rs
+++ b/crates/prek/src/http.rs
@@ -4,7 +4,8 @@ use std::sync::LazyLock;
 
 use anyhow::{Context, Result, bail};
 use futures_util::TryStreamExt;
-use prek_consts::env_vars::EnvVars;
+use owo_colors::OwoColorize;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use reqwest::Certificate;
 use tokio::io::AsyncWriteExt;
 use tokio_util::io::StreamReader;
@@ -15,7 +16,7 @@ use crate::fs::Simplified;
 use crate::store::Store;
 use crate::warn_user;
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Default, strum::EnumString)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default, strum::AsRefStr, strum::EnumString)]
 #[strum(serialize_all = "kebab-case")]
 pub(crate) enum DownloadChecksumPolicy {
     #[default]
@@ -25,15 +26,18 @@ pub(crate) enum DownloadChecksumPolicy {
 }
 
 impl DownloadChecksumPolicy {
-    pub(crate) fn from_env() -> Result<Self> {
-        match EnvVars::var(EnvVars::PREK_DOWNLOAD_CHECKSUM_POLICY) {
-            Ok(value) => Self::from_str(&value).with_context(|| {
-                format!(
-                    "Invalid {} value `{value}`; expected one of: warn-missing, required, disabled",
-                    EnvVars::PREK_DOWNLOAD_CHECKSUM_POLICY
-                )
+    pub(crate) fn from_env(env_vars: &impl EnvVarsRead) -> Self {
+        match env_vars.var(EnvVars::PREK_DOWNLOAD_CHECKSUM_POLICY) {
+            Ok(value) => Self::from_str(&value).unwrap_or_else(|_| {
+                warn_user!(
+                    "Invalid value for {}: {:?}. Expected warn-missing, required, or disabled; using default ({:?})",
+                    EnvVars::PREK_DOWNLOAD_CHECKSUM_POLICY,
+                    value,
+                    Self::default().as_ref(),
+                );
+                Self::default()
             }),
-            Err(_) => Ok(Self::default()),
+            Err(_) => Self::default(),
         }
     }
 }
@@ -59,7 +63,7 @@ pub(crate) async fn download_artifact(
         url,
         filename,
         store,
-        DownloadChecksumPolicy::from_env()?,
+        DownloadChecksumPolicy::from_env(&EnvVars),
         fetch_checksum,
         |req| req,
     )
@@ -139,11 +143,25 @@ async fn download_to_temp_file(
     ))
 }
 
-pub(crate) static REQWEST_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
-    let native_tls = EnvVars::var_as_bool(EnvVars::PREK_NATIVE_TLS).unwrap_or(false);
+pub(crate) static REQWEST_CLIENT: LazyLock<reqwest::Client> =
+    LazyLock::new(|| reqwest_client_from_env(&EnvVars));
 
-    let cert_file = EnvVars::var_os(EnvVars::SSL_CERT_FILE).map(PathBuf::from);
-    let cert_dirs: Vec<_> = if let Some(cert_dirs) = EnvVars::var_os(EnvVars::SSL_CERT_DIR) {
+fn reqwest_client_from_env(env_vars: &impl EnvVarsRead) -> reqwest::Client {
+    let native_tls = env_vars
+        .var_as_bool(EnvVars::PREK_NATIVE_TLS)
+        .unwrap_or_else(|value| {
+            warn_user!(
+                "Invalid value for {}: {:?}. Expected a boolean value; using default ({:?})",
+                EnvVars::PREK_NATIVE_TLS,
+                value,
+                "false",
+            );
+            Some(false)
+        })
+        .unwrap_or(false);
+
+    let cert_file = env_vars.var_os(EnvVars::SSL_CERT_FILE).map(PathBuf::from);
+    let cert_dirs: Vec<_> = if let Some(cert_dirs) = env_vars.var_os(EnvVars::SSL_CERT_DIR) {
         std::env::split_paths(&cert_dirs).collect()
     } else {
         vec![]
@@ -151,7 +169,7 @@ pub(crate) static REQWEST_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
 
     let certs = load_certs_from_paths(cert_file.as_deref(), &cert_dirs);
     create_reqwest_client(native_tls, certs)
-});
+}
 
 fn load_pem_certs_from_file(path: &Path) -> Result<Vec<Certificate>> {
     let cert_data = fs_err::read(path)?;
@@ -250,12 +268,15 @@ mod tests {
     use std::str::FromStr;
 
     use anyhow::Result;
+    use prek_consts::env_vars::EnvVars;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
     use tokio::task::JoinHandle;
 
     use crate::checksum::Sha256Digest;
     use crate::store::Store;
+
+    use super::DownloadChecksumPolicy;
 
     const DATA_SHA256: &str = "3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7";
     const EMPTY_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
@@ -328,6 +349,35 @@ YyRIHN8wfdVoOw==
         });
 
         Ok((url, handle))
+    }
+
+    #[test]
+    fn download_checksum_policy_reads_env() {
+        assert_eq!(
+            DownloadChecksumPolicy::from_env(&EnvVars::from_map(&[])),
+            DownloadChecksumPolicy::WarnMissing
+        );
+        assert_eq!(
+            DownloadChecksumPolicy::from_env(&EnvVars::from_map(&[(
+                EnvVars::PREK_DOWNLOAD_CHECKSUM_POLICY,
+                "required",
+            )])),
+            DownloadChecksumPolicy::Required
+        );
+        assert_eq!(
+            DownloadChecksumPolicy::from_env(&EnvVars::from_map(&[(
+                EnvVars::PREK_DOWNLOAD_CHECKSUM_POLICY,
+                "disabled",
+            )])),
+            DownloadChecksumPolicy::Disabled
+        );
+        assert_eq!(
+            DownloadChecksumPolicy::from_env(&EnvVars::from_map(&[(
+                EnvVars::PREK_DOWNLOAD_CHECKSUM_POLICY,
+                "always",
+            )])),
+            DownloadChecksumPolicy::WarnMissing
+        );
     }
 
     #[test]

--- a/crates/prek/src/languages/bun/installer.rs
+++ b/crates/prek/src/languages/bun/installer.rs
@@ -6,7 +6,7 @@ use std::sync::LazyLock;
 
 use anyhow::{Context, Result};
 use itertools::Itertools;
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use target_lexicon::{Architecture, HOST, OperatingSystem};
 use tracing::{debug, trace, warn};
 
@@ -35,7 +35,7 @@ impl Display for BunResult {
 
 /// Override the Bun binary name for testing.
 static BUN_BINARY_NAME: LazyLock<String> = LazyLock::new(|| {
-    if let Ok(name) = EnvVars::var(EnvVars::PREK_INTERNAL__BUN_BINARY_NAME) {
+    if let Ok(name) = EnvVars.var(EnvVars::PREK_INTERNAL__BUN_BINARY_NAME) {
         name
     } else {
         "bun".to_string()

--- a/crates/prek/src/languages/conda.rs
+++ b/crates/prek/src/languages/conda.rs
@@ -3,7 +3,7 @@ use std::process::Stdio;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use prek_consts::prepend_paths;
 use tracing::debug;
 
@@ -143,9 +143,9 @@ impl LanguageImpl for Conda {
 }
 
 fn conda_executable() -> &'static str {
-    if EnvVars::is_set(EnvVars::PRE_COMMIT_USE_MICROMAMBA) {
+    if EnvVars.is_set(EnvVars::PRE_COMMIT_USE_MICROMAMBA) {
         "micromamba"
-    } else if EnvVars::is_set(EnvVars::PRE_COMMIT_USE_MAMBA) {
+    } else if EnvVars.is_set(EnvVars::PRE_COMMIT_USE_MAMBA) {
         "mamba"
     } else {
         "conda"

--- a/crates/prek/src/languages/deno/installer.rs
+++ b/crates/prek/src/languages/deno/installer.rs
@@ -6,7 +6,7 @@ use std::sync::LazyLock;
 
 use anyhow::{Context, Result};
 use itertools::Itertools;
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use serde::Deserialize;
 use target_lexicon::{Architecture, HOST, OperatingSystem};
 use tracing::{debug, trace, warn};
@@ -35,7 +35,7 @@ impl Display for DenoResult {
 
 /// Override the Deno binary name for testing.
 static DENO_BINARY_NAME: LazyLock<String> = LazyLock::new(|| {
-    if let Ok(name) = EnvVars::var(EnvVars::PREK_INTERNAL__DENO_BINARY_NAME) {
+    if let Ok(name) = EnvVars.var(EnvVars::PREK_INTERNAL__DENO_BINARY_NAME) {
         name
     } else {
         "deno".to_string()

--- a/crates/prek/src/languages/docker.rs
+++ b/crates/prek/src/languages/docker.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 use std::sync::{Arc, LazyLock};
 
 use anyhow::{Context, Result};
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use regex::Regex;
 use tracing::{trace, warn};
 
@@ -19,6 +19,7 @@ use crate::languages::LanguageImpl;
 use crate::process::Cmd;
 use crate::run::{USE_COLOR, run_by_batch};
 use crate::store::Store;
+use crate::warn_user;
 
 static CGROUP_V2_CONTAINER_ID_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r".*/(containers|overlay-containers)/([0-9a-f]{64})/.*")
@@ -217,7 +218,7 @@ impl ContainerRuntimeInfo {
     /// Detect container runtime provider, prioritise docker over podman if
     /// both are on the path, unless `PREK_CONTAINER_RUNTIME` is set to override detection.
     fn resolve_runtime_kind<DF, PF, CF>(
-        env_override: Option<String>,
+        env_vars: &impl EnvVarsRead,
         docker_available: DF,
         podman_available: PF,
         apple_container_available: CF,
@@ -227,25 +228,23 @@ impl ContainerRuntimeInfo {
         PF: Fn() -> bool,
         CF: Fn() -> bool,
     {
-        if let Some(val) = env_override {
-            match RuntimeKind::from_str(&val) {
-                Ok(runtime) => {
-                    if runtime != RuntimeKind::Auto {
-                        trace!(
-                            "Container runtime overridden by {}={}",
-                            EnvVars::PREK_CONTAINER_RUNTIME,
-                            val
-                        );
-                        return runtime;
-                    }
-                }
-                Err(_) => {
-                    warn!(
-                        "Invalid value for {}: {}, falling back to auto detection",
+        if let Ok(val) = env_vars.var(EnvVars::PREK_CONTAINER_RUNTIME) {
+            if let Ok(runtime) = RuntimeKind::from_str(&val) {
+                if runtime != RuntimeKind::Auto {
+                    trace!(
+                        "Container runtime overridden by {}={}",
                         EnvVars::PREK_CONTAINER_RUNTIME,
                         val
                     );
+                    return runtime;
                 }
+            } else {
+                warn_user!(
+                    "Invalid value for {}: {:?}. Expected container, docker, podman, or auto; using default ({:?})",
+                    EnvVars::PREK_CONTAINER_RUNTIME,
+                    val,
+                    "auto",
+                );
             }
         }
 
@@ -265,7 +264,7 @@ impl ContainerRuntimeInfo {
 
     fn detect_runtime() -> Self {
         let runtime = Self::resolve_runtime_kind(
-            EnvVars::var(EnvVars::PREK_CONTAINER_RUNTIME).ok(),
+            &EnvVars,
             || which::which("docker").is_ok(),
             || which::which("podman").is_ok(),
             || which::which("container").is_ok(),
@@ -371,6 +370,10 @@ impl Docker {
     }
 
     pub(crate) fn docker_run_cmd(work_dir: &Path) -> Cmd {
+        Self::docker_run_cmd_with_env(work_dir, &EnvVars)
+    }
+
+    fn docker_run_cmd_with_env(work_dir: &Path, env_vars: &impl EnvVarsRead) -> Cmd {
         let mut command = Cmd::new(CONTAINER_RUNTIME.cmd());
         command.arg("run").arg("--rm");
 
@@ -408,7 +411,7 @@ impl Docker {
         let work_dir = CONTAINER_RUNTIME.map_to_host_path(work_dir);
         let volume = format!("{}:/src:rw,Z", work_dir.display());
 
-        if !EnvVars::var_as_bool(EnvVars::PREK_DOCKER_NO_INIT).unwrap_or(false) {
+        if Self::should_add_init(env_vars) {
             // Run an init inside the container that forwards signals and reaps processes
             command.arg("--init");
         }
@@ -419,6 +422,22 @@ impl Docker {
             .arg("/src");
 
         command
+    }
+
+    fn should_add_init(env_vars: &impl EnvVarsRead) -> bool {
+        let no_init = env_vars
+            .var_as_bool(EnvVars::PREK_DOCKER_NO_INIT)
+            .unwrap_or_else(|value| {
+                warn_user!(
+                    "Invalid value for {}: {:?}. Expected a boolean value; using default ({:?})",
+                    EnvVars::PREK_DOCKER_NO_INIT,
+                    value,
+                    "false",
+                );
+                Some(false)
+            })
+            .unwrap_or(false);
+        !no_init
     }
 }
 
@@ -690,76 +709,104 @@ mod tests {
     #[test]
     fn test_detect_container_runtime() {
         fn runtime_with(
-            env_override: Option<&str>,
+            env_vars: &[(&str, &str)],
             docker_available: bool,
             podman_available: bool,
             apple_container_available: bool,
         ) -> RuntimeKind {
             ContainerRuntimeInfo::resolve_runtime_kind(
-                env_override.map(ToString::to_string),
+                &EnvVars::from_map(env_vars),
                 || docker_available,
                 || podman_available,
                 || apple_container_available,
             )
         }
 
-        assert_eq!(runtime_with(None, true, false, false), RuntimeKind::Docker);
-        assert_eq!(runtime_with(None, false, true, false), RuntimeKind::Podman);
+        fn runtime_with_override(
+            env_override: &str,
+            docker_available: bool,
+            podman_available: bool,
+            apple_container_available: bool,
+        ) -> RuntimeKind {
+            runtime_with(
+                &[(EnvVars::PREK_CONTAINER_RUNTIME, env_override)],
+                docker_available,
+                podman_available,
+                apple_container_available,
+            )
+        }
+
+        assert_eq!(runtime_with(&[], true, false, false), RuntimeKind::Docker);
+        assert_eq!(runtime_with(&[], false, true, false), RuntimeKind::Podman);
         assert_eq!(
-            runtime_with(None, false, false, true),
+            runtime_with(&[], false, false, true),
             RuntimeKind::AppleContainer
         );
-        assert_eq!(runtime_with(None, false, false, false), RuntimeKind::Docker);
+        assert_eq!(runtime_with(&[], false, false, false), RuntimeKind::Docker);
 
         assert_eq!(
-            runtime_with(Some("auto"), true, false, false),
+            runtime_with_override("auto", true, false, false),
             RuntimeKind::Docker
         );
         assert_eq!(
-            runtime_with(Some("auto"), false, true, false),
+            runtime_with_override("auto", false, true, false),
             RuntimeKind::Podman
         );
         assert_eq!(
-            runtime_with(Some("auto"), false, false, true),
+            runtime_with_override("auto", false, false, true),
             RuntimeKind::AppleContainer
         );
         assert_eq!(
-            runtime_with(Some("auto"), false, false, false),
+            runtime_with_override("auto", false, false, false),
             RuntimeKind::Docker
-        );
-
-        assert_eq!(
-            runtime_with(Some("docker"), true, false, false),
-            RuntimeKind::Docker
-        );
-        assert_eq!(
-            runtime_with(Some("docker"), false, true, false),
-            RuntimeKind::Docker
-        );
-        assert_eq!(
-            runtime_with(Some("DOCKER"), false, false, false),
-            RuntimeKind::Docker
-        );
-        assert_eq!(
-            runtime_with(Some("podman"), true, false, false),
-            RuntimeKind::Podman
-        );
-        assert_eq!(
-            runtime_with(Some("podman"), false, true, false),
-            RuntimeKind::Podman
-        );
-        assert_eq!(
-            runtime_with(Some("podman"), false, false, false),
-            RuntimeKind::Podman
-        );
-        assert_eq!(
-            runtime_with(Some("container"), true, true, false),
-            RuntimeKind::AppleContainer
         );
 
         assert_eq!(
-            runtime_with(Some("invalid"), false, false, false),
+            runtime_with_override("docker", true, false, false),
             RuntimeKind::Docker
         );
+        assert_eq!(
+            runtime_with_override("docker", false, true, false),
+            RuntimeKind::Docker
+        );
+        assert_eq!(
+            runtime_with_override("DOCKER", false, false, false),
+            RuntimeKind::Docker
+        );
+        assert_eq!(
+            runtime_with_override("podman", true, false, false),
+            RuntimeKind::Podman
+        );
+        assert_eq!(
+            runtime_with_override("podman", false, true, false),
+            RuntimeKind::Podman
+        );
+        assert_eq!(
+            runtime_with_override("podman", false, false, false),
+            RuntimeKind::Podman
+        );
+        assert_eq!(
+            runtime_with_override("container", true, true, false),
+            RuntimeKind::AppleContainer
+        );
+
+        assert_eq!(
+            runtime_with_override("invalid", false, false, false),
+            RuntimeKind::Docker
+        );
+
+        assert!(Docker::should_add_init(&EnvVars::from_map(&[])));
+        assert!(!Docker::should_add_init(&EnvVars::from_map(&[(
+            EnvVars::PREK_DOCKER_NO_INIT,
+            "1",
+        )])));
+        assert!(Docker::should_add_init(&EnvVars::from_map(&[(
+            EnvVars::PREK_DOCKER_NO_INIT,
+            "0",
+        )])));
+        assert!(Docker::should_add_init(&EnvVars::from_map(&[(
+            EnvVars::PREK_DOCKER_NO_INIT,
+            "maybe",
+        )])));
     }
 }

--- a/crates/prek/src/languages/dotnet/installer.rs
+++ b/crates/prek/src/languages/dotnet/installer.rs
@@ -6,7 +6,7 @@ use std::sync::LazyLock;
 
 use anyhow::{Context, Result, bail};
 use itertools::Itertools;
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use tracing::{debug, trace, warn};
 
 use super::version::DotnetVersion;
@@ -16,7 +16,7 @@ use crate::languages::dotnet::DotnetRequest;
 use crate::process::Cmd;
 
 static DOTNET_BINARY_NAME: LazyLock<String> = LazyLock::new(|| {
-    if let Ok(name) = EnvVars::var(EnvVars::PREK_INTERNAL__DOTNET_BINARY_NAME) {
+    if let Ok(name) = EnvVars.var(EnvVars::PREK_INTERNAL__DOTNET_BINARY_NAME) {
         name
     } else {
         "dotnet".to_string()

--- a/crates/prek/src/languages/golang/installer.rs
+++ b/crates/prek/src/languages/golang/installer.rs
@@ -6,7 +6,7 @@ use std::sync::LazyLock;
 
 use anyhow::{Context, Result};
 use itertools::Itertools;
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use serde::Deserialize;
 use target_lexicon::{Architecture, HOST, OperatingSystem};
 use tracing::{debug, trace, warn};
@@ -37,7 +37,7 @@ impl Display for GoResult {
 
 /// Override the Go binary name for testing.
 static GO_BINARY_NAME: LazyLock<String> = LazyLock::new(|| {
-    if let Ok(name) = EnvVars::var(EnvVars::PREK_INTERNAL__GO_BINARY_NAME) {
+    if let Ok(name) = EnvVars.var(EnvVars::PREK_INTERNAL__GO_BINARY_NAME) {
         name
     } else {
         "go".to_string()

--- a/crates/prek/src/languages/haskell.rs
+++ b/crates/prek/src/languages/haskell.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, LazyLock};
 
 use anyhow::{Context, Result};
 use mea::once::OnceCell;
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use prek_consts::prepend_paths;
 use tracing::debug;
 
@@ -17,8 +17,11 @@ use crate::run::run_by_batch;
 use crate::store::Store;
 
 static CABAL_UPDATE_ONCE: OnceCell<()> = OnceCell::new();
-static SKIP_CABAL_UPDATE: LazyLock<bool> =
-    LazyLock::new(|| EnvVars::var(EnvVars::PREK_INTERNAL__SKIP_CABAL_UPDATE).is_ok());
+static SKIP_CABAL_UPDATE: LazyLock<bool> = LazyLock::new(|| {
+    EnvVars
+        .var(EnvVars::PREK_INTERNAL__SKIP_CABAL_UPDATE)
+        .is_ok()
+});
 
 #[derive(Debug, Copy, Clone)]
 pub(crate) struct Haskell;

--- a/crates/prek/src/languages/mod.rs
+++ b/crates/prek/src/languages/mod.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::Result;
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use prek_identify::parse_shebang;
 use tracing::{instrument, trace};
 
@@ -441,7 +441,7 @@ pub(crate) async fn extract_metadata(hook: &mut Hook) -> Result<()> {
 /// Resolve the actual process invocation, honoring shebangs and PATH lookups.
 pub(crate) fn resolve_command(mut cmds: Vec<String>, paths: Option<&OsStr>) -> Vec<String> {
     let env_path = if paths.is_none() {
-        EnvVars::var_os(EnvVars::PATH)
+        EnvVars.var_os(EnvVars::PATH)
     } else {
         None
     };

--- a/crates/prek/src/languages/node/installer.rs
+++ b/crates/prek/src/languages/node/installer.rs
@@ -7,7 +7,7 @@ use std::sync::LazyLock;
 
 use anyhow::{Context, Result};
 use itertools::Itertools;
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use target_lexicon::{Architecture, HOST, OperatingSystem};
 use tracing::{debug, trace, warn};
 
@@ -36,7 +36,7 @@ impl Display for NodeResult {
 
 /// Override the Node binary name for testing.
 static NODE_BINARY_NAME: LazyLock<String> = LazyLock::new(|| {
-    if let Ok(name) = EnvVars::var(EnvVars::PREK_INTERNAL__NODE_BINARY_NAME) {
+    if let Ok(name) = EnvVars.var(EnvVars::PREK_INTERNAL__NODE_BINARY_NAME) {
         name
     } else {
         "node".to_string()

--- a/crates/prek/src/languages/python/uv.rs
+++ b/crates/prek/src/languages/python/uv.rs
@@ -11,7 +11,7 @@ use target_lexicon::{Architecture, ArmArchitecture, Environment, HOST, Operating
 use tokio::task::JoinSet;
 use tracing::{debug, trace, warn};
 
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 
 use crate::archive;
 use crate::fs::LockedFile;
@@ -19,6 +19,7 @@ use crate::http::{DownloadChecksumPolicy, REQWEST_CLIENT, download_artifact_with
 use crate::process::Cmd;
 use crate::store::{CacheBucket, Store};
 use crate::version;
+use crate::warn_user;
 
 // The version range of `uv` we will install. Should update periodically.
 const CUR_UV_VERSION: &str = "0.11.23";
@@ -143,7 +144,7 @@ static UV_EXE: LazyLock<Option<(PathBuf, Version)>> = LazyLock::new(|| {
     None
 });
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 enum PyPiMirror {
     Pypi,
     Tuna,
@@ -171,7 +172,7 @@ impl PyPiMirror {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 enum InstallSource {
     /// Download uv from GitHub releases.
     GitHub,
@@ -541,7 +542,7 @@ impl Uv {
             }
         }
 
-        let source = if let Some(uv_source) = uv_source_from_env() {
+        let source = if let Some(uv_source) = uv_source_from_env(&EnvVars) {
             uv_source
         } else {
             Self::select_source().await?
@@ -567,8 +568,8 @@ impl Uv {
     }
 }
 
-fn uv_source_from_env() -> Option<InstallSource> {
-    let var = EnvVars::var(EnvVars::PREK_UV_SOURCE).ok()?;
+fn uv_source_from_env(env_vars: &impl EnvVarsRead) -> Option<InstallSource> {
+    let var = env_vars.var(EnvVars::PREK_UV_SOURCE).ok()?;
     match var.as_str() {
         "github" => Some(InstallSource::GitHub),
         "pypi" => Some(InstallSource::PyPi(PyPiMirror::Pypi)),
@@ -578,7 +579,12 @@ fn uv_source_from_env() -> Option<InstallSource> {
         "pip" => Some(InstallSource::Pip),
         custom if custom.starts_with("http") => Some(InstallSource::PyPi(PyPiMirror::Custom(var))),
         _ => {
-            warn!("Invalid UV_SOURCE value: {}", var);
+            warn_user!(
+                "Invalid value for {}: {:?}. Expected github, pypi, tuna, aliyun, tencent, pip, or an http(s) URL; using default ({:?})",
+                EnvVars::PREK_UV_SOURCE,
+                var,
+                "auto",
+            );
             None
         }
     }
@@ -595,6 +601,36 @@ mod tests {
             UV_VERSION_RANGE.matches(&version),
             "CUR_UV_VERSION {CUR_UV_VERSION} does not satisfy the version requirement {}",
             &*UV_VERSION_RANGE
+        );
+    }
+
+    #[test]
+    fn uv_source_from_env_reads_source_override() {
+        assert_eq!(uv_source_from_env(&EnvVars::from_map(&[])), None);
+        assert_eq!(
+            uv_source_from_env(&EnvVars::from_map(&[(EnvVars::PREK_UV_SOURCE, "github")])),
+            Some(InstallSource::GitHub)
+        );
+        assert_eq!(
+            uv_source_from_env(&EnvVars::from_map(&[(EnvVars::PREK_UV_SOURCE, "pypi")])),
+            Some(InstallSource::PyPi(PyPiMirror::Pypi))
+        );
+        assert_eq!(
+            uv_source_from_env(&EnvVars::from_map(&[(EnvVars::PREK_UV_SOURCE, "pip")])),
+            Some(InstallSource::Pip)
+        );
+        assert_eq!(
+            uv_source_from_env(&EnvVars::from_map(&[(
+                EnvVars::PREK_UV_SOURCE,
+                "https://example.com/simple",
+            )])),
+            Some(InstallSource::PyPi(PyPiMirror::Custom(
+                "https://example.com/simple".to_string()
+            )))
+        );
+        assert_eq!(
+            uv_source_from_env(&EnvVars::from_map(&[(EnvVars::PREK_UV_SOURCE, "unknown")])),
+            None
         );
     }
 

--- a/crates/prek/src/languages/r.rs
+++ b/crates/prek/src/languages/r.rs
@@ -5,7 +5,7 @@ use std::str;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use rustc_hash::FxHashSet;
 use tracing::debug;
 
@@ -321,7 +321,7 @@ fn validate_r_entry(entry: &[String]) -> Result<()> {
 }
 
 fn rscript_executable() -> PathBuf {
-    if let Some(r_home) = EnvVars::var_os(EnvVars::R_HOME) {
+    if let Some(r_home) = EnvVars.var_os(EnvVars::R_HOME) {
         PathBuf::from(r_home)
             .join("bin/Rscript")
             .with_extension(EXE_EXTENSION)

--- a/crates/prek/src/languages/ruby/gem.rs
+++ b/crates/prek/src/languages/ruby/gem.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use futures_util::{StreamExt, TryStreamExt};
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use prek_consts::prepend_paths;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::debug;
@@ -114,7 +114,7 @@ fn gem_env<'a>(cmd: &'a mut Cmd, ruby: &RubyResult, gem_home: &Path) -> Result<&
     // Parallelize native extension compilation (e.g. prism's C code).
     // Respect existing MAKEFLAGS if set (user may need to limit parallelism
     // in memory-constrained environments like Docker).
-    if EnvVars::var_os("MAKEFLAGS").is_none() {
+    if EnvVars.var_os("MAKEFLAGS").is_none() {
         cmd.env("MAKEFLAGS", format!("-j{}", *INTERNAL_CONCURRENCY));
     }
 

--- a/crates/prek/src/languages/ruby/installer.rs
+++ b/crates/prek/src/languages/ruby/installer.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use itertools::Itertools;
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use reqwest::Url;
 use serde::Deserialize;
 use target_lexicon::{Architecture, Environment, HOST, OperatingSystem, Triple};
@@ -19,8 +19,8 @@ use crate::store::Store;
 
 const RV_RUBY_DEFAULT_URL: &str = "https://github.com/spinel-coop/rv-ruby";
 
-fn rv_ruby_base_url() -> String {
-    match EnvVars::var(EnvVars::PREK_RUBY_MIRROR) {
+fn rv_ruby_base_url(env_vars: &impl EnvVarsRead) -> String {
+    match env_vars.var(EnvVars::PREK_RUBY_MIRROR) {
         Ok(mirror) => mirror.trim_end_matches('/').to_string(),
         Err(_) => RV_RUBY_DEFAULT_URL.to_string(),
     }
@@ -33,8 +33,8 @@ fn rv_ruby_base_url() -> String {
 /// When the mirror is a `github.com` URL, the path is rewritten to use the
 /// `api.github.com` host (e.g. `https://github.com/org/repo` becomes
 /// `https://api.github.com/repos/org/repo/releases/latest`).
-fn rv_ruby_api_url() -> (String, bool) {
-    let base = rv_ruby_base_url();
+fn rv_ruby_api_url(env_vars: &impl EnvVarsRead) -> (String, bool) {
+    let base = rv_ruby_base_url(env_vars);
     if let Some(path) = github_repo_path(&base) {
         (
             format!("https://api.github.com/repos{path}/releases/latest"),
@@ -69,9 +69,13 @@ fn github_repo_path(url: &str) -> Option<String> {
 
 /// Conditionally add a GitHub auth token to a request builder.
 /// Only sends `GITHUB_TOKEN` when `is_github` is true.
-fn maybe_add_github_auth(req: reqwest::RequestBuilder, is_github: bool) -> reqwest::RequestBuilder {
+fn maybe_add_github_auth(
+    req: reqwest::RequestBuilder,
+    is_github: bool,
+    env_vars: &impl EnvVarsRead,
+) -> reqwest::RequestBuilder {
     if is_github {
-        if let Ok(token) = EnvVars::var(EnvVars::GITHUB_TOKEN) {
+        if let Ok(token) = env_vars.var(EnvVars::GITHUB_TOKEN) {
             return req.bearer_auth(token);
         }
     }
@@ -268,13 +272,13 @@ impl RubyInstaller {
 
     /// Fetch available Ruby versions from the rv-ruby GitHub release.
     async fn list_remote_versions(&self, platform: &str) -> Result<Vec<semver::Version>> {
-        let (api_url, is_github) = rv_ruby_api_url();
+        let (api_url, is_github) = rv_ruby_api_url(&EnvVars);
         let suffix = format!(".{platform}.tar.gz");
 
         let req = REQWEST_CLIENT
             .get(&api_url)
             .header("Accept", "application/vnd.github+json");
-        let req = maybe_add_github_auth(req, is_github);
+        let req = maybe_add_github_auth(req, is_github, &EnvVars);
 
         let release: GitHubRelease = req
             .send()
@@ -307,7 +311,7 @@ impl RubyInstaller {
         platform: &str,
     ) -> Result<RubyResult> {
         let filename = format!("ruby-{version}.{platform}.tar.gz");
-        let base_url = rv_ruby_base_url();
+        let base_url = rv_ruby_base_url(&EnvVars);
         let is_github = github_repo_path(&base_url).is_some();
         let download_base_url = format!("{base_url}/releases/latest/download");
         let url = format!("{download_base_url}/{filename}");
@@ -322,9 +326,9 @@ impl RubyInstaller {
             &url,
             &filename,
             store,
-            DownloadChecksumPolicy::from_env()?,
+            DownloadChecksumPolicy::from_env(&EnvVars),
             async || Self::fetch_checksum(&checksum_url, &filename, is_github).await,
-            |req| maybe_add_github_auth(req, is_github),
+            |req| maybe_add_github_auth(req, is_github, &EnvVars),
         )
         .await
         .with_context(|| format!("Failed to download Ruby {version} from {url}"))?;
@@ -367,7 +371,7 @@ impl RubyInstaller {
         let req = REQWEST_CLIENT
             .get(checksum_url)
             .header("Accept", "application/octet-stream");
-        let req = maybe_add_github_auth(req, is_github);
+        let req = maybe_add_github_auth(req, is_github, &EnvVars);
 
         let response = req.send().await.with_context(|| {
             format!("Failed to fetch rv-ruby checksum file from {checksum_url}")
@@ -440,7 +444,7 @@ async fn try_ruby_path(ruby_path: &Path, request: &RubyRequest) -> Option<RubyRe
 /// Search version manager directories for suitable Ruby installations
 #[cfg(not(target_os = "windows"))]
 async fn search_version_managers(request: &RubyRequest) -> Option<RubyResult> {
-    let home = EnvVars::var(EnvVars::HOME).ok()?;
+    let home = EnvVars.var(EnvVars::HOME).ok()?;
     let home_path = PathBuf::from(home);
 
     // Common version manager and Homebrew directories
@@ -833,6 +837,62 @@ mod tests {
         assert!(github_repo_path("https://github.com/org").is_none());
         assert!(github_repo_path("https://github.com/org/repo/releases").is_none());
         assert!(github_repo_path("ftp://github.com/org/repo").is_none());
+    }
+
+    #[test]
+    fn rv_ruby_env_overrides() {
+        assert_eq!(
+            rv_ruby_base_url(&EnvVars::from_map(&[])),
+            RV_RUBY_DEFAULT_URL
+        );
+        assert_eq!(
+            rv_ruby_base_url(&EnvVars::from_map(&[(
+                EnvVars::PREK_RUBY_MIRROR,
+                "https://example.com/rv-ruby/",
+            )])),
+            "https://example.com/rv-ruby"
+        );
+
+        assert_eq!(
+            rv_ruby_api_url(&EnvVars::from_map(&[])),
+            (
+                "https://api.github.com/repos/spinel-coop/rv-ruby/releases/latest".to_string(),
+                true,
+            )
+        );
+        assert_eq!(
+            rv_ruby_api_url(&EnvVars::from_map(&[(
+                EnvVars::PREK_RUBY_MIRROR,
+                "https://mirror.example.com/rv-ruby",
+            )])),
+            (
+                "https://mirror.example.com/rv-ruby/releases/latest".to_string(),
+                false,
+            )
+        );
+
+        let env_vars = EnvVars::from_map(&[(EnvVars::GITHUB_TOKEN, "secret-token")]);
+        let client = reqwest::Client::new();
+
+        let request = maybe_add_github_auth(client.get("https://example.com"), true, &env_vars)
+            .build()
+            .unwrap();
+        assert_eq!(
+            request
+                .headers()
+                .get(reqwest::header::AUTHORIZATION)
+                .unwrap(),
+            "Bearer secret-token"
+        );
+
+        let request = maybe_add_github_auth(client.get("https://example.com"), false, &env_vars)
+            .build()
+            .unwrap();
+        assert!(
+            !request
+                .headers()
+                .contains_key(reqwest::header::AUTHORIZATION)
+        );
     }
 
     #[test]

--- a/crates/prek/src/languages/rust/rustup.rs
+++ b/crates/prek/src/languages/rust/rustup.rs
@@ -4,7 +4,7 @@ use std::sync::LazyLock;
 
 use anyhow::{Context, Result};
 use futures_util::StreamExt;
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use semver::Version;
 use target_lexicon::HOST;
 use tracing::{debug, trace, warn};
@@ -30,11 +30,12 @@ pub(crate) struct ToolchainInfo {
 }
 
 static RUSTUP_BINARY_NAME: LazyLock<String> = LazyLock::new(|| {
-    EnvVars::var(EnvVars::PREK_INTERNAL__RUSTUP_BINARY_NAME)
+    EnvVars
+        .var(EnvVars::PREK_INTERNAL__RUSTUP_BINARY_NAME)
         .unwrap_or_else(|_| "rustup".to_string())
 });
 
-#[derive(Clone, Copy, Default, strum::AsRefStr, strum::EnumString)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, strum::AsRefStr, strum::EnumString)]
 #[strum(serialize_all = "lowercase")]
 enum RustupProfile {
     #[default]
@@ -43,15 +44,15 @@ enum RustupProfile {
     Complete,
 }
 
-fn rustup_profile() -> RustupProfile {
-    let Ok(value) = EnvVars::var(EnvVars::PREK_RUST_PROFILE) else {
+fn rustup_profile(env_vars: &impl EnvVarsRead) -> RustupProfile {
+    let Ok(value) = env_vars.var(EnvVars::PREK_RUST_PROFILE) else {
         return RustupProfile::default();
     };
 
     value.parse().unwrap_or_else(|_| {
         let default = RustupProfile::default();
         warn_user!(
-            "Invalid value for {}: {:?}. Expected one of `minimal`, `default`, or `complete`; falling back to `{}`",
+            "Invalid value for {}: {:?}. Expected minimal, default, or complete; using default ({:?})",
             EnvVars::PREK_RUST_PROFILE,
             value,
             default.as_ref(),
@@ -162,7 +163,7 @@ impl Rustup {
             .arg("install")
             .arg("--no-self-update")
             .arg("--profile")
-            .arg(rustup_profile().as_ref())
+            .arg(rustup_profile(&EnvVars).as_ref())
             .arg(toolchain)
             .check(true)
             .output()
@@ -353,5 +354,20 @@ mod tests {
         let result = digest_from_rustup_checksum("")?;
         assert!(result.is_none());
         Ok(())
+    }
+
+    #[test]
+    fn rustup_profile_reads_env() {
+        fn profile_with(value: &str) -> RustupProfile {
+            rustup_profile(&EnvVars::from_map(&[(EnvVars::PREK_RUST_PROFILE, value)]))
+        }
+
+        assert_eq!(
+            rustup_profile(&EnvVars::from_map(&[])),
+            RustupProfile::Minimal
+        );
+        assert_eq!(profile_with("default"), RustupProfile::Default);
+        assert_eq!(profile_with("complete"), RustupProfile::Complete);
+        assert_eq!(profile_with("invalid"), RustupProfile::Minimal);
     }
 }

--- a/crates/prek/src/languages/swift.rs
+++ b/crates/prek/src/languages/swift.rs
@@ -3,7 +3,7 @@ use std::process::Stdio;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use prek_consts::prepend_paths;
 use semver::Version;
 use tracing::debug;
@@ -187,7 +187,7 @@ impl LanguageImpl for Swift {
             if let Some(bin_path) = hook.install_info().and_then(|i| i.get_extra(BIN_PATH_KEY)) {
                 prepend_paths(&[Path::new(bin_path)]).context("Failed to join PATH")?
             } else {
-                EnvVars::var_os(EnvVars::PATH).unwrap_or_default()
+                EnvVars.var_os(EnvVars::PATH).unwrap_or_default()
             };
 
         let entry = hook.entry.resolve(Some(&new_path), store)?;

--- a/crates/prek/src/main.rs
+++ b/crates/prek/src/main.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser};
 use clap_complete::CompleteEnv;
 use owo_colors::OwoColorize;
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use tracing::debug;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::filter::Directive;
@@ -208,7 +208,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
     // If `GIT_DIR` is not set, we let git discover `.git` after an optional `cd`.
     // See: https://www.spinics.net/lists/git/msg374197.html
     //      https://github.com/pre-commit/pre-commit/issues/2295
-    if EnvVars::is_set(EnvVars::GIT_DIR) && !EnvVars::is_set(EnvVars::GIT_WORK_TREE) {
+    if EnvVars.is_set(EnvVars::GIT_DIR) && !EnvVars.is_set(EnvVars::GIT_WORK_TREE) {
         let cwd = std::env::current_dir().context("Failed to get current directory")?;
         debug!("Setting {} to `{}`", EnvVars::GIT_WORK_TREE, cwd.display());
         unsafe { std::env::set_var(EnvVars::GIT_WORK_TREE, cwd) }

--- a/crates/prek/src/run.rs
+++ b/crates/prek/src/run.rs
@@ -45,7 +45,9 @@ fn resolve_concurrency(env_vars: &impl EnvVarsRead, primary_env_var: &str) -> us
         if let Ok(cap) = value.parse::<usize>() {
             return cap.max(1);
         }
-        warn_user!("Invalid value for {name}: {value:?}, using default ({cpu})");
+        warn_user!(
+            "Invalid value for {name}: {value:?}. Expected a positive integer; using default ({cpu})"
+        );
     }
 
     cpu

--- a/crates/prek/src/schema.rs
+++ b/crates/prek/src/schema.rs
@@ -404,7 +404,7 @@ impl schemars::JsonSchema for Repo {
 mod _gen {
     use crate::config::Config;
     use anyhow::bail;
-    use prek_consts::env_vars::EnvVars;
+    use prek_consts::env_vars::{EnvVars, EnvVarsRead};
     use pretty_assertions::StrComparison;
     use std::path::PathBuf;
 
@@ -432,7 +432,7 @@ mod _gen {
 
     #[test]
     fn generate_json_schema() -> anyhow::Result<()> {
-        let mode = if EnvVars::is_set(EnvVars::PREK_GENERATE) {
+        let mode = if EnvVars.is_set(EnvVars::PREK_GENERATE) {
             Mode::Write
         } else {
             Mode::Check

--- a/crates/prek/src/settings.rs
+++ b/crates/prek/src/settings.rs
@@ -4,11 +4,11 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use etcetera::BaseStrategy;
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use serde::Deserialize;
 
 fn user_config_path() -> Option<PathBuf> {
-    if let Some(path) = EnvVars::var_os(EnvVars::PREK_INTERNAL__USER_CONFIG_PATH) {
+    if let Some(path) = EnvVars.var_os(EnvVars::PREK_INTERNAL__USER_CONFIG_PATH) {
         return Some(PathBuf::from(path));
     }
 

--- a/crates/prek/src/store.rs
+++ b/crates/prek/src/store.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 use etcetera::BaseStrategy;
 use futures_util::StreamExt;
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use rustc_hash::{FxHashMap, FxHashSet};
 use seahash::SeaHasher;
 use thiserror::Error;
@@ -66,7 +66,7 @@ impl Store {
 
     /// Create a store from environment variables or default paths.
     pub(crate) fn from_settings() -> Result<Self, Error> {
-        let path = if let Some(path) = EnvVars::var_os(EnvVars::PREK_HOME) {
+        let path = if let Some(path) = EnvVars.var_os(EnvVars::PREK_HOME) {
             Some(expand_tilde(PathBuf::from(path)))
         } else {
             etcetera::choose_base_strategy()

--- a/crates/prek/src/warnings.rs
+++ b/crates/prek/src/warnings.rs
@@ -21,17 +21,16 @@
 // SOFTWARE.
 
 use std::collections::HashSet;
+use std::fmt;
 use std::sync::atomic::AtomicBool;
 use std::sync::{LazyLock, Mutex};
 
-// macro hygiene: The user might not have direct dependencies on those crates
-#[doc(hidden)]
-pub use anstream;
-#[doc(hidden)]
-pub use owo_colors;
+use anstream::eprintln;
+use owo_colors::OwoColorize;
 
 /// Whether user-facing warnings are enabled.
 pub static ENABLED: AtomicBool = AtomicBool::new(false);
+pub static WARNINGS: LazyLock<Mutex<HashSet<String>>> = LazyLock::new(Mutex::default);
 
 /// Enable user-facing warnings.
 pub fn enable() {
@@ -43,38 +42,62 @@ pub fn disable() {
     ENABLED.store(false, std::sync::atomic::Ordering::SeqCst);
 }
 
+/// Whether user-facing warnings are currently enabled.
+pub fn is_enabled() -> bool {
+    ENABLED.load(std::sync::atomic::Ordering::SeqCst)
+}
+
+/// Emit a user-facing warning.
+pub fn warn(message: fmt::Arguments<'_>) {
+    if is_enabled() {
+        emit(message.to_string());
+    }
+}
+
+/// Emit a user-facing warning once, with uniqueness determined by the content of the message.
+pub fn warn_once(message: fmt::Arguments<'_>) {
+    if !is_enabled() {
+        return;
+    }
+
+    let message = message.to_string();
+    let should_emit = match WARNINGS.lock() {
+        Ok(mut states) => states.insert(message.clone()),
+        Err(_) => false,
+    };
+    if should_emit {
+        emit(message);
+    }
+}
+
+fn emit(message: String) {
+    crate::cli::reporter::suspend(move || {
+        eprintln!(
+            "{}{} {}",
+            "warning".yellow().bold(),
+            ":".bold(),
+            message.bold()
+        );
+    });
+}
+
 /// Warn a user, if warnings are enabled.
 #[macro_export]
 macro_rules! warn_user {
     ($($arg:tt)*) => {
-        use $crate::warnings::anstream::eprintln;
-        use $crate::warnings::owo_colors::OwoColorize;
-
-        if $crate::warnings::ENABLED.load(std::sync::atomic::Ordering::SeqCst) {
-            let message = format!("{}", format_args!($($arg)*));
-            let formatted = message.bold();
-            eprintln!("{}{} {formatted}", "warning".yellow().bold(), ":".bold());
+        if $crate::warnings::is_enabled() {
+            $crate::warnings::warn(format_args!($($arg)*));
         }
     };
 }
-
-pub static WARNINGS: LazyLock<Mutex<HashSet<String>>> = LazyLock::new(Mutex::default);
 
 /// Warn a user once, if warnings are enabled, with uniqueness determined by the content of the
 /// message.
 #[macro_export]
 macro_rules! warn_user_once {
     ($($arg:tt)*) => {
-        use $crate::warnings::anstream::eprintln;
-        use $crate::warnings::owo_colors::OwoColorize;
-
-        if $crate::warnings::ENABLED.load(std::sync::atomic::Ordering::SeqCst) {
-            if let Ok(mut states) = $crate::warnings::WARNINGS.lock() {
-                let message = format!("{}", format_args!($($arg)*));
-                if states.insert(message.clone()) {
-                    eprintln!("{}{} {}", "warning".yellow().bold(), ":".bold(), message.bold());
-                }
-            }
+        if $crate::warnings::is_enabled() {
+            $crate::warnings::warn_once(format_args!($($arg)*));
         }
     };
 }

--- a/crates/prek/tests/builtin_hooks.rs
+++ b/crates/prek/tests/builtin_hooks.rs
@@ -1,5 +1,5 @@
 #[cfg(unix)]
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
@@ -3240,7 +3240,7 @@ fn builtin_hooks_ignore_system_path_binaries() -> Result<()> {
     context.git_add(".");
 
     // Prepend the fake bin directory to PATH so the fake binary is found first.
-    let original_path = EnvVars::var_os(EnvVars::PATH).unwrap_or_default();
+    let original_path = EnvVars.var_os(EnvVars::PATH).unwrap_or_default();
     let mut new_path = std::ffi::OsString::from(fake_bin_dir.path());
     new_path.push(":");
     new_path.push(&original_path);

--- a/crates/prek/tests/common/mod.rs
+++ b/crates/prek/tests/common/mod.rs
@@ -10,7 +10,7 @@ use etcetera::BaseStrategy;
 use rustc_hash::FxHashSet;
 
 use prek_consts::PRE_COMMIT_CONFIG_YAML;
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 
 pub fn git_cmd(dir: impl AsRef<Path>) -> Command {
     let mut cmd = Command::new("git");
@@ -77,7 +77,7 @@ impl TestContext {
                 .map(|pattern| (pattern, "[HOME]/".to_string())),
         );
 
-        if let Some(current_exe) = EnvVars::var_os("NEXTEST_BIN_EXE_prek") {
+        if let Some(current_exe) = EnvVars.var_os("NEXTEST_BIN_EXE_prek") {
             filters.extend(
                 Self::path_patterns(current_exe)
                     .into_iter()
@@ -100,7 +100,8 @@ impl TestContext {
     }
 
     pub fn test_bucket_dir() -> PathBuf {
-        EnvVars::var(EnvVars::PREK_INTERNAL__TEST_DIR)
+        EnvVars
+            .var(EnvVars::PREK_INTERNAL__TEST_DIR)
             .map(PathBuf::from)
             .unwrap_or_else(|_| {
                 etcetera::base_strategy::choose_base_strategy()
@@ -153,7 +154,7 @@ impl TestContext {
     }
 
     pub fn command(&self) -> Command {
-        let mut cmd = if EnvVars::is_set(EnvVars::PREK_INTERNAL__RUN_ORIGINAL_PRE_COMMIT) {
+        let mut cmd = if EnvVars.is_set(EnvVars::PREK_INTERNAL__RUN_ORIGINAL_PRE_COMMIT) {
             // Run the original pre-commit to check compatibility.
             let mut cmd = Command::new("pre-commit");
             cmd.current_dir(self.work_dir());
@@ -162,7 +163,8 @@ impl TestContext {
         } else {
             // The absolute path to a binary target's executable. This is only set when running an integration test or benchmark.
             // When reusing builds from an archive, this is set to the remapped path within the target directory.
-            let bin = EnvVars::var_os("NEXTEST_BIN_EXE_prek")
+            let bin = EnvVars
+                .var_os("NEXTEST_BIN_EXE_prek")
                 .map(PathBuf::from)
                 .unwrap_or_else(|| PathBuf::from(assert_cmd::cargo::cargo_bin!("prek")));
             let mut cmd = Command::new(bin);
@@ -464,7 +466,7 @@ macro_rules! cmd_snapshot {
 pub(crate) use cmd_snapshot;
 
 pub(crate) fn remove_bin_from_path(bin: &str, path: Option<OsString>) -> anyhow::Result<OsString> {
-    let path = path.unwrap_or(EnvVars::var_os(EnvVars::PATH).expect("Path must be set"));
+    let path = path.unwrap_or(EnvVars.var_os(EnvVars::PATH).expect("Path must be set"));
     let Ok(dirs) = which::which_all(bin) else {
         return Ok(path);
     };

--- a/crates/prek/tests/languages/bun.rs
+++ b/crates/prek/tests/languages/bun.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use assert_fs::assert::PathAssert;
 use assert_fs::fixture::PathChild;
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 
 use crate::common::{TestContext, cmd_snapshot};
 
@@ -108,7 +108,7 @@ fn additional_dependencies() {
 /// In CI, we ensure bun 1.3 is installed.
 #[test]
 fn language_version() -> Result<()> {
-    if !EnvVars::is_set(EnvVars::CI) {
+    if !EnvVars.is_set(EnvVars::CI) {
         // Skip when not running in CI, as we may have other go versions installed locally.
         return Ok(());
     }

--- a/crates/prek/tests/languages/deno.rs
+++ b/crates/prek/tests/languages/deno.rs
@@ -1,6 +1,6 @@
 use assert_fs::assert::PathAssert;
 use assert_fs::fixture::{FileWriteStr, PathChild};
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 
 use crate::common::{TestContext, cmd_snapshot, remove_bin_from_path};
 
@@ -324,7 +324,7 @@ fn additional_dependencies_local_file() {
 /// In CI, we ensure deno 2.x is installed via setup-deno action.
 #[test]
 fn language_version() {
-    if !EnvVars::is_set(EnvVars::CI) {
+    if !EnvVars.is_set(EnvVars::CI) {
         // Skip when not running in CI, as we may have other deno versions installed locally.
         return;
     }
@@ -531,7 +531,7 @@ fn without_system_deno() {
 /// Test semver range version specification.
 #[test]
 fn version_range() {
-    if !EnvVars::is_set(EnvVars::CI) {
+    if !EnvVars.is_set(EnvVars::CI) {
         // Skip when not running in CI.
         return;
     }

--- a/crates/prek/tests/languages/dotnet.rs
+++ b/crates/prek/tests/languages/dotnet.rs
@@ -1,12 +1,12 @@
 use assert_fs::fixture::{FileWriteStr, PathChild, PathCreateDir};
 use prek_consts::PRE_COMMIT_HOOKS_YAML;
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 
 use crate::common::{TestContext, cmd_snapshot, git_cmd};
 
 #[test]
 fn language_version() {
-    if !EnvVars::is_set(EnvVars::CI) {
+    if !EnvVars.is_set(EnvVars::CI) {
         return;
     }
 
@@ -132,7 +132,7 @@ fn invalid_language_version() {
 /// `net10.0` is preinstalled in the CI, `net8.0` will be installed by the test.
 #[test]
 fn multiple_sdk_versions() -> anyhow::Result<()> {
-    if !EnvVars::is_set(EnvVars::CI) {
+    if !EnvVars.is_set(EnvVars::CI) {
         return Ok(());
     }
 
@@ -215,7 +215,7 @@ fn multiple_sdk_versions() -> anyhow::Result<()> {
 /// Test installing a specific version of a dotnet tool.
 #[test]
 fn additional_dependencies_with_version() {
-    if !EnvVars::is_set(EnvVars::CI) {
+    if !EnvVars.is_set(EnvVars::CI) {
         return;
     }
 
@@ -276,7 +276,7 @@ fn additional_dependencies_with_version() {
 /// Test that additional dependencies in a remote repo are installed correctly.
 #[test]
 fn additional_dependencies_in_remote_repo() -> anyhow::Result<()> {
-    if !EnvVars::is_set(EnvVars::CI) {
+    if !EnvVars.is_set(EnvVars::CI) {
         return Ok(());
     }
 
@@ -339,7 +339,7 @@ fn additional_dependencies_in_remote_repo() -> anyhow::Result<()> {
 /// Ensure that stderr from hooks is captured and shown to the user.
 #[test]
 fn hook_stderr() -> anyhow::Result<()> {
-    if !EnvVars::is_set(EnvVars::CI) {
+    if !EnvVars.is_set(EnvVars::CI) {
         return Ok(());
     }
 

--- a/crates/prek/tests/languages/golang.rs
+++ b/crates/prek/tests/languages/golang.rs
@@ -1,6 +1,6 @@
 use assert_fs::assert::PathAssert;
 use assert_fs::fixture::{FileWriteStr, PathChild, PathCreateDir};
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use prek_consts::{PRE_COMMIT_CONFIG_YAML, PRE_COMMIT_HOOKS_YAML};
 
 use crate::common::{TestContext, cmd_snapshot, git_cmd};
@@ -9,7 +9,7 @@ use crate::common::{TestContext, cmd_snapshot, git_cmd};
 /// We use `setup-go` action to install go 1.24 in CI, so go 1.23 will be auto downloaded.
 #[test]
 fn language_version() -> anyhow::Result<()> {
-    if !EnvVars::is_set(EnvVars::CI) {
+    if !EnvVars.is_set(EnvVars::CI) {
         // Skip when not running in CI, as we may have other go versions installed locally.
         return Ok(());
     }

--- a/crates/prek/tests/languages/node.rs
+++ b/crates/prek/tests/languages/node.rs
@@ -1,6 +1,6 @@
 use assert_fs::assert::PathAssert;
 use assert_fs::fixture::{FileWriteStr, PathChild, PathCreateDir};
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 
 use crate::common::{TestContext, cmd_snapshot, remove_bin_from_path};
 
@@ -8,7 +8,7 @@ use crate::common::{TestContext, cmd_snapshot, remove_bin_from_path};
 /// We use `setup-node` action to install node 20 in CI, so node 19 should be downloaded by prek.
 #[test]
 fn language_version() -> anyhow::Result<()> {
-    if !EnvVars::is_set(EnvVars::CI) {
+    if !EnvVars.is_set(EnvVars::CI) {
         // Skip when not running in CI, as we may have other node versions installed locally.
         return Ok(());
     }

--- a/crates/prek/tests/languages/python.rs
+++ b/crates/prek/tests/languages/python.rs
@@ -1,7 +1,7 @@
 use assert_fs::assert::PathAssert;
 use assert_fs::fixture::{FileWriteStr, PathChild};
 use prek_consts::PRE_COMMIT_HOOKS_YAML;
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 
 use crate::common::{TestContext, cmd_snapshot};
 
@@ -10,7 +10,7 @@ use crate::common::{TestContext, cmd_snapshot};
 /// Other versions may need to be downloaded while running the tests.
 #[test]
 fn language_version() -> anyhow::Result<()> {
-    if !EnvVars::is_set(EnvVars::CI) {
+    if !EnvVars.is_set(EnvVars::CI) {
         // Skip when not running in CI, as we may have other Python versions installed locally.
         return Ok(());
     }

--- a/crates/prek/tests/languages/ruby.rs
+++ b/crates/prek/tests/languages/ruby.rs
@@ -1032,9 +1032,9 @@ fn process_files() -> anyhow::Result<()> {
 #[cfg(not(target_os = "windows"))]
 fn auto_download() -> anyhow::Result<()> {
     use assert_fs::assert::PathAssert;
-    use prek_consts::env_vars::EnvVars;
+    use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 
-    if !EnvVars::is_set(EnvVars::CI) {
+    if !EnvVars.is_set(EnvVars::CI) {
         // Skip when not running in CI: local environments may have
         // unexpected Ruby versions installed.
         return Ok(());

--- a/crates/prek/tests/languages/rust.rs
+++ b/crates/prek/tests/languages/rust.rs
@@ -1,14 +1,14 @@
 use anyhow::Result;
 use assert_fs::assert::PathAssert;
 use assert_fs::fixture::PathChild;
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 
 use crate::common::{TestContext, cmd_snapshot};
 
 /// Test `language_version` parsing and installation for Rust hooks.
 #[test]
 fn language_version() -> Result<()> {
-    if !EnvVars::is_set(EnvVars::CI) {
+    if !EnvVars.is_set(EnvVars::CI) {
         // Skip when not running in CI, as we may have other rust versions installed locally.
         return Ok(());
     }

--- a/crates/prek/tests/languages/swift.rs
+++ b/crates/prek/tests/languages/swift.rs
@@ -1,13 +1,13 @@
 use assert_fs::fixture::{FileWriteStr, PathChild, PathCreateDir};
 use prek_consts::PRE_COMMIT_HOOKS_YAML;
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 
 use crate::common::{TestContext, cmd_snapshot, git_cmd};
 
 /// Test that a local Swift hook with a system command works.
 #[test]
 fn local_hook_system_command() {
-    if !EnvVars::is_set(EnvVars::CI) {
+    if !EnvVars.is_set(EnvVars::CI) {
         return;
     }
 
@@ -46,7 +46,7 @@ fn local_hook_system_command() {
 /// Test that `language_version` is rejected for Swift.
 #[test]
 fn language_version_rejected() {
-    if !EnvVars::is_set(EnvVars::CI) {
+    if !EnvVars.is_set(EnvVars::CI) {
         return;
     }
 
@@ -82,7 +82,7 @@ fn language_version_rejected() {
 /// Test that health check works after install.
 #[test]
 fn health_check() {
-    if !EnvVars::is_set(EnvVars::CI) {
+    if !EnvVars.is_set(EnvVars::CI) {
         return;
     }
 
@@ -136,7 +136,7 @@ fn health_check() {
 /// Test that a Swift Package.swift is built and the executable is available.
 #[test]
 fn local_package_build() -> anyhow::Result<()> {
-    if !EnvVars::is_set(EnvVars::CI) {
+    if !EnvVars.is_set(EnvVars::CI) {
         return Ok(());
     }
 

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -6,7 +6,7 @@ use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
 use insta::assert_snapshot;
 use predicates::prelude::predicate;
-use prek_consts::env_vars::EnvVars;
+use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use prek_consts::{
     PRE_COMMIT_CONFIG_YAML, PRE_COMMIT_CONFIG_YML, PRE_COMMIT_HOOKS_YAML, PREK_TOML,
 };
@@ -3680,7 +3680,7 @@ fn run_log_file() {
 /// Test `language_version: system` works and disables downloading.
 #[test]
 fn system_language_version() {
-    if !EnvVars::is_set(EnvVars::CI) {
+    if !EnvVars.is_set(EnvVars::CI) {
         // Skip when not running in CI, as we may not have toolchains installed locally.
         return;
     }

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -31,15 +31,13 @@ fn run_basic() -> Result<()> {
               - id: check-json
     "});
 
-    // Create a repository with some files.
     cwd.child("file.txt").write_str("Hello, world!\n")?;
     cwd.child("valid.json").write_str("{}")?;
-    cwd.child("invalid.json").write_str("{}")?;
     cwd.child("main.py").write_str(r#"print "abc"  "#)?;
 
     context.git_add(".");
 
-    cmd_snapshot!(context.filters(), context.run(), @r#"
+    cmd_snapshot!(context.filters(), context.run().arg("-q"), @"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -54,13 +52,11 @@ fn run_basic() -> Result<()> {
     - exit code: 1
     - files were modified by this hook
 
-      Fixing main.py
-      Fixing invalid.json
       Fixing valid.json
-    check json...............................................................Passed
+      Fixing main.py
 
     ----- stderr -----
-    "#);
+    ");
 
     context.git_add(".");
 


### PR DESCRIPTION
## Summary

- add testable `EnvVarsRead` helpers and refactor env var call sites to use them
- centralize user warning emission under reporter suspension
- align invalid env var fallback behavior across run, Docker, HTTP, Python, Ruby, and Rust settings
