### PR TITLE
chore: update `pyproject.toml` metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dev = ["rooster"]
 docs = ["llmstxt-standalone>=0.2.0", "zensical>=0.0.24"]
 
 [tool.uv.sources]
-rooster = { git = "https://github.com/j178/rooster", rev = "747d16f" }
+rooster = { git = "https://github.com/j178/rooster", rev = "747d16f415e151f019b3645d982549db61e12b98" }
 
 [tool.uv.dependency-groups]
 dev = { requires-python = ">=3.12" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE", "licenses/*"]
 classifiers = [
-  "Development Status :: 4 - Beta",
+  "Development Status :: 5 - Production/Stable",
   "Environment :: Console",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",

--- a/uv.lock
+++ b/uv.lock
@@ -560,7 +560,7 @@ docs = [
 [package.metadata]
 
 [package.metadata.requires-dev]
-dev = [{ name = "rooster", marker = "python_full_version >= '3.12'", git = "https://github.com/j178/rooster?rev=747d16f" }]
+dev = [{ name = "rooster", marker = "python_full_version >= '3.12'", git = "https://github.com/j178/rooster?rev=747d16f415e151f019b3645d982549db61e12b98" }]
 docs = [
     { name = "llmstxt-standalone", marker = "python_full_version >= '3.12'", specifier = ">=0.2.0" },
     { name = "zensical", marker = "python_full_version >= '3.12'", specifier = ">=0.0.24" },
@@ -904,7 +904,7 @@ wheels = [
 [[package]]
 name = "rooster"
 version = "0.0.0"
-source = { git = "https://github.com/j178/rooster?rev=747d16f#747d16f415e151f019b3645d982549db61e12b98" }
+source = { git = "https://github.com/j178/rooster?rev=747d16f415e151f019b3645d982549db61e12b98#747d16f415e151f019b3645d982549db61e12b98" }
 dependencies = [
     { name = "hishel", marker = "python_full_version >= '3.12'" },
     { name = "httpx", marker = "python_full_version >= '3.12'" },


### PR DESCRIPTION
Updates `Development Status` classifier -- I think prek has been considered stable for some time :)

Also small cleanup to update rooster rev to the full commit SHA instead of SHA-1; I don't think this was a real concern since the `uv.lock` file had the full SHA, but seems worthwhile regardless. Using SHA-1 for anything has been generally advised against for some time now.