### PR TITLE
ci: rely on setup-node npm for npm publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -35,8 +35,6 @@ jobs:
         with:
           node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
-      - name: Update npm
-        run: npm install -g npm@latest
       - name: "Install uv"
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:


### PR DESCRIPTION
Resolves extant zizmor finding from new [`adhoc-packages`](https://docs.zizmor.sh/audits/#adhoc-packages) released in zizmor [`1.26.0`](https://docs.zizmor.sh/release-notes/#1260).

I first attempted to fully lock `npm` via `package-lock.json` (which is what this audit wants), but this is pretty unidiomatic for the JS-ecosystem and did not work well. I couldn't find any major project doing something similar; most that pin do so using only a top-level version pin (e.g., `npm@11.18.0`), which would not resolve the finding.

Decided to just delete this step since it doesn't seem necessary. I suspect this may have been necessary when using an older Node version or when npm Trusted Publishing was newly added? But the default `npm` installed by `actions/setup-node` is `11.13.0` which supports OIDC publishing.

See astral-sh/ruff#26488 which merged today fixing the same zizmor finding, coming to the same conclusion.