### PR TITLE
Rename `auto-update` to `update`

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,9 +371,9 @@ prek self update
 ### prek includes security-focused safeguards
 
 - For supported managed toolchain downloads, `prek` verifies the downloaded archive or installer checksum before extracting or installing it, helping ensure the integrity of downloaded toolchains.
-- [`prek auto-update`](https://prek.j178.dev/reference/cli/#prek-auto-update) supports `--cooldown-days`, so you can keep newly published releases on hold for a cooling-off period before adopting them.
-- [`prek auto-update`](https://prek.j178.dev/reference/cli/#prek-auto-update) validates pinned SHA revisions against the fetched upstream refs, including impostor-commit detection, and keeps `# frozen:` comments in sync with the configured commit.
-- [`prek auto-update --check`](https://prek.j178.dev/reference/cli/#prek-auto-update--check) is useful in CI when you want updates or frozen-reference mismatches to fail the job without rewriting the config.
+- [`prek update`](https://prek.j178.dev/reference/cli/#prek-update) supports `--cooldown-days`, so you can keep newly published releases on hold for a cooling-off period before adopting them.
+- [`prek update`](https://prek.j178.dev/reference/cli/#prek-update) validates pinned SHA revisions against the fetched upstream refs, including impostor-commit detection, and keeps `# frozen:` comments in sync with the configured commit.
+- [`prek update --check`](https://prek.j178.dev/reference/cli/#prek-update--check) is useful in CI when you want updates or frozen-reference mismatches to fail the job without rewriting the config.
 
 For more detailed improvements prek offers, take a look at [Difference from pre-commit](https://prek.j178.dev/diff/).
 

--- a/crates/prek/src/cli/mod.rs
+++ b/crates/prek/src/cli/mod.rs
@@ -269,7 +269,7 @@ pub(crate) enum Command {
     /// Produce a sample configuration file (prek.toml or .pre-commit-config.yaml).
     SampleConfig(SampleConfigArgs),
     /// Update the `rev` field of repositories in the config file to the latest version.
-    #[command(name = "update", alias = "auto-update", alias = "autoupdate")]
+    #[command(name = "update", aliases = ["auto-update", "autoupdate"])]
     Update(UpdateArgs),
     /// Manage the prek cache.
     Cache(CacheNamespace),

--- a/crates/prek/src/cli/mod.rs
+++ b/crates/prek/src/cli/mod.rs
@@ -12,7 +12,6 @@ use serde::{Deserialize, Serialize};
 use crate::config::{HookType, Language, Stage};
 use crate::fs::expand_tilde;
 
-mod auto_update;
 mod cache_clean;
 mod cache_gc;
 mod cache_size;
@@ -28,10 +27,10 @@ mod sample_config;
 #[cfg(feature = "self-update")]
 mod self_update;
 mod try_repo;
+mod update;
 mod validate;
 mod yaml_to_toml;
 
-pub(crate) use auto_update::auto_update;
 pub(crate) use cache_clean::cache_clean;
 pub(crate) use cache_gc::cache_gc;
 pub(crate) use cache_size::cache_size;
@@ -46,6 +45,7 @@ pub(crate) use sample_config::sample_config;
 #[cfg(feature = "self-update")]
 pub(crate) use self_update::self_update;
 pub(crate) use try_repo::try_repo;
+pub(crate) use update::update;
 pub(crate) use validate::{validate_configs, validate_manifest};
 pub(crate) use yaml_to_toml::yaml_to_toml;
 
@@ -268,9 +268,9 @@ pub(crate) enum Command {
     ValidateManifest(ValidateManifestArgs),
     /// Produce a sample configuration file (prek.toml or .pre-commit-config.yaml).
     SampleConfig(SampleConfigArgs),
-    /// Auto-update the `rev` field of repositories in the config file to the latest version.
-    #[command(alias = "autoupdate")]
-    AutoUpdate(AutoUpdateArgs),
+    /// Update the `rev` field of repositories in the config file to the latest version.
+    #[command(name = "update", alias = "auto-update", alias = "autoupdate")]
+    Update(UpdateArgs),
     /// Manage the prek cache.
     Cache(CacheNamespace),
     /// Clean unused cached repos.
@@ -769,7 +769,7 @@ impl From<Option<Option<PathBuf>>> for SampleConfigTarget {
 
 #[expect(clippy::struct_excessive_bools)]
 #[derive(Debug, Args)]
-pub(crate) struct AutoUpdateArgs {
+pub(crate) struct UpdateArgs {
     /// Update to the bleeding edge of the default branch instead of the latest tagged version.
     #[arg(long)]
     pub(crate) bleeding_edge: bool,
@@ -824,8 +824,8 @@ pub(crate) struct AutoUpdateArgs {
     /// Minimum release age (in days) required for a version to be eligible.
     ///
     /// The age is computed from the tag creation timestamp for annotated tags, or from the tagged commit timestamp for lightweight tags.
-    /// If the current `rev` is newer than the latest cooldown-eligible tag, `prek auto-update` keeps the current `rev` instead of downgrading it.
-    /// Defaults to `auto_update.cooldown_days` in the project or global config, or `0` when unset.
+    /// If the current `rev` is newer than the latest cooldown-eligible tag, `prek update` keeps the current `rev` instead of downgrading it.
+    /// Defaults to `update.cooldown_days` in the project or global config, or `0` when unset.
     /// Valid values are `0` through `255`; `0` disables this check.
     #[arg(long, value_name = "DAYS", conflicts_with = "bleeding_edge")]
     pub(crate) cooldown_days: Option<u8>,

--- a/crates/prek/src/cli/reporter.rs
+++ b/crates/prek/src/cli/reporter.rs
@@ -183,11 +183,11 @@ impl HookInstallReporter {
 }
 
 #[derive(Clone)]
-pub(crate) struct AutoUpdateReporter {
+pub(crate) struct UpdateReporter {
     reporter: Arc<ProgressReporter>,
 }
 
-impl AutoUpdateReporter {
+impl UpdateReporter {
     pub(crate) fn new(printer: Printer) -> Self {
         let reporter = Arc::new(ProgressReporter::from(printer));
         set_current_reporter(Some(&reporter));
@@ -195,7 +195,7 @@ impl AutoUpdateReporter {
     }
 }
 
-impl AutoUpdateReporter {
+impl UpdateReporter {
     pub fn on_update_start(&self, repo: &str) -> usize {
         self.reporter.set_root_prefix("Updating repos...");
 

--- a/crates/prek/src/cli/update/config.rs
+++ b/crates/prek/src/cli/update/config.rs
@@ -237,7 +237,7 @@ pub(super) fn render_updated_yaml_config(
 #[cfg(test)]
 mod tests {
     use super::{render_updated_toml_config, render_updated_yaml_config};
-    use crate::cli::auto_update::Revision;
+    use crate::cli::update::Revision;
     use std::path::Path;
 
     #[test]

--- a/crates/prek/src/cli/update/display.rs
+++ b/crates/prek/src/cli/update/display.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use itertools::Itertools;
 use owo_colors::OwoColorize;
 
-use crate::cli::auto_update::{
+use crate::cli::update::{
     ApplyRepoUpdatesResult, CommitPresence, DisplayEvent, DisplayEventKind, DisplayStream,
     FrozenMismatch, FrozenMismatchAction, FrozenMismatchReason, FrozenWarningEvent, ProjectUpdates,
     RepoOccurrences, RepoUpdate, Revision,

--- a/crates/prek/src/cli/update/mod.rs
+++ b/crates/prek/src/cli/update/mod.rs
@@ -7,11 +7,11 @@ use rustc_hash::FxHashMap;
 use semver::Version;
 
 use crate::cli::ExitStatus;
-use crate::cli::auto_update::config::write_new_config;
-use crate::cli::auto_update::display::{apply_repo_updates, warn_frozen_mismatches};
-use crate::cli::auto_update::source::{collect_repo_sources, evaluate_repo_source};
-use crate::cli::reporter::AutoUpdateReporter;
+use crate::cli::reporter::UpdateReporter;
 use crate::cli::run::Selectors;
+use crate::cli::update::config::write_new_config;
+use crate::cli::update::display::{apply_repo_updates, warn_frozen_mismatches};
+use crate::cli::update::source::{collect_repo_sources, evaluate_repo_source};
 use crate::config::GlobPatterns;
 use crate::fs::CWD;
 use crate::printer::Printer;
@@ -82,7 +82,7 @@ enum FrozenMismatchAction {
     NoReplacement,
 }
 
-/// Whether the pinned SHA is available from the refs fetched for `auto-update`.
+/// Whether the pinned SHA is available from the refs fetched for `prek update`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum CommitPresence {
     /// The commit is present in the fetched repository view.
@@ -367,7 +367,7 @@ type RepoOccurrences<'a> = FxHashMap<(&'a Path, &'a str), usize>;
 
 /// Updates remote repo revisions and, when possible, keeps existing `# frozen:` comments in sync.
 #[expect(clippy::fn_params_excessive_bools)]
-pub(crate) async fn auto_update(
+pub(crate) async fn update(
     store: &Store,
     config: Option<PathBuf>,
     filter_repos: Vec<String>,
@@ -398,7 +398,7 @@ pub(crate) async fn auto_update(
     } else {
         jobs
     };
-    let reporter = AutoUpdateReporter::new(printer);
+    let reporter = UpdateReporter::new(printer);
 
     let repo_sources = collect_repo_sources(&workspace, cooldown_days, filesystem.as_ref())?;
     let sources = repo_sources.iter().filter(|repo_source| {

--- a/crates/prek/src/cli/update/repository.rs
+++ b/crates/prek/src/cli/update/repository.rs
@@ -13,7 +13,7 @@ use rustc_hash::FxHashSet;
 use semver::Version;
 use tracing::{debug, trace};
 
-use crate::cli::auto_update::{CommitPresence, RevisionSelection, SkippedDowngrade, TagTimestamp};
+use crate::cli::update::{CommitPresence, RevisionSelection, SkippedDowngrade, TagTimestamp};
 use crate::{config, git};
 
 /// Initializes a temporary git repo and fetches the remote HEAD plus tags.
@@ -50,15 +50,15 @@ pub(super) async fn resolve_revision_to_commit(repo_path: &Path, rev: &str) -> R
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
-/// Returns whether a pinned commit SHA is already present in the refs fetched for `auto-update`.
+/// Returns whether a pinned commit SHA is already present in the refs fetched for `prek update`.
 ///
-/// `auto-update` fetches only `origin/HEAD` and tags, using `--filter=blob:none`. That filter
+/// `prek update` fetches only `origin/HEAD` and tags, using `--filter=blob:none`. That filter
 /// still downloads commits and trees reachable from those refs, but omits blobs. We intentionally
 /// use `git --no-lazy-fetch cat-file -e` here instead of `rev-parse`: in a partial clone,
 /// `rev-parse` may lazily fetch a missing commit from the promisor remote on demand. On GitHub,
 /// that can make a fork-only "impostor commit" appear to belong to the parent repository.
 ///
-/// `auto-update` only selects updates from tags, or from `HEAD` in `--bleeding-edge` mode. It
+/// `prek update` only selects updates from tags, or from `HEAD` in `--bleeding-edge` mode. It
 /// does not normally update to arbitrary branches, so we currently fetch only those refs here.
 ///
 /// So this helper answers a narrower question than "is this SHA valid anywhere on the remote?".
@@ -221,7 +221,7 @@ async fn current_tag_metadata<'a>(
         .min_by(|tag_a, tag_b| compare_tag_metadata(tag_a, tag_b))
 }
 
-/// Selects the revision action that `auto-update` should take for one fetched repo target.
+/// Selects the revision action that `prek update` should take for one fetched repo target.
 ///
 /// In normal mode this chooses the newest tag that satisfies the cooldown window.
 /// If that tag sorts older than the currently pinned tag, the current revision is kept.
@@ -429,7 +429,7 @@ mod tests {
         levenshtein_distance, list_tag_metadata, no_lazy_fetch_unsupported, resolve_bleeding_edge,
         select_best_tag, select_update_revision,
     };
-    use crate::cli::auto_update::{RevisionSelection, SkippedDowngrade};
+    use crate::cli::update::{RevisionSelection, SkippedDowngrade};
     use crate::git;
     use crate::process::Cmd;
     use std::path::Path;

--- a/crates/prek/src/cli/update/source.rs
+++ b/crates/prek/src/cli/update/source.rs
@@ -5,20 +5,20 @@ use anyhow::{Context, Result};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::{debug, trace, warn};
 
-use crate::cli::auto_update::config::read_frozen_refs;
-use crate::cli::auto_update::repository::{
+use crate::cli::update::config::read_frozen_refs;
+use crate::cli::update::repository::{
     checkout_and_validate_manifest, get_tags_pointing_at_revision, is_commit_present,
     list_tag_metadata, resolve_revision_to_commit, select_best_tag, select_update_revision,
     setup_and_fetch_repo,
 };
-use crate::cli::auto_update::{
+use crate::cli::update::{
     CommitPresence, FrozenMismatch, FrozenMismatchAction, FrozenMismatchReason, RepoSource,
     RepoTarget, RepoUpdate, RepoUsage, ResolvedRepoUpdate, Revision, RevisionSelection, TagFilters,
     TagTimestamp,
 };
 use crate::config::{Repo, looks_like_sha};
 use crate::fs::Simplified;
-use crate::settings::{AutoUpdateSettings, FilesystemOptions};
+use crate::settings::{FilesystemOptions, UpdateSettings};
 use crate::workspace::Workspace;
 
 type RepoTargetKey<'a> = (&'a str, Vec<&'a str>, u8);
@@ -34,12 +34,12 @@ pub(super) fn collect_repo_sources<'a>(
     let mut repo_sources: RepoSourcesByRepo<'a> = FxHashMap::default();
 
     for project in workspace.projects() {
-        let settings = AutoUpdateSettings::resolve(
+        let settings = UpdateSettings::resolve(
             cli_cooldown_days,
             filesystem,
             project
                 .config()
-                .auto_update
+                .update
                 .as_ref()
                 .and_then(|options| options.cooldown_days),
         );

--- a/crates/prek/src/config.rs
+++ b/crates/prek/src/config.rs
@@ -1137,11 +1137,11 @@ where
     })
 }
 
-/// Controls how `prek auto-update` selects eligible releases.
+/// Controls how `prek update` selects eligible releases.
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default, rename_all = "snake_case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-pub(crate) struct AutoUpdateOptions {
+pub(crate) struct UpdateOptions {
     pub(crate) cooldown_days: Option<u8>,
 }
 
@@ -1157,8 +1157,9 @@ pub(crate) struct AutoUpdateOptions {
     schemars(extend("x-tombi-toml-version" = "v1.1.0")),
 )]
 pub(crate) struct Config {
-    /// Default settings for `prek auto-update` in this project.
-    pub auto_update: Option<AutoUpdateOptions>,
+    /// Default settings for `prek update` in this project.
+    #[serde(alias = "auto_update")]
+    pub update: Option<UpdateOptions>,
     pub repos: Vec<Repo>,
     /// A list of `--hook-types` which will be used by default when running `prek install`.
     /// Default is `[pre-commit]`.
@@ -1361,7 +1362,7 @@ pub(crate) fn read_config(path: &Path) -> Result<Config, Error> {
             {}
             Mutable references are never updated after first install and are not supported.
             See https://pre-commit.com/#using-the-latest-version-for-a-repository for more details.
-            hint: `prek auto-update` often fixes this",
+            hint: `prek update` often fixes this",
             "#,
             msg
             }
@@ -1936,6 +1937,36 @@ mod tests {
         "};
         let result = serde_saphyr::from_str::<Config>(yaml);
         insta::assert_debug_snapshot!(result);
+    }
+
+    #[test]
+    fn parse_update_options() {
+        let yaml = indoc::indoc! {r"
+            update:
+              cooldown_days: 7
+            repos: []
+        "};
+        let result = serde_saphyr::from_str::<Config>(yaml).unwrap();
+
+        assert_eq!(
+            result.update.and_then(|options| options.cooldown_days),
+            Some(7)
+        );
+    }
+
+    #[test]
+    fn parse_legacy_update_key_alias() {
+        let yaml = indoc::indoc! {r"
+            auto_update:
+              cooldown_days: 7
+            repos: []
+        "};
+        let result = serde_saphyr::from_str::<Config>(yaml).unwrap();
+
+        assert_eq!(
+            result.update.and_then(|options| options.cooldown_days),
+            Some(7)
+        );
     }
 
     #[test]

--- a/crates/prek/src/hook.rs
+++ b/crates/prek/src/hook.rs
@@ -944,7 +944,7 @@ mod tests {
                 relative_path: "",
                 idx: 0,
                 config: Config {
-                    auto_update: None,
+                    update: None,
                     repos: [],
                     default_install_hook_types: None,
                     default_language_version: Some(

--- a/crates/prek/src/main.rs
+++ b/crates/prek/src/main.rs
@@ -378,11 +378,11 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             cli::validate_manifest(args.manifests, printer)
         }
         Command::SampleConfig(args) => cli::sample_config(args.file.into(), args.format, printer),
-        Command::AutoUpdate(args) => {
+        Command::Update(args) => {
             let filesystem = FilesystemOptions::user()?;
             show_settings!(args);
 
-            cli::auto_update(
+            cli::update(
                 &store,
                 cli.globals.config,
                 args.repo,

--- a/crates/prek/src/schema.rs
+++ b/crates/prek/src/schema.rs
@@ -120,6 +120,32 @@ fn strip_null_acceptance(schema: &mut schemars::Schema) {
     }
 }
 
+fn add_compatibility_aliases(schema: &mut schemars::Schema) {
+    use serde_json::Value;
+
+    let Some(properties) = schema
+        .as_object_mut()
+        .and_then(|schema| schema.get_mut("properties"))
+        .and_then(Value::as_object_mut)
+    else {
+        return;
+    };
+
+    let Some(update_schema) = properties.get("update").cloned() else {
+        return;
+    };
+    let mut auto_update_schema = update_schema;
+    if let Some(obj) = auto_update_schema.as_object_mut() {
+        obj.insert(
+            "description".to_string(),
+            Value::String(
+                "Compatibility alias for `update`. Prefer `update` in new configs.".to_string(),
+            ),
+        );
+    }
+    properties.insert("auto_update".to_string(), auto_update_schema);
+}
+
 impl schemars::JsonSchema for Stages {
     fn inline_schema() -> bool {
         true
@@ -426,7 +452,8 @@ mod _gen {
             .with_transform(schemars::transform::RestrictFormats::default())
             .with_transform(super::RemoveNullTypes);
         let generator = schemars::SchemaGenerator::new(settings);
-        let schema = generator.into_root_schema_for::<Config>();
+        let mut schema = generator.into_root_schema_for::<Config>();
+        super::add_compatibility_aliases(&mut schema);
         serde_json::to_string_pretty(&schema).unwrap() + "\n"
     }
 

--- a/crates/prek/src/settings.rs
+++ b/crates/prek/src/settings.rs
@@ -78,23 +78,24 @@ impl Deref for FilesystemOptions {
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default, rename_all = "snake_case")]
 pub(crate) struct Options {
-    auto_update: Option<AutoUpdateOptions>,
+    #[serde(alias = "auto_update")]
+    update: Option<UpdateOptions>,
 }
 
-/// Options for the `auto-update` command.
+/// Options for the `update` command.
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default, rename_all = "snake_case")]
-struct AutoUpdateOptions {
+struct UpdateOptions {
     cooldown_days: Option<u8>,
 }
 
-/// Resolved settings for the `auto-update` command.
+/// Resolved settings for the `update` command.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct AutoUpdateSettings {
+pub(crate) struct UpdateSettings {
     pub(crate) cooldown_days: u8,
 }
 
-impl AutoUpdateSettings {
+impl UpdateSettings {
     pub(crate) fn resolve(
         cli_cooldown_days: Option<u8>,
         filesystem: Option<&FilesystemOptions>,
@@ -105,10 +106,47 @@ impl AutoUpdateSettings {
                 .or(project_cooldown_days)
                 .or_else(|| {
                     filesystem
-                        .and_then(|fs| fs.auto_update.as_ref())
+                        .and_then(|fs| fs.update.as_ref())
                         .and_then(|options| options.cooldown_days)
                 })
                 .unwrap_or_default(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Options;
+
+    #[test]
+    fn options_deserializes_update_settings() {
+        let options: Options = toml::from_str(
+            r"
+            [update]
+            cooldown_days = 7
+            ",
+        )
+        .unwrap();
+
+        assert_eq!(
+            options.update.and_then(|options| options.cooldown_days),
+            Some(7)
+        );
+    }
+
+    #[test]
+    fn options_deserializes_legacy_update_key_alias() {
+        let options: Options = toml::from_str(
+            r"
+            [auto_update]
+            cooldown_days = 7
+            ",
+        )
+        .unwrap();
+
+        assert_eq!(
+            options.update.and_then(|options| options.cooldown_days),
+            Some(7)
+        );
     }
 }

--- a/crates/prek/src/snapshots/prek__config__tests__language_version.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__language_version.snap
@@ -4,7 +4,7 @@ expression: result
 ---
 Ok(
     Config {
-        auto_update: None,
+        update: None,
         repos: [
             Local(
                 LocalRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__meta_hooks-5.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__meta_hooks-5.snap
@@ -3,7 +3,7 @@ source: crates/prek/src/config.rs
 expression: result
 ---
 Config {
-    auto_update: None,
+    update: None,
     repos: [
         Meta(
             MetaRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__numeric_rev_is_parsed_as_string.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__numeric_rev_is_parsed_as_string.snap
@@ -3,7 +3,7 @@ source: crates/prek/src/config.rs
 expression: config
 ---
 Config {
-    auto_update: None,
+    update: None,
     repos: [
         Remote(
             RemoteRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__parse_hooks-3.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__parse_hooks-3.snap
@@ -3,7 +3,7 @@ source: crates/prek/src/config.rs
 expression: result
 ---
 Config {
-    auto_update: None,
+    update: None,
     repos: [
         Local(
             LocalRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__parse_repos-3.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__parse_repos-3.snap
@@ -3,7 +3,7 @@ source: crates/prek/src/config.rs
 expression: result
 ---
 Config {
-    auto_update: None,
+    update: None,
     repos: [
         Local(
             LocalRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__parse_repos-4.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__parse_repos-4.snap
@@ -3,7 +3,7 @@ source: crates/prek/src/config.rs
 expression: result
 ---
 Config {
-    auto_update: None,
+    update: None,
     repos: [
         Remote(
             RemoteRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__parse_repos-6.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__parse_repos-6.snap
@@ -3,7 +3,7 @@ source: crates/prek/src/config.rs
 expression: result
 ---
 Config {
-    auto_update: None,
+    update: None,
     repos: [
         Remote(
             RemoteRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__parse_repos.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__parse_repos.snap
@@ -3,7 +3,7 @@ source: crates/prek/src/config.rs
 expression: result
 ---
 Config {
-    auto_update: None,
+    update: None,
     repos: [
         Local(
             LocalRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__read_config_with_merge_keys.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__read_config_with_merge_keys.snap
@@ -3,7 +3,7 @@ source: crates/prek/src/config.rs
 expression: config
 ---
 Config {
-    auto_update: None,
+    update: None,
     repos: [
         Local(
             LocalRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__read_config_with_nested_merge_keys.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__read_config_with_nested_merge_keys.snap
@@ -3,7 +3,7 @@ source: crates/prek/src/config.rs
 expression: config
 ---
 Config {
-    auto_update: None,
+    update: None,
     repos: [
         Local(
             LocalRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__read_toml_config.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__read_toml_config.snap
@@ -3,7 +3,7 @@ source: crates/prek/src/config.rs
 expression: config
 ---
 Config {
-    auto_update: None,
+    update: None,
     repos: [
         Local(
             LocalRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__read_yaml_config.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__read_yaml_config.snap
@@ -3,7 +3,7 @@ source: crates/prek/src/config.rs
 expression: config
 ---
 Config {
-    auto_update: None,
+    update: None,
     repos: [
         Remote(
             RemoteRepo {

--- a/crates/prek/tests/common/mod.rs
+++ b/crates/prek/tests/common/mod.rs
@@ -253,9 +253,9 @@ impl TestContext {
         command
     }
 
-    pub fn auto_update(&self) -> Command {
+    pub fn update(&self) -> Command {
         let mut cmd = self.command();
-        cmd.arg("auto-update");
+        cmd.arg("update");
         cmd
     }
 

--- a/crates/prek/tests/global_config.rs
+++ b/crates/prek/tests/global_config.rs
@@ -8,7 +8,7 @@ fn global_config_missing_file_is_optional() {
     context.init_project();
     context.write_pre_commit_config("repos: []");
 
-    cmd_snapshot!(context.filters(), context.auto_update(), @"
+    cmd_snapshot!(context.filters(), context.update(), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -25,12 +25,27 @@ fn global_config_ignores_unknown_options() {
     context.write_user_config(indoc::indoc! {r#"
         future_option = true
 
-        [auto_update]
+        [update]
         cooldown_days = 3
         future_option = "ignored"
     "#});
 
-    cmd_snapshot!(context.filters(), context.auto_update(), @"
+    cmd_snapshot!(context.filters(), context.update(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn update_command_accepts_legacy_command_alias() {
+    let context = TestContext::new();
+    context.init_project();
+    context.write_pre_commit_config("repos: []");
+
+    cmd_snapshot!(context.filters(), context.command().arg("auto-update"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -45,11 +60,11 @@ fn global_config_invalid_file_reports_parse_error() {
     context.init_project();
     context.write_pre_commit_config("repos: []");
     context.write_user_config(indoc::indoc! {r#"
-        [auto_update]
+        [update]
         cooldown_days = "soon"
     "#});
 
-    cmd_snapshot!(context.filters(), context.auto_update(), @r#"
+    cmd_snapshot!(context.filters(), context.update(), @r#"
     success: false
     exit_code: 2
     ----- stdout -----

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -3029,7 +3029,7 @@ fn selectors_completion() -> Result<()> {
     validate-config	Validate configuration files (prek.toml or .pre-commit-config.yaml)
     validate-manifest	Validate `.pre-commit-hooks.yaml` files
     sample-config	Produce a sample configuration file (prek.toml or .pre-commit-config.yaml)
-    auto-update	Auto-update the `rev` field of repositories in the config file to the latest version
+    update	Update the `rev` field of repositories in the config file to the latest version
     cache	Manage the prek cache
     try-repo	Try the pre-commit hooks in the current repo
     util	Utility commands

--- a/crates/prek/tests/update.rs
+++ b/crates/prek/tests/update.rs
@@ -144,7 +144,7 @@ fn create_local_git_repo_with_tag_timestamps(
 }
 
 #[test]
-fn auto_update_basic() -> Result<()> {
+fn update_basic() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -161,7 +161,7 @@ fn auto_update_basic() -> Result<()> {
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--cooldown-days").arg("0"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -188,7 +188,7 @@ fn auto_update_basic() -> Result<()> {
 }
 
 #[test]
-fn auto_update_already_up_to_date() -> Result<()> {
+fn update_already_up_to_date() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -206,7 +206,7 @@ fn auto_update_already_up_to_date() -> Result<()> {
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--cooldown-days").arg("0"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -231,7 +231,7 @@ fn auto_update_already_up_to_date() -> Result<()> {
 }
 
 #[test]
-fn auto_update_cooldown_does_not_downgrade_current_rev() -> Result<()> {
+fn update_cooldown_does_not_downgrade_current_rev() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -253,7 +253,7 @@ fn auto_update_cooldown_does_not_downgrade_current_rev() -> Result<()> {
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--cooldown-days").arg("7"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--cooldown-days").arg("7"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -280,7 +280,7 @@ fn auto_update_cooldown_does_not_downgrade_current_rev() -> Result<()> {
 }
 
 #[test]
-fn auto_update_freeze_still_freezes_skipped_cooldown_downgrade() -> Result<()> {
+fn update_freeze_still_freezes_skipped_cooldown_downgrade() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -306,7 +306,7 @@ fn auto_update_freeze_still_freezes_skipped_cooldown_downgrade() -> Result<()> {
         .chain([(r"[a-f0-9]{40}", r"[COMMIT_SHA]")])
         .collect::<Vec<_>>();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--freeze").arg("--cooldown-days").arg("7"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--freeze").arg("--cooldown-days").arg("7"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -333,7 +333,7 @@ fn auto_update_freeze_still_freezes_skipped_cooldown_downgrade() -> Result<()> {
 }
 
 #[test]
-fn auto_update_already_up_to_date_verbose() -> Result<()> {
+fn update_already_up_to_date_verbose() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -351,7 +351,7 @@ fn auto_update_already_up_to_date_verbose() -> Result<()> {
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters, context.auto_update().arg("-v").arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters, context.update().arg("-v").arg("--cooldown-days").arg("0"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -366,7 +366,7 @@ fn auto_update_already_up_to_date_verbose() -> Result<()> {
 
 #[test]
 #[cfg(unix)]
-fn auto_update_does_not_rewrite_config_when_up_to_date() -> Result<()> {
+fn update_does_not_rewrite_config_when_up_to_date() -> Result<()> {
     use std::time::UNIX_EPOCH;
 
     let context = TestContext::new();
@@ -391,7 +391,7 @@ fn auto_update_does_not_rewrite_config_when_up_to_date() -> Result<()> {
         .as_secs();
 
     let assert = context
-        .auto_update()
+        .update()
         .arg("--cooldown-days")
         .arg("0")
         .assert()
@@ -409,7 +409,7 @@ fn auto_update_does_not_rewrite_config_when_up_to_date() -> Result<()> {
 }
 
 #[test]
-fn auto_update_multiple_repos_mixed() -> Result<()> {
+fn update_multiple_repos_mixed() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -436,7 +436,7 @@ fn auto_update_multiple_repos_mixed() -> Result<()> {
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--cooldown-days").arg("0"), @"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -472,7 +472,7 @@ fn auto_update_multiple_repos_mixed() -> Result<()> {
     Ok(())
 }
 
-/// Test that `auto-update` ignores the `GIT_DIR` environment variable.
+/// Test that `prek update` ignores the `GIT_DIR` environment variable.
 #[test]
 fn test_resolve_revision_ignores_git_dir_env_var() -> Result<()> {
     let context = TestContext::new();
@@ -492,7 +492,7 @@ fn test_resolve_revision_ignores_git_dir_env_var() -> Result<()> {
 
     let filters = context.filters();
 
-    let mut cmd = context.auto_update();
+    let mut cmd = context.update();
     cmd.arg("--cooldown-days")
         .arg("0")
         .env("GIT_DIR", ChildPath::new(&external_repo_path).join(".git"));
@@ -524,7 +524,7 @@ fn test_resolve_revision_ignores_git_dir_env_var() -> Result<()> {
 }
 
 #[test]
-fn auto_update_specific_repos() -> Result<()> {
+fn update_specific_repos() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -548,7 +548,7 @@ fn auto_update_specific_repos() -> Result<()> {
     let filters = context.filters();
 
     // Update only repo1
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--repo").arg(&repo1_path).arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--repo").arg(&repo1_path).arg("--cooldown-days").arg("0"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -576,7 +576,7 @@ fn auto_update_specific_repos() -> Result<()> {
     );
 
     // Update both repo1 and repo2
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--repo").arg(&repo1_path).arg("--repo").arg(&repo2_path).arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--repo").arg(&repo1_path).arg("--repo").arg(&repo2_path).arg("--cooldown-days").arg("0"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -607,7 +607,7 @@ fn auto_update_specific_repos() -> Result<()> {
 }
 
 #[test]
-fn auto_update_exclude_repo_skips_fetching_repo() -> Result<()> {
+fn update_exclude_repo_skips_fetching_repo() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -634,7 +634,7 @@ fn auto_update_exclude_repo_skips_fetching_repo() -> Result<()> {
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--exclude-repo").arg(&missing_repo_path).arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--exclude-repo").arg(&missing_repo_path).arg("--cooldown-days").arg("0"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -665,7 +665,7 @@ fn auto_update_exclude_repo_skips_fetching_repo() -> Result<()> {
 }
 
 #[test]
-fn auto_update_tag_filters_include_then_exclude() -> Result<()> {
+fn update_tag_filters_include_then_exclude() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -687,7 +687,7 @@ fn auto_update_tag_filters_include_then_exclude() -> Result<()> {
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters.clone(), context.auto_update()
+    cmd_snapshot!(filters.clone(), context.update()
         .arg("--include-tag").arg("v1.*")
         .arg("--include-tag").arg("v2.*")
         .arg("--exclude-tag").arg("v2.*")
@@ -718,7 +718,7 @@ fn auto_update_tag_filters_include_then_exclude() -> Result<()> {
 }
 
 #[test]
-fn auto_update_tag_filters_can_select_older_track_without_cooldown() -> Result<()> {
+fn update_tag_filters_can_select_older_track_without_cooldown() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -740,7 +740,7 @@ fn auto_update_tag_filters_can_select_older_track_without_cooldown() -> Result<(
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters.clone(), context.auto_update()
+    cmd_snapshot!(filters.clone(), context.update()
         .arg("--include-tag").arg("v1.*")
         .arg("--cooldown-days").arg("0"), @"
     success: true
@@ -769,7 +769,7 @@ fn auto_update_tag_filters_can_select_older_track_without_cooldown() -> Result<(
 }
 
 #[test]
-fn auto_update_repo_include_tag_is_repo_specific() -> Result<()> {
+fn update_repo_include_tag_is_repo_specific() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -801,7 +801,7 @@ fn auto_update_repo_include_tag_is_repo_specific() -> Result<()> {
     let filters = context.filters();
     let repo1_filter = format!("{repo1_path}=v1.*");
 
-    cmd_snapshot!(filters.clone(), context.auto_update()
+    cmd_snapshot!(filters.clone(), context.update()
         .arg("--jobs").arg("1")
         .arg("--repo-include-tag").arg(repo1_filter)
         .arg("--cooldown-days").arg("0"), @"
@@ -838,7 +838,7 @@ fn auto_update_repo_include_tag_is_repo_specific() -> Result<()> {
 }
 
 #[test]
-fn auto_update_repo_include_tag_overrides_global_include_tag() -> Result<()> {
+fn update_repo_include_tag_overrides_global_include_tag() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -861,7 +861,7 @@ fn auto_update_repo_include_tag_overrides_global_include_tag() -> Result<()> {
     let filters = context.filters();
     let repo_filter = format!("{repo_path}=v*.1.0");
 
-    cmd_snapshot!(filters.clone(), context.auto_update()
+    cmd_snapshot!(filters.clone(), context.update()
         .arg("--include-tag").arg("v1.*")
         .arg("--repo-include-tag").arg(repo_filter)
         .arg("--cooldown-days").arg("0"), @"
@@ -891,7 +891,7 @@ fn auto_update_repo_include_tag_overrides_global_include_tag() -> Result<()> {
 }
 
 #[test]
-fn auto_update_repo_exclude_tag_can_leave_repo_unchanged() -> Result<()> {
+fn update_repo_exclude_tag_can_leave_repo_unchanged() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -915,7 +915,7 @@ fn auto_update_repo_exclude_tag_can_leave_repo_unchanged() -> Result<()> {
     let filters = context.filters();
     let repo1_filter = format!("{repo1_path}=v2.*");
 
-    cmd_snapshot!(filters.clone(), context.auto_update()
+    cmd_snapshot!(filters.clone(), context.update()
         .arg("--jobs").arg("1")
         .arg("--include-tag").arg("v2.*")
         .arg("--repo-exclude-tag").arg(repo1_filter)
@@ -950,7 +950,7 @@ fn auto_update_repo_exclude_tag_can_leave_repo_unchanged() -> Result<()> {
 }
 
 #[test]
-fn auto_update_bleeding_edge() -> Result<()> {
+fn update_bleeding_edge() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -972,7 +972,7 @@ fn auto_update_bleeding_edge() -> Result<()> {
         .chain([("[a-f0-9]{40}", "[COMMIT_SHA]")])
         .collect::<Vec<_>>();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--bleeding-edge"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--bleeding-edge"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -999,7 +999,7 @@ fn auto_update_bleeding_edge() -> Result<()> {
 }
 
 #[test]
-fn auto_update_freeze() -> Result<()> {
+fn update_freeze() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -1030,7 +1030,7 @@ fn auto_update_freeze() -> Result<()> {
         .chain([(r"[a-f0-9]{40}", r"[COMMIT_SHA]")])
         .collect::<Vec<_>>();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--freeze").arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--freeze").arg("--cooldown-days").arg("0"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1058,7 +1058,7 @@ fn auto_update_freeze() -> Result<()> {
 }
 
 #[test]
-fn auto_update_freeze_uses_dereferenced_commit_for_annotated_tags() -> Result<()> {
+fn update_freeze_uses_dereferenced_commit_for_annotated_tags() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -1092,7 +1092,7 @@ fn auto_update_freeze_uses_dereferenced_commit_for_annotated_tags() -> Result<()
     context.git_add(".");
 
     context
-        .auto_update()
+        .update()
         .arg("--freeze")
         .arg("--cooldown-days")
         .arg("0")
@@ -1117,7 +1117,7 @@ fn auto_update_freeze_uses_dereferenced_commit_for_annotated_tags() -> Result<()
 }
 
 #[test]
-fn auto_update_shared_target_with_different_frozen_comments_displays_sha() -> Result<()> {
+fn update_shared_target_with_different_frozen_comments_displays_sha() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -1160,7 +1160,7 @@ fn auto_update_shared_target_with_different_frozen_comments_displays_sha() -> Re
         .chain([(old_commit_sha.as_str(), "[OLD_COMMIT_SHA]")])
         .collect::<Vec<_>>();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--cooldown-days").arg("0"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1192,7 +1192,7 @@ fn auto_update_shared_target_with_different_frozen_comments_displays_sha() -> Re
 }
 
 #[test]
-fn auto_update_preserve_quote_style() -> Result<()> {
+fn update_preserve_quote_style() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -1227,7 +1227,7 @@ fn auto_update_preserve_quote_style() -> Result<()> {
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--cooldown-days").arg("0"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1273,7 +1273,7 @@ fn auto_update_preserve_quote_style() -> Result<()> {
 }
 
 #[test]
-fn auto_update_with_existing_frozen_comment() -> Result<()> {
+fn update_with_existing_frozen_comment() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -1298,7 +1298,7 @@ fn auto_update_with_existing_frozen_comment() -> Result<()> {
         .chain([(commit_sha, "[COMMIT_SHA]")])
         .collect::<Vec<_>>();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--cooldown-days").arg("0"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1332,7 +1332,7 @@ fn auto_update_with_existing_frozen_comment() -> Result<()> {
 }
 
 #[test]
-fn auto_update_updates_mismatched_frozen_comment() -> Result<()> {
+fn update_updates_mismatched_frozen_comment() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -1360,7 +1360,7 @@ fn auto_update_updates_mismatched_frozen_comment() -> Result<()> {
         .chain([(commit_sha.as_str(), "[COMMIT_SHA]")])
         .collect::<Vec<_>>();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--freeze"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--freeze"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1394,7 +1394,7 @@ fn auto_update_updates_mismatched_frozen_comment() -> Result<()> {
 }
 
 #[test]
-fn auto_update_updates_unresolvable_frozen_comment() -> Result<()> {
+fn update_updates_unresolvable_frozen_comment() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -1426,7 +1426,7 @@ fn auto_update_updates_unresolvable_frozen_comment() -> Result<()> {
         .chain([(commit_sha.as_str(), "[COMMIT_SHA]")])
         .collect::<Vec<_>>();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--freeze"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--freeze"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1460,7 +1460,7 @@ fn auto_update_updates_unresolvable_frozen_comment() -> Result<()> {
 }
 
 #[test]
-fn auto_update_removes_frozen_comment_when_pinned_commit_has_no_tag() -> Result<()> {
+fn update_removes_frozen_comment_when_pinned_commit_has_no_tag() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -1492,7 +1492,7 @@ fn auto_update_removes_frozen_comment_when_pinned_commit_has_no_tag() -> Result<
         .chain([(commit_sha.as_str(), "[COMMIT_SHA]")])
         .collect::<Vec<_>>();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--bleeding-edge").arg("--freeze"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--bleeding-edge").arg("--freeze"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1526,7 +1526,7 @@ fn auto_update_removes_frozen_comment_when_pinned_commit_has_no_tag() -> Result<
 }
 
 #[test]
-fn auto_update_warns_for_branch_only_pinned_commit_with_frozen_comment() -> Result<()> {
+fn update_warns_for_branch_only_pinned_commit_with_frozen_comment() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -1580,7 +1580,7 @@ fn auto_update_warns_for_branch_only_pinned_commit_with_frozen_comment() -> Resu
         ])
         .collect::<Vec<_>>();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--freeze").arg("--dry-run"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--freeze").arg("--dry-run"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1614,7 +1614,7 @@ fn auto_update_warns_for_branch_only_pinned_commit_with_frozen_comment() -> Resu
 }
 
 #[test]
-fn auto_update_warns_for_invalid_pinned_commit_with_frozen_comment() -> Result<()> {
+fn update_warns_for_invalid_pinned_commit_with_frozen_comment() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -1645,7 +1645,7 @@ fn auto_update_warns_for_invalid_pinned_commit_with_frozen_comment() -> Result<(
         ])
         .collect::<Vec<_>>();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--freeze").arg("--dry-run"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--freeze").arg("--dry-run"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1679,7 +1679,7 @@ fn auto_update_warns_for_invalid_pinned_commit_with_frozen_comment() -> Result<(
 }
 
 #[test]
-fn auto_update_dry_run_warns_for_mismatched_frozen_comment() -> Result<()> {
+fn update_dry_run_warns_for_mismatched_frozen_comment() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -1708,7 +1708,7 @@ fn auto_update_dry_run_warns_for_mismatched_frozen_comment() -> Result<()> {
         .chain([(commit_sha.as_str(), "[COMMIT_SHA]")])
         .collect::<Vec<_>>();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--freeze").arg("--dry-run"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--freeze").arg("--dry-run"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1742,7 +1742,7 @@ fn auto_update_dry_run_warns_for_mismatched_frozen_comment() -> Result<()> {
 }
 
 #[test]
-fn auto_update_check_fails_for_mismatched_frozen_comment() -> Result<()> {
+fn update_check_fails_for_mismatched_frozen_comment() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -1771,7 +1771,7 @@ fn auto_update_check_fails_for_mismatched_frozen_comment() -> Result<()> {
         .chain([(commit_sha.as_str(), "[COMMIT_SHA]")])
         .collect::<Vec<_>>();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--freeze").arg("--check"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--freeze").arg("--check"), @"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1805,7 +1805,7 @@ fn auto_update_check_fails_for_mismatched_frozen_comment() -> Result<()> {
 }
 
 #[test]
-fn auto_update_updates_mismatched_frozen_comment_toml() -> Result<()> {
+fn update_updates_mismatched_frozen_comment_toml() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -1838,7 +1838,7 @@ fn auto_update_updates_mismatched_frozen_comment_toml() -> Result<()> {
         .chain([(commit_sha.as_str(), "[COMMIT_SHA]")])
         .collect::<Vec<_>>();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--freeze"), @r#"
+    cmd_snapshot!(filters.clone(), context.update().arg("--freeze"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1873,7 +1873,7 @@ fn auto_update_updates_mismatched_frozen_comment_toml() -> Result<()> {
 }
 
 #[test]
-fn auto_update_local_repo_ignored() -> Result<()> {
+fn update_local_repo_ignored() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -1897,7 +1897,7 @@ fn auto_update_local_repo_ignored() -> Result<()> {
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--cooldown-days").arg("0"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1972,7 +1972,7 @@ fn missing_hook_ids() -> Result<()> {
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--cooldown-days").arg("0"), @"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1986,7 +1986,7 @@ fn missing_hook_ids() -> Result<()> {
 }
 
 #[test]
-fn auto_update_workspace() -> Result<()> {
+fn update_workspace() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -2034,7 +2034,7 @@ fn auto_update_workspace() -> Result<()> {
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--cooldown-days").arg("0"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -2090,11 +2090,11 @@ fn auto_update_workspace() -> Result<()> {
 }
 
 #[test]
-fn auto_update_workspace_same_repo_uses_project_cooldown() -> Result<()> {
+fn update_workspace_same_repo_uses_project_cooldown() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
     context.write_user_config(indoc::indoc! {r"
-        [auto_update]
+        [update]
         cooldown_days = 1
     "});
 
@@ -2124,7 +2124,7 @@ fn auto_update_workspace_same_repo_uses_project_cooldown() -> Result<()> {
         .work_dir()
         .child("project-a/.pre-commit-config.yaml")
         .write_str(&indoc::formatdoc! {r"
-        auto_update:
+        update:
           cooldown_days: 0
         repos:
           - repo: {}
@@ -2148,7 +2148,7 @@ fn auto_update_workspace_same_repo_uses_project_cooldown() -> Result<()> {
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters.clone(), context.auto_update(), @"
+    cmd_snapshot!(filters.clone(), context.update(), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -2167,7 +2167,7 @@ fn auto_update_workspace_same_repo_uses_project_cooldown() -> Result<()> {
         { filters => filters.clone() },
         {
             assert_snapshot!(context.read("project-a/.pre-commit-config.yaml"), @"
-            auto_update:
+            update:
               cooldown_days: 0
             repos:
               - repo: [HOME]/test-repos/workspace-cooldown-repo
@@ -2245,7 +2245,7 @@ fn prefer_similar_tags() -> Result<()> {
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--cooldown-days").arg("0"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -2278,7 +2278,7 @@ fn prefer_similar_tags() -> Result<()> {
 }
 
 #[test]
-fn auto_update_dry_run() -> Result<()> {
+fn update_dry_run() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -2295,7 +2295,7 @@ fn auto_update_dry_run() -> Result<()> {
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--dry-run").arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--dry-run").arg("--cooldown-days").arg("0"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -2322,7 +2322,7 @@ fn auto_update_dry_run() -> Result<()> {
 }
 
 #[test]
-fn auto_update_check() -> Result<()> {
+fn update_check() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -2340,7 +2340,7 @@ fn auto_update_check() -> Result<()> {
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--check").arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--check").arg("--cooldown-days").arg("0"), @"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -2367,7 +2367,7 @@ fn auto_update_check() -> Result<()> {
 }
 
 #[test]
-fn auto_update_dry_run_exit_code() -> Result<()> {
+fn update_dry_run_exit_code() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -2388,7 +2388,7 @@ fn auto_update_dry_run_exit_code() -> Result<()> {
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--dry-run").arg("--exit-code").arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--dry-run").arg("--exit-code").arg("--cooldown-days").arg("0"), @"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -2415,7 +2415,7 @@ fn auto_update_dry_run_exit_code() -> Result<()> {
 }
 
 #[test]
-fn auto_update_exit_code_updates_config() -> Result<()> {
+fn update_exit_code_updates_config() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -2436,7 +2436,7 @@ fn auto_update_exit_code_updates_config() -> Result<()> {
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--exit-code").arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--exit-code").arg("--cooldown-days").arg("0"), @"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -2463,7 +2463,7 @@ fn auto_update_exit_code_updates_config() -> Result<()> {
 }
 
 #[test]
-fn auto_update_exit_code_succeeds_when_up_to_date() -> Result<()> {
+fn update_exit_code_succeeds_when_up_to_date() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -2484,7 +2484,7 @@ fn auto_update_exit_code_succeeds_when_up_to_date() -> Result<()> {
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--exit-code").arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--exit-code").arg("--cooldown-days").arg("0"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -2528,7 +2528,7 @@ fn quoting_float_like_version_number() -> Result<()> {
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--cooldown-days").arg("0"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -2572,7 +2572,7 @@ fn quoting_float_like_version_number_without_existing_quotes() -> Result<()> {
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--cooldown-days").arg("0"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -2599,7 +2599,7 @@ fn quoting_float_like_version_number_without_existing_quotes() -> Result<()> {
 }
 
 #[test]
-fn auto_update_with_invalid_config_file() -> Result<()> {
+fn update_with_invalid_config_file() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -2611,7 +2611,7 @@ fn auto_update_with_invalid_config_file() -> Result<()> {
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters.clone(), context.auto_update(), @"
+    cmd_snapshot!(filters.clone(), context.update(), @"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -2629,7 +2629,7 @@ fn auto_update_with_invalid_config_file() -> Result<()> {
 }
 
 #[test]
-fn auto_update_toml() -> Result<()> {
+fn update_toml() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -2651,7 +2651,7 @@ fn auto_update_toml() -> Result<()> {
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--cooldown-days").arg("0"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -2679,7 +2679,7 @@ fn auto_update_toml() -> Result<()> {
 }
 
 #[test]
-fn auto_update_toml_with_comment() -> Result<()> {
+fn update_toml_with_comment() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -2702,7 +2702,7 @@ fn auto_update_toml_with_comment() -> Result<()> {
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--cooldown-days").arg("0"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -2741,7 +2741,7 @@ fn auto_update_toml_with_comment() -> Result<()> {
 
     context.git_add(".");
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--cooldown-days").arg("0"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -2769,7 +2769,7 @@ fn auto_update_toml_with_comment() -> Result<()> {
 }
 
 #[test]
-fn auto_update_freeze_toml() -> Result<()> {
+fn update_freeze_toml() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -2804,7 +2804,7 @@ fn auto_update_freeze_toml() -> Result<()> {
         .chain([(r"[a-f0-9]{40}", r"[COMMIT_SHA]")])
         .collect::<Vec<_>>();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--freeze").arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--freeze").arg("--cooldown-days").arg("0"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -2833,7 +2833,7 @@ fn auto_update_freeze_toml() -> Result<()> {
 }
 
 #[test]
-fn auto_update_equal_timestamp_tags_picks_highest_version() -> Result<()> {
+fn update_equal_timestamp_tags_picks_highest_version() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -2854,7 +2854,7 @@ fn auto_update_equal_timestamp_tags_picks_highest_version() -> Result<()> {
     context.git_add(".");
 
     let filters = context.filters();
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--cooldown-days").arg("0"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -2883,7 +2883,7 @@ fn auto_update_equal_timestamp_tags_picks_highest_version() -> Result<()> {
 // When all tags share a timestamp and some are non-semver (e.g. "latest", "stable"),
 // semver tags should be preferred and sorted highest-first.
 #[test]
-fn auto_update_equal_timestamp_prefers_semver_over_nonsemver() -> Result<()> {
+fn update_equal_timestamp_prefers_semver_over_nonsemver() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -2905,7 +2905,7 @@ fn auto_update_equal_timestamp_prefers_semver_over_nonsemver() -> Result<()> {
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--cooldown-days").arg("0"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -2934,7 +2934,7 @@ fn auto_update_equal_timestamp_prefers_semver_over_nonsemver() -> Result<()> {
 // When tags span multiple timestamp groups, the newest group should be selected first.
 // Within an equal-timestamp group, semver tiebreaker picks the highest version.
 #[test]
-fn auto_update_mixed_timestamps_with_equal_subgroups() -> Result<()> {
+fn update_mixed_timestamps_with_equal_subgroups() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -2977,7 +2977,7 @@ fn auto_update_mixed_timestamps_with_equal_subgroups() -> Result<()> {
 
     let filters = context.filters();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--cooldown-days").arg("0"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -3004,7 +3004,7 @@ fn auto_update_mixed_timestamps_with_equal_subgroups() -> Result<()> {
 }
 
 #[test]
-fn auto_update_freeze_toml_with_comment() -> Result<()> {
+fn update_freeze_toml_with_comment() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -3041,7 +3041,7 @@ fn auto_update_freeze_toml_with_comment() -> Result<()> {
         .chain([(r"[a-f0-9]{40}", r"[COMMIT_SHA]")])
         .collect::<Vec<_>>();
 
-    cmd_snapshot!(filters.clone(), context.auto_update().arg("--freeze").arg("--cooldown-days").arg("0"), @"
+    cmd_snapshot!(filters.clone(), context.update().arg("--freeze").arg("--cooldown-days").arg("0"), @"
     success: true
     exit_code: 0
     ----- stdout -----

--- a/docs/authoring-hooks.md
+++ b/docs/authoring-hooks.md
@@ -132,16 +132,16 @@ Invocation shape:
 my-hook --max-line-length=120 path/to/file1 path/to/file2
 ```
 
-## Versioning for `prek auto-update`
+## Versioning for `prek update`
 
 End users pin your repository using the `rev` field in their config. To make
-[`prek auto-update`](reference/cli.md#prek-auto-update) work as expected, publish git tags for releases:
+[`prek update`](reference/cli.md#prek-update) work as expected, publish git tags for releases:
 
 - Prefer semantic version tags like `v1.2.3` or `1.2.3`.
 - Push tags to the remote (annotated or lightweight tags both work).
 - Avoid moving tags; treat them as immutable release references.
 
-`prek auto-update` selects the newest tag by default. With `--bleeding-edge`, it
+`prek update` selects the newest tag by default. With `--bleeding-edge`, it
 uses the default branch tip instead of tags. With `--freeze`, it writes commit
 SHAs into `rev` instead of tag names.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -10,18 +10,27 @@
 
 ## Preferred command and flag spellings
 
-`prek` keeps compatibility aliases for the commands below, but the preferred spellings use a more descriptive CLI layout.
+`prek` keeps compatibility aliases for the commands below, but the preferred spellings use the current CLI layout.
 
 | Compatibility spelling | Preferred `prek` spelling |
 | -- | -- |
 | `prek install-hooks` | `prek prepare-hooks` |
 | `prek install --install-hooks` | `prek install --prepare-hooks` |
-| `prek autoupdate` | `prek auto-update` |
+| `prek auto-update` | `prek update` |
+| `prek autoupdate` | `prek update` |
 | `prek gc` | `prek cache gc` |
 | `prek clean` | `prek cache clean` |
 | `prek init-templatedir` | `prek util init-template-dir` |
 | `prek init-template-dir` | `prek util init-template-dir` |
 | `pre-commit migrate-config` | Not provided directly; use `prek util yaml-to-toml` to migrate YAML to `prek.toml` |
+
+## Preferred config key spellings
+
+`prek` still accepts legacy config keys below as aliases.
+
+| Compatibility spelling | Preferred `prek` spelling |
+| -- | -- |
+| `auto_update.cooldown_days` | `update.cooldown_days` |
 
 ## Why the CLI is reorganized
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,7 +32,7 @@ Both formats are first-class and will be supported long-term. They describe the 
 - Windows: `%APPDATA%\prek\prek.toml`
 
 This file is for user-level `prek` settings, not hook definitions. Project hooks still live in the project config files described below.
-For the supported global settings, see the [configuration reference](reference/configuration.md#global-auto_updatecooldown_days).
+For the supported global settings, see the [configuration reference](reference/configuration.md#global-updatecooldown_days).
 
 ## Pre-commit compatibility
 
@@ -50,7 +50,7 @@ These entries are implemented by `prek` and are not part of the documented upstr
 They work in both YAML and TOML, but they only matter for compatibility if you share a YAML config with upstream `pre-commit`.
 
 - Top-level:
-    - [`auto_update.cooldown_days`](reference/configuration.md#auto_updatecooldown_days)
+    - [`update.cooldown_days`](reference/configuration.md#updatecooldown_days)
     - [`minimum_prek_version`](reference/configuration.md#prek-only-minimum-prek-version-config)
     - [`orphan`](reference/configuration.md#prek-only-orphan)
 - Repo type:

--- a/docs/diff.md
+++ b/docs/diff.md
@@ -65,16 +65,16 @@ For a compatibility-focused command mapping, see [Compatibility with pre-commit]
 
 `prek list` lists all available hooks, their ids, and descriptions. This provides a better overview of the configured hooks.
 
-### `prek auto-update`
+### `prek update`
 
-- `prek auto-update` updates all projects in the workspace to their latest revisions.
-- `prek auto-update` checks updates for the same repository only once, speeding up the process in workspace mode.
-- `prek auto-update` supports `--dry-run` to preview the updates without applying them.
-- `prek auto-update` supports `--exit-code` to exit non-zero when updates are available, and `--check` as an alias for `--dry-run --exit-code`.
-- `prek auto-update` validates pinned SHA revisions against fetched upstream refs, including impostor-commit detection, and keeps stale `# frozen:` comments in sync when it can.
-- `prek auto-update` supports the `--cooldown-days` option to skip releases newer than the specified number of days (based on the tag creation timestamp for annotated tags, or the tagged commit timestamp for lightweight tags).
-- `prek auto-update` supports `--exclude-repo` to skip selected repositories while updating everything else.
-- `prek auto-update` supports tag filtering with `--include-tag`, `--exclude-tag`, `--repo-include-tag`, and `--repo-exclude-tag`, using glob patterns to keep or remove matching tags before selecting an update.
+- `prek update` updates all projects in the workspace to their latest revisions.
+- `prek update` checks updates for the same repository only once, speeding up the process in workspace mode.
+- `prek update` supports `--dry-run` to preview the updates without applying them.
+- `prek update` supports `--exit-code` to exit non-zero when updates are available, and `--check` as an alias for `--dry-run --exit-code`.
+- `prek update` validates pinned SHA revisions against fetched upstream refs, including impostor-commit detection, and keeps stale `# frozen:` comments in sync when it can.
+- `prek update` supports the `--cooldown-days` option to skip releases newer than the specified number of days (based on the tag creation timestamp for annotated tags, or the tagged commit timestamp for lightweight tags).
+- `prek update` supports `--exclude-repo` to skip selected repositories while updating everything else.
+- `prek update` supports tag filtering with `--include-tag`, `--exclude-tag`, `--repo-include-tag`, and `--repo-exclude-tag`, using glob patterns to keep or remove matching tags before selecting an update.
 
 ### `prek sample-config`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -20,7 +20,7 @@ prek [OPTIONS] [HOOK|PROJECT]... [COMMAND]
 <dt><a href="#prek-validate-config"><code>prek validate-config</code></a></dt><dd><p>Validate configuration files (prek.toml or .pre-commit-config.yaml)</p></dd>
 <dt><a href="#prek-validate-manifest"><code>prek validate-manifest</code></a></dt><dd><p>Validate <code>.pre-commit-hooks.yaml</code> files</p></dd>
 <dt><a href="#prek-sample-config"><code>prek sample-config</code></a></dt><dd><p>Produce a sample configuration file (prek.toml or .pre-commit-config.yaml)</p></dd>
-<dt><a href="#prek-auto-update"><code>prek auto-update</code></a></dt><dd><p>Auto-update the <code>rev</code> field of repositories in the config file to the latest version</p></dd>
+<dt><a href="#prek-update"><code>prek update</code></a></dt><dd><p>Update the <code>rev</code> field of repositories in the config file to the latest version</p></dd>
 <dt><a href="#prek-cache"><code>prek cache</code></a></dt><dd><p>Manage the prek cache</p></dd>
 <dt><a href="#prek-try-repo"><code>prek try-repo</code></a></dt><dd><p>Try the pre-commit hooks in the current repo</p></dd>
 <dt><a href="#prek-util"><code>prek util</code></a></dt><dd><p>Utility commands</p></dd>
@@ -546,55 +546,55 @@ prek sample-config [OPTIONS]
 </dd><dt id="prek-sample-config--version"><a href="#prek-sample-config--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
 </dd></dl>
 
-## prek auto-update
+## prek update
 
-Auto-update the `rev` field of repositories in the config file to the latest version
+Update the `rev` field of repositories in the config file to the latest version
 
 <h3 class="cli-reference">Usage</h3>
 
 ```
-prek auto-update [OPTIONS]
+prek update [OPTIONS]
 ```
 
 <h3 class="cli-reference">Options</h3>
 
-<dl class="cli-reference"><dt id="prek-auto-update--bleeding-edge"><a href="#prek-auto-update--bleeding-edge"><code>--bleeding-edge</code></a></dt><dd><p>Update to the bleeding edge of the default branch instead of the latest tagged version</p>
-</dd><dt id="prek-auto-update--cd"><a href="#prek-auto-update--cd"><code>--cd</code></a>, <code>-C</code> <i>dir</i></dt><dd><p>Change to directory before running</p>
-</dd><dt id="prek-auto-update--check"><a href="#prek-auto-update--check"><code>--check</code></a></dt><dd><p>Alias of <code>--dry-run --exit-code</code></p>
-</dd><dt id="prek-auto-update--color"><a href="#prek-auto-update--color"><code>--color</code></a> <i>color</i></dt><dd><p>Whether to use color in output</p>
+<dl class="cli-reference"><dt id="prek-update--bleeding-edge"><a href="#prek-update--bleeding-edge"><code>--bleeding-edge</code></a></dt><dd><p>Update to the bleeding edge of the default branch instead of the latest tagged version</p>
+</dd><dt id="prek-update--cd"><a href="#prek-update--cd"><code>--cd</code></a>, <code>-C</code> <i>dir</i></dt><dd><p>Change to directory before running</p>
+</dd><dt id="prek-update--check"><a href="#prek-update--check"><code>--check</code></a></dt><dd><p>Alias of <code>--dry-run --exit-code</code></p>
+</dd><dt id="prek-update--color"><a href="#prek-update--color"><code>--color</code></a> <i>color</i></dt><dd><p>Whether to use color in output</p>
 <p>May also be set with the <code>PREK_COLOR</code> environment variable.</p><p>[default: auto]</p><p>Possible values:</p>
 <ul>
 <li><code>auto</code>:  Enables colored output only when the output is going to a terminal or TTY with support</li>
 <li><code>always</code>:  Enables colored output regardless of the detected environment</li>
 <li><code>never</code>:  Disables colored output</li>
-</ul></dd><dt id="prek-auto-update--config"><a href="#prek-auto-update--config"><code>--config</code></a>, <code>-c</code> <i>config</i></dt><dd><p>Path to alternate config file</p>
-</dd><dt id="prek-auto-update--cooldown-days"><a href="#prek-auto-update--cooldown-days"><code>--cooldown-days</code></a> <i>days</i></dt><dd><p>Minimum release age (in days) required for a version to be eligible.</p>
-<p>The age is computed from the tag creation timestamp for annotated tags, or from the tagged commit timestamp for lightweight tags. If the current <code>rev</code> is newer than the latest cooldown-eligible tag, <code>prek auto-update</code> keeps the current <code>rev</code> instead of downgrading it. Defaults to <code>auto_update.cooldown_days</code> in the project or global config, or <code>0</code> when unset. Valid values are <code>0</code> through <code>255</code>; <code>0</code> disables this check.</p>
-</dd><dt id="prek-auto-update--dry-run"><a href="#prek-auto-update--dry-run"><code>--dry-run</code></a></dt><dd><p>Do not write changes to the config file, only display what would be changed</p>
-</dd><dt id="prek-auto-update--exclude-repo"><a href="#prek-auto-update--exclude-repo"><code>--exclude-repo</code></a> <i>repo</i></dt><dd><p>Do not update this repository. This option may be specified multiple times</p>
-</dd><dt id="prek-auto-update--exclude-tag"><a href="#prek-auto-update--exclude-tag"><code>--exclude-tag</code></a> <i>pattern</i></dt><dd><p>Ignore tags matching this glob pattern. This option may be specified multiple times.</p>
+</ul></dd><dt id="prek-update--config"><a href="#prek-update--config"><code>--config</code></a>, <code>-c</code> <i>config</i></dt><dd><p>Path to alternate config file</p>
+</dd><dt id="prek-update--cooldown-days"><a href="#prek-update--cooldown-days"><code>--cooldown-days</code></a> <i>days</i></dt><dd><p>Minimum release age (in days) required for a version to be eligible.</p>
+<p>The age is computed from the tag creation timestamp for annotated tags, or from the tagged commit timestamp for lightweight tags. If the current <code>rev</code> is newer than the latest cooldown-eligible tag, <code>prek update</code> keeps the current <code>rev</code> instead of downgrading it. Defaults to <code>update.cooldown_days</code> in the project or global config, or <code>0</code> when unset. Valid values are <code>0</code> through <code>255</code>; <code>0</code> disables this check.</p>
+</dd><dt id="prek-update--dry-run"><a href="#prek-update--dry-run"><code>--dry-run</code></a></dt><dd><p>Do not write changes to the config file, only display what would be changed</p>
+</dd><dt id="prek-update--exclude-repo"><a href="#prek-update--exclude-repo"><code>--exclude-repo</code></a> <i>repo</i></dt><dd><p>Do not update this repository. This option may be specified multiple times</p>
+</dd><dt id="prek-update--exclude-tag"><a href="#prek-update--exclude-tag"><code>--exclude-tag</code></a> <i>pattern</i></dt><dd><p>Ignore tags matching this glob pattern. This option may be specified multiple times.</p>
 <p>For example, use <code>--exclude-tag nightly</code> to skip a moving tag, or <code>--exclude-tag '*-{alpha,beta,rc}*'</code> to skip common prerelease tags.</p>
-</dd><dt id="prek-auto-update--exit-code"><a href="#prek-auto-update--exit-code"><code>--exit-code</code></a></dt><dd><p>Exit with status 1 if updates are available</p>
-</dd><dt id="prek-auto-update--freeze"><a href="#prek-auto-update--freeze"><code>--freeze</code></a></dt><dd><p>Store &quot;frozen&quot; hashes in <code>rev</code> instead of tag names</p>
-</dd><dt id="prek-auto-update--help"><a href="#prek-auto-update--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Display the concise help for this command</p>
-</dd><dt id="prek-auto-update--include-tag"><a href="#prek-auto-update--include-tag"><code>--include-tag</code></a> <i>pattern</i></dt><dd><p>Only consider tags matching this glob pattern. This option may be specified multiple times.</p>
+</dd><dt id="prek-update--exit-code"><a href="#prek-update--exit-code"><code>--exit-code</code></a></dt><dd><p>Exit with status 1 if updates are available</p>
+</dd><dt id="prek-update--freeze"><a href="#prek-update--freeze"><code>--freeze</code></a></dt><dd><p>Store &quot;frozen&quot; hashes in <code>rev</code> instead of tag names</p>
+</dd><dt id="prek-update--help"><a href="#prek-update--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Display the concise help for this command</p>
+</dd><dt id="prek-update--include-tag"><a href="#prek-update--include-tag"><code>--include-tag</code></a> <i>pattern</i></dt><dd><p>Only consider tags matching this glob pattern. This option may be specified multiple times.</p>
 <p>For example, use <code>--include-tag 'v*'</code> to only consider version tags and ignore tags such as <code>nightly</code>.</p>
-</dd><dt id="prek-auto-update--jobs"><a href="#prek-auto-update--jobs"><code>--jobs</code></a>, <code>-j</code> <i>jobs</i></dt><dd><p>Number of threads to use</p>
-<p>[default: 0]</p></dd><dt id="prek-auto-update--log-file"><a href="#prek-auto-update--log-file"><code>--log-file</code></a> <i>log-file</i></dt><dd><p>Write trace logs to the specified file. If not specified, trace logs will be written to <code>$PREK_HOME/prek.log</code></p>
-</dd><dt id="prek-auto-update--no-progress"><a href="#prek-auto-update--no-progress"><code>--no-progress</code></a></dt><dd><p>Hide all progress outputs.</p>
+</dd><dt id="prek-update--jobs"><a href="#prek-update--jobs"><code>--jobs</code></a>, <code>-j</code> <i>jobs</i></dt><dd><p>Number of threads to use</p>
+<p>[default: 0]</p></dd><dt id="prek-update--log-file"><a href="#prek-update--log-file"><code>--log-file</code></a> <i>log-file</i></dt><dd><p>Write trace logs to the specified file. If not specified, trace logs will be written to <code>$PREK_HOME/prek.log</code></p>
+</dd><dt id="prek-update--no-progress"><a href="#prek-update--no-progress"><code>--no-progress</code></a></dt><dd><p>Hide all progress outputs.</p>
 <p>For example, spinners or progress bars.</p>
-</dd><dt id="prek-auto-update--quiet"><a href="#prek-auto-update--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
+</dd><dt id="prek-update--quiet"><a href="#prek-update--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
 <p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which prek will write no output to stdout.</p>
-<p>May also be set with the <code>PREK_QUIET</code> environment variable.</p></dd><dt id="prek-auto-update--refresh"><a href="#prek-auto-update--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
-</dd><dt id="prek-auto-update--repo"><a href="#prek-auto-update--repo"><code>--repo</code></a> <i>repo</i></dt><dd><p>Only update this repository. This option may be specified multiple times</p>
-</dd><dt id="prek-auto-update--repo-exclude-tag"><a href="#prek-auto-update--repo-exclude-tag"><code>--repo-exclude-tag</code></a> <i>repo=pattern</i></dt><dd><p>Ignore tags matching this glob pattern for a repository (<code>&lt;repo&gt;=&lt;pattern&gt;</code>). This option may be specified multiple times.</p>
+<p>May also be set with the <code>PREK_QUIET</code> environment variable.</p></dd><dt id="prek-update--refresh"><a href="#prek-update--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
+</dd><dt id="prek-update--repo"><a href="#prek-update--repo"><code>--repo</code></a> <i>repo</i></dt><dd><p>Only update this repository. This option may be specified multiple times</p>
+</dd><dt id="prek-update--repo-exclude-tag"><a href="#prek-update--repo-exclude-tag"><code>--repo-exclude-tag</code></a> <i>repo=pattern</i></dt><dd><p>Ignore tags matching this glob pattern for a repository (<code>&lt;repo&gt;=&lt;pattern&gt;</code>). This option may be specified multiple times.</p>
 <p>Repo-specific exclude filters are added to global <code>--exclude-tag</code> filters; matching either filter excludes the tag for that repository.</p>
 <p>For example, use <code>--repo-exclude-tag https://github.com/example/repo=nightly</code> or <code>--repo-exclude-tag https://github.com/example/repo=*-rc*</code> to skip nightly or prerelease tags for one repository.</p>
-</dd><dt id="prek-auto-update--repo-include-tag"><a href="#prek-auto-update--repo-include-tag"><code>--repo-include-tag</code></a> <i>repo=pattern</i></dt><dd><p>Only consider tags matching this glob pattern for a repository (<code>&lt;repo&gt;=&lt;pattern&gt;</code>). This option may be specified multiple times.</p>
+</dd><dt id="prek-update--repo-include-tag"><a href="#prek-update--repo-include-tag"><code>--repo-include-tag</code></a> <i>repo=pattern</i></dt><dd><p>Only consider tags matching this glob pattern for a repository (<code>&lt;repo&gt;=&lt;pattern&gt;</code>). This option may be specified multiple times.</p>
 <p>When set for a repository, this overrides any global <code>--include-tag</code> filters for that repository.</p>
 <p>For example, use <code>--repo-include-tag https://github.com/example/repo=v*</code> to only consider version tags for one repository.</p>
-</dd><dt id="prek-auto-update--verbose"><a href="#prek-auto-update--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output</p>
-</dd><dt id="prek-auto-update--version"><a href="#prek-auto-update--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
+</dd><dt id="prek-update--verbose"><a href="#prek-update--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output</p>
+</dd><dt id="prek-update--version"><a href="#prek-update--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
 </dd></dl>
 
 ## prek cache

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -11,16 +11,16 @@ This page documents the configuration keys that `prek` understands.
 
 This file stores user-level `prek` settings and does not define project hooks.
 
-### Global `auto_update.cooldown_days`
+### Global `update.cooldown_days`
 
-Default cooldown for [`prek auto-update`](cli.md#prek-auto-update).
+Default cooldown for [`prek update`](cli.md#prek-update).
 
 - Type: integer days, `0` to `255`
 - Default: `0`
-- CLI override: [`prek auto-update --cooldown-days <DAYS>`](cli.md#prek-auto-update)
+- CLI override: [`prek update --cooldown-days <DAYS>`](cli.md#prek-update)
 
 ```toml
-[auto_update]
+[update]
 cooldown_days = 7
 ```
 
@@ -28,11 +28,15 @@ The age is computed from the tag creation timestamp for annotated tags, or from 
 
 !!! tip "Cooldowns never downgrade"
 
-    If the current `rev` is newer than the latest cooldown-eligible tag, [`prek auto-update`](cli.md#prek-auto-update) keeps the current `rev` instead of downgrading it.
+    If the current `rev` is newer than the latest cooldown-eligible tag, [`prek update`](cli.md#prek-update) keeps the current `rev` instead of downgrading it.
 
-Project configs can also set [`auto_update.cooldown_days`](#auto_updatecooldown_days). The effective precedence is:
+!!! note "Compatibility alias"
 
-1. [`prek auto-update --cooldown-days <DAYS>`](cli.md#prek-auto-update)
+    The legacy `auto_update.cooldown_days` key is still accepted as an alias.
+
+Project configs can also set [`update.cooldown_days`](#updatecooldown_days). The effective precedence is:
+
+1. [`prek update --cooldown-days <DAYS>`](cli.md#prek-update)
 2. project config
 3. user-level global config
 4. default `0`
@@ -291,33 +295,37 @@ Allowed values:
 - `pre-merge-commit`
 - `pre-rebase`
 
-### `auto_update.cooldown_days`
+### `update.cooldown_days`
 
 !!! note "prek-only"
 
     This top-level key is a `prek` extension and is not recognized by upstream `pre-commit`.
 
-Project default cooldown for [`prek auto-update`](cli.md#prek-auto-update).
+Project default cooldown for [`prek update`](cli.md#prek-update).
 
 - Type: integer days, `0` to `255`
 - Default: inherited from the user-level global config, or `0`
-- CLI override: [`prek auto-update --cooldown-days <DAYS>`](cli.md#prek-auto-update)
+- CLI override: [`prek update --cooldown-days <DAYS>`](cli.md#prek-update)
 
 === "prek.toml"
 
     ```toml
-    [auto_update]
+    [update]
     cooldown_days = 7
     ```
 
 === ".pre-commit-config.yaml"
 
     ```yaml
-    auto_update:
+    update:
       cooldown_days: 7
     ```
 
-In workspace mode, this setting is scoped to the project config file that defines it. It applies only to that project and is not inherited by nested projects. Sub-projects use their own `auto_update` setting, then the user-level global config, then the default. If two projects use the same repo URL with different cooldown settings, [`prek auto-update`](cli.md#prek-auto-update) fetches the repo once but evaluates each project with its own cooldown.
+!!! note "Compatibility alias"
+
+    The legacy `auto_update.cooldown_days` key is still accepted as an alias.
+
+In workspace mode, this setting is scoped to the project config file that defines it. It applies only to that project and is not inherited by nested projects. Sub-projects use their own `update` setting, then the user-level global config, then the default. If two projects use the same repo URL with different cooldown settings, [`prek update`](cli.md#prek-update) fetches the repo once but evaluates each project with its own cooldown.
 
 ### `minimum_prek_version`
 
@@ -454,7 +462,7 @@ Example:
 Notes:
 
 - For reproducibility, prefer immutable pins (tags or commit SHAs).
-- [`prek auto-update`](cli.md#prek-auto-update) can help update [`rev`](#rev) values.
+- [`prek update`](cli.md#prek-update) can help update [`rev`](#rev) values.
 
 ### `repo: local`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -81,7 +81,7 @@ prek run -vvv
 Update pinned hook repository revisions:
 
 ```bash
-prek auto-update
+prek update
 ```
 
 Prepare hook environments without touching Git shims:

--- a/prek.schema.json
+++ b/prek.schema.json
@@ -125,6 +125,10 @@
     "orphan": {
       "description": "Set to true to isolate this project from parent configurations in workspace mode.\nWhen true, files in this project are \"consumed\" by this project and will not be processed\nby parent projects.\nWhen false (default), files in subprojects are processed by both the subproject and\nany parent projects that contain them.",
       "type": "boolean"
+    },
+    "auto_update": {
+      "description": "Compatibility alias for `update`. Prefer `update` in new configs.",
+      "$ref": "#/definitions/UpdateOptions"
     }
   },
   "required": [

--- a/prek.schema.json
+++ b/prek.schema.json
@@ -5,9 +5,9 @@
   "description": "The configuration file for prek, a git hook manager written in Rust.",
   "type": "object",
   "properties": {
-    "auto_update": {
-      "description": "Default settings for `prek auto-update` in this project.",
-      "$ref": "#/definitions/AutoUpdateOptions"
+    "update": {
+      "description": "Default settings for `prek update` in this project.",
+      "$ref": "#/definitions/UpdateOptions"
     },
     "repos": {
       "type": "array",
@@ -133,8 +133,8 @@
   "additionalProperties": true,
   "x-tombi-toml-version": "v1.1.0",
   "definitions": {
-    "AutoUpdateOptions": {
-      "description": "Controls how `prek auto-update` selects eligible releases.",
+    "UpdateOptions": {
+      "description": "Controls how `prek update` selects eligible releases.",
       "type": "object",
       "properties": {
         "cooldown_days": {


### PR DESCRIPTION
## Summary

- Rename `prek auto-update` to `prek update`
- Keep legacy command and config aliases
- Update docs, schema, and tests