### PR TITLE
Preserve additional dependency order

### DIFF
--- a/crates/prek/src/cli/cache_gc.rs
+++ b/crates/prek/src/cli/cache_gc.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt::Write;
 use std::fmt::{Display, Formatter};
 use std::ops::AddAssign;
@@ -15,7 +16,9 @@ use crate::cli::ExitStatus;
 use crate::cli::cache_size::{dir_size_bytes, human_readable_bytes};
 use crate::cli::run::InstallCache;
 use crate::config::{self, Error as ConfigError, Repo as ConfigRepo, load_config};
-use crate::hook::{HOOK_MARKER, HookEnvKey, HookSpec, InstallInfo, Repo as HookRepo};
+use crate::hook::{
+    HOOK_MARKER, HookEnvRequirement, HookSpec, InstallInfo, Repo as HookRepo, RepoIdentityRef,
+};
 use crate::printer::Printer;
 use crate::store::{CacheBucket, REPO_MARKER, Store, ToolBucket};
 
@@ -160,7 +163,7 @@ pub(crate) async fn cache_gc(
     let mut used_tools: FxHashSet<ToolBucket> = FxHashSet::default();
     let mut used_tool_versions: FxHashMap<ToolBucket, FxHashSet<String>> = FxHashMap::default();
     let mut used_cache: FxHashSet<CacheBucket> = FxHashSet::default();
-    let mut used_env_keys: Vec<HookEnvKey> = Vec::new();
+    let mut used_env_requirements: Vec<HookEnvRequirement> = Vec::new();
 
     // Always keep Prek's own cache.
     used_cache.insert(CacheBucket::Prek);
@@ -187,7 +190,7 @@ pub(crate) async fn cache_gc(
         };
         kept_configs.insert(config_path);
 
-        used_env_keys.extend(hook_env_keys_from_config(store, &config));
+        used_env_requirements.extend(hook_env_requirements_from_config(store, &config));
 
         // Mark repos referenced by this config (if present in store).
         // We do this via config parsing (no clone), so GC won't keep repos for missing configs.
@@ -206,9 +209,9 @@ pub(crate) async fn cache_gc(
     }
 
     // Mark tools/caches from hook languages.
-    for key in &used_env_keys {
-        used_tools.extend(key.language.tool_buckets());
-        used_cache.extend(key.language.cache_buckets());
+    for requirement in &used_env_requirements {
+        used_tools.extend(requirement.language.tool_buckets());
+        used_cache.extend(requirement.language.cache_buckets());
     }
 
     // Mark hook environments by matching already-installed env metadata.
@@ -216,7 +219,10 @@ pub(crate) async fn cache_gc(
     // `InstallInfo.toolchain` (which is persisted in `.prek-hook.json`).
     for installed in install_cache.installed_hooks(store).await {
         let info = installed.info_ref();
-        if used_env_keys.iter().any(|k| k.matches_install_info(info)) {
+        if used_env_requirements
+            .iter()
+            .any(|requirement| requirement.as_ref().is_satisfied_by(info))
+        {
             if let Some(dir) = info
                 .env_path
                 .file_name()
@@ -352,8 +358,11 @@ fn print_removed_details(printer: Printer, verb: &str, removal: &Removal) -> Res
     Ok(())
 }
 
-fn hook_env_keys_from_config(store: &Store, config: &config::Config) -> Vec<HookEnvKey> {
-    let mut keys = Vec::new();
+fn hook_env_requirements_from_config(
+    store: &Store,
+    config: &config::Config,
+) -> Vec<HookEnvRequirement> {
+    let mut requirements = Vec::new();
 
     for repo_config in &config.repos {
         match repo_config {
@@ -375,7 +384,7 @@ fn hook_env_keys_from_config(store: &Store, config: &config::Config) -> Vec<Hook
                     }
                 };
 
-                let remote_dep = repo_config.to_string();
+                let remote_repo = RepoIdentityRef::new(&repo_config.repo, &repo_config.rev);
 
                 for hook_config in &repo_config.hooks {
                     let Some(manifest_hook) = repo.get_hook(&hook_config.id) else {
@@ -385,11 +394,11 @@ fn hook_env_keys_from_config(store: &Store, config: &config::Config) -> Vec<Hook
                     let mut hook_spec = manifest_hook.clone();
                     hook_spec.apply_remote_hook_overrides(hook_config);
 
-                    match HookEnvKey::from_hook_spec(config, hook_spec, Some(&remote_dep)) {
-                        Ok(Some(key)) => keys.push(key),
+                    match HookEnvRequirement::from_hook_spec(config, hook_spec, Some(remote_repo)) {
+                        Ok(Some(requirement)) => requirements.push(requirement),
                         Ok(None) => {}
                         Err(err) => {
-                            warn!(hook = %hook_config.id, repo = %remote_dep, %err, "Failed to compute hook env key, skipping");
+                            warn!(hook = %hook_config.id, repo = %remote_repo, %err, "Failed to compute hook environment requirement, skipping");
                         }
                     }
                 }
@@ -397,11 +406,11 @@ fn hook_env_keys_from_config(store: &Store, config: &config::Config) -> Vec<Hook
             ConfigRepo::Local(repo_config) => {
                 for hook in &repo_config.hooks {
                     let hook_spec = HookSpec::from(hook.clone());
-                    match HookEnvKey::from_hook_spec(config, hook_spec, None) {
-                        Ok(Some(key)) => keys.push(key),
+                    match HookEnvRequirement::from_hook_spec(config, hook_spec, None) {
+                        Ok(Some(requirement)) => requirements.push(requirement),
                         Ok(None) => {}
                         Err(err) => {
-                            warn!(hook = %hook.id, %err, "Failed to compute hook env key, skipping");
+                            warn!(hook = %hook.id, %err, "Failed to compute hook environment requirement, skipping");
                         }
                     }
                 }
@@ -410,7 +419,7 @@ fn hook_env_keys_from_config(store: &Store, config: &config::Config) -> Vec<Hook
         }
     }
 
-    keys
+    requirements
 }
 
 fn mark_tool_versions_from_install_info(
@@ -735,7 +744,7 @@ fn detail_lines_for_entry(
                 info.language_version
             ));
 
-            let (repo_dep, deps) = split_repo_dependency(&info.dependencies);
+            let (repo_dep, deps) = marker_repo_and_dependencies(info);
             if let Some(repo_dep) = repo_dep {
                 lines.push(format!(
                     "{}: {}",
@@ -784,8 +793,8 @@ fn truncate_end(s: &str, max_chars: usize) -> String {
     out
 }
 
-fn split_repo_dependency(deps: &FxHashSet<String>) -> (Option<String>, Vec<String>) {
-    // Best-effort: the remote repo dependency is typically `repo@rev`.
+fn split_repo_dependency(deps: &[String]) -> (Option<String>, Vec<String>) {
+    // Legacy markers stored the remote repo identity as a `repo@rev` dependency.
     // Prefer URL-like values to avoid accidentally treating PEP508 deps as repo identifiers.
     let mut repo_dep: Option<String> = None;
     let mut rest = Vec::new();
@@ -806,6 +815,18 @@ fn split_repo_dependency(deps: &FxHashSet<String>) -> (Option<String>, Vec<Strin
 
     rest.sort_unstable();
     (repo_dep, rest)
+}
+
+fn marker_repo_and_dependencies(info: &InstallInfo) -> (Option<String>, Cow<'_, [String]>) {
+    if info.schema_version() == 0 {
+        let (repo, dependencies) = split_repo_dependency(&info.dependencies);
+        (repo, Cow::Owned(dependencies))
+    } else {
+        (
+            info.repo().map(|repo| repo.to_string()),
+            Cow::Borrowed(&info.dependencies),
+        )
+    }
 }
 
 fn format_dependency_list(deps: &[String], max_items: usize, max_chars: usize) -> String {
@@ -847,10 +868,11 @@ mod tests {
 
     #[test]
     fn split_repo_dependency_prefers_url_like_repo_at_rev() {
-        let mut deps = FxHashSet::default();
-        deps.insert("requests==2.32.0".to_string());
-        deps.insert("black==24.1.0".to_string());
-        deps.insert("https://github.com/pre-commit/pre-commit-hooks@v1.0.0".to_string());
+        let deps = vec![
+            "requests==2.32.0".to_string(),
+            "black==24.1.0".to_string(),
+            "https://github.com/pre-commit/pre-commit-hooks@v1.0.0".to_string(),
+        ];
 
         let (repo_dep, rest) = split_repo_dependency(&deps);
 
@@ -863,13 +885,37 @@ mod tests {
 
     #[test]
     fn split_repo_dependency_returns_none_when_no_repo_like_dep() {
-        let mut deps = FxHashSet::default();
-        deps.insert("requests==2.32.0".to_string());
-        deps.insert("black==24.1.0".to_string());
+        let deps = vec!["requests==2.32.0".to_string(), "black==24.1.0".to_string()];
 
         let (repo_dep, rest) = split_repo_dependency(&deps);
         assert!(repo_dep.is_none());
         assert_eq!(rest, vec!["black==24.1.0", "requests==2.32.0"]);
+    }
+
+    #[test]
+    fn marker_repo_and_dependencies_uses_structured_repo() {
+        let info: InstallInfo = serde_json::from_value(serde_json::json!({
+            "schema_version": 1,
+            "language": "python",
+            "language_version": "3.12.0",
+            "repo": {
+                "url": "https://example.com/repo",
+                "rev": "v1.0.0",
+            },
+            "dependencies": ["https://example.com/dependency@v2.0.0"],
+            "env_path": "/tmp/hook-env",
+            "toolchain": "/usr/bin/python3",
+            "extra": {},
+        }))
+        .expect("deserialize install info");
+
+        let (repo, dependencies) = marker_repo_and_dependencies(&info);
+
+        assert_eq!(repo.as_deref(), Some("https://example.com/repo@v1.0.0"));
+        assert_eq!(
+            dependencies.as_ref(),
+            &["https://example.com/dependency@v2.0.0".to_string()]
+        );
     }
 
     #[test]

--- a/crates/prek/src/cli/run/install.rs
+++ b/crates/prek/src/cli/run/install.rs
@@ -5,7 +5,6 @@ use anyhow::{Context, Result};
 use futures_util::stream::{FuturesUnordered, StreamExt};
 use mea::once::OnceCell;
 use mea::semaphore::Semaphore;
-use rustc_hash::FxHashMap;
 use tracing::{debug, warn};
 
 use crate::cli::reporter::HookInstallReporter;
@@ -73,17 +72,24 @@ async fn install_partition(
     for hook in hooks {
         debug_assert!(hook.needs_install_env());
 
-        let installed_hook = if let Some(info) = installed_hooks.iter().find_map(|installed| {
-            let InstalledHook::Installed { info, .. } = installed else {
-                return None;
-            };
-            info.matches(&hook).then(|| info.clone())
-        }) {
+        let reusable_info = hook.environment_requirement().and_then(|requirement| {
+            installed_hooks.iter().find_map(|installed| {
+                let InstalledHook::Installed { info, .. } = installed else {
+                    return None;
+                };
+                requirement.is_satisfied_by(info).then_some(info)
+            })
+        });
+
+        let installed_hook = if let Some(info) = reusable_info {
             debug!(
                 "Found installed environment for hook `{hook}` at `{}`",
                 info.env_path.display()
             );
-            InstalledHook::Installed { hook, info }
+            InstalledHook::Installed {
+                hook,
+                info: Arc::clone(info),
+            }
         } else {
             let _permit = semaphore.acquire(1).await;
 
@@ -117,41 +123,39 @@ async fn install_partition(
 
 /// Group hooks so each partition can install independently.
 ///
-/// Different languages can install concurrently. Hooks with the same language and dependency set
-/// stay in one partition so later hooks can reuse an environment installed by an earlier hook.
+/// Hooks with the same install language, repository, and dependency sequence stay in one
+/// partition so later hooks can reuse an environment installed by an earlier hook. Version
+/// requirements are checked by the full environment requirement and intentionally do not split
+/// partitions.
 fn partition_hooks(hooks: Vec<Arc<Hook>>) -> Vec<Vec<Arc<Hook>>> {
-    let mut hooks_by_language = FxHashMap::default();
+    let mut partitions: Vec<Vec<Arc<Hook>>> = Vec::new();
     for hook in hooks {
-        // `pygrep` hooks use Python installation and can share Python environments.
-        let language = if hook.language == Language::Pygrep {
-            Language::Python
+        if let Some(partition) = partitions
+            .iter_mut()
+            .find(|partition| same_install_partition(&partition[0], &hook))
+        {
+            partition.push(hook);
         } else {
-            hook.language
-        };
-        hooks_by_language
-            .entry(language)
-            .or_insert_with(Vec::new)
-            .push(hook);
-    }
-
-    let mut partitions = Vec::new();
-    for (_, hooks) in hooks_by_language {
-        let mut groups: Vec<Vec<Arc<Hook>>> = Vec::new();
-        for hook in hooks {
-            let group_index = groups
-                .iter()
-                .position(|group| group[0].env_key_dependencies() == hook.env_key_dependencies());
-
-            if let Some(index) = group_index {
-                groups[index].push(hook);
-            } else {
-                groups.push(vec![hook]);
-            }
+            partitions.push(vec![hook]);
         }
-        partitions.extend(groups);
     }
 
     partitions
+}
+
+fn same_install_partition(left: &Hook, right: &Hook) -> bool {
+    partition_language(left.language) == partition_language(right.language)
+        && left.repo().identity() == right.repo().identity()
+        && left.additional_dependencies == right.additional_dependencies
+}
+
+fn partition_language(language: Language) -> Language {
+    // Both `pygrep` and Python may provision Python, so schedule them as one language.
+    if language == Language::Pygrep {
+        Language::Python
+    } else {
+        language
+    }
 }
 
 /// Cached metadata for one environment found in the store hooks directory.
@@ -170,10 +174,6 @@ impl CachedInstallInfo {
             info,
             health: OnceCell::new(),
         }
-    }
-
-    fn matches(&self, hook: &Hook) -> bool {
-        self.info.matches(hook)
     }
 
     fn info(&self) -> Arc<InstallInfo> {
@@ -238,15 +238,16 @@ impl InstallCache {
     /// Return a healthy installed environment from the store cache for this hook.
     ///
     /// This only looks at environments loaded from `store.hooks_dir()`. Environments created
-    /// during the current install call are reused inside `install_partition`, where hooks with
-    /// the same install key are installed sequentially.
+    /// during the current install call are reused inside `install_partition`, where hooks in the
+    /// same install partition are processed sequentially.
     pub(crate) async fn installed_hook(
         &self,
         store: &Store,
         hook: Arc<Hook>,
     ) -> Option<InstalledHook> {
+        let requirement = hook.environment_requirement()?;
         for env in self.installed_hooks(store).await {
-            if env.matches(&hook) && env.ensure_healthy().await {
+            if requirement.is_satisfied_by(env.info_ref()) && env.ensure_healthy().await {
                 return Some(InstalledHook::Installed {
                     hook,
                     info: env.info(),

--- a/crates/prek/src/hook.rs
+++ b/crates/prek/src/hook.rs
@@ -3,12 +3,12 @@ use std::collections::BTreeSet;
 use std::fmt::{Display, Formatter};
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use prek_consts::PRE_COMMIT_HOOKS_YAML;
 use prek_identify::{TagSet, tags};
-use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use tempfile::TempDir;
 use thiserror::Error;
@@ -164,6 +164,51 @@ impl From<BuiltinHook> for HookSpec {
     }
 }
 
+#[derive(Debug, Clone, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub(crate) struct RepoIdentity {
+    url: String,
+    rev: String,
+}
+
+impl RepoIdentity {
+    pub(crate) fn as_ref(&self) -> RepoIdentityRef<'_> {
+        RepoIdentityRef::new(&self.url, &self.rev)
+    }
+}
+
+impl Display for RepoIdentity {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.as_ref().fmt(f)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
+pub(crate) struct RepoIdentityRef<'a> {
+    url: &'a str,
+    rev: &'a str,
+}
+
+impl<'a> RepoIdentityRef<'a> {
+    pub(crate) fn new(url: &'a str, rev: &'a str) -> Self {
+        Self { url, rev }
+    }
+}
+
+impl Display for RepoIdentityRef<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}@{}", self.url, self.rev)
+    }
+}
+
+impl From<RepoIdentityRef<'_>> for RepoIdentity {
+    fn from(value: RepoIdentityRef<'_>) -> Self {
+        Self {
+            url: value.url.to_string(),
+            rev: value.rev.to_string(),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) enum Repo {
     Remote {
@@ -228,6 +273,13 @@ impl Repo {
         match self {
             Repo::Remote { path, .. } => Some(path),
             _ => None,
+        }
+    }
+
+    pub(crate) fn identity(&self) -> Option<RepoIdentityRef<'_>> {
+        match self {
+            Repo::Remote { url, rev, .. } => Some(RepoIdentityRef::new(url, rev)),
+            Repo::Local { .. } | Repo::Meta { .. } | Repo::Builtin { .. } => None,
         }
     }
 
@@ -389,11 +441,7 @@ impl HookBuilder {
         let verbose = options.verbose.unwrap_or(false);
         let stages = options.stages.unwrap_or(Stages::ALL);
         let shell = options.shell;
-        let additional_dependencies = options
-            .additional_dependencies
-            .unwrap_or_default()
-            .into_iter()
-            .collect::<FxHashSet<_>>();
+        let additional_dependencies = options.additional_dependencies.unwrap_or_default();
         let language_request = LanguageRequest::parse(self.hook_spec.language, &language_version)
             .map_err(|e| Error::Hook {
             hook: self.hook_spec.id.clone(),
@@ -408,7 +456,6 @@ impl HookBuilder {
             .unwrap_or_else(|| u32::try_from(self.idx).expect("idx too large"));
 
         let mut hook = Hook {
-            dependencies: OnceLock::new(),
             project: self.project,
             repo: self.repo,
             idx: self.idx,
@@ -458,8 +505,6 @@ impl HookBuilder {
 pub(crate) struct Hook {
     project: Arc<Project>,
     repo: Arc<Repo>,
-    // Cached computed dependencies.
-    dependencies: OnceLock<FxHashSet<String>>,
 
     /// The index of the hook defined in the configuration file.
     pub idx: usize,
@@ -473,7 +518,7 @@ pub(crate) struct Hook {
     pub types: TagSet,
     pub types_or: TagSet,
     pub exclude_types: TagSet,
-    pub additional_dependencies: FxHashSet<String>,
+    pub additional_dependencies: Vec<String>,
     pub args: Vec<String>,
     pub env: FxHashMap<String, String>,
     pub always_run: bool,
@@ -528,39 +573,23 @@ impl Hook {
         self.project.path()
     }
 
-    pub(crate) fn is_remote(&self) -> bool {
-        matches!(&*self.repo, Repo::Remote { .. })
-    }
-
     pub(crate) fn needs_install_env(&self) -> bool {
         !matches!(self.repo(), Repo::Meta { .. } | Repo::Builtin { .. })
             && self.language.supports_install_env()
     }
 
-    /// Dependencies used to identify whether an existing hook environment can be reused.
-    ///
-    /// For remote hooks, the repo URL is included to avoid reusing an environment created
-    /// from a different remote repository.
-    pub(crate) fn env_key_dependencies(&self) -> &FxHashSet<String> {
-        if !self.is_remote() {
-            return &self.additional_dependencies;
-        }
-        self.dependencies.get_or_init(|| {
-            env_key_dependencies(&self.additional_dependencies, Some(&self.repo.to_string()))
-        })
-    }
-
-    /// Returns a lightweight view of the hook environment identity used for reusing installs.
+    /// Returns a lightweight view of the hook's environment requirement.
     ///
     /// Returns `None` for hooks that do not install an environment.
-    pub(crate) fn env_key(&self) -> Option<HookEnvKeyRef<'_>> {
+    pub(crate) fn environment_requirement(&self) -> Option<HookEnvRequirementRef<'_>> {
         if !self.needs_install_env() {
             return None;
         }
 
-        Some(HookEnvKeyRef {
+        Some(HookEnvRequirementRef {
             language: self.language,
-            dependencies: self.env_key_dependencies(),
+            repo: self.repo.identity(),
+            dependencies: &self.additional_dependencies,
             language_request: &self.language_request,
         })
     }
@@ -569,10 +598,11 @@ impl Hook {
     ///
     /// For remote hooks, this includes the local path to the cloned repository so that
     /// installers can install the hook's package/project itself.
-    pub(crate) fn install_dependencies(&self) -> Cow<'_, FxHashSet<String>> {
+    pub(crate) fn install_dependencies(&self) -> Cow<'_, [String]> {
         if let Some(repo_path) = self.repo_path() {
-            let mut deps = self.additional_dependencies.clone();
-            deps.insert(repo_path.to_string_lossy().into_owned());
+            let mut deps = Vec::with_capacity(self.additional_dependencies.len() + 1);
+            deps.push(repo_path.to_string_lossy().into_owned());
+            deps.extend(self.additional_dependencies.iter().cloned());
             Cow::Owned(deps)
         } else {
             Cow::Borrowed(&self.additional_dependencies)
@@ -581,61 +611,31 @@ impl Hook {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct HookEnvKey {
+pub(crate) struct HookEnvRequirement {
     pub(crate) language: Language,
-    pub(crate) dependencies: FxHashSet<String>,
-    pub(crate) language_request: LanguageRequest,
+    repo: Option<RepoIdentity>,
+    dependencies: Vec<String>,
+    language_request: LanguageRequest,
 }
 
-/// Borrowed form of [`HookEnvKey`] for comparing a hook to an existing installation
-/// without allocating/cloning dependency sets.
+/// Borrowed form of [`HookEnvRequirement`] for comparing a hook to an existing installation
+/// without allocating or cloning the dependency sequence.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct HookEnvKeyRef<'a> {
-    pub(crate) language: Language,
-    pub(crate) dependencies: &'a FxHashSet<String>,
-    pub(crate) language_request: &'a LanguageRequest,
-}
-
-/// Builds the dependency set used to identify a hook environment.
-///
-/// For remote hooks, `remote_repo_dependency` is included so environments from different
-/// repositories are not reused accidentally.
-fn env_key_dependencies(
-    additional_dependencies: &FxHashSet<String>,
-    remote_repo_dependency: Option<&str>,
-) -> FxHashSet<String> {
-    let mut deps = FxHashSet::with_capacity_and_hasher(
-        additional_dependencies.len() + usize::from(remote_repo_dependency.is_some()),
-        FxBuildHasher,
-    );
-    deps.extend(additional_dependencies.iter().cloned());
-    if let Some(dep) = remote_repo_dependency {
-        deps.insert(dep.to_string());
-    }
-    deps
-}
-
-/// Shared matching logic between a computed hook env key (owned or borrowed) and an installed
-/// environment described by [`InstallInfo`].
-fn matches_install_info(
+pub(crate) struct HookEnvRequirementRef<'a> {
     language: Language,
-    dependencies: &FxHashSet<String>,
-    language_request: &LanguageRequest,
-    info: &InstallInfo,
-) -> bool {
-    info.language == language
-        && info.dependencies == *dependencies
-        && language_request.satisfied_by(info)
+    repo: Option<RepoIdentityRef<'a>>,
+    dependencies: &'a [String],
+    language_request: &'a LanguageRequest,
 }
 
-impl HookEnvKey {
-    /// Compute the key used to match an installed hook environment.
+impl HookEnvRequirement {
+    /// Compute the requirement used to match an installed hook environment.
     ///
     /// Returns `Ok(None)` if this hook does not install an environment.
     pub(crate) fn from_hook_spec(
         config: &Config,
         mut hook_spec: HookSpec,
-        remote_repo_dependency: Option<&str>,
+        repo: Option<RepoIdentityRef<'_>>,
     ) -> Result<Option<Self>> {
         let language = hook_spec.language;
         if !language.supports_install_env() {
@@ -657,40 +657,39 @@ impl HookEnvKey {
             )
         })?;
 
-        let additional_dependencies: FxHashSet<String> = hook_spec
+        let dependencies = hook_spec
             .options
             .additional_dependencies
-            .as_ref()
-            .map_or_else(FxHashSet::default, |deps| deps.iter().cloned().collect());
-
-        let dependencies = env_key_dependencies(&additional_dependencies, remote_repo_dependency);
+            .as_deref()
+            .unwrap_or_default()
+            .to_vec();
 
         Ok(Some(Self {
             language,
+            repo: repo.map(RepoIdentity::from),
             dependencies,
             language_request,
         }))
     }
 
-    pub(crate) fn matches_install_info(&self, info: &InstallInfo) -> bool {
-        matches_install_info(
-            self.language,
-            &self.dependencies,
-            &self.language_request,
-            info,
-        )
+    pub(crate) fn as_ref(&self) -> HookEnvRequirementRef<'_> {
+        HookEnvRequirementRef {
+            language: self.language,
+            repo: self.repo.as_ref().map(RepoIdentity::as_ref),
+            dependencies: &self.dependencies,
+            language_request: &self.language_request,
+        }
     }
 }
 
-impl HookEnvKeyRef<'_> {
-    /// Returns true if this env key matches the given installed environment.
-    pub(crate) fn matches_install_info(&self, info: &InstallInfo) -> bool {
-        matches_install_info(
-            self.language,
-            self.dependencies,
-            self.language_request,
-            info,
-        )
+impl HookEnvRequirementRef<'_> {
+    /// Returns true if the installed environment satisfies this requirement.
+    pub(crate) fn is_satisfied_by(&self, info: &InstallInfo) -> bool {
+        info.is_current_schema()
+            && info.language == self.language
+            && info.repo.as_ref().map(RepoIdentity::as_ref) == self.repo
+            && info.dependencies == self.dependencies
+            && self.language_request.satisfied_by(info)
     }
 }
 
@@ -722,6 +721,7 @@ impl Display for InstalledHook {
 }
 
 pub(crate) const HOOK_MARKER: &str = ".prek-hook.json";
+pub(crate) const INSTALL_INFO_SCHEMA_VERSION: u8 = 1;
 
 impl InstalledHook {
     /// Get the path to the environment where the hook is installed.
@@ -767,9 +767,13 @@ impl InstalledHook {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub(crate) struct InstallInfo {
+    #[serde(default)]
+    schema_version: u8,
     pub(crate) language: Language,
     pub(crate) language_version: semver::Version,
-    pub(crate) dependencies: FxHashSet<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    repo: Option<RepoIdentity>,
+    pub(crate) dependencies: Vec<String>,
     pub(crate) env_path: PathBuf,
     pub(crate) toolchain: PathBuf,
     extra: FxHashMap<String, String>,
@@ -780,8 +784,10 @@ pub(crate) struct InstallInfo {
 impl Clone for InstallInfo {
     fn clone(&self) -> Self {
         Self {
+            schema_version: self.schema_version,
             language: self.language,
             language_version: self.language_version.clone(),
+            repo: self.repo.clone(),
             dependencies: self.dependencies.clone(),
             env_path: self.env_path.clone(),
             toolchain: self.toolchain.clone(),
@@ -792,9 +798,19 @@ impl Clone for InstallInfo {
 }
 
 impl InstallInfo {
-    pub(crate) fn new(
+    pub(crate) fn new(hook: &Hook, hooks_dir: &Path) -> Result<Self, Error> {
+        Self::create(
+            hook.language,
+            hook.repo.identity().map(RepoIdentity::from),
+            hook.additional_dependencies.clone(),
+            hooks_dir,
+        )
+    }
+
+    pub(crate) fn create(
         language: Language,
-        dependencies: FxHashSet<String>,
+        repo: Option<RepoIdentity>,
+        dependencies: Vec<String>,
         hooks_dir: &Path,
     ) -> Result<Self, Error> {
         let env_path = tempfile::Builder::new()
@@ -803,7 +819,9 @@ impl InstallInfo {
             .tempdir_in(hooks_dir)?;
 
         Ok(Self {
+            schema_version: INSTALL_INFO_SCHEMA_VERSION,
             language,
+            repo,
             dependencies,
             env_path: env_path.path().to_path_buf(),
             language_version: semver::Version::new(0, 0, 0),
@@ -817,6 +835,18 @@ impl InstallInfo {
         if let Some(temp_dir) = self.temp_dir.take() {
             self.env_path = temp_dir.keep();
         }
+    }
+
+    pub(crate) fn is_current_schema(&self) -> bool {
+        self.schema_version == INSTALL_INFO_SCHEMA_VERSION
+    }
+
+    pub(crate) fn schema_version(&self) -> u8 {
+        self.schema_version
+    }
+
+    pub(crate) fn repo(&self) -> Option<RepoIdentityRef<'_>> {
+        self.repo.as_ref().map(RepoIdentity::as_ref)
     }
 
     pub(crate) async fn from_env_path(path: &Path) -> Result<Self> {
@@ -848,11 +878,6 @@ impl InstallInfo {
     pub(crate) fn get_extra(&self, key: &str) -> Option<&String> {
         self.extra.get(key)
     }
-
-    pub(crate) fn matches(&self, hook: &Hook) -> bool {
-        hook.env_key()
-            .is_some_and(|key| key.matches_install_info(self))
-    }
 }
 
 #[cfg(test)]
@@ -865,6 +890,7 @@ mod tests {
     use prek_consts::PRE_COMMIT_CONFIG_YAML;
     use prek_identify::tags;
     use rustc_hash::FxHashMap;
+    use serde_json::json;
 
     use crate::config::{
         Config, HookOptions, Language, PassFilenames, RemoteHook, Shell, Stage, Stages,
@@ -873,7 +899,10 @@ mod tests {
     use crate::languages::version::LanguageRequest;
     use crate::workspace::Project;
 
-    use super::{Hook, HookBuilder, Repo};
+    use super::{
+        Hook, HookBuilder, HookEnvRequirementRef, INSTALL_INFO_SCHEMA_VERSION, InstallInfo, Repo,
+        RepoIdentityRef,
+    };
 
     #[tokio::test]
     async fn hook_builder_build_fills_and_merges_attributes() -> Result<()> {
@@ -986,9 +1015,6 @@ mod tests {
             repo: Local {
                 hooks: [],
             },
-            dependencies: OnceLock(
-                <uninit>,
-            ),
             idx: 7,
             id: "test-hook",
             name: "override-name",
@@ -1008,7 +1034,7 @@ mod tests {
             ],
             types_or: [],
             exclude_types: [],
-            additional_dependencies: {},
+            additional_dependencies: [],
             args: [
                 "--flag",
             ],
@@ -1188,6 +1214,133 @@ mod tests {
             .await?;
 
         assert_eq!(hook.stages, Stages::ALL);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn hook_builder_preserves_additional_dependency_order() -> Result<()> {
+        let (temp, project) = setup_python_hook_test()?;
+        let repo_path = temp.path().join("remote-repo");
+        let repo = Arc::new(Repo::Remote {
+            path: repo_path.clone(),
+            url: "https://example.invalid/hooks".to_string(),
+            rev: "v0.1.0".to_string(),
+            hooks: vec![],
+        });
+        let repo_identity = RepoIdentityRef::new("https://example.invalid/hooks", "v0.1.0");
+        let additional_dependencies = vec![
+            "dep-c".to_string(),
+            "dep-a".to_string(),
+            "dep-c".to_string(),
+        ];
+
+        let hook_spec = HookSpec {
+            id: "test-hook".to_string(),
+            name: "test-hook".to_string(),
+            entry: "./hook.py".to_string(),
+            language: Language::Python,
+            priority: None,
+            groups: None,
+            options: HookOptions {
+                additional_dependencies: Some(additional_dependencies.clone()),
+                ..Default::default()
+            },
+        };
+
+        let hook = HookBuilder::new(project, repo, hook_spec, 0)
+            .build()
+            .await?;
+        let install_dependencies = hook.install_dependencies();
+        let mut expected_install_dependencies = vec![repo_path.to_string_lossy().into_owned()];
+        expected_install_dependencies.extend(additional_dependencies.iter().cloned());
+        let requirement = hook
+            .environment_requirement()
+            .expect("Python hook installs an environment");
+
+        assert_eq!(hook.additional_dependencies, additional_dependencies);
+        assert_eq!(
+            install_dependencies.as_ref(),
+            expected_install_dependencies.as_slice()
+        );
+        assert_eq!(requirement.repo, Some(repo_identity));
+        assert_eq!(requirement.dependencies, additional_dependencies);
+
+        let hooks_dir = temp.path().join("hooks");
+        fs_err::create_dir(&hooks_dir)?;
+        let install_info = InstallInfo::new(&hook, &hooks_dir)?;
+        assert_eq!(install_info.schema_version(), INSTALL_INFO_SCHEMA_VERSION);
+        assert_eq!(install_info.repo(), Some(repo_identity));
+        assert_eq!(install_info.dependencies, additional_dependencies);
+        assert!(requirement.is_satisfied_by(&install_info));
+
+        let marker = serde_json::to_value(&install_info)?;
+        assert_eq!(marker["schema_version"], json!(INSTALL_INFO_SCHEMA_VERSION));
+        assert_eq!(
+            marker["repo"],
+            json!({
+                "url": "https://example.invalid/hooks",
+                "rev": "v0.1.0",
+            })
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn legacy_install_info_does_not_satisfy_current_requirement() -> Result<()> {
+        let install_info: InstallInfo = serde_json::from_value(json!({
+            "language": "python",
+            "language_version": "3.12.0",
+            "dependencies": ["dep"],
+            "env_path": "/tmp/legacy-env",
+            "toolchain": "/usr/bin/python3",
+            "extra": {},
+        }))?;
+        let dependencies = vec!["dep".to_string()];
+        let language_request = LanguageRequest::parse(Language::Python, "")?;
+        let requirement = HookEnvRequirementRef {
+            language: Language::Python,
+            repo: None,
+            dependencies: &dependencies,
+            language_request: &language_request,
+        };
+
+        assert_eq!(install_info.schema_version(), 0);
+        assert!(!requirement.is_satisfied_by(&install_info));
+        Ok(())
+    }
+
+    #[test]
+    fn structured_repo_distinguishes_remote_and_local_requirements() -> Result<()> {
+        let repo = RepoIdentityRef::new("https://example.invalid/hooks", "v0.1.0");
+        let repo_like_dependency = repo.to_string();
+        let install_info: InstallInfo = serde_json::from_value(json!({
+            "schema_version": INSTALL_INFO_SCHEMA_VERSION,
+            "language": "python",
+            "language_version": "3.12.0",
+            "repo": {
+                "url": "https://example.invalid/hooks",
+                "rev": "v0.1.0",
+            },
+            "dependencies": [repo_like_dependency],
+            "env_path": "/tmp/remote-env",
+            "toolchain": "/usr/bin/python3",
+            "extra": {},
+        }))?;
+        let dependencies = vec![repo.to_string()];
+        let language_request = LanguageRequest::parse(Language::Python, "")?;
+        let remote_requirement = HookEnvRequirementRef {
+            language: Language::Python,
+            repo: Some(repo),
+            dependencies: &dependencies,
+            language_request: &language_request,
+        };
+        let local_requirement = HookEnvRequirementRef {
+            repo: None,
+            ..remote_requirement
+        };
+
+        assert!(remote_requirement.is_satisfied_by(&install_info));
+        assert!(!local_requirement.is_satisfied_by(&install_info));
         Ok(())
     }
 

--- a/crates/prek/src/languages/bun/bun.rs
+++ b/crates/prek/src/languages/bun/bun.rs
@@ -52,11 +52,7 @@ impl LanguageImpl for Bun {
             .await
             .context("Failed to install bun")?;
 
-        let mut info = InstallInfo::new(
-            hook.language,
-            hook.env_key_dependencies().clone(),
-            &store.hooks_dir(),
-        )?;
+        let mut info = InstallInfo::new(&hook, &store.hooks_dir())?;
 
         info.with_toolchain(bun.bun().to_path_buf());
         // BunVersion implements Deref<Target = semver::Version>, so we clone the inner version

--- a/crates/prek/src/languages/conda.rs
+++ b/crates/prek/src/languages/conda.rs
@@ -27,11 +27,7 @@ impl LanguageImpl for Conda {
     ) -> Result<InstalledHook> {
         let progress = reporter.on_install_start(&hook);
 
-        let mut info = InstallInfo::new(
-            hook.language,
-            hook.env_key_dependencies().clone(),
-            &store.hooks_dir(),
-        )?;
+        let mut info = InstallInfo::new(&hook, &store.hooks_dir())?;
 
         debug!(%hook, target = %info.env_path.display(), "Installing Conda environment");
         let conda = conda_executable();

--- a/crates/prek/src/languages/coursier.rs
+++ b/crates/prek/src/languages/coursier.rs
@@ -60,23 +60,14 @@ impl LanguageImpl for Coursier {
     ) -> Result<InstalledHook> {
         let progress = reporter.on_install_start(&hook);
 
-        let mut dependencies = hook
-            .additional_dependencies
-            .iter()
-            .cloned()
-            .collect::<Vec<_>>();
-        dependencies.sort_unstable();
+        let dependencies = &hook.additional_dependencies;
 
         let cs = which::which("cs")
             .or_else(|_| which::which("coursier"))
             .context(
                 "Coursier hooks require system-installed `cs` or `coursier` executables in PATH",
             )?;
-        let mut info = InstallInfo::new(
-            hook.language,
-            hook.env_key_dependencies().clone(),
-            &store.hooks_dir(),
-        )?;
+        let mut info = InstallInfo::new(&hook, &store.hooks_dir())?;
 
         debug!(%hook, target = %info.env_path.display(), "Installing Coursier environment");
 
@@ -115,7 +106,7 @@ impl LanguageImpl for Coursier {
             let mut fetch_cmd = Cmd::new(&cs);
             fetch_cmd
                 .arg("fetch")
-                .args(&dependencies)
+                .args(dependencies)
                 .env(EnvVars::PATH, &path_env)
                 .env(EnvVars::COURSIER_CACHE, &coursier_cache);
             if let Some(repo_path) = hook.repo_path() {
@@ -130,7 +121,7 @@ impl LanguageImpl for Coursier {
                 .arg("install")
                 .arg("--dir")
                 .arg(&info.env_path)
-                .args(&dependencies)
+                .args(dependencies)
                 .env(EnvVars::PATH, path_env)
                 .env(EnvVars::COURSIER_CACHE, &coursier_cache);
             if let Some(repo_path) = hook.repo_path() {

--- a/crates/prek/src/languages/dart.rs
+++ b/crates/prek/src/languages/dart.rs
@@ -97,11 +97,7 @@ impl LanguageImpl for Dart {
     ) -> Result<InstalledHook> {
         let progress = reporter.on_install_start(&hook);
 
-        let mut info = InstallInfo::new(
-            hook.language,
-            hook.env_key_dependencies().clone(),
-            &store.hooks_dir(),
-        )?;
+        let mut info = InstallInfo::new(&hook, &store.hooks_dir())?;
 
         debug!(%hook, target = %info.env_path.display(), "Installing Dart environment");
 
@@ -323,12 +319,9 @@ async fn compile_executables(
 fn build_env_pubspec(
     source_path: Option<&Path>,
     package_name: Option<&str>,
-    dependencies: &rustc_hash::FxHashSet<String>,
+    dependencies: &[String],
 ) -> Pubspec {
     let mut resolved_dependencies = BTreeMap::new();
-
-    let mut dependencies = dependencies.iter().collect::<Vec<_>>();
-    dependencies.sort_unstable();
 
     for dep in dependencies {
         if let Some((package, version)) = dep.split_once(':') {
@@ -365,7 +358,7 @@ async fn install_package_config(
     env_path: &Path,
     source_path: Option<&Path>,
     package_name: Option<&str>,
-    dependencies: &rustc_hash::FxHashSet<String>,
+    dependencies: &[String],
 ) -> Result<()> {
     let pubspec = build_env_pubspec(source_path, package_name, dependencies);
     let pubspec_content = serde_saphyr::to_string(&pubspec)?;
@@ -389,7 +382,7 @@ async fn install_from_pubspec(
     dart: &Path,
     env_path: &Path,
     source_path: &Path,
-    dependencies: &rustc_hash::FxHashSet<String>,
+    dependencies: &[String],
 ) -> Result<()> {
     let pubspec_path = source_path.join(PUBSPEC_YAML);
     let pubspec_content = fs_err::read_to_string(&pubspec_path)?;
@@ -497,7 +490,7 @@ mod tests {
     #[test]
     fn build_env_pubspec_serializes_path_dependency() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let dependencies = rustc_hash::FxHashSet::default();
+        let dependencies = Vec::new();
 
         let pubspec = build_env_pubspec(Some(temp_dir.path()), Some("sample"), &dependencies);
 

--- a/crates/prek/src/languages/deno/deno.rs
+++ b/crates/prek/src/languages/deno/deno.rs
@@ -79,11 +79,7 @@ impl LanguageImpl for Deno {
             .await
             .context("Failed to install deno")?;
 
-        let mut info = InstallInfo::new(
-            hook.language,
-            hook.env_key_dependencies().clone(),
-            &store.hooks_dir(),
-        )?;
+        let mut info = InstallInfo::new(&hook, &store.hooks_dir())?;
 
         info.with_toolchain(deno.deno().to_path_buf());
         info.with_language_version((**deno.version()).clone());

--- a/crates/prek/src/languages/docker.rs
+++ b/crates/prek/src/languages/docker.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
@@ -324,8 +323,8 @@ impl Docker {
 
         info.language.hash(&mut hasher);
         info.language_version.hash(&mut hasher);
-        let deps = info.dependencies.iter().collect::<BTreeSet<&String>>();
-        deps.hash(&mut hasher);
+        info.repo().hash(&mut hasher);
+        info.dependencies.hash(&mut hasher);
 
         let digest = hex::encode(hasher.finish().to_le_bytes());
         format!("prek-{digest}")
@@ -450,11 +449,7 @@ impl LanguageImpl for Docker {
     ) -> Result<InstalledHook> {
         let progress = reporter.on_install_start(&hook);
 
-        let mut info = InstallInfo::new(
-            hook.language,
-            hook.env_key_dependencies().clone(),
-            &store.hooks_dir(),
-        )?;
+        let mut info = InstallInfo::new(&hook, &store.hooks_dir())?;
 
         Docker::build_docker_image(&hook, &info, true)
             .await

--- a/crates/prek/src/languages/dotnet/dotnet.rs
+++ b/crates/prek/src/languages/dotnet/dotnet.rs
@@ -58,11 +58,7 @@ impl LanguageImpl for Dotnet {
             .await
             .context("Failed to install dotnet SDK")?;
 
-        let mut info = InstallInfo::new(
-            hook.language,
-            hook.env_key_dependencies().clone(),
-            &store.hooks_dir(),
-        )?;
+        let mut info = InstallInfo::new(&hook, &store.hooks_dir())?;
 
         let tools_dir = tools_dir(&info.env_path);
 

--- a/crates/prek/src/languages/dotnet/version.rs
+++ b/crates/prek/src/languages/dotnet/version.rs
@@ -230,8 +230,6 @@ impl DotnetRequest {
 mod tests {
     use std::path::PathBuf;
 
-    use rustc_hash::FxHashSet;
-
     use super::*;
     use crate::config::Language;
     use crate::languages::version::LanguageRequest;
@@ -389,7 +387,7 @@ mod tests {
     fn test_satisfied_by() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let mut install_info =
-            InstallInfo::new(Language::Dotnet, FxHashSet::default(), temp_dir.path())?;
+            InstallInfo::create(Language::Dotnet, None, Vec::new(), temp_dir.path())?;
         install_info
             .with_language_version(semver::Version::new(8, 0, 100))
             .with_toolchain(PathBuf::from("/usr/share/dotnet/dotnet"));

--- a/crates/prek/src/languages/golang/golang.rs
+++ b/crates/prek/src/languages/golang/golang.rs
@@ -44,11 +44,7 @@ impl LanguageImpl for Golang {
             .await
             .context("Failed to install go")?;
 
-        let mut info = InstallInfo::new(
-            hook.language,
-            hook.env_key_dependencies().clone(),
-            &store.hooks_dir(),
-        )?;
+        let mut info = InstallInfo::new(&hook, &store.hooks_dir())?;
         info.with_toolchain(go.bin().to_path_buf())
             .with_language_version(go.version().deref().clone());
 

--- a/crates/prek/src/languages/haskell.rs
+++ b/crates/prek/src/languages/haskell.rs
@@ -35,11 +35,7 @@ impl LanguageImpl for Haskell {
     ) -> Result<InstalledHook> {
         let progress = reporter.on_install_start(&hook);
 
-        let mut info = InstallInfo::new(
-            hook.language,
-            hook.env_key_dependencies().clone(),
-            &store.hooks_dir(),
-        )?;
+        let mut info = InstallInfo::new(&hook, &store.hooks_dir())?;
 
         debug!(%hook, target = %info.env_path.display(), "Installing Haskell environment");
 

--- a/crates/prek/src/languages/julia.rs
+++ b/crates/prek/src/languages/julia.rs
@@ -25,11 +25,7 @@ impl LanguageImpl for Julia {
     ) -> Result<InstalledHook> {
         let progress = reporter.on_install_start(&hook);
 
-        let mut info = InstallInfo::new(
-            hook.language,
-            hook.env_key_dependencies().clone(),
-            &store.hooks_dir(),
-        )?;
+        let mut info = InstallInfo::new(&hook, &store.hooks_dir())?;
 
         debug!(%hook, target = %info.env_path.display(), "Installing Julia environment");
 

--- a/crates/prek/src/languages/lua.rs
+++ b/crates/prek/src/languages/lua.rs
@@ -59,11 +59,7 @@ impl LanguageImpl for Lua {
     ) -> Result<InstalledHook> {
         let progress = reporter.on_install_start(&hook);
 
-        let mut info = InstallInfo::new(
-            hook.language,
-            hook.env_key_dependencies().clone(),
-            &store.hooks_dir(),
-        )?;
+        let mut info = InstallInfo::new(&hook, &store.hooks_dir())?;
 
         debug!(%hook, target = %info.env_path.display(), "Installing Lua environment");
 

--- a/crates/prek/src/languages/node/node.rs
+++ b/crates/prek/src/languages/node/node.rs
@@ -70,11 +70,7 @@ impl LanguageImpl for Node {
             .await
             .context("Failed to install node")?;
 
-        let mut info = InstallInfo::new(
-            hook.language,
-            hook.env_key_dependencies().clone(),
-            &store.hooks_dir(),
-        )?;
+        let mut info = InstallInfo::new(&hook, &store.hooks_dir())?;
 
         let lts = serde_json::to_string(&node.version().lts).context("Failed to serialize LTS")?;
         info.with_toolchain(node.node().to_path_buf());

--- a/crates/prek/src/languages/node/version.rs
+++ b/crates/prek/src/languages/node/version.rs
@@ -240,7 +240,6 @@ mod tests {
     use super::{EXTRA_KEY_LTS, NodeRequest};
     use crate::config::Language;
     use crate::hook::InstallInfo;
-    use rustc_hash::FxHashSet;
     use std::path::PathBuf;
     use std::str::FromStr;
 
@@ -294,7 +293,7 @@ mod tests {
     fn test_node_request_satisfied_by() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let mut install_info =
-            InstallInfo::new(Language::Node, FxHashSet::default(), temp_dir.path())?;
+            InstallInfo::create(Language::Node, None, Vec::new(), temp_dir.path())?;
         install_info
             .with_language_version(semver::Version::new(12, 18, 3))
             .with_toolchain(PathBuf::from("/usr/bin/node"))

--- a/crates/prek/src/languages/perl.rs
+++ b/crates/prek/src/languages/perl.rs
@@ -28,11 +28,7 @@ impl LanguageImpl for Perl {
     ) -> Result<InstalledHook> {
         let progress = reporter.on_install_start(&hook);
 
-        let mut info = InstallInfo::new(
-            hook.language,
-            hook.env_key_dependencies().clone(),
-            &store.hooks_dir(),
-        )?;
+        let mut info = InstallInfo::new(&hook, &store.hooks_dir())?;
 
         debug!(%hook, target = %info.env_path.display(), "Installing Perl environment");
 

--- a/crates/prek/src/languages/pygrep/pygrep.rs
+++ b/crates/prek/src/languages/pygrep/pygrep.rs
@@ -155,11 +155,7 @@ impl LanguageImpl for Pygrep {
             anyhow::bail!("Failed to find or install a Python interpreter for `pygrep`.");
         };
 
-        let mut info = InstallInfo::new(
-            hook.language,
-            hook.env_key_dependencies().clone(),
-            &store.hooks_dir(),
-        )?;
+        let mut info = InstallInfo::new(&hook, &store.hooks_dir())?;
         info.with_toolchain(python);
 
         info.persist_env_path();

--- a/crates/prek/src/languages/python/pep723.rs
+++ b/crates/prek/src/languages/python/pep723.rs
@@ -280,7 +280,7 @@ pub(crate) async fn extract_pep723_metadata(hook: &mut Hook) -> Result<()> {
     };
 
     if let Some(dependencies) = script.metadata.dependencies {
-        hook.additional_dependencies = dependencies.into_iter().collect();
+        hook.additional_dependencies = dependencies;
     }
     if let Some(language_request) = script.metadata.requires_python {
         if !hook.language_request.is_any() {

--- a/crates/prek/src/languages/python/python.rs
+++ b/crates/prek/src/languages/python/python.rs
@@ -107,11 +107,7 @@ impl LanguageImpl for Python {
             .await
             .context("Failed to install uv")?;
 
-        let mut info = InstallInfo::new(
-            hook.language,
-            hook.env_key_dependencies().clone(),
-            &store.hooks_dir(),
-        )?;
+        let mut info = InstallInfo::new(&hook, &store.hooks_dir())?;
 
         debug!(%hook, target = %info.env_path.display(), "Installing environment");
 
@@ -402,22 +398,20 @@ mod tests {
     use std::collections::HashMap;
     use std::path::PathBuf;
 
-    use prek_consts::env_vars::EnvVars;
-    use rustc_hash::FxHashSet;
-
     use super::Python;
     use crate::config::Language;
     use crate::hook::InstallInfo;
     use crate::languages::python::uv::Uv;
     use crate::languages::version::LanguageRequest;
     use crate::store::Store;
+    use prek_consts::env_vars::EnvVars;
 
     fn setup_test_install() -> (tempfile::TempDir, Uv, Store, InstallInfo) {
         let temp = tempfile::tempdir().expect("create tempdir");
         let hooks_dir = temp.path().join("hooks");
         fs_err::create_dir_all(&hooks_dir).expect("create hooks dir");
 
-        let info = InstallInfo::new(Language::Python, FxHashSet::default(), &hooks_dir)
+        let info = InstallInfo::create(Language::Python, None, Vec::new(), &hooks_dir)
             .expect("create install info");
         let store = Store::from_path(temp.path().join("store"));
         let uv = Uv::new(PathBuf::from("uv"));

--- a/crates/prek/src/languages/python/version.rs
+++ b/crates/prek/src/languages/python/version.rs
@@ -121,7 +121,6 @@ fn split_wheel_tag_version(mut version: Vec<u64>) -> Vec<u64> {
 mod tests {
     use super::*;
     use crate::config::Language;
-    use rustc_hash::FxHashSet;
     use std::path::PathBuf;
 
     #[test]
@@ -204,7 +203,7 @@ mod tests {
     fn test_satisfied_by() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let mut install_info =
-            InstallInfo::new(Language::Python, FxHashSet::default(), temp_dir.path())?;
+            InstallInfo::create(Language::Python, None, Vec::new(), temp_dir.path())?;
         install_info
             .with_language_version(semver::Version::new(3, 12, 1))
             .with_toolchain(PathBuf::from("/usr/bin/python3.12"));

--- a/crates/prek/src/languages/r.rs
+++ b/crates/prek/src/languages/r.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use prek_consts::env_vars::{EnvVars, EnvVarsRead};
-use rustc_hash::FxHashSet;
 use tracing::debug;
 
 use crate::cli::reporter::HookInstallReporter;
@@ -29,11 +28,7 @@ impl LanguageImpl for R {
     ) -> Result<InstalledHook> {
         let progress = reporter.on_install_start(&hook);
 
-        let mut info = InstallInfo::new(
-            hook.language,
-            hook.env_key_dependencies().clone(),
-            &store.hooks_dir(),
-        )?;
+        let mut info = InstallInfo::new(&hook, &store.hooks_dir())?;
 
         debug!(%hook, target = %info.env_path.display(), "Installing R environment");
 
@@ -177,12 +172,7 @@ impl LanguageImpl for R {
     }
 }
 
-async fn run_r_code(
-    rscript: &Path,
-    code: &str,
-    args: &FxHashSet<String>,
-    cwd: &Path,
-) -> Result<()> {
+async fn run_r_code(rscript: &Path, code: &str, args: &[String], cwd: &Path) -> Result<()> {
     let script_dir = tempfile::tempdir()?;
     let script_path = script_dir.path().join("script.R");
     fs_err::tokio::write(

--- a/crates/prek/src/languages/ruby/gem.rs
+++ b/crates/prek/src/languages/ruby/gem.rs
@@ -4,7 +4,6 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use prek_consts::prepend_paths;
-use rustc_hash::FxHashSet;
 use tracing::debug;
 
 use crate::languages::ruby::installer::RubyResult;
@@ -113,7 +112,7 @@ pub(crate) async fn install_gems(
     ruby: &RubyResult,
     gem_home: &Path,
     repo_path: Option<&Path>,
-    additional_dependencies: &FxHashSet<String>,
+    additional_dependencies: &[String],
 ) -> Result<()> {
     // Collect gems from repository. Many of these were probably built from gemspecs earlier,
     // but install all .gem files found (matches pre-commit behavior)

--- a/crates/prek/src/languages/ruby/ruby.rs
+++ b/crates/prek/src/languages/ruby/ruby.rs
@@ -48,11 +48,7 @@ impl LanguageImpl for Ruby {
             .context("Failed to install Ruby")?;
 
         // 2. Create InstallInfo
-        let mut info = InstallInfo::new(
-            hook.language,
-            hook.env_key_dependencies().clone(),
-            &store.hooks_dir(),
-        )?;
+        let mut info = InstallInfo::new(&hook, &store.hooks_dir())?;
 
         info.with_toolchain(ruby.ruby_bin().to_path_buf())
             .with_language_version(ruby.version().clone());

--- a/crates/prek/src/languages/ruby/version.rs
+++ b/crates/prek/src/languages/ruby/version.rs
@@ -118,7 +118,6 @@ impl RubyRequest {
 mod tests {
     use super::*;
     use crate::config::Language;
-    use rustc_hash::FxHashSet;
     use std::path::PathBuf;
 
     #[test]
@@ -165,7 +164,7 @@ mod tests {
     fn test_version_matching() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let mut install_info =
-            InstallInfo::new(Language::Ruby, FxHashSet::default(), temp_dir.path())?;
+            InstallInfo::create(Language::Ruby, None, Vec::new(), temp_dir.path())?;
         install_info
             .with_language_version(semver::Version::new(3, 3, 6))
             .with_toolchain(PathBuf::from("/usr/bin/ruby"));
@@ -185,7 +184,7 @@ mod tests {
 
         let temp_dir = tempfile::tempdir()?;
         let mut install_info =
-            InstallInfo::new(Language::Ruby, FxHashSet::default(), temp_dir.path())?;
+            InstallInfo::create(Language::Ruby, None, Vec::new(), temp_dir.path())?;
         install_info
             .with_language_version(semver::Version::new(3, 1, 0))
             .with_toolchain(PathBuf::from("/usr/bin/ruby3.1"));

--- a/crates/prek/src/languages/rust/rust.rs
+++ b/crates/prek/src/languages/rust/rust.rs
@@ -438,11 +438,7 @@ impl LanguageImpl for Rust {
         // Add toolchain bin to PATH, for cargo to use correct rustc
         let new_path = prepend_paths(&[&rustc_bin]).context("Failed to join PATH")?;
 
-        let mut info = InstallInfo::new(
-            hook.language,
-            hook.env_key_dependencies().clone(),
-            &store.hooks_dir(),
-        )?;
+        let mut info = InstallInfo::new(&hook, &store.hooks_dir())?;
         info.with_toolchain(rust.toolchain().to_path_buf())
             .with_language_version(rust.version().deref().clone());
 

--- a/crates/prek/src/languages/rust/version.rs
+++ b/crates/prek/src/languages/rust/version.rs
@@ -237,7 +237,6 @@ mod tests {
     use super::*;
     use crate::config::Language;
     use crate::hook::InstallInfo;
-    use rustc_hash::FxHashSet;
     use std::path::PathBuf;
     use std::str::FromStr;
 
@@ -315,7 +314,7 @@ mod tests {
         fs_err::write(&toolchain_path, b"")?;
 
         let mut install_info =
-            InstallInfo::new(Language::Rust, FxHashSet::default(), temp_dir.path())?;
+            InstallInfo::create(Language::Rust, None, Vec::new(), temp_dir.path())?;
         install_info
             .with_language_version(semver::Version::new(1, 71, 0))
             .with_toolchain(toolchain_path);
@@ -342,7 +341,7 @@ mod tests {
     fn test_satisfied_by_channel() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let mut install_info =
-            InstallInfo::new(Language::Rust, FxHashSet::default(), temp_dir.path())?;
+            InstallInfo::create(Language::Rust, None, Vec::new(), temp_dir.path())?;
         install_info
             .with_language_version(semver::Version::new(1, 75, 0))
             .with_toolchain(PathBuf::from("/some/path"))
@@ -360,7 +359,7 @@ mod tests {
     fn test_satisfied_by_any_with_stable_channel() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let mut install_info =
-            InstallInfo::new(Language::Rust, FxHashSet::default(), temp_dir.path())?;
+            InstallInfo::create(Language::Rust, None, Vec::new(), temp_dir.path())?;
         install_info
             .with_language_version(semver::Version::new(1, 75, 0))
             .with_toolchain(PathBuf::from("/some/path"))
@@ -376,7 +375,7 @@ mod tests {
     fn test_satisfied_by_any_without_channel() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let mut install_info =
-            InstallInfo::new(Language::Rust, FxHashSet::default(), temp_dir.path())?;
+            InstallInfo::create(Language::Rust, None, Vec::new(), temp_dir.path())?;
         install_info
             .with_language_version(semver::Version::new(1, 75, 0))
             .with_toolchain(PathBuf::from("/some/path"));

--- a/crates/prek/src/languages/swift.rs
+++ b/crates/prek/src/languages/swift.rs
@@ -93,11 +93,7 @@ impl LanguageImpl for Swift {
     ) -> Result<InstalledHook> {
         let progress = reporter.on_install_start(&hook);
 
-        let mut info = InstallInfo::new(
-            hook.language,
-            hook.env_key_dependencies().clone(),
-            &store.hooks_dir(),
-        )?;
+        let mut info = InstallInfo::new(&hook, &store.hooks_dir())?;
 
         debug!(%hook, target = %info.env_path.display(), "Installing Swift environment");
 

--- a/crates/prek/tests/cache.rs
+++ b/crates/prek/tests/cache.rs
@@ -104,6 +104,64 @@ fn cache_gc_verbose_shows_removed_entries() {
 }
 
 #[test]
+fn cache_gc_removes_legacy_hook_env_when_config_matches() -> anyhow::Result<()> {
+    let context = TestContext::new();
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: local-python
+                name: Local Python Hook
+                entry: "python -c \"print(1)\""
+                language: python
+    "#});
+
+    let home = context.home_dir();
+    let config_path = context.work_dir().child(PRE_COMMIT_CONFIG_YAML);
+    write_config_tracking_file(home, &[config_path.path()])?;
+    let legacy_env = home.child("hooks/python-legacy");
+    let current_env = home.child("hooks/python-current");
+    legacy_env.create_dir_all()?;
+    current_env.create_dir_all()?;
+
+    legacy_env
+        .child(".prek-hook.json")
+        .write_str(&serde_json::to_string_pretty(&json!({
+            "language": "python",
+            "language_version": "3.12.0",
+            "dependencies": [],
+            "env_path": legacy_env.path(),
+            "toolchain": "/usr/bin/python3",
+            "extra": {},
+        }))?)?;
+    current_env
+        .child(".prek-hook.json")
+        .write_str(&serde_json::to_string_pretty(&json!({
+            "schema_version": 1,
+            "language": "python",
+            "language_version": "3.12.0",
+            "dependencies": [],
+            "env_path": current_env.path(),
+            "toolchain": "/usr/bin/python3",
+            "extra": {},
+        }))?)?;
+
+    cmd_snapshot!(context.filters(), context.command().args(["cache", "gc"]), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Removed 1 hook env ([SIZE])
+
+    ----- stderr -----
+    ");
+
+    legacy_env.assert(predicates::path::missing());
+    current_env.assert(predicates::path::is_dir());
+
+    Ok(())
+}
+
+#[test]
 fn cache_clean() -> anyhow::Result<()> {
     let context = TestContext::new().with_filtered_cache_clean_summary();
 
@@ -321,6 +379,7 @@ fn cache_gc_prunes_unused_tool_versions() -> anyhow::Result<()> {
 
     // Match logic for local hooks: empty deps + language request is `Any` by default.
     let marker_py = json!({
+        "schema_version": 1,
         "language": "python",
         "language_version": "3.12.0",
         "dependencies": [],
@@ -333,6 +392,7 @@ fn cache_gc_prunes_unused_tool_versions() -> anyhow::Result<()> {
         .write_str(&serde_json::to_string_pretty(&marker_py)?)?;
 
     let marker_node = json!({
+        "schema_version": 1,
         "language": "node",
         "language_version": "22.0.0",
         "dependencies": [],
@@ -345,6 +405,7 @@ fn cache_gc_prunes_unused_tool_versions() -> anyhow::Result<()> {
         .write_str(&serde_json::to_string_pretty(&marker_node)?)?;
 
     let marker_go = json!({
+        "schema_version": 1,
         "language": "golang",
         "language_version": "1.24.0",
         "dependencies": [],
@@ -431,6 +492,7 @@ fn cache_gc_prunes_tool_versions_without_positive_identification() -> anyhow::Re
     let env_py = home.child("hooks/python-keep");
     env_py.create_dir_all()?;
     let marker_py = json!({
+        "schema_version": 1,
         "language": "python",
         "language_version": "3.12.0",
         "dependencies": [],


### PR DESCRIPTION
Preserve the user-specified order and duplicates of hook `additional_dependencies` for installation and environment reuse.

Hook environment markers now use schema version 1 and store remote repository identity as structured `{ url, rev }` data. Legacy markers are invalidated, and cache matching distinguishes dependency order, duplicates, and repository identity.

Closes #1602
Partially supersedes #1603