### PR TITLE
Validate complete XML documents in check-xml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,7 +1344,7 @@ dependencies = [
  "log",
  "num-format",
  "once_cell",
- "quick-xml 0.26.0",
+ "quick-xml",
  "rgb",
  "str_stack",
 ]
@@ -2003,7 +2003,6 @@ dependencies = [
  "prek-identify",
  "prek-pty",
  "pretty_assertions",
- "quick-xml 0.40.1",
  "regex",
  "reqwest",
  "rustc-hash",
@@ -2033,6 +2032,7 @@ dependencies = [
  "walkdir",
  "webpki-root-certs",
  "which",
+ "xml",
 ]
 
 [[package]]
@@ -2107,15 +2107,6 @@ name = "quick-xml"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.40.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
 ]
@@ -3842,6 +3833,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xml"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "636f85e5ca6488e96401b61eb7de54f4e44755c988af0f52cf90230c312a1a89"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,6 @@ memchr = { version = "2.7.5" }
 owo-colors = { version = "4.1.0" }
 phf = { version = "0.14.0", default-features = false, features = ["macros"] }
 pprof = { version = "0.15.0" }
-quick-xml = { version = "0.40" }
 reqwest = {
   version = "0.13.2",
   default-features = false,
@@ -132,6 +131,7 @@ unicode-width = { version = "0.2.0", default-features = false }
 walkdir = { version = "2.5.0" }
 webpki-root-certs = { version = "1.0.6" }
 which = { version = "8.0.0" }
+xml = { version = "1.3.0" }
 
 # dev-dependencies
 assert_cmd = { version = "2.2.0" }

--- a/crates/prek/Cargo.toml
+++ b/crates/prek/Cargo.toml
@@ -60,7 +60,6 @@ liblzma = { workspace = true }
 mea = { workspace = true }
 memchr = { workspace = true }
 owo-colors = { workspace = true }
-quick-xml = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
 aws-lc-rs = { workspace = true }
@@ -90,6 +89,7 @@ unicode-width = { workspace = true }
 walkdir = { workspace = true }
 webpki-root-certs = { workspace = true }
 which = { workspace = true }
+xml = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 prek-pty = { workspace = true }

--- a/crates/prek/src/hooks/pre_commit_hooks/check_xml.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_xml.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use anyhow::Result;
+use xml::reader::ParserConfig;
 
 use crate::hook::Hook;
 use crate::hooks::run_concurrent_file_checks;
@@ -18,46 +19,21 @@ pub(crate) async fn check_xml(hook: &Hook, filenames: &[&Path]) -> Result<(i32, 
 async fn check_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)> {
     let content = fs_err::tokio::read(file_base.join(filename)).await?;
 
-    // Empty XML is invalid - should have at least one element
-    if content.is_empty() {
-        let error_message = format!(
-            "{}: Failed to xml parse (no element found)\n",
-            filename.display()
-        );
-        return Ok((1, error_message.into_bytes()));
-    }
+    // Parse the whole document once with xml-rs. This is stricter than the upstream Python
+    // check-xml (xml.sax/Expat) in two cases:
+    // - `<p:root/>` passes upstream because namespace processing is off; xml-rs requires
+    //   `xmlns:p`.
+    // - `<!DOCTYPE root SYSTEM "x.dtd"><root>&ext;</root>` passes upstream because `ext` may be
+    //   declared by the unloaded DTD; xml-rs reports it as unknown.
+    // Keeping these differences avoids rewriting or repeatedly parsing the input.
+    let parser = ParserConfig::new()
+        .allow_multiple_root_elements(false)
+        .create_reader(content.as_slice());
 
-    let mut reader = quick_xml::Reader::from_reader(&content[..]);
-    reader.config_mut().check_end_names = true;
-    reader.config_mut().expand_empty_elements = true;
-
-    let mut root_count = 0;
-    let mut depth = 0;
-
-    loop {
-        match reader.read_event() {
-            Ok(quick_xml::events::Event::Eof) => break,
-            Ok(quick_xml::events::Event::Start(_)) => {
-                if depth == 0 {
-                    root_count += 1;
-                    if root_count > 1 {
-                        let error_message = format!(
-                            "{}: Failed to xml parse (junk after document element)\n",
-                            filename.display()
-                        );
-                        return Ok((1, error_message.into_bytes()));
-                    }
-                }
-                depth += 1;
-            }
-            Ok(quick_xml::events::Event::End(_)) => {
-                depth -= 1;
-            }
-            Err(e) => {
-                let error_message = format!("{}: Failed to xml parse ({e})\n", filename.display());
-                return Ok((1, error_message.into_bytes()));
-            }
-            Ok(_) => {}
+    for event in parser {
+        if let Err(error) = event {
+            let error_message = format!("{}: Failed to xml parse ({error})\n", filename.display());
+            return Ok((1, error_message.into_bytes()));
         }
     }
 
@@ -88,6 +64,17 @@ mod tests {
     <element>value</element>
 </root>"#;
         let file_path = create_test_file(&dir, "valid.xml", content).await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 0);
+        assert!(output.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_valid_xml_with_leading_processing_instruction() -> Result<()> {
+        let dir = tempdir()?;
+        let content = br#"<?xml-stylesheet href="style.xsl"?><root/>"#;
+        let file_path = create_test_file(&dir, "processing_instruction.xml", content).await?;
         let (code, output) = check_file(Path::new(""), &file_path).await?;
         assert_eq!(code, 0);
         assert!(output.is_empty());
@@ -139,15 +126,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_invalid_xml_trailing_text() -> Result<()> {
+        let dir = tempdir()?;
+        let file_path = create_test_file(&dir, "trailing.xml", b"<root/>junk").await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 1);
+        assert!(!output.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_empty_xml() -> Result<()> {
         let dir = tempdir()?;
         let content = b"";
         let file_path = create_test_file(&dir, "empty.xml", content).await?;
         let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1); // Changed from 0 to 1
-        assert!(!output.is_empty()); // Changed from is_empty() to !is_empty()
+        assert_eq!(code, 1);
+        assert!(!output.is_empty());
         let output_str = String::from_utf8_lossy(&output);
-        assert!(output_str.contains("no element found"));
+        assert!(output_str.contains("no root element found"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_whitespace_only_xml() -> Result<()> {
+        let dir = tempdir()?;
+        let file_path = create_test_file(&dir, "whitespace.xml", b" \n\t").await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 1);
+        assert!(!output.is_empty());
         Ok(())
     }
 
@@ -163,6 +170,31 @@ mod tests {
         let (code, output) = check_file(Path::new(""), &file_path).await?;
         assert_eq!(code, 0);
         assert!(output.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_invalid_xml_duplicate_attribute() -> Result<()> {
+        let dir = tempdir()?;
+        let file_path = create_test_file(
+            &dir,
+            "duplicate_attribute.xml",
+            br#"<root key="1" key="2"/>"#,
+        )
+        .await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 1);
+        assert!(!output.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_invalid_xml_element_name() -> Result<()> {
+        let dir = tempdir()?;
+        let file_path = create_test_file(&dir, "invalid_name.xml", b"<1root/>").await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 1);
+        assert!(!output.is_empty());
         Ok(())
     }
 
@@ -205,6 +237,54 @@ mod tests {
     <element>value</element>
 </root>"#;
         let file_path = create_test_file(&dir, "doctype.xml", content).await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 0);
+        assert!(output.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_rejects_unresolved_external_dtd_entity() -> Result<()> {
+        let dir = tempdir()?;
+        let content = br#"<!DOCTYPE html SYSTEM "xhtml.dtd"><html>&nbsp;</html>"#;
+        let file_path = create_test_file(&dir, "external_entity.xml", content).await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 1);
+        assert!(!output.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_invalid_xml_unknown_entity_without_external_dtd() -> Result<()> {
+        let dir = tempdir()?;
+        let file_path =
+            create_test_file(&dir, "unknown_entity.xml", b"<root>&unknown;</root>").await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 1);
+        assert!(!output.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_xml_with_internal_entity() -> Result<()> {
+        let dir = tempdir()?;
+        let content = br#"<!DOCTYPE root [<!ENTITY value "ok">]>
+<root>&value;</root>"#;
+        let file_path = create_test_file(&dir, "internal_entity.xml", content).await?;
+        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(code, 0);
+        assert!(output.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_valid_utf16_xml() -> Result<()> {
+        let dir = tempdir()?;
+        let mut content = vec![0xff, 0xfe];
+        for code_unit in "<?xml version=\"1.0\" encoding=\"UTF-16\"?><root/>".encode_utf16() {
+            content.extend_from_slice(&code_unit.to_le_bytes());
+        }
+        let file_path = create_test_file(&dir, "utf16.xml", &content).await?;
         let (code, output) = check_file(Path::new(""), &file_path).await?;
         assert_eq!(code, 0);
         assert!(output.is_empty());

--- a/crates/prek/tests/builtin_hooks.rs
+++ b/crates/prek/tests/builtin_hooks.rs
@@ -2128,10 +2128,10 @@ fn check_xml_hook() -> Result<()> {
     - hook id: check-xml
     - exit code: 1
 
-      empty.xml: Failed to xml parse (no element found)
-      invalid_mismatched.xml: Failed to xml parse (ill-formed document: expected `</element>`, but `</different>` was found)
-      multiple_roots.xml: Failed to xml parse (junk after document element)
-      invalid_unclosed.xml: Failed to xml parse (ill-formed document: expected `</element>`, but `</root>` was found)
+      empty.xml: Failed to xml parse (1:1 Unexpected end of stream: no root element found)
+      invalid_mismatched.xml: Failed to xml parse (3:30 Unexpected closing tag: different != element)
+      multiple_roots.xml: Failed to xml parse (3:1 Unexpected token: <)
+      invalid_unclosed.xml: Failed to xml parse (4:7 Unexpected closing tag: root != element)
 
     ----- stderr -----
     "#);
@@ -2168,7 +2168,7 @@ fn check_xml_hook() -> Result<()> {
     - hook id: check-xml
     - exit code: 1
 
-      empty.xml: Failed to xml parse (no element found)
+      empty.xml: Failed to xml parse (1:1 Unexpected end of stream: no root element found)
 
     ----- stderr -----
     ");


### PR DESCRIPTION
Supersedes #2303.

Use a complete XML document parser for `check-xml` instead of maintaining a partial event-state check. This rejects truncated documents, trailing text, multiple roots, invalid names, duplicate attributes, and other malformed XML while retaining support for DTD entities and UTF-16.