### PR TITLE
Update Rust to 1.97

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 version = "0.4.8"
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.95"
 repository = "https://github.com/j178/prek"
 homepage = "https://prek.j178.dev/"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ cargo binstall prek
 
 <!-- --8<-- [start: cargo-install] -->
 
-Build from source using Cargo (Rust 1.89+ is required):
+Build from source using Cargo (Rust 1.95+ is required):
 
 ```bash
 cargo install --locked prek

--- a/crates/prek/src/cli/cache_gc.rs
+++ b/crates/prek/src/cli/cache_gc.rs
@@ -722,11 +722,7 @@ fn detail_lines_for_entry(
 
     match kind {
         RemovalKind::Repos => vec![],
-        RemovalKind::HookEnvs => {
-            let Some(info) = hook_marker else {
-                return Vec::new();
-            };
-
+        RemovalKind::HookEnvs if let Some(info) = hook_marker => {
             let mut lines = Vec::new();
             lines.push(format!(
                 "{}: {} ({})",

--- a/crates/prek/src/hook_entry.rs
+++ b/crates/prek/src/hook_entry.rs
@@ -143,7 +143,7 @@ impl DirectHookEntry {
     pub(crate) fn split(&self) -> Result<Vec<String>, Error> {
         let splits = shlex::split(&self.entry).ok_or_else(|| Error::Hook {
             hook: self.hook.clone(),
-            error: anyhow::anyhow!("Failed to parse entry `{}` as commands", &self.entry),
+            error: anyhow::anyhow!("Failed to parse entry `{}` as commands", self.entry),
         })?;
         if splits.is_empty() {
             return Err(Error::Hook {

--- a/crates/prek/src/languages/python/uv.rs
+++ b/crates/prek/src/languages/python/uv.rs
@@ -111,7 +111,7 @@ fn validate_uv_binary(uv_path: &Path) -> Result<Version> {
     if !UV_VERSION_RANGE.matches(&version) {
         bail!(
             "uv version `{version}` does not satisfy required range `{}`",
-            &*UV_VERSION_RANGE
+            *UV_VERSION_RANGE
         );
     }
     Ok(version)
@@ -600,7 +600,7 @@ mod tests {
         assert!(
             UV_VERSION_RANGE.matches(&version),
             "CUR_UV_VERSION {CUR_UV_VERSION} does not satisfy the version requirement {}",
-            &*UV_VERSION_RANGE
+            *UV_VERSION_RANGE
         );
     }
 

--- a/crates/prek/src/run.rs
+++ b/crates/prek/src/run.rs
@@ -123,23 +123,18 @@ static PAGE_SIZE: LazyLock<usize> = LazyLock::new(|| {
 // https://github.com/uutils/findutils/blob/af48c151fe9b29cb7d25471b5388013ca15748ba/src/xargs/mod.rs#L177
 // https://github.com/sharkdp/argmax
 fn platform_max_cli_length() -> usize {
-    #[cfg(unix)]
-    {
-        let mut arg_max = *ARG_MAX;
-        // Assume arguments are counted with the granularity of a single page,
-        // so allow a one page cushion to account for rounding up
-        arg_max -= *PAGE_SIZE;
-        // POSIX recommends an additional 2048 bytes of headroom
-        arg_max -= ARG_HEADROOM;
-        arg_max.clamp(1 << 12, 1 << 20)
-    }
-    #[cfg(windows)]
-    {
-        (1 << 15) - ARG_HEADROOM // UNICODE_STRING max - headroom
-    }
-    #[cfg(not(any(unix, windows)))]
-    {
-        1 << 12
+    cfg_select! {
+        unix => {
+            let mut arg_max = *ARG_MAX;
+            // Assume arguments are counted with the granularity of a single page,
+            // so allow a one page cushion to account for rounding up
+            arg_max -= *PAGE_SIZE;
+            // POSIX recommends an additional 2048 bytes of headroom
+            arg_max -= ARG_HEADROOM;
+            arg_max.clamp(1 << 12, 1 << 20)
+        },
+        windows => (1 << 15) - ARG_HEADROOM, // UNICODE_STRING max - headroom
+        _ => 1 << 12,
     }
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.96"
+channel = "1.97"


### PR DESCRIPTION
Bump the Rust toolchain to 1.97 and MSRV to 1.95, and adopt features stabilized in Rust 1.95.