### PR TITLE
Warn for missing update repositories

### DIFF
--- a/crates/prek/src/cli/update/mod.rs
+++ b/crates/prek/src/cli/update/mod.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use futures_util::{StreamExt, TryStreamExt};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use semver::Version;
 
 use crate::cli::ExitStatus;
@@ -18,6 +18,7 @@ use crate::printer::Printer;
 use crate::run::INTERNAL_CONCURRENCY;
 use crate::settings::FilesystemOptions;
 use crate::store::Store;
+use crate::warn_user;
 use crate::workspace::{Project, Workspace};
 
 mod config;
@@ -270,6 +271,35 @@ fn build_repo_tag_patterns(
         .collect()
 }
 
+fn warn_missing_repos(
+    repo_sources: &[RepoSource<'_>],
+    filter_repos: &[String],
+    tag_filters: &TagFilters,
+) {
+    let configured_repos = repo_sources
+        .iter()
+        .map(|repo_source| repo_source.repo)
+        .collect::<FxHashSet<_>>();
+    let mut missing_repos = filter_repos
+        .iter()
+        .map(String::as_str)
+        .chain(tag_filters.repo_include.keys().map(String::as_str))
+        .chain(tag_filters.repo_exclude.keys().map(String::as_str))
+        .filter(|repo| !configured_repos.contains(*repo))
+        .collect::<Vec<_>>();
+    missing_repos.sort_unstable();
+    missing_repos.dedup();
+
+    match missing_repos.as_slice() {
+        [] => {}
+        [repo] => warn_user!("repo `{repo}` was not found in the configuration"),
+        _ => warn_user!(
+            "repos `{}` were not found in the configuration",
+            missing_repos.join("`, `")
+        ),
+    }
+}
+
 /// The successful result of evaluating one configured `repo + rev + hook set` target.
 struct ResolvedRepoUpdate<'a> {
     /// The revision data that may be written back to config.
@@ -401,6 +431,7 @@ pub(crate) async fn update(
     let reporter = UpdateReporter::new(printer);
 
     let repo_sources = collect_repo_sources(&workspace, cooldown_days, filesystem.as_ref())?;
+    warn_missing_repos(&repo_sources, &filter_repos, &tag_filters);
     let sources = repo_sources.iter().filter(|repo_source| {
         (filter_repos.is_empty() || filter_repos.iter().any(|repo| repo == repo_source.repo))
             && !exclude_repos.iter().any(|repo| repo == repo_source.repo)

--- a/crates/prek/tests/update.rs
+++ b/crates/prek/tests/update.rs
@@ -607,6 +607,45 @@ fn update_specific_repos() -> Result<()> {
 }
 
 #[test]
+fn update_warns_for_missing_repos() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    let repo_path = create_local_git_repo(&context, "configured-repo", &["v1.0.0", "v1.1.0"])?;
+
+    context.write_pre_commit_config(&indoc::formatdoc! {r"
+        repos:
+          - repo: {}
+            rev: v1.0.0
+            hooks:
+              - id: test-hook
+    ", repo_path});
+    context.git_add(".");
+
+    let filters = context.filters();
+
+    cmd_snapshot!(filters, context.update()
+        .arg("--repo").arg(&repo_path)
+        .arg("--repo").arg("missing-from-repo")
+        .arg("--repo-include-tag").arg(format!("{repo_path}=v*"))
+        .arg("--repo-include-tag").arg("missing-from-include=v*")
+        .arg("--repo-exclude-tag").arg(format!("{repo_path}=nightly"))
+        .arg("--repo-exclude-tag").arg("missing-from-exclude=nightly")
+        .arg("--cooldown-days").arg("0"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [HOME]/test-repos/configured-repo
+      updating rev `v1.0.0` -> `v1.1.0`
+
+    ----- stderr -----
+    warning: repos `missing-from-exclude`, `missing-from-include`, `missing-from-repo` were not found in the configuration
+    ");
+
+    Ok(())
+}
+
+#[test]
 fn update_exclude_repo_skips_fetching_repo() -> Result<()> {
     let context = TestContext::new();
     context.init_project();


### PR DESCRIPTION
Warn when `--repo`, `--repo-include-tag`, or `--repo-exclude-tag` references an unconfigured repository.