### PR TITLE
Configure Tombi to use TOML 1.0 for Cargo.toml

### DIFF
--- a/.config/tombi.toml
+++ b/.config/tombi.toml
@@ -3,6 +3,7 @@ dotted-keys-out-of-order = "off"
 tables-out-of-order = "off"
 
 [[schemas]]
+toml-version = "v1.0.0"
 path = "tombi://www.schemastore.org/cargo.json"
 include = ["Cargo.toml"]
 format.rules.array-values-order.enabled = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,39 +21,30 @@ anstream = { version = "1.0.0" }
 anstyle-query = { version = "1.1.5" }
 anyhow = { version = "1.0.86" }
 async-compression = { version = "0.4.18", features = ["gzip", "xz", "tokio"] }
-async_zip = {
-  version = "0.0.18",
-  package = "astral_async_zip",
-  features = ["deflate", "tokio"]
-}
-axoupdater = {
-  version = "0.10.0",
-  default-features = false,
-  features = ["github_releases"]
-}
+async_zip = { version = "0.0.18", package = "astral_async_zip", features = [
+  "deflate",
+  "tokio"
+] }
+axoupdater = { version = "0.10.0", default-features = false, features = [
+  "github_releases"
+] }
 bstr = { version = "1.11.0" }
 cargo_metadata = { version = "0.23.1" }
-clap = {
-  version = "4.6.0",
-  features = ["derive", "env", "string", "wrap_help"]
-}
+clap = { version = "4.6.0", features = ["derive", "env", "string", "wrap_help"] }
 clap_complete = { version = "4.6.0", features = ["unstable-dynamic"] }
-console = {
-  version = "0.16",
-  default-features = false,
-  features = ["ansi-parsing", "std"]
-}
+console = { version = "0.16", default-features = false, features = [
+  "ansi-parsing",
+  "std"
+] }
 ctrlc = { version = "3.4.5" }
 dunce = { version = "1.0.5" }
 etcetera = { version = "0.11.0" }
 fancy-regex = { version = "0.18.0" }
 fastrand = { version = "2.4.1", default-features = false }
 fs-err = { version = "3.3.0", features = ["tokio"] }
-futures-util = {
-  version = "0.3.31",
-  default-features = false,
-  features = ["alloc"]
-}
+futures-util = { version = "0.3.31", default-features = false, features = [
+  "alloc"
+] }
 hex = { version = "0.4.3" }
 http = { version = "1.1.0" }
 ignore = { version = "0.4.23" }
@@ -70,32 +61,32 @@ memchr = { version = "2.7.5" }
 owo-colors = { version = "4.1.0" }
 phf = { version = "0.14.0", default-features = false, features = ["macros"] }
 pprof = { version = "0.15.0" }
-reqwest = {
-  version = "0.13.2",
-  default-features = false,
-  features = ["http2", "stream", "json", "rustls", "system-proxy", "socks"]
-}
-aws-lc-rs = {
-  version = "1.17.0",
-  default-features = false,
-  features = ["aws-lc-sys"]
-}
+reqwest = { version = "0.13.2", default-features = false, features = [
+  "http2",
+  "stream",
+  "json",
+  "rustls",
+  "system-proxy",
+  "socks"
+] }
+aws-lc-rs = { version = "1.17.0", default-features = false, features = [
+  "aws-lc-sys"
+] }
 rustc-hash = { version = "2.1.1" }
 rustix = { version = "1.0.8", features = ["pty", "process", "fs", "termios"] }
 same-file = { version = "1.0.6" }
 seahash = { version = "4.1.0" }
 semver = { version = "1.0.24", features = ["serde"] }
 serde = { version = "1.0.210", features = ["derive"] }
-serde_json = {
-  version = "1.0.132",
-  features = ["preserve_order", "unbounded_depth"]
-}
+serde_json = { version = "1.0.132", features = [
+  "preserve_order",
+  "unbounded_depth"
+] }
 serde_stacker = { version = "0.1.12" }
-serde-saphyr = {
-  version = "0.0.28",
-  default-features = false,
-  features = ["deserialize", "serialize"]
-}
+serde-saphyr = { version = "0.0.28", default-features = false, features = [
+  "deserialize",
+  "serialize"
+] }
 shlex = { version = "2.0.0" }
 globset = { version = "0.4.18" }
 similar = { version = "3.0.0" }
@@ -103,27 +94,25 @@ strum = { version = "0.28.0", features = ["derive"] }
 target-lexicon = { version = "0.13.0" }
 tempfile = { version = "3.25.0" }
 thiserror = { version = "2.0.11" }
-tokio = {
-  version = "1.47.1",
-  features = [
-    "fs",
-    "io-std",
-    "io-util",
-    "process",
-    "rt",
-    "sync",
-    "macros",
-    "net",
-    "time"
-  ]
-}
+tokio = { version = "1.47.1", features = [
+  "fs",
+  "io-std",
+  "io-util",
+  "process",
+  "rt",
+  "sync",
+  "macros",
+  "net",
+  "time"
+] }
 tokio-tar = { version = "0.6.0", package = "astral-tokio-tar" }
 tokio-util = { version = "0.7.13", features = ["compat", "io"] }
-toml = {
-  version = "1.0.1",
-  default-features = false,
-  features = ["fast_hash", "parse", "preserve_order", "serde"]
-}
+toml = { version = "1.0.1", default-features = false, features = [
+  "fast_hash",
+  "parse",
+  "preserve_order",
+  "serde"
+] }
 toml_edit = { version = "0.25.1" }
 tracing = { version = "0.1.40" }
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }


### PR DESCRIPTION
Renovate seems doesn't support TOML 1.1 yet.