### PR TITLE
Run Julia tests sequentially

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -15,6 +15,11 @@ filter = "test(lua::)"
 threads-required = "num-test-threads"
 
 [[profile.ci-language.overrides]]
+# Julia package operations share user-level depot and registry state.
+filter = "test(julia::)"
+threads-required = "num-test-threads"
+
+[[profile.ci-language.overrides]]
 platform = "cfg(windows)"
 filter = "test(perl::)"
 threads-required = "num-test-threads"


### PR DESCRIPTION
Serialize Julia language tests to avoid races in shared depot and registry state.