### PR TITLE
Add aliases for hook priorities

### DIFF
--- a/crates/prek/src/cli/run/selector.rs
+++ b/crates/prek/src/cli/run/selector.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-use crate::config::validate_group_name;
+use crate::config::validate_name;
 use crate::hook::Hook;
 use crate::warn_user;
 
@@ -419,7 +419,7 @@ impl GroupFilters {
             let mut names = Vec::new();
 
             for group in groups {
-                if let Err(reason) = validate_group_name(group) {
+                if let Err(reason) = validate_name(group) {
                     return Err(Error::GroupSelector {
                         selector: format!("{flag}={group}"),
                         source: anyhow!("group name {reason}"),

--- a/crates/prek/src/config.rs
+++ b/crates/prek/src/config.rs
@@ -20,14 +20,113 @@ use crate::version;
 use crate::warn_user;
 use crate::warn_user_once;
 
-pub(crate) fn validate_group_name(group: &str) -> std::result::Result<(), &'static str> {
-    if group.is_empty() {
+pub(crate) fn validate_name(name: &str) -> std::result::Result<(), &'static str> {
+    if name.is_empty() {
         Err("cannot be empty")
-    } else if group.chars().any(char::is_whitespace) {
+    } else if name.chars().any(char::is_whitespace) {
         Err("cannot contain whitespace")
     } else {
         Ok(())
     }
+}
+
+#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub(crate) struct PriorityAlias(
+    #[cfg_attr(feature = "schemars", schemars(regex(pattern = r"^\S+$")))] String,
+);
+
+impl TryFrom<String> for PriorityAlias {
+    type Error = String;
+
+    fn try_from(alias: String) -> std::result::Result<Self, Self::Error> {
+        validate_name(&alias).map_err(|reason| priority_alias_error(&alias, reason))?;
+        Ok(Self(alias))
+    }
+}
+
+impl<'de> Deserialize<'de> for PriorityAlias {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::try_from(String::deserialize(deserializer)?).map_err(D::Error::custom)
+    }
+}
+
+impl std::fmt::Debug for PriorityAlias {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&self.0, f)
+    }
+}
+
+impl Display for PriorityAlias {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[derive(Clone)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schemars", serde(untagged))]
+pub(crate) enum Priority {
+    Number(u32),
+    Alias(PriorityAlias),
+}
+
+impl<'de> Deserialize<'de> for Priority {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum PriorityWire {
+            Number(u32),
+            Alias(String),
+        }
+
+        match PriorityWire::deserialize(deserializer)? {
+            PriorityWire::Number(priority) => Ok(Self::Number(priority)),
+            PriorityWire::Alias(alias) => PriorityAlias::try_from(alias)
+                .map(Self::Alias)
+                .map_err(D::Error::custom),
+        }
+    }
+}
+
+impl std::fmt::Debug for Priority {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Number(priority) => std::fmt::Debug::fmt(priority, f),
+            Self::Alias(alias) => std::fmt::Debug::fmt(alias, f),
+        }
+    }
+}
+
+impl Priority {
+    pub(crate) fn resolve(
+        &self,
+        priorities: &BTreeMap<PriorityAlias, u32>,
+        hook: &str,
+    ) -> std::result::Result<u32, Error> {
+        match self {
+            Self::Number(priority) => Ok(*priority),
+            Self::Alias(alias) => {
+                priorities
+                    .get(alias)
+                    .copied()
+                    .ok_or_else(|| Error::UnknownPriorityAlias {
+                        hook: hook.to_owned(),
+                        alias: alias.clone(),
+                    })
+            }
+        }
+    }
+}
+
+fn priority_alias_error(alias: &str, reason: &str) -> String {
+    format!("priority alias `{alias}` {reason}")
 }
 
 fn deserialize_groups<'de, D>(deserializer: D) -> std::result::Result<Option<Vec<String>>, D::Error>
@@ -37,7 +136,7 @@ where
     let groups = Option::<Vec<String>>::deserialize(deserializer)?;
     if let Some(groups) = &groups {
         for group in groups {
-            if let Err(reason) = validate_group_name(group) {
+            if let Err(reason) = validate_name(group) {
                 return Err(D::Error::custom(format!("group name `{group}` {reason}")));
             }
         }
@@ -711,7 +810,7 @@ pub(crate) struct RemoteHook {
     ///
     /// This is only allowed in project config files (e.g. `.pre-commit-config.yaml`).
     /// It is not allowed in manifests (e.g. `.pre-commit-hooks.yaml`).
-    pub priority: Option<u32>,
+    pub priority: Option<Priority>,
     /// User-defined hook groups used by `prek run --group` and `--no-group`.
     /// Group names cannot be empty or contain whitespace.
     #[serde(default, deserialize_with = "deserialize_groups")]
@@ -738,7 +837,7 @@ pub(crate) struct LocalHook {
     pub language: Language,
     /// Priority used by the scheduler to determine ordering and concurrency.
     /// Hooks with the same priority can run in parallel.
-    pub priority: Option<u32>,
+    pub priority: Option<Priority>,
     /// User-defined hook groups used by `prek run --group` and `--no-group`.
     /// Group names cannot be empty or contain whitespace.
     #[serde(default, deserialize_with = "deserialize_groups")]
@@ -761,7 +860,7 @@ pub(crate) struct MetaHook {
     pub name: String,
     /// Priority used by the scheduler to determine ordering and concurrency.
     /// Hooks with the same priority can run in parallel.
-    pub priority: Option<u32>,
+    pub priority: Option<Priority>,
     /// User-defined hook groups used by `prek run --group` and `--no-group`.
     /// Group names cannot be empty or contain whitespace.
     #[serde(default, deserialize_with = "deserialize_groups")]
@@ -852,7 +951,7 @@ pub(crate) struct BuiltinHook {
     pub entry: String,
     /// Priority used by the scheduler to determine ordering and concurrency.
     /// Hooks with the same priority can run in parallel.
-    pub priority: Option<u32>,
+    pub priority: Option<Priority>,
     /// User-defined hook groups used by `prek run --group` and `--no-group`.
     /// Group names cannot be empty or contain whitespace.
     #[serde(default, deserialize_with = "deserialize_groups")]
@@ -1273,6 +1372,9 @@ pub(crate) struct Config {
     /// Default settings for `prek update` in this project.
     #[serde(alias = "auto_update")]
     pub update: Option<UpdateOptions>,
+    /// Configuration-local aliases for numeric hook priorities.
+    #[serde(default)]
+    pub priorities: BTreeMap<PriorityAlias, u32>,
     pub repos: Vec<Repo>,
     /// A list of `--hook-types` which will be used by default when running `prek install`.
     /// Default is `[pre-commit]`.
@@ -1306,6 +1408,28 @@ pub(crate) struct Config {
 }
 
 impl Config {
+    fn validate_priorities(&self) -> std::result::Result<(), Error> {
+        macro_rules! validate_hooks {
+            ($hooks:expr) => {
+                for hook in $hooks {
+                    if let Some(priority) = &hook.priority {
+                        priority.resolve(&self.priorities, &hook.id)?;
+                    }
+                }
+            };
+        }
+
+        for repo in &self.repos {
+            match repo {
+                Repo::Remote(repo) => validate_hooks!(&repo.hooks),
+                Repo::Local(repo) => validate_hooks!(&repo.hooks),
+                Repo::Meta(repo) => validate_hooks!(&repo.hooks),
+                Repo::Builtin(repo) => validate_hooks!(&repo.hooks),
+            }
+        }
+        Ok(())
+    }
+
     /// Resolve local relative repository sources from the config file, not the process cwd.
     fn resolve_relative_repo_sources(&mut self, config_path: &Path) -> Result<(), Error> {
         let config_dir = config_path
@@ -1349,6 +1473,9 @@ pub(crate) enum Error {
 
     #[error("Failed to parse `{0}`")]
     Toml(String, #[source] Box<toml::de::Error>),
+
+    #[error("Priority alias `{alias}` referenced by hook `{hook}` is not declared in `priorities`")]
+    UnknownPriorityAlias { hook: String, alias: PriorityAlias },
 }
 
 impl Error {
@@ -1471,6 +1598,7 @@ pub(crate) fn load_config(path: &Path) -> Result<Config, Error> {
         _ => serde_saphyr::from_str(&content)
             .map_err(|e| Error::Yaml(path.user_display().to_string(), Box::new(e)))?,
     };
+    config.validate_priorities()?;
     config.resolve_relative_repo_sources(path)?;
 
     Ok(config)

--- a/crates/prek/src/hook.rs
+++ b/crates/prek/src/hook.rs
@@ -54,7 +54,7 @@ pub(crate) struct HookSpec {
     pub name: String,
     pub entry: String,
     pub language: Language,
-    pub priority: Option<u32>,
+    pub priority: Option<config::Priority>,
     pub groups: Option<Vec<String>>,
     pub options: HookOptions,
 }
@@ -70,8 +70,8 @@ impl HookSpec {
         if let Some(language) = &config.language {
             self.language.clone_from(language);
         }
-        if let Some(priority) = config.priority {
-            self.priority = Some(priority);
+        if config.priority.is_some() {
+            self.priority.clone_from(&config.priority);
         }
         if config.groups.is_some() {
             self.groups.clone_from(&config.groups);
@@ -419,6 +419,14 @@ impl HookBuilder {
 
         self.check()?;
 
+        let priority = self
+            .hook_spec
+            .priority
+            .as_ref()
+            .map(|priority| priority.resolve(&self.project.config().priorities, &self.hook_spec.id))
+            .transpose()?
+            .unwrap_or_else(|| u32::try_from(self.idx).expect("idx too large"));
+
         let groups = self
             .hook_spec
             .groups
@@ -449,11 +457,6 @@ impl HookBuilder {
         })?;
 
         let entry = HookEntry::new(self.hook_spec.id.clone(), self.hook_spec.entry, shell);
-
-        let priority = self
-            .hook_spec
-            .priority
-            .unwrap_or_else(|| u32::try_from(self.idx).expect("idx too large"));
 
         let mut hook = Hook {
             project: self.project,
@@ -893,7 +896,7 @@ mod tests {
     use serde_json::json;
 
     use crate::config::{
-        Config, HookOptions, Language, PassFilenames, RemoteHook, Shell, Stage, Stages,
+        Config, HookOptions, Language, PassFilenames, Priority, RemoteHook, Shell, Stage, Stages,
     };
     use crate::hook::HookSpec;
     use crate::languages::version::LanguageRequest;
@@ -957,7 +960,7 @@ mod tests {
             name: Some("override-name".to_string()),
             entry: Some("python3 -c 'print(2)'".to_string()),
             language: None,
-            priority: Some(42),
+            priority: Some(Priority::Number(42)),
             groups: Some(vec!["ci".to_string(), "format".to_string()]),
             options: HookOptions {
                 alias: Some("alias-1".to_string()),
@@ -986,6 +989,7 @@ mod tests {
                 idx: 0,
                 config: Config {
                     update: None,
+                    priorities: {},
                     repos: [],
                     default_install_hook_types: None,
                     default_language_version: Some(

--- a/crates/prek/src/snapshots/prek__config__tests__language_version.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__language_version.snap
@@ -5,6 +5,7 @@ expression: result
 Ok(
     Config {
         update: None,
+        priorities: {},
         repos: [
             Local(
                 LocalRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__meta_hooks-5.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__meta_hooks-5.snap
@@ -4,6 +4,7 @@ expression: result
 ---
 Config {
     update: None,
+    priorities: {},
     repos: [
         Meta(
             MetaRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__numeric_rev_is_parsed_as_string.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__numeric_rev_is_parsed_as_string.snap
@@ -4,6 +4,7 @@ expression: config
 ---
 Config {
     update: None,
+    priorities: {},
     repos: [
         Remote(
             RemoteRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__parse_hooks-3.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__parse_hooks-3.snap
@@ -4,6 +4,7 @@ expression: result
 ---
 Config {
     update: None,
+    priorities: {},
     repos: [
         Local(
             LocalRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__parse_repos-3.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__parse_repos-3.snap
@@ -4,6 +4,7 @@ expression: result
 ---
 Config {
     update: None,
+    priorities: {},
     repos: [
         Local(
             LocalRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__parse_repos-4.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__parse_repos-4.snap
@@ -4,6 +4,7 @@ expression: result
 ---
 Config {
     update: None,
+    priorities: {},
     repos: [
         Remote(
             RemoteRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__parse_repos-6.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__parse_repos-6.snap
@@ -4,6 +4,7 @@ expression: result
 ---
 Config {
     update: None,
+    priorities: {},
     repos: [
         Remote(
             RemoteRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__parse_repos.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__parse_repos.snap
@@ -4,6 +4,7 @@ expression: result
 ---
 Config {
     update: None,
+    priorities: {},
     repos: [
         Local(
             LocalRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__read_config_with_merge_keys.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__read_config_with_merge_keys.snap
@@ -4,6 +4,7 @@ expression: config
 ---
 Config {
     update: None,
+    priorities: {},
     repos: [
         Local(
             LocalRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__read_config_with_nested_merge_keys.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__read_config_with_nested_merge_keys.snap
@@ -4,6 +4,7 @@ expression: config
 ---
 Config {
     update: None,
+    priorities: {},
     repos: [
         Local(
             LocalRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__read_toml_config.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__read_toml_config.snap
@@ -4,6 +4,7 @@ expression: config
 ---
 Config {
     update: None,
+    priorities: {},
     repos: [
         Local(
             LocalRepo {

--- a/crates/prek/src/snapshots/prek__config__tests__read_yaml_config.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__read_yaml_config.snap
@@ -4,6 +4,7 @@ expression: config
 ---
 Config {
     update: None,
+    priorities: {},
     repos: [
         Remote(
             RemoteRepo {

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -556,6 +556,52 @@ fn priorities_respected() {
 }
 
 #[test]
+fn priority_aliases_are_resolved_before_scheduling() {
+    let context = TestContext::new();
+    context.init_project();
+
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        priorities:
+          early: 0
+          late: 10
+        repos:
+          - repo: local
+            hooks:
+              - id: late
+                name: Late Hook
+                language: system
+                entry: python3 -c "print('late')"
+                always_run: true
+                priority: late
+              - id: early
+                name: Early Hook
+                language: system
+                entry: python3 -c "print('early')"
+                always_run: true
+                priority: early
+              - id: numeric
+                name: Numeric Hook
+                language: system
+                entry: python3 -c "print('numeric')"
+                always_run: true
+                priority: 5
+    "#});
+
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run(), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Early Hook...............................................................Passed
+    Numeric Hook.............................................................Passed
+    Late Hook................................................................Passed
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
 fn run_group_without_stage_selects_hooks_across_stages() {
     let context = TestContext::new();
     context.init_project();
@@ -3374,6 +3420,55 @@ fn prek_toml() -> Result<()> {
     - duration: [TIME]
 
       Hello, world!
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn prek_toml_resolves_priority_aliases() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    context
+        .work_dir()
+        .child(PREK_TOML)
+        .write_str(indoc::indoc! {r#"
+        [priorities]
+        early = 0
+        late = 10
+
+        [[repos]]
+        repo = "local"
+        hooks = [
+          {
+            id = "late",
+            name = "Late Hook",
+            language = "system",
+            entry = "python3 -c \"print('late')\"",
+            always_run = true,
+            priority = "late",
+          },
+          {
+            id = "early",
+            name = "Early Hook",
+            language = "system",
+            entry = "python3 -c \"print('early')\"",
+            always_run = true,
+            priority = "early",
+          },
+        ]
+    "#})?;
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Early Hook...............................................................Passed
+    Late Hook................................................................Passed
 
     ----- stderr -----
     ");

--- a/crates/prek/tests/validate.rs
+++ b/crates/prek/tests/validate.rs
@@ -117,6 +117,92 @@ fn invalid_config_error() {
 }
 
 #[test]
+fn unknown_priority_alias_is_invalid() {
+    let context = TestContext::new();
+    context.write_pre_commit_config(indoc::indoc! {r"
+        priorities:
+          checks: 10
+        repos:
+          - repo: local
+            hooks:
+              - id: format
+                name: Format
+                entry: ruff format
+                language: system
+                priority: formatting
+    "});
+
+    cmd_snapshot!(context.filters(), context.validate_config().arg(PRE_COMMIT_CONFIG_YAML), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Priority alias `formatting` referenced by hook `format` is not declared in `priorities`
+    ");
+}
+
+#[test]
+fn priority_aliases_cannot_contain_whitespace() {
+    let context = TestContext::new();
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        priorities:
+          "static checks": 10
+        repos: []
+    "#});
+
+    cmd_snapshot!(context.filters(), context.validate_config().arg(PRE_COMMIT_CONFIG_YAML), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to parse `.pre-commit-config.yaml`
+      caused by: error: line 2 column 3: priority alias `static checks` cannot contain whitespace
+     --> <input>:2:3
+      |
+    1 | priorities:
+    2 |   "static checks": 10
+      |   ^ priority alias `static checks` cannot contain whitespace
+    3 | repos: []
+      |
+    "#);
+}
+
+#[test]
+fn duplicate_and_unused_priority_aliases_are_valid() {
+    let context = TestContext::new();
+    context.write_pre_commit_config(indoc::indoc! {r"
+        priorities:
+          checks: 10
+          verification: 10
+          unused: 20
+        repos:
+          - repo: local
+            hooks:
+              - id: check
+                name: Check
+                entry: check
+                language: system
+                priority: checks
+              - id: verify
+                name: Verify
+                entry: verify
+                language: system
+                priority: verification
+    "});
+
+    cmd_snapshot!(context.filters(), context.validate_config().arg(PRE_COMMIT_CONFIG_YAML), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    success: All configs are valid
+    ");
+}
+
+#[test]
 fn validate_manifest() -> anyhow::Result<()> {
     let context = TestContext::new();
 

--- a/crates/prek/tests/yaml_to_toml.rs
+++ b/crates/prek/tests/yaml_to_toml.rs
@@ -9,6 +9,8 @@ mod common;
 const YAML_CONFIG: &str = r#"
 fail_fast: true
 default_install_hook_types: [pre-push]
+priorities:
+  checks: 1
 exclude: |
   (?x)^(
     .*/(snapshots)/.*|
@@ -36,7 +38,7 @@ repos:
         args: [--number, --compact-tables, --align-semantic-breaks-in-lists]
         env:
           Hello: World
-        priority: 1
+        priority: checks
         additional_dependencies:
           - mdformat-mkdocs==5.1.4
           - mdformat-simple-breaks==0.1.0
@@ -85,6 +87,7 @@ fn yaml_to_toml_writes_default_output() -> anyhow::Result<()> {
 
     fail_fast = true
     default_install_hook_types = ["pre-push"]
+    priorities = { checks = 1 }
     exclude = """
     (?x)^(
       .*/(snapshots)/.*|
@@ -121,7 +124,7 @@ fn yaml_to_toml_writes_default_output() -> anyhow::Result<()> {
           "--align-semantic-breaks-in-lists"
         ],
         env = { Hello = "World" },
-        priority = 1,
+        priority = "checks",
         additional_dependencies = [
           "mdformat-mkdocs==5.1.4",
           "mdformat-simple-breaks==0.1.0"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,6 +52,7 @@ They work in both YAML and TOML, but they only matter for compatibility if you s
 - Top-level:
     - [`update`](reference/configuration.md#update)
     - [`default_env`](reference/configuration.md#default_env)
+    - [`priorities`](reference/configuration.md#priorities)
     - [`minimum_prek_version`](reference/configuration.md#prek-only-minimum-prek-version-config)
     - [`orphan`](reference/configuration.md#prek-only-orphan)
 - Repo type:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -62,6 +62,24 @@ Each entry is one of:
 
 See [Repo entries](#repo-entries).
 
+### `priorities`
+
+!!! note "prek-only"
+
+    Priority aliases are a `prek` extension and do not exist in upstream `pre-commit`.
+
+An optional mapping that declares configuration-local aliases for non-negative integer priorities.
+A hook can use one of these aliases in its [`priority`](#priority) field instead of repeating the
+integer.
+
+- Type: mapping from string to non-negative integer
+- Default: empty mapping
+- Scope: the current project configuration only
+- Aliases: non-empty, case-sensitive strings without whitespace
+
+Different aliases may map to the same integer. Unused declarations are allowed. Referencing an
+alias that is not declared in the current configuration is an error.
+
 <a id="top-level-files"></a>
 
 ### `files`
@@ -1214,12 +1232,15 @@ This is useful for tools that use global caches/locks or otherwise can’t handl
 
     `priority` controls `prek`'s scheduler and does not exist in upstream `pre-commit`.
 
-Each hook can set an explicit `priority` (a non-negative integer) that controls when it runs and with which hooks it may execute in parallel.
+Each hook can set an explicit `priority` that controls when it runs and with which hooks it may
+execute in parallel. The value may be either a non-negative integer or a [priority
+alias](#priorities) declared by the current configuration.
 
 Scope:
 
 - `priority` is evaluated **within a single configuration file** and is compared across **all hooks in that file**, even if they appear under different `repos:` entries.
 - `priority` does **not** coordinate across different config files. In workspace mode, each project’s config file is scheduled independently.
+- Numeric priorities and aliases can be mixed. Aliases resolve to their declared integer before scheduling.
 
 Hooks run in ascending priority order: **lower `priority` values run earlier**. Hooks that share the same `priority` value run concurrently, subject to `PREK_CONCURRENT_HOOKS`.
 
@@ -1230,6 +1251,11 @@ Example:
 === "prek.toml"
 
     ```toml
+    [priorities]
+    format = 0
+    checks = 10
+    tests = 20
+
     [[repos]]
     repo = "local"
     hooks = [
@@ -1239,7 +1265,7 @@ Example:
         language = "system",
         entry = "python3 -m ruff format",
         always_run = true,
-        priority = 0,
+        priority = "format",
       },
       {
         id = "lint",
@@ -1247,7 +1273,7 @@ Example:
         language = "system",
         entry = "python3 -m ruff check",
         always_run = true,
-        priority = 10,
+        priority = "checks",
       },
       {
         id = "tests",
@@ -1255,7 +1281,7 @@ Example:
         language = "system",
         entry = "just test",
         always_run = true,
-        priority = 20,
+        priority = "tests",
       },
     ]
     ```
@@ -1263,6 +1289,11 @@ Example:
 === ".pre-commit-config.yaml"
 
     ```yaml
+    priorities:
+      format: 0
+      checks: 10
+      tests: 20
+
     repos:
       - repo: local
         hooks:
@@ -1271,21 +1302,21 @@ Example:
             language: system
             entry: python3 -m ruff format
             always_run: true
-            priority: 0
+            priority: format
 
           - id: lint
             name: Lint
             language: system
             entry: python3 -m ruff check
             always_run: true
-            priority: 10
+            priority: checks
 
           - id: tests
             name: Tests
             language: system
             entry: just test
             always_run: true
-            priority: 20
+            priority: tests
     ```
 
 !!! danger "Parallel hooks modifying files"
@@ -1303,6 +1334,11 @@ Example:
 
     [`require_serial`](#require_serial) set to `true` prevents concurrent batches of the *same hook*.
     It does not prevent other hooks from running alongside it; use a unique `priority` if you need exclusivity.
+
+!!! note "Priority aliases are not hook groups"
+
+    Priority aliases control scheduling. [`groups`](#groups) select which hooks run and have no
+    ordering or concurrency meaning.
 
 ### `fail_fast`
 

--- a/prek.schema.json
+++ b/prek.schema.json
@@ -9,6 +9,17 @@
       "description": "Default settings for `prek update` in this project.",
       "$ref": "#/definitions/UpdateOptions"
     },
+    "priorities": {
+      "description": "Configuration-local aliases for numeric hook priorities.",
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\S+$": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
     "repos": {
       "type": "array",
       "items": {
@@ -272,8 +283,7 @@
         },
         "priority": {
           "description": "Priority used by the scheduler to determine ordering and concurrency.\nHooks with the same priority can run in parallel.\n\nThis is only allowed in project config files (e.g. `.pre-commit-config.yaml`).\nIt is not allowed in manifests (e.g. `.pre-commit-hooks.yaml`).",
-          "type": "integer",
-          "minimum": 0
+          "$ref": "#/definitions/Priority"
         },
         "groups": {
           "description": "User-defined hook groups used by `prek run --group` and `--no-group`.\nGroup names cannot be empty or contain whitespace.",
@@ -423,6 +433,21 @@
         "system"
       ]
     },
+    "Priority": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": 0
+        },
+        {
+          "$ref": "#/definitions/PriorityAlias"
+        }
+      ]
+    },
+    "PriorityAlias": {
+      "type": "string",
+      "pattern": "^\\S+$"
+    },
     "FilePattern": {
       "description": "A file pattern, either a regex or glob pattern(s).",
       "oneOf": [
@@ -538,8 +563,7 @@
         },
         "priority": {
           "description": "Priority used by the scheduler to determine ordering and concurrency.\nHooks with the same priority can run in parallel.",
-          "type": "integer",
-          "minimum": 0
+          "$ref": "#/definitions/Priority"
         },
         "groups": {
           "description": "User-defined hook groups used by `prek run --group` and `--no-group`.\nGroup names cannot be empty or contain whitespace.",
@@ -709,8 +733,7 @@
         },
         "priority": {
           "description": "Priority used by the scheduler to determine ordering and concurrency.\nHooks with the same priority can run in parallel.\n\nThis is only allowed in project config files (e.g. `.pre-commit-config.yaml`).\nIt is not allowed in manifests (e.g. `.pre-commit-hooks.yaml`).",
-          "type": "integer",
-          "minimum": 0
+          "$ref": "#/definitions/Priority"
         },
         "groups": {
           "description": "User-defined hook groups used by `prek run --group` and `--no-group`.\nGroup names cannot be empty or contain whitespace.",
@@ -885,8 +908,7 @@
         },
         "priority": {
           "description": "Priority used by the scheduler to determine ordering and concurrency.\nHooks with the same priority can run in parallel.\n\nThis is only allowed in project config files (e.g. `.pre-commit-config.yaml`).\nIt is not allowed in manifests (e.g. `.pre-commit-hooks.yaml`).",
-          "type": "integer",
-          "minimum": 0
+          "$ref": "#/definitions/Priority"
         },
         "groups": {
           "description": "User-defined hook groups used by `prek run --group` and `--no-group`.\nGroup names cannot be empty or contain whitespace.",

--- a/skills/prek/SKILL.md
+++ b/skills/prek/SKILL.md
@@ -106,11 +106,14 @@ Scheduling:
 
 - smaller `priority` values run earlier
 - hooks with the same `priority` can run concurrently
+- top-level `priorities` can declare configuration-local aliases for numeric priorities
+- hook `priority` accepts either a non-negative integer or a declared alias
 - `priority` is evaluated within one config file, not across workspace projects
 
 Useful `prek`-specific hook/config fields when editing TOML:
 
 - `env` for per-hook environment variables
+- `priorities` for readable, reusable priority aliases
 - `priority` for hook ordering and concurrency
 - `minimum_prek_version` for gating newer config features
 - `orphan = true` to isolate a nested workspace project from parent configs


### PR DESCRIPTION
In projects with lots of hooks (and therefore repos) I found it very hard to follow which hooks run in which priority. I want to run as many as possible in parallel and therefore assign them to groups. Until now, I had to assign the same integer to hooks that can run at the same time (=belong to the same group), so I always wished for this feature.

I tried to do it in such a way that needs minimal changes and decided to basically only change the config parsing. In the end, it will still result in an u32 and all further logic still applies.

I also changed validate_group_name to validate_config_name to apply the same restrictions to the priorities names as for groups.

Used AI to find all docs that needs to be updated and updated them.

My first contribution here, so tell me if I missed something or if you want some changes.