### PR TITLE
Use OsString for hook commands

### DIFF
--- a/crates/prek/src/cli/hook_impl.rs
+++ b/crates/prek/src/cli/hook_impl.rs
@@ -218,7 +218,7 @@ async fn run_legacy(
         return Ok(0);
     }
 
-    let entry = resolve_command(vec![legacy_hook.to_string_lossy().into_owned()], None);
+    let entry = resolve_command(vec![legacy_hook.into_os_string()], None);
     let mut cmd = Cmd::new(&entry[0]);
     cmd.check(false).args(&entry[1..]).args(args);
     cmd.env(EnvVars::PREK_RUNNING_LEGACY, "1");

--- a/crates/prek/src/hook_entry.rs
+++ b/crates/prek/src/hook_entry.rs
@@ -1,4 +1,4 @@
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::ops::Deref;
 use std::path::Path;
 
@@ -11,36 +11,36 @@ use crate::store::Store;
 
 #[derive(Debug)]
 pub(crate) struct PreparedHookEntry {
-    argv: Vec<String>,
+    argv: Vec<OsString>,
     _temp_dir: Option<TempDir>,
 }
 
 impl PreparedHookEntry {
-    fn direct(argv: Vec<String>) -> Self {
+    fn direct(argv: Vec<OsString>) -> Self {
         Self {
             argv,
             _temp_dir: None,
         }
     }
 
-    fn shell(argv: Vec<String>, temp_dir: TempDir) -> Self {
+    fn shell(argv: Vec<OsString>, temp_dir: TempDir) -> Self {
         Self {
             argv,
             _temp_dir: Some(temp_dir),
         }
     }
 
-    pub(crate) fn argv(&self) -> &[String] {
+    pub(crate) fn argv(&self) -> &[OsString] {
         &self.argv
     }
 
-    pub(crate) fn argv_mut(&mut self) -> &mut Vec<String> {
+    pub(crate) fn argv_mut(&mut self) -> &mut Vec<OsString> {
         &mut self.argv
     }
 }
 
 impl Deref for PreparedHookEntry {
-    type Target = [String];
+    type Target = [OsString];
 
     fn deref(&self) -> &Self::Target {
         &self.argv
@@ -134,13 +134,13 @@ impl DirectHookEntry {
     ) -> Result<PreparedHookEntry, Error> {
         let mut split = self.split()?;
         let cmd = repo_path.join(&split[0]);
-        split[0] = cmd.to_string_lossy().into_owned();
+        split[0] = cmd.into_os_string();
 
         Ok(PreparedHookEntry::direct(resolve_command(split, env_path)))
     }
 
     /// Split the entry into a list of commands.
-    pub(crate) fn split(&self) -> Result<Vec<String>, Error> {
+    pub(crate) fn split(&self) -> Result<Vec<OsString>, Error> {
         let splits = shlex::split(&self.entry).ok_or_else(|| Error::Hook {
             hook: self.hook.clone(),
             error: anyhow::anyhow!("Failed to parse entry `{}` as commands", self.entry),
@@ -151,7 +151,13 @@ impl DirectHookEntry {
                 error: anyhow::anyhow!("Failed to parse entry: entry is empty"),
             });
         }
-        Ok(splits)
+        Ok(splits.into_iter().map(OsString::from).collect())
+    }
+
+    pub(crate) fn split_with_args(&self, args: &[String]) -> Result<Vec<OsString>, Error> {
+        let mut split = self.split()?;
+        split.extend(args.iter().map(OsString::from));
+        Ok(split)
     }
 
     /// Get the original entry string.
@@ -193,10 +199,10 @@ impl Shell {
         }
     }
 
-    fn argv_for_script(self, script_path: &Path) -> Vec<String> {
-        let script = script_path.to_string_lossy().into_owned();
+    fn argv_for_script(self, script_path: &Path) -> Vec<OsString> {
+        let script = script_path.as_os_str().to_owned();
         match self {
-            Self::Sh => vec!["sh".to_string(), "-e".to_string(), script],
+            Self::Sh => vec![OsString::from("sh"), OsString::from("-e"), script],
             Self::Bash => bash_argv(script),
             Self::Pwsh => powershell_argv("pwsh", script),
             Self::Powershell => powershell_argv("powershell", script),
@@ -205,34 +211,34 @@ impl Shell {
     }
 }
 
-fn bash_argv(script: String) -> Vec<String> {
+fn bash_argv(script: OsString) -> Vec<OsString> {
     // Avoid user startup files for deterministic hook behavior. `-e` fails on the first
     // failing command, and `-o pipefail` makes failing pipeline segments fail the script.
     const BASH_ARGV_PREFIX: &[&str] = &["bash", "--noprofile", "--norc", "-eo", "pipefail"];
 
     let mut argv = BASH_ARGV_PREFIX
         .iter()
-        .map(ToString::to_string)
+        .map(OsString::from)
         .collect::<Vec<_>>();
     argv.push(script);
     argv
 }
 
-fn powershell_argv(command: &str, script: String) -> Vec<String> {
+fn powershell_argv(command: &str, script: OsString) -> Vec<OsString> {
     let mut argv = vec![
-        command.to_string(),
+        OsString::from(command),
         // Avoid user profile scripts and prompts in hook execution.
-        "-NoProfile".to_string(),
-        "-NonInteractive".to_string(),
+        OsString::from("-NoProfile"),
+        OsString::from("-NonInteractive"),
     ];
     #[cfg(windows)]
     // Allow running prek's temporary script without changing the user's execution policy.
-    argv.extend(["-ExecutionPolicy".to_string(), "Bypass".to_string()]);
-    argv.extend(["-File".to_string(), script]);
+    argv.extend([OsString::from("-ExecutionPolicy"), OsString::from("Bypass")]);
+    argv.extend([OsString::from("-File"), script]);
     argv
 }
 
-fn cmd_argv(script: String) -> Vec<String> {
+fn cmd_argv(script: OsString) -> Vec<OsString> {
     // `/D` disables AutoRun, `/E:ON` enables command extensions, `/V:OFF` disables
     // delayed expansion, `/S` normalizes quote handling, `/C` runs and exits, and
     // `CALL` executes the temporary script while preserving `%*` argument access.
@@ -240,7 +246,7 @@ fn cmd_argv(script: String) -> Vec<String> {
 
     let mut argv = CMD_ARGV_PREFIX
         .iter()
-        .map(ToString::to_string)
+        .map(OsString::from)
         .collect::<Vec<_>>();
     argv.push(script);
     argv

--- a/crates/prek/src/hooks/pre_commit_hooks/check_added_large_files.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_added_large_files.rs
@@ -23,7 +23,7 @@ pub(crate) async fn check_added_large_files(
     hook: &Hook,
     filenames: &[&Path],
 ) -> anyhow::Result<(i32, Vec<u8>)> {
-    let args = Args::try_parse_from(hook.entry.expect_direct().split()?.iter().chain(&hook.args))?;
+    let args = Args::try_parse_from(hook.entry.expect_direct().split_with_args(&hook.args)?)?;
 
     let candidate_filenames;
     let filenames = if args.enforce_all {

--- a/crates/prek/src/hooks/pre_commit_hooks/check_merge_conflict.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_merge_conflict.rs
@@ -28,7 +28,7 @@ pub(crate) async fn check_merge_conflict(
     hook: &Hook,
     filenames: &[&Path],
 ) -> Result<(i32, Vec<u8>)> {
-    let args = Args::try_parse_from(hook.entry.expect_direct().split()?.iter().chain(&hook.args))?;
+    let args = Args::try_parse_from(hook.entry.expect_direct().split_with_args(&hook.args)?)?;
 
     // Check if we're in a merge state or assuming merge
     if !args.assume_in_merge && !is_in_merge().await? {

--- a/crates/prek/src/hooks/pre_commit_hooks/check_vcs_permalinks.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_vcs_permalinks.rs
@@ -82,7 +82,7 @@ pub(crate) async fn check_vcs_permalinks(
     hook: &Hook,
     filenames: &[&Path],
 ) -> Result<(i32, Vec<u8>)> {
-    let args = Args::try_parse_from(hook.entry.expect_direct().split()?.iter().chain(&hook.args))?;
+    let args = Args::try_parse_from(hook.entry.expect_direct().split_with_args(&hook.args)?)?;
     let matcher = GithubNonPermalinkMatcher::new(args.additional_github_domains);
 
     let file_base = hook.project().relative_path();

--- a/crates/prek/src/hooks/pre_commit_hooks/check_yaml.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_yaml.rs
@@ -21,7 +21,7 @@ struct Args {
 }
 
 pub(crate) async fn check_yaml(hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
-    let args = Args::try_parse_from(hook.entry.expect_direct().split()?.iter().chain(&hook.args))?;
+    let args = Args::try_parse_from(hook.entry.expect_direct().split_with_args(&hook.args)?)?;
 
     run_concurrent_file_checks(
         filenames.iter().copied(),

--- a/crates/prek/src/hooks/pre_commit_hooks/file_contents_sorter.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/file_contents_sorter.rs
@@ -23,7 +23,7 @@ pub(crate) async fn file_contents_sorter(
     hook: &Hook,
     filenames: &[&Path],
 ) -> Result<(i32, Vec<u8>)> {
-    let args = Args::try_parse_from(hook.entry.expect_direct().split()?.iter().chain(&hook.args))?;
+    let args = Args::try_parse_from(hook.entry.expect_direct().split_with_args(&hook.args)?)?;
     let file_base = hook.project().relative_path();
 
     run_concurrent_file_checks(

--- a/crates/prek/src/hooks/pre_commit_hooks/fix_trailing_whitespace.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/fix_trailing_whitespace.rs
@@ -62,7 +62,7 @@ pub(crate) async fn fix_trailing_whitespace(
     hook: &Hook,
     filenames: &[&Path],
 ) -> Result<(i32, Vec<u8>)> {
-    let args = Args::try_parse_from(hook.entry.expect_direct().split()?.iter().chain(&hook.args))?;
+    let args = Args::try_parse_from(hook.entry.expect_direct().split_with_args(&hook.args)?)?;
 
     let force_markdown = args.force_markdown();
     let markdown_exts = args.markdown_exts()?;

--- a/crates/prek/src/hooks/pre_commit_hooks/mixed_line_ending.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/mixed_line_ending.rs
@@ -59,7 +59,7 @@ impl LineEndingCounts {
 }
 
 pub(crate) async fn mixed_line_ending(hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
-    let args = Args::try_parse_from(hook.entry.expect_direct().split()?.iter().chain(&hook.args))?;
+    let args = Args::try_parse_from(hook.entry.expect_direct().split_with_args(&hook.args)?)?;
 
     run_concurrent_file_checks(
         filenames.iter().copied(),

--- a/crates/prek/src/hooks/pre_commit_hooks/no_commit_to_branch.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/no_commit_to_branch.rs
@@ -34,7 +34,7 @@ impl Args {
 }
 
 pub(crate) async fn no_commit_to_branch(hook: &Hook) -> Result<(i32, Vec<u8>)> {
-    let args = Args::try_parse_from(hook.entry.expect_direct().split()?.iter().chain(&hook.args))?;
+    let args = Args::try_parse_from(hook.entry.expect_direct().split_with_args(&hook.args)?)?;
 
     let output = git_cmd()?
         .arg("symbolic-ref")

--- a/crates/prek/src/hooks/pre_commit_hooks/pretty_format_json.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/pretty_format_json.rs
@@ -69,7 +69,7 @@ impl From<&Args> for PreparedArgs {
 }
 
 pub(crate) async fn pretty_format_json(hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
-    let args = Args::try_parse_from(hook.entry.expect_direct().split()?.iter().chain(&hook.args))?;
+    let args = Args::try_parse_from(hook.entry.expect_direct().split_with_args(&hook.args)?)?;
     let prepared = PreparedArgs::from(&args);
 
     run_concurrent_file_checks(

--- a/crates/prek/src/languages/dart.rs
+++ b/crates/prek/src/languages/dart.rs
@@ -12,6 +12,7 @@
 
 use std::collections::BTreeMap;
 use std::env::consts::EXE_EXTENSION;
+use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
@@ -171,9 +172,10 @@ impl LanguageBackend for Dart {
         if packages_path.exists()
             && let Some(index) = packages_arg_insert_position(entry.argv(), &hook.args)
         {
-            entry
-                .argv_mut()
-                .insert(index, format!("--packages={}", packages_path.display()));
+            entry.argv_mut().insert(
+                index,
+                format!("--packages={}", packages_path.display()).into(),
+            );
         }
 
         let run = async |batch: &[&Path]| {
@@ -223,29 +225,31 @@ fn package_config_path(env_path: &Path) -> PathBuf {
 }
 
 /// Return the `entry` argv position where `--packages=...` should be inserted.
-fn packages_arg_insert_position(entry: &[String], hook_args: &[String]) -> Option<usize> {
-    fn is_dart_binary(arg: &str) -> bool {
+fn packages_arg_insert_position(entry: &[OsString], hook_args: &[String]) -> Option<usize> {
+    fn is_dart_binary(arg: &OsStr) -> bool {
         Path::new(arg)
             .file_name()
             .and_then(|name| name.to_str())
             .is_some_and(|name| matches!(name, "dart" | "dart.exe"))
     }
 
-    fn has_packages_arg(arg: &str) -> bool {
-        arg == "-p" || arg == "--packages" || arg.starts_with("--packages=")
+    fn has_packages_arg(arg: &OsStr) -> bool {
+        arg.to_str()
+            .is_some_and(|arg| arg == "-p" || arg == "--packages" || arg.starts_with("--packages="))
     }
 
-    fn is_dart_script(arg: &str) -> bool {
+    fn is_dart_script(arg: &OsStr) -> bool {
         Path::new(arg)
             .extension()
             .is_some_and(|ext| ext.eq_ignore_ascii_case("dart"))
     }
 
-    let dart_index = entry.iter().position(|arg| is_dart_binary(arg))?;
+    let dart_index = entry.iter().position(|arg| is_dart_binary(arg.as_ref()))?;
 
     for (index, arg) in entry
         .iter()
-        .chain(hook_args)
+        .map(AsRef::as_ref)
+        .chain(hook_args.iter().map(OsStr::new))
         .enumerate()
         .skip(dart_index + 1)
     {
@@ -255,7 +259,7 @@ fn packages_arg_insert_position(entry: &[String], hook_args: &[String]) -> Optio
             return None;
         }
 
-        if !arg.starts_with('-') {
+        if !arg.to_str().is_some_and(|arg| arg.starts_with('-')) {
             // `--packages` is a VM flag, so place it before `run` or a script target.
             if arg != "run" && !is_dart_script(arg) {
                 return None;
@@ -417,13 +421,17 @@ mod tests {
     use super::*;
     use anyhow::Result;
 
+    fn make_entry(values: &[&str]) -> Vec<OsString> {
+        values.iter().map(OsString::from).collect()
+    }
+
     fn strings(values: &[&str]) -> Vec<String> {
         values.iter().map(ToString::to_string).collect()
     }
 
     #[test]
     fn packages_arg_insert_position_inserts_before_dart_run() {
-        let entry = strings(&["/usr/bin/dart", "run", "bin/hook.dart"]);
+        let entry = make_entry(&["/usr/bin/dart", "run", "bin/hook.dart"]);
 
         assert_eq!(packages_arg_insert_position(&entry, &[]), Some(1));
     }
@@ -431,16 +439,19 @@ mod tests {
     #[test]
     fn packages_arg_insert_position_keeps_existing_packages_arg() {
         assert_eq!(
-            packages_arg_insert_position(&strings(&["dart", "--packages=custom", "run"]), &[]),
-            None
-        );
-        assert_eq!(
-            packages_arg_insert_position(&strings(&["dart", "--packages", "custom", "run"]), &[]),
+            packages_arg_insert_position(&make_entry(&["dart", "--packages=custom", "run"]), &[]),
             None
         );
         assert_eq!(
             packages_arg_insert_position(
-                &strings(&["dart"]),
+                &make_entry(&["dart", "--packages", "custom", "run"]),
+                &[]
+            ),
+            None
+        );
+        assert_eq!(
+            packages_arg_insert_position(
+                &make_entry(&["dart"]),
                 &strings(&["--packages=custom", "run"])
             ),
             None
@@ -450,19 +461,19 @@ mod tests {
     #[test]
     fn packages_arg_insert_position_only_checks_vm_options_for_packages_arg() {
         assert_eq!(
-            packages_arg_insert_position(&strings(&["dart", "run", "tool.dart", "-p"]), &[]),
+            packages_arg_insert_position(&make_entry(&["dart", "run", "tool.dart", "-p"]), &[]),
             Some(1)
         );
         assert_eq!(
             packages_arg_insert_position(
-                &strings(&["dart", "tool.dart", "--packages=script-value"]),
+                &make_entry(&["dart", "tool.dart", "--packages=script-value"]),
                 &[]
             ),
             Some(1)
         );
         assert_eq!(
             packages_arg_insert_position(
-                &strings(&["dart"]),
+                &make_entry(&["dart"]),
                 &strings(&["run", "tool.dart", "--packages=script-value"])
             ),
             Some(1)
@@ -472,16 +483,19 @@ mod tests {
     #[test]
     fn packages_arg_insert_position_checks_hook_args() {
         assert_eq!(
-            packages_arg_insert_position(&strings(&["dart"]), &strings(&["run", "bin/hook.dart"])),
+            packages_arg_insert_position(
+                &make_entry(&["dart"]),
+                &strings(&["run", "bin/hook.dart"])
+            ),
             Some(1)
         );
         assert_eq!(
-            packages_arg_insert_position(&strings(&["dart"]), &strings(&["bin/hook.dart"])),
+            packages_arg_insert_position(&make_entry(&["dart"]), &strings(&["bin/hook.dart"])),
             Some(1)
         );
         assert_eq!(
             packages_arg_insert_position(
-                &strings(&["dart", "--enable-asserts"]),
+                &make_entry(&["dart", "--enable-asserts"]),
                 &strings(&["run", "bin/hook.dart"])
             ),
             Some(2)

--- a/crates/prek/src/languages/julia.rs
+++ b/crates/prek/src/languages/julia.rs
@@ -110,7 +110,7 @@ impl LanguageBackend for Julia {
         if let Some(repo_path) = hook.repo_path() {
             let jl_path = repo_path.join(&entry[0]);
             if jl_path.exists() {
-                entry[0] = jl_path.to_string_lossy().into_owned();
+                entry[0] = jl_path.into_os_string();
             }
         }
 

--- a/crates/prek/src/languages/mod.rs
+++ b/crates/prek/src/languages/mod.rs
@@ -1,6 +1,6 @@
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::future::Future;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -392,7 +392,11 @@ pub(crate) async fn extract_metadata(hook: &mut Hook) -> Result<()> {
 }
 
 /// Resolve the actual process invocation, honoring shebangs and PATH lookups.
-pub(crate) fn resolve_command(mut cmds: Vec<String>, paths: Option<&OsStr>) -> Vec<String> {
+pub(crate) fn resolve_command(mut cmds: Vec<OsString>, paths: Option<&OsStr>) -> Vec<OsString> {
+    let Some(candidate) = cmds.first() else {
+        return cmds;
+    };
+
     let env_path = if paths.is_none() {
         EnvVars.var_os(EnvVars::PATH)
     } else {
@@ -400,50 +404,51 @@ pub(crate) fn resolve_command(mut cmds: Vec<String>, paths: Option<&OsStr>) -> V
     };
     let paths = paths.or(env_path.as_deref());
 
-    let candidate = &cmds[0];
-    let resolved_binary = match which::which_in(candidate, paths, &*CWD) {
-        Ok(p) => p,
-        Err(_) => PathBuf::from(candidate),
-    };
-    trace!("Resolved command: {}", resolved_binary.display());
+    let resolved_binary =
+        which::which_in(candidate, paths, &*CWD).unwrap_or_else(|_| Path::new(candidate).into());
 
-    if let Ok(mut shebang_argv) = parse_shebang(&resolved_binary) {
-        trace!("Found shebang: {:?}", shebang_argv);
-        #[allow(unused_mut)]
-        let mut interpreter = shebang_argv[0].as_str();
-        #[cfg(windows)]
+    let Ok(shebang_argv) = parse_shebang(&resolved_binary) else {
+        cmds[0] = resolved_binary.into_os_string();
+        return cmds;
+    };
+
+    let mut shebang_argv = shebang_argv
+        .into_iter()
+        .map(OsString::from)
+        .collect::<Vec<_>>();
+    trace!("Found shebang: {:?}", shebang_argv);
+    let interpreter = shebang_argv[0].as_os_str();
+    #[cfg(windows)]
+    let interpreter = {
+        let interpreter_path = Path::new(interpreter);
+        if !interpreter_path.exists()
+            && (interpreter_path.has_root() || interpreter_path.components().count() > 1)
         {
-            let interpreter_path = Path::new(interpreter);
             // Git for Windows behavior: if a shebang points to a Unix-style absolute
             // interpreter path (e.g. `/bin/sh`) that does not exist on Windows,
             // fall back to PATH lookup of its basename (`sh`).
-            if !interpreter_path.exists()
-                // Restrict this fallback to path-like interpreter values so plain
-                // commands (like `python`) keep their normal resolution path below.
-                && (interpreter_path.has_root() || interpreter.contains(['/', '\\']))
-                // Extract basename from shebang path (`/bin/sh` -> `sh`) and resolve it.
-                && let Some(file_name) = interpreter_path.file_name().and_then(OsStr::to_str)
-            {
-                interpreter = file_name;
-            }
+            interpreter_path.file_name().unwrap_or(interpreter)
+        } else {
+            interpreter
         }
-        // Resolve the interpreter path, convert "python3" to "python3.exe" on Windows
-        if let Ok(p) = which::which_in(interpreter, paths, &*CWD) {
-            shebang_argv[0] = p.to_string_lossy().into_owned();
-            trace!("Resolved interpreter: {}", shebang_argv[0]);
-        }
-        shebang_argv.push(resolved_binary.to_string_lossy().into_owned());
-        shebang_argv.extend_from_slice(&cmds[1..]);
-        shebang_argv
-    } else {
-        cmds[0] = resolved_binary.to_string_lossy().into_owned();
-        cmds
+    };
+
+    // Resolve the interpreter path, converting "python3" to "python3.exe" on Windows.
+    if let Ok(path) = which::which_in(interpreter, paths, &*CWD) {
+        shebang_argv[0] = path.into_os_string();
     }
+    shebang_argv.push(resolved_binary.into_os_string());
+    shebang_argv.extend(cmds.drain(1..));
+    shebang_argv
 }
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    use std::ffi::OsStr;
     use std::ffi::OsString;
+    #[cfg(unix)]
+    use std::os::unix::ffi::OsStringExt;
     use std::path::Path;
 
     use tempfile::tempdir;
@@ -457,18 +462,35 @@ mod tests {
 
     #[test]
     fn resolve_command_passthrough_when_not_found() {
-        let cmd = "__prek_nonexistent_command__".to_string();
+        let cmd = OsString::from("__prek_nonexistent_command__");
         let resolved = resolve_command(vec![cmd.clone()], None);
         assert_eq!(resolved, vec![cmd]);
     }
 
     #[test]
-    fn resolve_command_resolves_shebang_interpreter_from_path() {
+    fn resolve_command_passthrough_when_empty() {
+        assert_eq!(resolve_command(Vec::new(), None), Vec::<OsString>::new());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_command_preserves_non_utf8_arguments() {
+        let cmd = OsString::from("__prek_nonexistent_command__");
+        let arg = OsString::from_vec(vec![b'f', b'o', 0x80]);
+
+        assert_eq!(
+            resolve_command(vec![cmd.clone(), arg.clone()], Some(OsStr::new("")),),
+            vec![cmd, arg]
+        );
+    }
+
+    #[test]
+    fn resolve_command_resolves_shebang_and_preserves_arguments() {
         let dir = tempdir().expect("create temp dir");
         let script_path = dir.path().join("hook-script");
         write_file(
             &script_path,
-            "#!/usr/bin/env prek-test-interpreter\necho hi\n",
+            "#!/usr/bin/env -S prek-test-interpreter --from-shebang\necho hi\n",
         );
 
         #[cfg(windows)]
@@ -480,13 +502,21 @@ mod tests {
         make_executable(&interpreter_path).expect("set executable bit");
 
         let paths = OsString::from(dir.path().as_os_str());
+        let script = script_path.into_os_string();
         let resolved = resolve_command(
-            vec![script_path.to_string_lossy().into_owned()],
+            vec![script.clone(), OsString::from("--from-entry")],
             Some(paths.as_os_str()),
         );
 
-        assert_eq!(resolved[0], interpreter_path.to_string_lossy());
-        assert_eq!(resolved[1], script_path.to_string_lossy());
+        assert_eq!(
+            resolved,
+            vec![
+                interpreter_path.into_os_string(),
+                OsString::from("--from-shebang"),
+                script,
+                OsString::from("--from-entry"),
+            ]
+        );
     }
 
     #[cfg(windows)]
@@ -501,12 +531,12 @@ mod tests {
 
         let paths = OsString::from(dir.path().as_os_str());
         let resolved = resolve_command(
-            vec![script_path.to_string_lossy().into_owned()],
+            vec![script_path.as_os_str().to_owned()],
             Some(paths.as_os_str()),
         );
 
-        assert_eq!(resolved[0], sh_path.to_string_lossy());
-        assert_eq!(resolved[1], script_path.to_string_lossy());
+        assert_eq!(resolved[0].as_os_str(), sh_path.as_os_str());
+        assert_eq!(resolved[1].as_os_str(), script_path.as_os_str());
     }
 
     #[cfg(windows)]
@@ -528,12 +558,12 @@ mod tests {
 
         let paths = OsString::from(dir.path().as_os_str());
         let resolved = resolve_command(
-            vec![script_path.to_string_lossy().into_owned()],
+            vec![script_path.as_os_str().to_owned()],
             Some(paths.as_os_str()),
         );
 
         let resolved_interp = Path::new(&resolved[0]);
         assert_eq!(resolved_interp, interp_path.as_path());
-        assert_eq!(resolved[1], script_path.to_string_lossy());
+        assert_eq!(resolved[1].as_os_str(), script_path.as_os_str());
     }
 }

--- a/crates/prek/src/languages/r.rs
+++ b/crates/prek/src/languages/r.rs
@@ -1,4 +1,5 @@
 use std::env::consts::EXE_EXTENSION;
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::str;
@@ -264,7 +265,7 @@ fn additional_dependency_install_code(env_path: &Path) -> String {
     "#}
 }
 
-fn r_hook_entry(hook: &InstalledHook) -> Result<Vec<String>> {
+fn r_hook_entry(hook: &InstalledHook) -> Result<Vec<OsString>> {
     let entry = hook.entry.expect_direct().split()?;
     validate_r_entry(&entry)?;
 
@@ -277,14 +278,14 @@ fn r_hook_entry(hook: &InstalledHook) -> Result<Vec<String>> {
             "--no-site-file",
             "--no-environ",
         ]
-        .map(String::from),
+        .map(OsString::from),
     );
 
     if let Some(repo_path) = hook.repo_path() {
         if entry[1] == "-e" {
             cmd.extend(entry[1..].iter().cloned());
         } else {
-            cmd.push(repo_path.join(&entry[1]).to_string_lossy().into_owned());
+            cmd.push(repo_path.join(&entry[1]).into_os_string());
         }
     } else {
         cmd.extend(entry[1..].iter().cloned());
@@ -293,7 +294,7 @@ fn r_hook_entry(hook: &InstalledHook) -> Result<Vec<String>> {
     Ok(cmd)
 }
 
-fn validate_r_entry(entry: &[String]) -> Result<()> {
+fn validate_r_entry(entry: &[OsString]) -> Result<()> {
     if entry.len() < 2 || entry[0] != "Rscript" {
         anyhow::bail!("entry must start with `Rscript`");
     }

--- a/crates/prek/src/languages/rust/rust.rs
+++ b/crates/prek/src/languages/rust/rust.rs
@@ -193,8 +193,8 @@ async fn find_package_dir(
 }
 
 /// Check if two names match, accounting for hyphen/underscore normalization.
-fn names_match(a: &str, b: &str) -> bool {
-    a == b || a.replace('-', "_") == b.replace('-', "_")
+fn names_match(name: &str, binary_name: &str) -> bool {
+    name == binary_name || name.replace('-', "_") == binary_name.replace('-', "_")
 }
 
 /// Check if a package produces a binary with the given name.
@@ -251,9 +251,7 @@ async fn install_local_project(
         }
         Ok(Some((package_dir, package_name, is_workspace))) => {
             debug!(
-                "Found package `{}` for binary `{}` in repo `{}` at `{}`",
-                package_name,
-                hook_binary,
+                "Found package `{package_name}` for binary `{hook_binary}` in repo `{}` at `{}`",
                 repo_path.display(),
                 package_dir.display(),
             );
@@ -261,8 +259,7 @@ async fn install_local_project(
         }
         Ok(None) => {
             debug!(
-                "Binary `{}` not found in cargo metadata for repo `{}`, falling back to repo root",
-                hook_binary,
+                "Binary `{hook_binary}` not found in cargo metadata for repo `{}`, falling back to repo root",
                 repo_path.display(),
             );
             (repo_path.to_path_buf(), String::new(), false)
@@ -457,7 +454,9 @@ impl LanguageBackend for Rust {
 
         // Use the hook entry as the binary name to find the package, this could be improved by allowing an explicit binary name in the hook config.
         let hook_entry = hook.entry.expect_direct().split()?;
-        let hook_bin = &hook_entry[0];
+        let hook_bin = hook_entry[0]
+            .to_str()
+            .context("Rust hook entry binary must be valid UTF-8")?;
 
         // Install library dependencies and local project
         if let Some(repo) = hook.repo_path() {

--- a/crates/prek/src/run.rs
+++ b/crates/prek/src/run.rs
@@ -1,5 +1,5 @@
 use std::cmp::max;
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::path::Path;
 use std::sync::LazyLock;
 
@@ -162,7 +162,7 @@ fn env_size(override_envs: &FxHashMap<String, String>) -> usize {
 impl<'a> Partitions<'a> {
     fn split(
         hook: &'a Hook,
-        entry: &'a [String],
+        entry: &[OsString],
         filenames: &'a [&'a Path],
         concurrency: usize,
     ) -> anyhow::Result<Self> {
@@ -189,11 +189,8 @@ impl<'a> Partitions<'a> {
             arg_max -= POINTER_SIZE_CONSERVATIVE;
         }
 
-        let args_size = entry
-            .iter()
-            .chain(hook.args.iter())
-            .map(arg_size)
-            .sum::<usize>()
+        let args_size = entry.iter().map(arg_size).sum::<usize>()
+            + hook.args.iter().map(arg_size).sum::<usize>()
             + POINTER_SIZE_CONSERVATIVE; // terminating NULL
 
         if args_size >= arg_max {
@@ -260,7 +257,7 @@ impl<'a> Iterator for Partitions<'a> {
 pub(crate) async fn run_by_batch<T, F>(
     hook: &Hook,
     filenames: &[&Path],
-    entry: &[String],
+    entry: &[OsString],
     run: F,
 ) -> anyhow::Result<Vec<T>>
 where


### PR DESCRIPTION
Preserve OS-native hook command arguments through parsing, resolution, and process execution.