### PR TITLE
Publish Alpine Docker images

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,6 +32,7 @@
     'pre-commit',
     'cargo',
     'custom.regex',
+    'dockerfile',
     'pep621',
   ],
   customManagers: [
@@ -133,7 +134,7 @@
       commitMessageTopic: "Rust",
     },
     {
-      matchManagers: [ 'cargo', 'pre-commit', 'github-actions', 'pep621', 'custom.regex' ],
+      matchManagers: [ 'cargo', 'pre-commit', 'github-actions', 'pep621', 'custom.regex', 'dockerfile' ],
       minimumReleaseAge: '7 days'
     },
     {

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,10 +1,10 @@
-# Build and publish a Docker image.
+# Build and publish Docker images.
 #
 # Assumed to run as a subworkflow of .github/workflows/release.yml; specifically, as a local
 # artifacts job within `cargo-dist`.
 #
 # Adapted from https://github.com/astral-sh/ty/blob/main/.github/workflows/build-docker.yml
-name: "Build Docker image"
+name: "Build Docker images"
 
 on:
   workflow_call:
@@ -15,44 +15,58 @@ on:
 
 env:
   PREK_BASE_IMG: ghcr.io/${{ github.repository_owner }}/prek
+  ALPINE_VERSION: "3.24"
 
-permissions:
-  contents: read
-  packages: write # zizmor: ignore[excessive-permissions]
+permissions: {}
 
 jobs:
   plan:
     runs-on: ubuntu-slim
     outputs:
-      publish: ${{ steps.plan.outputs.publish }}
+      push: ${{ steps.plan.outputs.push }}
+      tag: ${{ steps.plan.outputs.tag }}
+      base-tag: ${{ steps.plan.outputs.base-tag }}
+      floating-tags: ${{ steps.plan.outputs.floating-tags }}
+      action: ${{ steps.plan.outputs.action }}
     steps:
       - name: Plan
         id: plan
         shell: bash
         env:
-          HAS_PLAN: ${{ inputs.plan != '' }}
-          HAS_IMPLICIT_TAG: ${{ inputs.plan != '' && fromJson(inputs.plan).announcement_tag_is_implicit }}
+          DRY_RUN: ${{ inputs.plan == '' || fromJson(inputs.plan).announcement_tag_is_implicit }}
+          PRERELEASE: ${{ inputs.plan != '' && fromJson(inputs.plan).announcement_is_prerelease }}
+          TAG: ${{ inputs.plan != '' && fromJson(inputs.plan).announcement_tag }}
         run: |
-          [[ "$HAS_PLAN" == "true" && "$HAS_IMPLICIT_TAG" != "true" ]] && publish=1
-
-          if [[ "$publish" ]]; then
-            echo "publish=true" >> "$GITHUB_OUTPUT"
+          if [[ "$DRY_RUN" == "false" ]]; then
+            version="${TAG#v}"
+            echo "push=true" >> "$GITHUB_OUTPUT"
+            echo "tag=${version}" >> "$GITHUB_OUTPUT"
+            echo "base-tag=${version}" >> "$GITHUB_OUTPUT"
+            echo "action=Build and publish" >> "$GITHUB_OUTPUT"
+            if [[ "$PRERELEASE" == "true" ]]; then
+              echo "floating-tags=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "floating-tags=true" >> "$GITHUB_OUTPUT"
+            fi
           else
-            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "push=false" >> "$GITHUB_OUTPUT"
+            echo "tag=dry-run" >> "$GITHUB_OUTPUT"
+            echo "base-tag=latest" >> "$GITHUB_OUTPUT"
+            echo "floating-tags=false" >> "$GITHUB_OUTPUT"
+            echo "action=Build" >> "$GITHUB_OUTPUT"
           fi
 
-  docker-build:
-    name: Build Docker image ghcr.io/j178/prek for ${{ matrix.platform }}
+  docker-publish-base:
+    name: ${{ needs.plan.outputs.action }} Docker image
     needs: plan
     runs-on: ubuntu-latest
     environment:
       name: release
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -61,19 +75,19 @@ jobs:
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        if: ${{ needs.plan.outputs.publish == 'true' }}
+        if: ${{ needs.plan.outputs.push == 'true' }}
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check tag consistency
-        if: ${{ needs.plan.outputs.publish == 'true' }}
+        if: ${{ needs.plan.outputs.push == 'true' }}
         env:
-          TAG: ${{ inputs.plan != '' && fromJson(inputs.plan).announcement_tag || 'dry-run' }}
+          TAG: ${{ needs.plan.outputs.tag }}
         run: |
           version=$(grep -m 1 "^version = " pyproject.toml | sed -e 's/version = "\(.*\)"/\1/g')
-          if [ "${TAG}" != "v${version}" ]; then
+          if [ "${TAG}" != "${version}" ]; then
             echo "The input tag does not match the version from pyproject.toml:" >&2
             echo "${TAG}" >&2
             echo "${version}" >&2
@@ -91,64 +105,83 @@ jobs:
           images: ${{ env.PREK_BASE_IMG }}
           # Defining this makes sure the org.opencontainers.image.version OCI label becomes the actual release version and not the branch name
           tags: |
-            type=raw,value=dry-run,enable=${{ needs.plan.outputs.publish != 'true' }}
-            type=semver,pattern={{ raw }},value=${{ inputs.plan != '' && fromJson(inputs.plan).announcement_tag || 'dry-run' }},enable=${{ needs.plan.outputs.publish == 'true' }}
+            type=raw,value=dry-run,enable=${{ needs.plan.outputs.push == 'false' }}
+            type=semver,pattern={{ raw }},value=${{ needs.plan.outputs.tag }},enable=${{ needs.plan.outputs.push == 'true' }}
+            type=semver,pattern={{ major }}.{{ minor }},value=${{ needs.plan.outputs.tag }},enable=${{ needs.plan.outputs.push == 'true' }}
 
-      - name: Normalize Platform Pair (replace / with -)
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_TUPLE=${platform//\//-}" >> "$GITHUB_ENV"
-
-      # Adapted from https://docs.docker.com/build/ci/github-actions/multi-platform/
-      - name: Build and push by digest
+      - name: Build and push
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
-          platforms: ${{ matrix.platform }}
-          cache-from: type=gha,scope=prek-${{ env.PLATFORM_TUPLE }}
-          cache-to: type=gha,mode=min,scope=prek-${{ env.PLATFORM_TUPLE }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha,scope=prek
+          cache-to: type=gha,mode=min,scope=prek
+          push: ${{ needs.plan.outputs.push }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.PREK_BASE_IMG }},push-by-digest=true,name-canonical=true,push=${{ needs.plan.outputs.publish == 'true' }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          provenance: mode=max
+          sbom: true
 
-      - name: Export digests
-        env:
-          digest: ${{ steps.build.outputs.digest }}
-        run: |
-          mkdir -p /tmp/digests
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - name: Upload digests
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - name: Generate artifact attestation
+        if: ${{ needs.plan.outputs.push == 'true' }}
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
-          name: digests-${{ env.PLATFORM_TUPLE }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
+          subject-name: ${{ env.PREK_BASE_IMG }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
 
-  docker-publish:
-    name: Publish Docker image (ghcr.io/j178/prek)
+  docker-publish-alpine:
+    name: ${{ needs.plan.outputs.action }} Alpine Docker image
     runs-on: ubuntu-latest
     environment:
       name: release
     needs:
       - plan
-      - docker-build
+      - docker-publish-base
     permissions:
       contents: read
       packages: write
       id-token: write
       attestations: write
-    if: ${{ needs.plan.outputs.publish == 'true' }}
+    if: ${{ needs.plan.result == 'success' && needs.docker-publish-base.result == 'success' }}
     steps:
-      - name: Download digests
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
+          persist-credentials: false
+
+      # Installing Alpine packages executes target-architecture binaries.
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          platforms: arm64
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        if: ${{ needs.plan.outputs.push == 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Alpine Dockerfile
+        env:
+          PREK_IMAGE: ${{ format('{0}:{1}', env.PREK_BASE_IMG, needs.plan.outputs.base-tag) }}
+        run: |
+          cat <<EOF > Dockerfile.alpine
+          FROM ${PREK_IMAGE} AS prek
+          FROM alpine:${ALPINE_VERSION}
+
+          RUN apk add --no-cache \
+            ca-certificates \
+            git \
+            && git config --system --add safe.directory /io
+
+          COPY --from=prek /prek /usr/local/bin/prek
+          WORKDIR /io
+          ENTRYPOINT ["/usr/local/bin/prek"]
+          EOF
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -157,48 +190,36 @@ jobs:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: index
         with:
           images: ${{ env.PREK_BASE_IMG }}
-          # Order is on purpose such that the label org.opencontainers.image.version has the first pattern with the full version
+          flavor: latest=false
           tags: |
-            type=raw,value=${{ fromJson(inputs.plan).announcement_tag }}
-            type=semver,pattern=v{{ major }}.{{ minor }},value=${{ fromJson(inputs.plan).announcement_tag }}
+            type=raw,value=dry-run-alpine,enable=${{ needs.plan.outputs.push == 'false' }}
+            type=semver,pattern={{ raw }},suffix=-alpine${{ env.ALPINE_VERSION }},value=${{ needs.plan.outputs.tag }},enable=${{ needs.plan.outputs.push == 'true' }}
+            type=semver,pattern={{ major }}.{{ minor }},suffix=-alpine${{ env.ALPINE_VERSION }},value=${{ needs.plan.outputs.tag }},enable=${{ needs.plan.outputs.push == 'true' }}
+            type=raw,value=alpine${{ env.ALPINE_VERSION }},enable=${{ needs.plan.outputs.floating-tags == 'true' }}
+            type=semver,pattern={{ raw }},suffix=-alpine,value=${{ needs.plan.outputs.tag }},enable=${{ needs.plan.outputs.push == 'true' }}
+            type=semver,pattern={{ major }}.{{ minor }},suffix=-alpine,value=${{ needs.plan.outputs.tag }},enable=${{ needs.plan.outputs.push == 'true' }}
+            type=raw,value=alpine,enable=${{ needs.plan.outputs.floating-tags == 'true' }}
 
-      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Adapted from https://docs.docker.com/build/ci/github-actions/multi-platform/
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
-        # The jq command expands the docker/metadata json "tags" array entry to `-t tag1 -t tag2 ...` for each tag in the array
-        # The printf will expand the base image with the `<PREK_BASE_IMG>@sha256:<sha256> ...` for each sha256 in the directory
-        # The final command becomes `docker buildx imagetools create -t tag1 -t tag2 ... <PREK_BASE_IMG>@sha256:<sha256_1> <PREK_BASE_IMG>@sha256:<sha256_2> ...`
-        run: |
-          # shellcheck disable=SC2046
-          readarray -t lines <<< "$DOCKER_METADATA_OUTPUT_ANNOTATIONS"; annotations=(); for line in "${lines[@]}"; do annotations+=(--annotation "$line"); done
-
-          docker buildx imagetools create \
-            "${annotations[@]}" \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf "${PREK_BASE_IMG}@sha256:%s " *)
-
-      - name: Export manifest digest
-        id: manifest-digest
-        env:
-          IMAGE: ${{ env.PREK_BASE_IMG }}
-          VERSION: ${{ steps.meta.outputs.version }}
-        run: |
-          digest="$(
-            docker buildx imagetools inspect \
-              "${IMAGE}:${VERSION}" \
-              --format '{{json .Manifest}}' \
-            | jq -r '.digest'
-          )"
-          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          context: .
+          file: Dockerfile.alpine
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha,scope=prek-alpine
+          cache-to: type=gha,mode=min,scope=prek-alpine
+          push: ${{ needs.plan.outputs.push }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          provenance: mode=max
+          sbom: true
 
       - name: Generate artifact attestation
+        if: ${{ needs.plan.outputs.push == 'true' }}
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-name: ${{ env.PREK_BASE_IMG }}
-          subject-digest: ${{ steps.manifest-digest.outputs.digest }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,29 @@
-FROM --platform=$BUILDPLATFORM ubuntu AS build
+FROM --platform=$BUILDPLATFORM ghcr.io/astral-sh/uv:0.11.28@sha256:0f36cb9361a3346885ca3677e3767016687b5a170c1a6b88465ec14aefec90aa AS uv
+
+FROM --platform=$BUILDPLATFORM ubuntu:24.04@sha256:d1e2e92c075e5ca139d51a140fff46f84315c0fdce203eab2807c7e495eff4f9 AS build
+
+ARG UBUNTU_SNAPSHOT=20260301T000000Z
+ARG RUSTUP_VERSION=1.28.2
+
 ENV HOME="/root"
 WORKDIR $HOME
 
-RUN apt update \
-  && apt install -y --no-install-recommends \
+# Retry apt downloads to handle transient mirror failures.
+RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
+
+# Install dependencies from an Ubuntu snapshot for reproducibility.
+RUN --mount=type=cache,target=/var/lib/apt/lists \
+  apt install -y --update ca-certificates \
+  && apt install -y --update --snapshot ${UBUNTU_SNAPSHOT} --no-install-recommends \
   build-essential \
-  curl \
-  python3-venv \
-  && apt clean \
-  && rm -rf /var/lib/apt/lists/*
+  curl
+
+# Install uv
+COPY --from=uv /uv /usr/local/bin/uv
 
 # Setup zig as cross compiling linker
-RUN python3 -m venv $HOME/.venv
-RUN .venv/bin/pip install cargo-zigbuild
+COPY pyproject.toml uv.lock ./
+RUN uv sync --only-group docker --locked
 ENV PATH="$HOME/.venv/bin:$PATH"
 
 # Install rust
@@ -23,11 +34,17 @@ RUN case "$TARGETPLATFORM" in \
   *) exit 1 ;; \
   esac
 
-# Update rustup whenever we bump the rust version
-COPY rust-toolchain.toml rust-toolchain.toml
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --target $(cat rust_target.txt) --profile minimal --default-toolchain none
+# Install a pinned rustup release.
+RUN curl --proto '=https' --tlsv1.2 -sSf \
+  "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/$(uname -m)-unknown-linux-gnu/rustup-init" \
+  -o rustup-init \
+  && chmod +x rustup-init \
+  && ./rustup-init -y --target $(cat rust_target.txt) --profile minimal --default-toolchain none \
+  && rm rustup-init
 ENV PATH="$HOME/.cargo/bin:$PATH"
-# Install the toolchain then the musl target
+
+# Install the toolchain in the musl target
+COPY rust-toolchain.toml rust-toolchain.toml
 RUN rustup toolchain install
 RUN rustup target add $(cat rust_target.txt)
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -4,9 +4,21 @@ This page documents common ways to integrate prek into CI and container workflow
 
 ## Docker
 
-prek is published as a distroless container image at:
+prek publishes container images under `ghcr.io/j178/prek`:
 
-- `ghcr.io/j178/prek`
+| Tags | Base | Contents |
+| -- | -- | -- |
+| `X.Y.Z`, `X.Y`, `latest` | `scratch` | The `prek` binary only |
+| `X.Y.Z-alpine`, `X.Y-alpine`, `alpine` | Current Alpine release | `prek`, Git, and CA certificates |
+| `X.Y.Z-alpine3.24`, `X.Y-alpine3.24`, `alpine3.24` | `alpine:3.24` | Version-pinned Alpine variant |
+
+!!! note
+
+    Docker image tags before `0.4.10` include a leading `v`, for example
+    `ghcr.io/j178/prek:v0.4.9`. The Alpine variant is available starting with
+    `0.4.10`.
+
+### Minimal (scratch)
 
 The image is based on `scratch` (no shell, no package manager). It contains the prek binary at `/prek`.
 
@@ -14,18 +26,30 @@ A common pattern is to copy the binary into your own image:
 
 ```dockerfile
 FROM debian:bookworm-slim
-COPY --from=ghcr.io/j178/prek:v0.4.9 /prek /usr/local/bin/prek
+COPY --from=ghcr.io/j178/prek:0.4.10 /prek /usr/local/bin/prek
 ```
 
 If you prefer, you can also run the distroless image directly:
 
 ```bash
-docker run --rm ghcr.io/j178/prek:v0.4.9 --version
+docker run --rm ghcr.io/j178/prek:0.4.10 --version
 ```
+
+### Alpine
+
+The Alpine variant includes `prek`, Git, CA certificates, a shell, and the Alpine package manager.
+
+```bash
+docker run --rm ghcr.io/j178/prek:0.4.10-alpine --version
+```
+
+Use `X.Y.Z-alpine3.24` to pin both the prek and Alpine versions, or `alpine3.24` to pin only the
+Alpine version while tracking the latest prek release. Tags without the numbered Alpine suffix,
+such as `X.Y.Z-alpine` and `alpine`, use the current supported Alpine release.
 
 ### Verifying Images
 
-Docker images are signed with
+All Docker image variants are signed with
 [GitHub Attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)
 to verify they were built by official prek workflows. Verify using the
 [GitHub CLI](https://cli.github.com/):
@@ -43,7 +67,7 @@ Loaded 1 attestation from GitHub API
 
 !!! tip
 
-    Use a specific version tag (e.g., `ghcr.io/j178/prek:v0.4.9`) or image
+    Use a specific version tag (e.g., `ghcr.io/j178/prek:0.4.10`) or image
     digest rather than `latest` for verification.
 
 ## GitHub Actions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ Homepage = "https://prek.j178.dev/"
 [dependency-groups]
 dev = ["rooster"]
 docs = ["llmstxt-standalone>=0.2.0", "zensical>=0.0.24"]
+docker = ["cargo-zigbuild>=0.19.8"]
 
 [tool.uv.sources]
 rooster = { git = "https://github.com/j178/rooster", rev = "c1901e113611dbe4c2c30917a4d4d392e6d0c679" }
@@ -67,7 +68,8 @@ version_files = [
   { target = "Cargo.toml", match = "^prek-", version_format = "cargo" },
   "README.md",
   "docs/installation.md",
-  "docs/integrations.md",
+  # Update current Docker examples without rewriting historical tag references.
+  { target = "docs/integrations.md", match = "ghcr.io/j178/prek:[0-9]", version_format = "cargo" },
   { target = ".github/ISSUE_TEMPLATE/bug_report.yaml", match = "current:", version_format = "cargo" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -29,8 +29,8 @@ name = "anyio"
 version = "4.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "idna", marker = "python_full_version >= '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.12.*'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/b5/001890774a9552aff22502b8da382593109ce0c95314abaebbb116567545/anyio-4.14.0.tar.gz", hash = "sha256:b47c1f9ccf73e67021df785332508f99379c68fa7d0684e8e3492cb1d4b23f89", size = 253586, upload-time = "2026-06-15T22:00:49.021Z" }
 wheels = [
@@ -42,7 +42,7 @@ name = "anysqlite"
 version = "0.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version >= '3.12'" },
+    { name = "anyio" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4b/cd5d66b9f87e773bc71344a368b9472987e33514e6627e28342b9c3e7c43/anysqlite-0.0.5.tar.gz", hash = "sha256:9dfcf87baf6b93426ad1d9118088c41dbf24ef01b445eea4a5d486bac2755cce", size = 3432, upload-time = "2023-10-02T13:49:25.135Z" }
 wheels = [
@@ -54,12 +54,30 @@ name = "beautifulsoup4"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "soupsieve", marker = "python_full_version >= '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
+name = "cargo-zigbuild"
+version = "0.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ziglang" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/9a/74bde207d36fb5d37e270359d233c2a3c959b6c2ba4a6465eba153d12098/cargo_zigbuild-0.23.0-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:5ba093cd9d08f8c40efc2211ef64db4c63fb616513a2bbe26f80adf23cf82afb", size = 2904882, upload-time = "2026-06-18T07:01:15.195Z" },
+    { url = "https://files.pythonhosted.org/packages/55/a8/484359ae59fcb696fd031a9ed986b54faadbd1204cd55d76d4c38e2ec283/cargo_zigbuild-0.23.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d984af93da7a230606452ef5f6df47e6a081b12dcead8a3e8e5ff024728c94f0", size = 1487435, upload-time = "2026-06-18T07:01:13.761Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/13/81a4cd75b92c90b0f669624eed41c23c699f796de909a8e5699ebbedb809/cargo_zigbuild-0.23.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:be4e371ebd151a11080e4d1c4c6b0fda3f45a41f58a00c709e771307db4a6a00", size = 1427734, upload-time = "2026-06-18T07:01:20.976Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/90/22ce5c3826fb60c178e394e10fffafcecf43cc687154ae5fd7049529f103/cargo_zigbuild-0.23.0-py3-none-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0404ba70c7b0e9034e19a453fdb0d09cff4c105ab2d7604e2bd49f4bafd24ac7", size = 1609725, upload-time = "2026-06-18T07:01:19.433Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0f/215889165d22e2c8203264ac478aa412077b6cb1aa0c29f06af1807c3560/cargo_zigbuild-0.23.0-py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:3a2e021435a5e3c8b3a70bfc490580a3af6952185aa5ffb722b005d1fbe000c9", size = 1601044, upload-time = "2026-06-18T07:01:16.874Z" },
+    { url = "https://files.pythonhosted.org/packages/89/fc/4883d4d9fad8760051e999a4278ec9fdc2c616aca62198069a61eed9b995/cargo_zigbuild-0.23.0-py3-none-win32.whl", hash = "sha256:37d2946f0e029b60715784ff45af55e3948b296299cc3ccccfa883a8cf1429c8", size = 1322964, upload-time = "2026-06-18T07:01:18.353Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a6/f6e3635ef3e80609e95c6625d4d38a002f3f71b4179c028aba71d6656be6/cargo_zigbuild-0.23.0-py3-none-win_amd64.whl", hash = "sha256:a2a66e1fbd0e67045bb1cb4d3afff4337ea56a7ecfd324dab0f7e9578be045b0", size = 1469871, upload-time = "2026-06-18T07:01:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/d9/95ee594a2d5cc40825afacf819cdd38a8d114d62d4a66587aa4e49c9fcef/cargo_zigbuild-0.23.0-py3-none-win_arm64.whl", hash = "sha256:16a08fef38742a7f2310f53d61600a100ad08acd8102bbcdc8566f21346d98a1", size = 1400969, upload-time = "2026-06-18T07:01:10.714Z" },
 ]
 
 [[package]]
@@ -76,7 +94,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "python_full_version >= '3.12' and implementation_name != 'PyPy'" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -170,7 +188,7 @@ name = "click"
 version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
 wheels = [
@@ -209,11 +227,11 @@ name = "hishel"
 version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version >= '3.12'" },
-    { name = "anysqlite", marker = "python_full_version >= '3.12'" },
-    { name = "httpx", marker = "python_full_version >= '3.12'" },
-    { name = "msgpack", marker = "python_full_version >= '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+    { name = "anyio" },
+    { name = "anysqlite" },
+    { name = "httpx" },
+    { name = "msgpack" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e5/64/a104ccac48f123f853254483617b16e0efc1649bd7e35bcdc5a5a5ef0ae2/hishel-0.1.5.tar.gz", hash = "sha256:9d40c682cd94fd6e1394fb05713ae20a75ed8aeba6f5272380444039ce6257f2", size = 75468, upload-time = "2025-10-18T13:32:41.854Z" }
 wheels = [
@@ -225,8 +243,8 @@ name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi", marker = "python_full_version >= '3.12'" },
-    { name = "h11", marker = "python_full_version >= '3.12'" },
+    { name = "certifi" },
+    { name = "h11" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
@@ -238,10 +256,10 @@ name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version >= '3.12'" },
-    { name = "certifi", marker = "python_full_version >= '3.12'" },
-    { name = "httpcore", marker = "python_full_version >= '3.12'" },
-    { name = "idna", marker = "python_full_version >= '3.12'" },
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
@@ -262,7 +280,7 @@ name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markupsafe", marker = "python_full_version >= '3.12'" },
+    { name = "markupsafe" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
@@ -274,14 +292,14 @@ name = "llmstxt-standalone"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "beautifulsoup4", marker = "python_full_version >= '3.12'" },
-    { name = "markdownify", marker = "python_full_version >= '3.12'" },
-    { name = "mdformat", marker = "python_full_version >= '3.12'" },
-    { name = "mdformat-tables", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.12'" },
-    { name = "ruamel-yaml", marker = "python_full_version >= '3.12'" },
-    { name = "typer", marker = "python_full_version >= '3.12'" },
+    { name = "beautifulsoup4" },
+    { name = "markdownify" },
+    { name = "mdformat" },
+    { name = "mdformat-tables" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "ruamel-yaml" },
+    { name = "typer" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/f4/3335a699ff42daed5c9504078fd6518e87d4541b521658d063a4ac277105/llmstxt_standalone-0.2.0.tar.gz", hash = "sha256:9dadbd6a51dcb7b2f7bacc289a2f0a64833b8d161f70127b76c7550ace877be3", size = 13502, upload-time = "2026-02-04T00:36:46.645Z" }
 wheels = [
@@ -302,7 +320,7 @@ name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mdurl", marker = "python_full_version >= '3.12'" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
@@ -314,8 +332,8 @@ name = "markdownify"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "beautifulsoup4", marker = "python_full_version >= '3.12'" },
-    { name = "six", marker = "python_full_version >= '3.12'" },
+    { name = "beautifulsoup4" },
+    { name = "six" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3f/bc/c8c8eea5335341306b0fa7e1cb33c5e1c8d24ef70ddd684da65f41c49c92/markdownify-1.2.2.tar.gz", hash = "sha256:b274f1b5943180b031b699b199cbaeb1e2ac938b75851849a31fd0c3d6603d09", size = 18816, upload-time = "2025-11-16T19:21:18.565Z" }
 wheels = [
@@ -432,7 +450,7 @@ name = "mdformat"
 version = "0.7.22"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py", marker = "python_full_version >= '3.12'" },
+    { name = "markdown-it-py" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/eb/b5cbf2484411af039a3d4aeb53a5160fae25dd8c84af6a4243bc2f3fedb3/mdformat-0.7.22.tar.gz", hash = "sha256:eef84fa8f233d3162734683c2a8a6222227a229b9206872e6139658d99acb1ea", size = 34610, upload-time = "2025-01-30T18:00:51.418Z" }
 wheels = [
@@ -444,8 +462,8 @@ name = "mdformat-tables"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mdformat", marker = "python_full_version >= '3.12'" },
-    { name = "wcwidth", marker = "python_full_version >= '3.12'" },
+    { name = "mdformat" },
+    { name = "wcwidth" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/64/fc/995ba209096bdebdeb8893d507c7b32b7e07d9a9f2cdc2ec07529947794b/mdformat_tables-1.0.0.tar.gz", hash = "sha256:a57db1ac17c4a125da794ef45539904bb8a9592e80557d525e1f169c96daa2c8", size = 6106, upload-time = "2024-08-23T23:41:33.413Z" }
 wheels = [
@@ -552,6 +570,9 @@ source = { virtual = "." }
 dev = [
     { name = "rooster", marker = "python_full_version >= '3.12'" },
 ]
+docker = [
+    { name = "cargo-zigbuild" },
+]
 docs = [
     { name = "llmstxt-standalone", marker = "python_full_version >= '3.12'" },
     { name = "zensical", marker = "python_full_version >= '3.12'" },
@@ -561,6 +582,7 @@ docs = [
 
 [package.metadata.requires-dev]
 dev = [{ name = "rooster", marker = "python_full_version >= '3.12'", git = "https://github.com/j178/rooster?rev=c1901e113611dbe4c2c30917a4d4d392e6d0c679" }]
+docker = [{ name = "cargo-zigbuild", specifier = ">=0.19.8" }]
 docs = [
     { name = "llmstxt-standalone", marker = "python_full_version >= '3.12'", specifier = ">=0.2.0" },
     { name = "zensical", marker = "python_full_version >= '3.12'", specifier = ">=0.0.24" },
@@ -580,10 +602,10 @@ name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-types", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic-core", marker = "python_full_version >= '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
-    { name = "typing-inspection", marker = "python_full_version >= '3.12'" },
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
@@ -595,7 +617,7 @@ name = "pydantic-core"
 version = "2.46.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
 wheels = [
@@ -725,7 +747,7 @@ name = "pygit2"
 version = "1.19.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "python_full_version >= '3.12'" },
+    { name = "cffi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/44/415aa93422b4bfc21a6448acb7e16280d5f33a9a3fae38a384e37b046ae4/pygit2-1.19.3.tar.gz", hash = "sha256:a543e6d4ebb43825564935758dc234e770016fed673b84370d46ae9580558831", size = 810489, upload-time = "2026-06-13T08:06:04.982Z" }
 wheels = [
@@ -800,8 +822,8 @@ name = "pymdown-extensions"
 version = "10.21.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown", marker = "python_full_version >= '3.12'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.12'" },
+    { name = "markdown" },
+    { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
 wheels = [
@@ -893,8 +915,8 @@ name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
+    { name = "markdown-it-py" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
@@ -906,15 +928,15 @@ name = "rooster"
 version = "0.0.0"
 source = { git = "https://github.com/j178/rooster?rev=c1901e113611dbe4c2c30917a4d4d392e6d0c679#c1901e113611dbe4c2c30917a4d4d392e6d0c679" }
 dependencies = [
-    { name = "hishel", marker = "python_full_version >= '3.12'" },
-    { name = "httpx", marker = "python_full_version >= '3.12'" },
-    { name = "marko", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "pygit2", marker = "python_full_version >= '3.12'" },
-    { name = "tomli", marker = "python_full_version >= '3.12'" },
-    { name = "tqdm", marker = "python_full_version >= '3.12'" },
-    { name = "typer", marker = "python_full_version >= '3.12'" },
+    { name = "hishel" },
+    { name = "httpx" },
+    { name = "marko" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "pygit2" },
+    { name = "tomli" },
+    { name = "tqdm" },
+    { name = "typer" },
 ]
 
 [[package]]
@@ -1012,7 +1034,7 @@ name = "tqdm"
 version = "4.68.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/87/d7/0535a28b1f5f24f6612fb3ff1e89fb1a8d160fee0f976e0aa6803862134b/tqdm-4.68.3.tar.gz", hash = "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482", size = 170596, upload-time = "2026-06-17T07:36:52.105Z" }
 wheels = [
@@ -1024,10 +1046,10 @@ name = "typer"
 version = "0.26.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-doc", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "rich", marker = "python_full_version >= '3.12'" },
-    { name = "shellingham", marker = "python_full_version >= '3.12'" },
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
 wheels = [
@@ -1048,7 +1070,7 @@ name = "typing-inspection"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
@@ -1069,14 +1091,14 @@ name = "zensical"
 version = "0.0.46"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "python_full_version >= '3.12'" },
-    { name = "deepmerge", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "markdown", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "pymdown-extensions", marker = "python_full_version >= '3.12'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.12'" },
-    { name = "tomli", marker = "python_full_version >= '3.12'" },
+    { name = "click" },
+    { name = "deepmerge" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "pyyaml" },
+    { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/aa/57/c7bbb71f943e1e0ba5ce460f4930ec836ead7286969e7fd742f7a6c049ab/zensical-0.0.46.tar.gz", hash = "sha256:3ec21f4fb1e78cd7c0d6b07ae336b04770e27ba020dabc457b2790e5d34f1978", size = 3973968, upload-time = "2026-06-21T18:52:40.368Z" }
 wheels = [
@@ -1092,4 +1114,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/91/16/515f81db8055b109a510063be481e60a657c4fad1a883680b2ee4aa9a424/zensical-0.0.46-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f42a4683c762f026878d19ede4bcf7bfbb84dbecb5ad923949abb77806ed88a5", size = 13369382, upload-time = "2026-06-21T18:52:32.521Z" },
     { url = "https://files.pythonhosted.org/packages/b9/5c/da54ee65b642eb7d88dd4a3db35845d0765915638e05d5d434a10b42f1c3/zensical-0.0.46-cp310-abi3-win32.whl", hash = "sha256:85f018f2a7ee76a83915c87ddb12b58cf343fd6154081d33ac95b6751b011dd7", size = 12354298, upload-time = "2026-06-21T18:52:34.976Z" },
     { url = "https://files.pythonhosted.org/packages/73/26/fc7ef081acbdada8436825221cb728ee84a81d4d78a7bb79aa58bd150d31/zensical-0.0.46-cp310-abi3-win_amd64.whl", hash = "sha256:1543a693a160de60e86ca589592401b584670e7e12c5ae30e3c2ba76786f7ec3", size = 12599687, upload-time = "2026-06-21T18:52:37.913Z" },
+]
+
+[[package]]
+name = "ziglang"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/59/012f0c2800f7428b87bb16c5c78db7ef806efed274491998155955c02558/ziglang-0.16.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:b61e5413c49508d9d62e5dcea543e3af491594154d74a00ff52f84ed508260cc", size = 97252633, upload-time = "2026-04-15T03:55:02.488Z" },
+    { url = "https://files.pythonhosted.org/packages/75/60/f924aa24b95a1ad347e845acc7ab6b5d062ae5b0b540d494654cd40d4e0b/ziglang-0.16.0-py3-none-macosx_12_0_x86_64.whl", hash = "sha256:18e14f6b25678d7b7c65708c82501ee6090fe39ed5c783477d56267af1fa5629", size = 101228024, upload-time = "2026-04-15T03:55:12.268Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/aa/7966d158d768fb0e40bf5fef6e7ffe230dfee502382782ec39be1331ee4a/ziglang-0.16.0-py3-none-manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686.whl", hash = "sha256:8b83661247430aa335b3cbc29569084900412dde5633b02c80a6d2ff734de3d2", size = 101810276, upload-time = "2026-04-15T03:55:17.843Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/ed/7b79023aa27ceb5d461ecf761181e7c33c57bbc1a6256a39535d1c7083d2/ziglang-0.16.0-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:9fcda73f62b851dd72a54b710ad40a209896db14cfb13649e62191243556342b", size = 97941847, upload-time = "2026-04-15T03:55:23.246Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/ed/d6663a5e52c504944d578b9e0bfcb7857f292803bcd09ebe0d10fe2b293d/ziglang-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:e27d409812b11e0fb89ed0200cf2e55b6464d43f9461553104e4a4f9a94a1fd5", size = 95008112, upload-time = "2026-04-15T03:55:32.025Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e4/beae76926e3070978d06fa156b243642d5f75ffd784f7cd64e783520e456/ziglang-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:7249779f0f916cfd2d1a9d54eb7600f3901384dc8dcbe1eea226bd32a8237fb5", size = 95860236, upload-time = "2026-04-15T03:55:37.069Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/fc/5cb1555281d2a998355ee7081f05f45d2f6a2789ca0fcb02015cfcb4b900/ziglang-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:0fd671c599f6961638cc302cf1f9461486696385311d4c0276171dcf7d2b67f5", size = 104100995, upload-time = "2026-04-15T03:55:42.594Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/e0138d89ec47da986ac08009ae8802af052c1e335163d983c074d9eaa1c3/ziglang-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.musllinux_1_1_s390x.whl", hash = "sha256:df0e6599e41d087c912b0d3d7cedef6c9cb1f0032465c8fc820e9986772d11e4", size = 103517876, upload-time = "2026-04-15T03:55:48.695Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/29/d281591fa0be47aefcb23ac379cdbff5b34a1fdaafa139a5f8703ca9559c/ziglang-0.16.0-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:d4bd8197344fffe276e1d6446e4ef7bc38637d821b4685fe96a936503d4b0619", size = 98388042, upload-time = "2026-04-15T03:55:54.114Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/f0/10a5203071af21bd649a0f97e29f70b710d6ad97b1ac1995a0bb30f51a71/ziglang-0.16.0-py3-none-win32.whl", hash = "sha256:f978c12b5337cf418034964de00023b7ec5ec484383dc97c6a6585f4a9105840", size = 100655765, upload-time = "2026-04-15T03:55:59.7Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3c/baff40b3fc8ab4e83530246a52e8f3a5186c3606562712dfb58483b04f79/ziglang-0.16.0-py3-none-win_amd64.whl", hash = "sha256:089a16a4eb5a2f45151993342f8fabad24ff1a0723dc146642895c29208a3939", size = 98676957, upload-time = "2026-04-15T03:56:05.934Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/0b/bff28a4acc437cb7da705bffafd81fafbbd37a23144363cecc72becaef93/ziglang-0.16.0-py3-none-win_arm64.whl", hash = "sha256:e44a5271f7b72f7980017bb615823ed52e765f96b6482d93a2fd338cd53101bf", size = 94347646, upload-time = "2026-04-15T03:56:11.85Z" },
 ]


### PR DESCRIPTION
Git is installed only in the Alpine variant; the scratch image remains the `prek` binary only. Git is included because it is required for normal `prek` operation.

The Alpine variant is intended as a customizable base, not a batteries-included development image. It does not include Python, Node.js, or other language toolchains. Users should install the tools required by their hooks in their own derived images.

Closes #1946 
Closes #1949 