### PR TITLE
Print hook description on failure with --verbose

### DIFF
--- a/crates/prek-consts/src/env_vars.rs
+++ b/crates/prek-consts/src/env_vars.rs
@@ -99,6 +99,7 @@ impl EnvVars {
     pub const PREK_CONTAINER_RUNTIME: &'static str = "PREK_CONTAINER_RUNTIME";
     pub const PREK_DOCKER_NO_INIT: &'static str = "PREK_DOCKER_NO_INIT";
     pub const PREK_QUIET: &'static str = "PREK_QUIET";
+    pub const PREK_VERBOSE: &'static str = "PREK_VERBOSE";
 
     // PREK internal environment variables
     pub const PREK_INTERNAL__TEST_DIR: &'static str = "PREK_INTERNAL__TEST_DIR";

--- a/crates/prek/src/cli/hook_impl.rs
+++ b/crates/prek/src/cli/hook_impl.rs
@@ -33,6 +33,7 @@ pub(crate) async fn hook_impl(
     skip_on_missing_config: bool,
     script_version: Option<usize>,
     args: Vec<OsString>,
+    verbose: bool,
     printer: Printer,
 ) -> Result<ExitStatus> {
     let stdin = read_hook_stdin(hook_type).await?;
@@ -138,7 +139,7 @@ pub(crate) async fn hook_impl(
         false,
         false,
         run_args.extra,
-        false,
+        verbose,
         printer,
     )
     .await?;

--- a/crates/prek/src/cli/mod.rs
+++ b/crates/prek/src/cli/mod.rs
@@ -208,7 +208,10 @@ pub(crate) struct GlobalArgs {
     pub quiet: u8,
 
     /// Use verbose output.
-    #[arg(global = true, short, long, action = ArgAction::Count)]
+    ///
+    /// When running hooks, this also prints a hook's `description`, if set, whenever the
+    /// hook fails, to help explain the failure.
+    #[arg(global = true, short, long, env = EnvVars::PREK_VERBOSE, action = ArgAction::Count)]
     pub(crate) verbose: u8,
 
     /// Write trace logs to the specified file.

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -1005,6 +1005,16 @@ impl<'a> HookRunSession<'a> {
                     "{detail_prefix}{}",
                     format!("- hook id: {}", result.hook.id).dimmed()
                 )?;
+                if status == RunStatus::Failed
+                    && (self.verbose || result.hook.verbose)
+                    && let Some(description) = result.hook.description.as_deref()
+                {
+                    writeln!(
+                        stdout,
+                        "{detail_prefix}{}",
+                        format!("- description: {description}").dimmed()
+                    )?;
+                }
                 if self.verbose || result.hook.verbose {
                     writeln!(
                         stdout,

--- a/crates/prek/src/config.rs
+++ b/crates/prek/src/config.rs
@@ -595,7 +595,8 @@ pub(crate) struct HookOptions {
     /// Append filenames that would be checked to the hook entry as arguments.
     /// Default is true.
     pub pass_filenames: Option<PassFilenames>,
-    /// A description of the hook. For metadata only.
+    /// A description of the hook, shown in listings and, when `--verbose` is enabled, printed
+    /// if the hook fails to help explain the failure.
     pub description: Option<String>,
     /// Run the hook on a specific version of the language.
     /// Default is `default`.

--- a/crates/prek/src/config.rs
+++ b/crates/prek/src/config.rs
@@ -595,8 +595,8 @@ pub(crate) struct HookOptions {
     /// Append filenames that would be checked to the hook entry as arguments.
     /// Default is true.
     pub pass_filenames: Option<PassFilenames>,
-    /// A description of the hook, shown in listings and, when `--verbose` is enabled, printed
-    /// if the hook fails to help explain the failure.
+    /// A description of the hook, shown in listings and printed on failure when verbose output is
+    /// enabled (via `--verbose`/`PREK_VERBOSE` or `verbose: true`).
     pub description: Option<String>,
     /// Run the hook on a specific version of the language.
     /// Default is `default`.

--- a/crates/prek/src/main.rs
+++ b/crates/prek/src/main.rs
@@ -333,6 +333,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.skip_on_missing_config,
                 args.script_version,
                 args.args,
+                cli.globals.verbose > 0,
                 printer,
             )
             .await

--- a/crates/prek/tests/hook_impl.rs
+++ b/crates/prek/tests/hook_impl.rs
@@ -58,6 +58,62 @@ fn hook_impl() {
     ");
 }
 
+/// Test that `PREK_VERBOSE=1` makes a Git-triggered hook (e.g. `git commit`) print a
+/// failing hook's `description`, since Git does not let users pass CLI flags like
+/// `--verbose` through to the underlying `prek hook-impl` invocation.
+#[test]
+fn hook_impl_verbose_env_var_prints_hook_description() {
+    let context = TestContext::new();
+    context.init_project();
+    context.write_pre_commit_config(indoc! { r"
+        repos:
+        - repo: local
+          hooks:
+           - id: fail
+             name: fail
+             description: This hook always fails.
+             language: fail
+             entry: always fail
+             always_run: true
+    "});
+
+    context.git_add(".");
+
+    let mut commit = git_cmd(context.work_dir());
+    commit
+        .arg("commit")
+        .env(EnvVars::PREK_HOME, &**context.home_dir())
+        .env(EnvVars::PREK_VERBOSE, "1")
+        .arg("-m")
+        .arg("Initial commit");
+
+    cmd_snapshot!(context.filters(), context.install(), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    prek installed at `.git/hooks/pre-commit`
+
+    ----- stderr -----
+    "#);
+
+    cmd_snapshot!(context.filters(), commit, @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    fail.....................................................................Failed
+    - hook id: fail
+    - description: This hook always fails.
+    - duration: [TIME]
+    - exit code: 1
+
+      always fail
+
+      .pre-commit-config.yaml
+    ");
+}
+
 #[test]
 fn hook_impl_allows_missing_hook_dir() -> anyhow::Result<()> {
     let context = TestContext::new();

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -1519,6 +1519,105 @@ fn fail_fast_cli_flag() {
     ");
 }
 
+/// Test that `--verbose` prints a hook's `description` when it fails, to help
+/// explain the failure without needing to inspect the config file.
+#[test]
+fn verbose_prints_hook_description_on_failure() {
+    let context = TestContext::new();
+    context.init_project();
+
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: failing-hook
+                name: failing-hook
+                description: Checks that things are correct.
+                language: system
+                entry: python3 -c 'print("Failed"); exit(1)'
+                always_run: true
+              - id: passing-hook
+                name: passing-hook
+                description: This one always passes.
+                language: system
+                entry: python3 -c 'print("Passed")'
+                always_run: true
+    "#});
+    context.git_add(".");
+
+    // Without `--verbose`, the description is not shown.
+    cmd_snapshot!(context.filters(), context.run(), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    failing-hook.............................................................Failed
+    - hook id: failing-hook
+    - exit code: 1
+
+      Failed
+    passing-hook.............................................................Passed
+
+    ----- stderr -----
+    ");
+
+    // With `--verbose`, the description is shown only for the failing hook.
+    cmd_snapshot!(context.filters(), context.run().arg("--verbose"), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    failing-hook.............................................................Failed
+    - hook id: failing-hook
+    - description: Checks that things are correct.
+    - duration: [TIME]
+    - exit code: 1
+
+      Failed
+    passing-hook.............................................................Passed
+    - hook id: passing-hook
+    - duration: [TIME]
+
+      Passed
+
+    ----- stderr -----
+    ");
+}
+
+/// Test that `PREK_VERBOSE` environment variable enables the same behavior as `--verbose`,
+/// which is needed since Git-triggered hooks (e.g. `git commit`) can't be passed CLI flags.
+#[test]
+fn prek_verbose_env_var_prints_hook_description_on_failure() {
+    let context = TestContext::new();
+    context.init_project();
+
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: failing-hook
+                name: failing-hook
+                description: Checks that things are correct.
+                language: system
+                entry: python3 -c 'print("Failed"); exit(1)'
+                always_run: true
+    "#});
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run().env(EnvVars::PREK_VERBOSE, "1"), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    failing-hook.............................................................Failed
+    - hook id: failing-hook
+    - description: Checks that things are correct.
+    - duration: [TIME]
+    - exit code: 1
+
+      Failed
+
+    ----- stderr -----
+    ");
+}
+
 /// Test --no-fail-fast CLI flag overrides config-level `fail_fast`.
 #[test]
 fn no_fail_fast_cli_flag() {

--- a/docs/authoring-hooks.md
+++ b/docs/authoring-hooks.md
@@ -34,7 +34,7 @@ each manifest hook:
 | `always_run` | No | No | boolean | Run even when no files match. |
 | `fail_fast` | No | No | boolean | Stop the run immediately if this hook fails. |
 | `pass_filenames` | No | No | boolean or positive integer | Control whether, or how many, matching filenames are passed. |
-| `description` | No | No | string | Free-form metadata shown in listings. |
+| `description` | No | No | string | Free-form metadata shown in listings; printed on failure when `--verbose` is enabled. |
 | `language_version` | No | No | string | Language/toolchain version request. |
 | `log_file` | No | No | string path | Write hook output to a file when the hook fails or is verbose. |
 | `require_serial` | No | No | boolean | Avoid concurrent invocations of this hook. |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -113,8 +113,9 @@ prek install [OPTIONS] [HOOK|PROJECT]...
 </li>
 </ul>
 <p>Can be specified multiple times. Also accepts <code>PREK_SKIP</code> or <code>SKIP</code> environment variables (comma-delimited).</p>
-</dd><dt id="prek-install--verbose"><a href="#prek-install--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output</p>
-</dd><dt id="prek-install--version"><a href="#prek-install--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
+</dd><dt id="prek-install--verbose"><a href="#prek-install--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
+<p>When running hooks, this also prints a hook's <code>description</code>, if set, whenever the hook fails, to help explain the failure.</p>
+<p>May also be set with the <code>PREK_VERBOSE</code> environment variable.</p></dd><dt id="prek-install--version"><a href="#prek-install--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
 </dd></dl>
 
 ## prek prepare-hooks
@@ -178,8 +179,9 @@ prek prepare-hooks [OPTIONS] [HOOK|PROJECT]...
 </li>
 </ul>
 <p>Can be specified multiple times. Also accepts <code>PREK_SKIP</code> or <code>SKIP</code> environment variables (comma-delimited).</p>
-</dd><dt id="prek-prepare-hooks--verbose"><a href="#prek-prepare-hooks--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output</p>
-</dd><dt id="prek-prepare-hooks--version"><a href="#prek-prepare-hooks--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
+</dd><dt id="prek-prepare-hooks--verbose"><a href="#prek-prepare-hooks--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
+<p>When running hooks, this also prints a hook's <code>description</code>, if set, whenever the hook fails, to help explain the failure.</p>
+<p>May also be set with the <code>PREK_VERBOSE</code> environment variable.</p></dd><dt id="prek-prepare-hooks--version"><a href="#prek-prepare-hooks--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
 </dd></dl>
 
 ## prek run
@@ -270,8 +272,9 @@ prek run [OPTIONS] [HOOK|PROJECT]...
 <li><code>pre-rebase</code></li>
 <li><code>prepare-commit-msg</code></li>
 </ul></dd><dt id="prek-run--to-ref"><a href="#prek-run--to-ref"><code>--to-ref</code></a>, <code>--origin</code>, <code>-o</code> <i>to-ref</i></dt><dd><p>The destination ref in a <code>from_ref...to_ref</code> diff expression. Defaults to <code>HEAD</code> if <code>from_ref</code> is specified</p>
-</dd><dt id="prek-run--verbose"><a href="#prek-run--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output</p>
-</dd><dt id="prek-run--version"><a href="#prek-run--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
+</dd><dt id="prek-run--verbose"><a href="#prek-run--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
+<p>When running hooks, this also prints a hook's <code>description</code>, if set, whenever the hook fails, to help explain the failure.</p>
+<p>May also be set with the <code>PREK_VERBOSE</code> environment variable.</p></dd><dt id="prek-run--version"><a href="#prek-run--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
 </dd></dl>
 
 ## prek list
@@ -383,8 +386,9 @@ prek list [OPTIONS] [HOOK|PROJECT]...
 </li>
 </ul>
 <p>Can be specified multiple times. Also accepts <code>PREK_SKIP</code> or <code>SKIP</code> environment variables (comma-delimited).</p>
-</dd><dt id="prek-list--verbose"><a href="#prek-list--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output</p>
-</dd><dt id="prek-list--version"><a href="#prek-list--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
+</dd><dt id="prek-list--verbose"><a href="#prek-list--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
+<p>When running hooks, this also prints a hook's <code>description</code>, if set, whenever the hook fails, to help explain the failure.</p>
+<p>May also be set with the <code>PREK_VERBOSE</code> environment variable.</p></dd><dt id="prek-list--version"><a href="#prek-list--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
 </dd></dl>
 
 ## prek uninstall
@@ -433,8 +437,9 @@ prek uninstall [OPTIONS]
 </dd><dt id="prek-uninstall--quiet"><a href="#prek-uninstall--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
 <p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which prek will write no output to stdout.</p>
 <p>May also be set with the <code>PREK_QUIET</code> environment variable.</p></dd><dt id="prek-uninstall--refresh"><a href="#prek-uninstall--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
-</dd><dt id="prek-uninstall--verbose"><a href="#prek-uninstall--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output</p>
-</dd><dt id="prek-uninstall--version"><a href="#prek-uninstall--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
+</dd><dt id="prek-uninstall--verbose"><a href="#prek-uninstall--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
+<p>When running hooks, this also prints a hook's <code>description</code>, if set, whenever the hook fails, to help explain the failure.</p>
+<p>May also be set with the <code>PREK_VERBOSE</code> environment variable.</p></dd><dt id="prek-uninstall--version"><a href="#prek-uninstall--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
 </dd></dl>
 
 ## prek validate-config
@@ -469,8 +474,9 @@ prek validate-config [OPTIONS] [CONFIG]...
 </dd><dt id="prek-validate-config--quiet"><a href="#prek-validate-config--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
 <p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which prek will write no output to stdout.</p>
 <p>May also be set with the <code>PREK_QUIET</code> environment variable.</p></dd><dt id="prek-validate-config--refresh"><a href="#prek-validate-config--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
-</dd><dt id="prek-validate-config--verbose"><a href="#prek-validate-config--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output</p>
-</dd><dt id="prek-validate-config--version"><a href="#prek-validate-config--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
+</dd><dt id="prek-validate-config--verbose"><a href="#prek-validate-config--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
+<p>When running hooks, this also prints a hook's <code>description</code>, if set, whenever the hook fails, to help explain the failure.</p>
+<p>May also be set with the <code>PREK_VERBOSE</code> environment variable.</p></dd><dt id="prek-validate-config--version"><a href="#prek-validate-config--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
 </dd></dl>
 
 ## prek validate-manifest
@@ -505,8 +511,9 @@ prek validate-manifest [OPTIONS] [MANIFEST]...
 </dd><dt id="prek-validate-manifest--quiet"><a href="#prek-validate-manifest--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
 <p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which prek will write no output to stdout.</p>
 <p>May also be set with the <code>PREK_QUIET</code> environment variable.</p></dd><dt id="prek-validate-manifest--refresh"><a href="#prek-validate-manifest--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
-</dd><dt id="prek-validate-manifest--verbose"><a href="#prek-validate-manifest--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output</p>
-</dd><dt id="prek-validate-manifest--version"><a href="#prek-validate-manifest--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
+</dd><dt id="prek-validate-manifest--verbose"><a href="#prek-validate-manifest--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
+<p>When running hooks, this also prints a hook's <code>description</code>, if set, whenever the hook fails, to help explain the failure.</p>
+<p>May also be set with the <code>PREK_VERBOSE</code> environment variable.</p></dd><dt id="prek-validate-manifest--version"><a href="#prek-validate-manifest--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
 </dd></dl>
 
 ## prek sample-config
@@ -543,8 +550,9 @@ prek sample-config [OPTIONS]
 </dd><dt id="prek-sample-config--quiet"><a href="#prek-sample-config--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
 <p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which prek will write no output to stdout.</p>
 <p>May also be set with the <code>PREK_QUIET</code> environment variable.</p></dd><dt id="prek-sample-config--refresh"><a href="#prek-sample-config--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
-</dd><dt id="prek-sample-config--verbose"><a href="#prek-sample-config--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output</p>
-</dd><dt id="prek-sample-config--version"><a href="#prek-sample-config--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
+</dd><dt id="prek-sample-config--verbose"><a href="#prek-sample-config--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
+<p>When running hooks, this also prints a hook's <code>description</code>, if set, whenever the hook fails, to help explain the failure.</p>
+<p>May also be set with the <code>PREK_VERBOSE</code> environment variable.</p></dd><dt id="prek-sample-config--version"><a href="#prek-sample-config--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
 </dd></dl>
 
 ## prek update
@@ -594,8 +602,9 @@ prek update [OPTIONS]
 </dd><dt id="prek-update--repo-include-tag"><a href="#prek-update--repo-include-tag"><code>--repo-include-tag</code></a> <i>repo=pattern</i></dt><dd><p>Only consider tags matching this glob pattern for a repository (<code>&lt;repo&gt;=&lt;pattern&gt;</code>). This option may be specified multiple times. Overrides the effective include filters for the named repository.</p>
 <p>When set for a repository, this overrides any global <code>--include-tag</code> filters for that repository.</p>
 <p>For example, use <code>--repo-include-tag https://github.com/example/repo=v*</code> to only consider version tags for one repository.</p>
-</dd><dt id="prek-update--verbose"><a href="#prek-update--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output</p>
-</dd><dt id="prek-update--version"><a href="#prek-update--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
+</dd><dt id="prek-update--verbose"><a href="#prek-update--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
+<p>When running hooks, this also prints a hook's <code>description</code>, if set, whenever the hook fails, to help explain the failure.</p>
+<p>May also be set with the <code>PREK_VERBOSE</code> environment variable.</p></dd><dt id="prek-update--version"><a href="#prek-update--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
 </dd></dl>
 
 ## prek cache
@@ -643,8 +652,9 @@ prek cache dir [OPTIONS]
 </dd><dt id="prek-cache-dir--quiet"><a href="#prek-cache-dir--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
 <p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which prek will write no output to stdout.</p>
 <p>May also be set with the <code>PREK_QUIET</code> environment variable.</p></dd><dt id="prek-cache-dir--refresh"><a href="#prek-cache-dir--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
-</dd><dt id="prek-cache-dir--verbose"><a href="#prek-cache-dir--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output</p>
-</dd><dt id="prek-cache-dir--version"><a href="#prek-cache-dir--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
+</dd><dt id="prek-cache-dir--verbose"><a href="#prek-cache-dir--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
+<p>When running hooks, this also prints a hook's <code>description</code>, if set, whenever the hook fails, to help explain the failure.</p>
+<p>May also be set with the <code>PREK_VERBOSE</code> environment variable.</p></dd><dt id="prek-cache-dir--version"><a href="#prek-cache-dir--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
 </dd></dl>
 
 ### prek cache gc
@@ -675,8 +685,9 @@ prek cache gc [OPTIONS]
 </dd><dt id="prek-cache-gc--quiet"><a href="#prek-cache-gc--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
 <p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which prek will write no output to stdout.</p>
 <p>May also be set with the <code>PREK_QUIET</code> environment variable.</p></dd><dt id="prek-cache-gc--refresh"><a href="#prek-cache-gc--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
-</dd><dt id="prek-cache-gc--verbose"><a href="#prek-cache-gc--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output</p>
-</dd><dt id="prek-cache-gc--version"><a href="#prek-cache-gc--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
+</dd><dt id="prek-cache-gc--verbose"><a href="#prek-cache-gc--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
+<p>When running hooks, this also prints a hook's <code>description</code>, if set, whenever the hook fails, to help explain the failure.</p>
+<p>May also be set with the <code>PREK_VERBOSE</code> environment variable.</p></dd><dt id="prek-cache-gc--version"><a href="#prek-cache-gc--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
 </dd></dl>
 
 ### prek cache clean
@@ -706,8 +717,9 @@ prek cache clean [OPTIONS]
 </dd><dt id="prek-cache-clean--quiet"><a href="#prek-cache-clean--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
 <p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which prek will write no output to stdout.</p>
 <p>May also be set with the <code>PREK_QUIET</code> environment variable.</p></dd><dt id="prek-cache-clean--refresh"><a href="#prek-cache-clean--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
-</dd><dt id="prek-cache-clean--verbose"><a href="#prek-cache-clean--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output</p>
-</dd><dt id="prek-cache-clean--version"><a href="#prek-cache-clean--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
+</dd><dt id="prek-cache-clean--verbose"><a href="#prek-cache-clean--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
+<p>When running hooks, this also prints a hook's <code>description</code>, if set, whenever the hook fails, to help explain the failure.</p>
+<p>May also be set with the <code>PREK_VERBOSE</code> environment variable.</p></dd><dt id="prek-cache-clean--version"><a href="#prek-cache-clean--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
 </dd></dl>
 
 ### prek cache size
@@ -738,8 +750,9 @@ prek cache size [OPTIONS]
 </dd><dt id="prek-cache-size--quiet"><a href="#prek-cache-size--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
 <p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which prek will write no output to stdout.</p>
 <p>May also be set with the <code>PREK_QUIET</code> environment variable.</p></dd><dt id="prek-cache-size--refresh"><a href="#prek-cache-size--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
-</dd><dt id="prek-cache-size--verbose"><a href="#prek-cache-size--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output</p>
-</dd><dt id="prek-cache-size--version"><a href="#prek-cache-size--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
+</dd><dt id="prek-cache-size--verbose"><a href="#prek-cache-size--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
+<p>When running hooks, this also prints a hook's <code>description</code>, if set, whenever the hook fails, to help explain the failure.</p>
+<p>May also be set with the <code>PREK_VERBOSE</code> environment variable.</p></dd><dt id="prek-cache-size--version"><a href="#prek-cache-size--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
 </dd></dl>
 
 ## prek try-repo
@@ -828,8 +841,9 @@ prek try-repo [OPTIONS] <REPO> [HOOK|PROJECT]...
 <li><code>pre-rebase</code></li>
 <li><code>prepare-commit-msg</code></li>
 </ul></dd><dt id="prek-try-repo--to-ref"><a href="#prek-try-repo--to-ref"><code>--to-ref</code></a>, <code>--origin</code>, <code>-o</code> <i>to-ref</i></dt><dd><p>The destination ref in a <code>from_ref...to_ref</code> diff expression. Defaults to <code>HEAD</code> if <code>from_ref</code> is specified</p>
-</dd><dt id="prek-try-repo--verbose"><a href="#prek-try-repo--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output</p>
-</dd><dt id="prek-try-repo--version"><a href="#prek-try-repo--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
+</dd><dt id="prek-try-repo--verbose"><a href="#prek-try-repo--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
+<p>When running hooks, this also prints a hook's <code>description</code>, if set, whenever the hook fails, to help explain the failure.</p>
+<p>May also be set with the <code>PREK_VERBOSE</code> environment variable.</p></dd><dt id="prek-try-repo--version"><a href="#prek-try-repo--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
 </dd></dl>
 
 ## prek util
@@ -887,8 +901,9 @@ prek util identify [OPTIONS] [PATH]...
 </ul></dd><dt id="prek-util-identify--quiet"><a href="#prek-util-identify--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
 <p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which prek will write no output to stdout.</p>
 <p>May also be set with the <code>PREK_QUIET</code> environment variable.</p></dd><dt id="prek-util-identify--refresh"><a href="#prek-util-identify--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
-</dd><dt id="prek-util-identify--verbose"><a href="#prek-util-identify--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output</p>
-</dd><dt id="prek-util-identify--version"><a href="#prek-util-identify--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
+</dd><dt id="prek-util-identify--verbose"><a href="#prek-util-identify--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
+<p>When running hooks, this also prints a hook's <code>description</code>, if set, whenever the hook fails, to help explain the failure.</p>
+<p>May also be set with the <code>PREK_VERBOSE</code> environment variable.</p></dd><dt id="prek-util-identify--version"><a href="#prek-util-identify--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
 </dd></dl>
 
 ### prek util list-builtins
@@ -923,8 +938,9 @@ prek util list-builtins [OPTIONS]
 </ul></dd><dt id="prek-util-list-builtins--quiet"><a href="#prek-util-list-builtins--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
 <p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which prek will write no output to stdout.</p>
 <p>May also be set with the <code>PREK_QUIET</code> environment variable.</p></dd><dt id="prek-util-list-builtins--refresh"><a href="#prek-util-list-builtins--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
-</dd><dt id="prek-util-list-builtins--verbose"><a href="#prek-util-list-builtins--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output</p>
-</dd><dt id="prek-util-list-builtins--version"><a href="#prek-util-list-builtins--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
+</dd><dt id="prek-util-list-builtins--verbose"><a href="#prek-util-list-builtins--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
+<p>When running hooks, this also prints a hook's <code>description</code>, if set, whenever the hook fails, to help explain the failure.</p>
+<p>May also be set with the <code>PREK_VERBOSE</code> environment variable.</p></dd><dt id="prek-util-list-builtins--version"><a href="#prek-util-list-builtins--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
 </dd></dl>
 
 ### prek util init-template-dir
@@ -975,8 +991,9 @@ prek util init-template-dir [OPTIONS] <DIRECTORY>
 </dd><dt id="prek-util-init-template-dir--quiet"><a href="#prek-util-init-template-dir--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
 <p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which prek will write no output to stdout.</p>
 <p>May also be set with the <code>PREK_QUIET</code> environment variable.</p></dd><dt id="prek-util-init-template-dir--refresh"><a href="#prek-util-init-template-dir--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
-</dd><dt id="prek-util-init-template-dir--verbose"><a href="#prek-util-init-template-dir--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output</p>
-</dd><dt id="prek-util-init-template-dir--version"><a href="#prek-util-init-template-dir--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
+</dd><dt id="prek-util-init-template-dir--verbose"><a href="#prek-util-init-template-dir--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
+<p>When running hooks, this also prints a hook's <code>description</code>, if set, whenever the hook fails, to help explain the failure.</p>
+<p>May also be set with the <code>PREK_VERBOSE</code> environment variable.</p></dd><dt id="prek-util-init-template-dir--version"><a href="#prek-util-init-template-dir--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
 </dd></dl>
 
 ### prek util yaml-to-toml
@@ -1013,8 +1030,9 @@ prek util yaml-to-toml [OPTIONS] [CONFIG]
 </dd><dt id="prek-util-yaml-to-toml--quiet"><a href="#prek-util-yaml-to-toml--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
 <p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which prek will write no output to stdout.</p>
 <p>May also be set with the <code>PREK_QUIET</code> environment variable.</p></dd><dt id="prek-util-yaml-to-toml--refresh"><a href="#prek-util-yaml-to-toml--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
-</dd><dt id="prek-util-yaml-to-toml--verbose"><a href="#prek-util-yaml-to-toml--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output</p>
-</dd><dt id="prek-util-yaml-to-toml--version"><a href="#prek-util-yaml-to-toml--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
+</dd><dt id="prek-util-yaml-to-toml--verbose"><a href="#prek-util-yaml-to-toml--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
+<p>When running hooks, this also prints a hook's <code>description</code>, if set, whenever the hook fails, to help explain the failure.</p>
+<p>May also be set with the <code>PREK_VERBOSE</code> environment variable.</p></dd><dt id="prek-util-yaml-to-toml--version"><a href="#prek-util-yaml-to-toml--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
 </dd></dl>
 
 ## prek self
@@ -1065,6 +1083,7 @@ prek self update [OPTIONS] [TARGET_VERSION]
 <p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which prek will write no output to stdout.</p>
 <p>May also be set with the <code>PREK_QUIET</code> environment variable.</p></dd><dt id="prek-self-update--refresh"><a href="#prek-self-update--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
 </dd><dt id="prek-self-update--token"><a href="#prek-self-update--token"><code>--token</code></a> <i>token</i></dt><dd><p>A GitHub token for authentication. A token is not required but can be used to reduce the chance of encountering rate limits</p>
-<p>May also be set with the <code>GITHUB_TOKEN</code> environment variable.</p></dd><dt id="prek-self-update--verbose"><a href="#prek-self-update--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output</p>
-</dd><dt id="prek-self-update--version"><a href="#prek-self-update--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
+<p>May also be set with the <code>GITHUB_TOKEN</code> environment variable.</p></dd><dt id="prek-self-update--verbose"><a href="#prek-self-update--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
+<p>When running hooks, this also prints a hook's <code>description</code>, if set, whenever the hook fails, to help explain the failure.</p>
+<p>May also be set with the <code>PREK_VERBOSE</code> environment variable.</p></dd><dt id="prek-self-update--version"><a href="#prek-self-update--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the prek version</p>
 </dd></dl>

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1328,7 +1328,9 @@ Write hook output to a file when the hook fails (and also when `verbose: true`).
 
 ### `description`
 
-Free-form description shown in listings / metadata.
+Free-form description shown in listings / metadata. When `--verbose` (or the `PREK_VERBOSE`
+environment variable) is enabled, this description is also printed if the hook fails, to help
+explain why the hook exists and what it checks.
 
 - Type: string
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -165,6 +165,15 @@ Use verbose output when a hook fails without enough context:
 prek run -vvv
 ```
 
+If a hook defines a `description` in the config, `--verbose` also prints it when the
+hook fails, which can help explain what the hook checks for. This works for `prek run`
+as well as for hooks triggered by Git (e.g. `git commit`); for the latter, set the
+`PREK_VERBOSE` environment variable since Git does not forward CLI flags to the hook:
+
+```bash
+PREK_VERBOSE=1 git commit
+```
+
 prek also writes a log file to `~/.cache/prek/prek.log` by default. See
 [Debugging](debugging.md) when reporting a prek problem.
 

--- a/prek.schema.json
+++ b/prek.schema.json
@@ -353,7 +353,7 @@
           "$ref": "#/definitions/PassFilenames"
         },
         "description": {
-          "description": "A description of the hook. For metadata only.",
+          "description": "A description of the hook, shown in listings and, when `--verbose` is enabled, printed\nif the hook fails to help explain the failure.",
           "type": "string"
         },
         "language_version": {
@@ -619,7 +619,7 @@
           "$ref": "#/definitions/PassFilenames"
         },
         "description": {
-          "description": "A description of the hook. For metadata only.",
+          "description": "A description of the hook, shown in listings and, when `--verbose` is enabled, printed\nif the hook fails to help explain the failure.",
           "type": "string"
         },
         "language_version": {
@@ -790,7 +790,7 @@
           "$ref": "#/definitions/PassFilenames"
         },
         "description": {
-          "description": "A description of the hook. For metadata only.",
+          "description": "A description of the hook, shown in listings and, when `--verbose` is enabled, printed\nif the hook fails to help explain the failure.",
           "type": "string"
         },
         "language_version": {
@@ -966,7 +966,7 @@
           "$ref": "#/definitions/PassFilenames"
         },
         "description": {
-          "description": "A description of the hook. For metadata only.",
+          "description": "A description of the hook, shown in listings and, when `--verbose` is enabled, printed\nif the hook fails to help explain the failure.",
           "type": "string"
         },
         "language_version": {


### PR DESCRIPTION
## Summary

When `--verbose` (or the new `PREK_VERBOSE` environment variable) is enabled and a hook fails, prek now prints the hook's `description` field alongside the existing hook id/duration/exit code details. The goal is to help users understand why a hook failed without needing to dig through `prek.toml`/`.pre-commit-config.yaml`. This is opt-in, but could become default behavior in the future.

The `PREK_VERBOSE` env var lets this work for hooks triggered via Git (e.g. `git commit`) too, since Git has no way to forward CLI flags like `--verbose` to the installed hook shim.

### Changes

- `crates/prek/src/cli/run/run.rs`: print `- description: ...` after `- hook id: ...` when a hook fails and verbose mode (global `--verbose`/`-v` or per-hook `verbose: true`) is active.
- `crates/prek-consts/src/env_vars.rs`: added `PREK_VERBOSE` env var, mirroring the existing `PREK_QUIET`.
- `crates/prek/src/cli/mod.rs`: wired `env = EnvVars::PREK_VERBOSE` onto the `--verbose` arg and updated its help text.
- `crates/prek/src/cli/hook_impl.rs` / `crates/prek/src/main.rs`: threaded `verbose` through `hook-impl` so hooks invoked by Git shims respect it.
- `crates/prek/src/config.rs`: updated the `description` field doc comment to mention it's now surfaced on failure.
- Docs: `docs/usage.md`, `docs/authoring-hooks.md`, `docs/reference/configuration.md`, `docs/reference/cli.md` (regenerated), and `prek.schema.json` (regenerated).

### Tests

- `crates/prek/tests/run.rs`: `verbose_prints_hook_description_on_failure` and `prek_verbose_env_var_prints_hook_description_on_failure`.
- `crates/prek/tests/hook_impl.rs`: `hook_impl_verbose_env_var_prints_hook_description`, exercising the Git-hook (`git commit`) path end-to-end.

`cargo fmt --check` and `cargo clippy --all-targets` are clean, and the full `run`/`hook_impl` integration test suites pass locally.
