### PR TITLE
Support `--glob` patterns in `prek run`

### DIFF
--- a/crates/prek/src/cli/hook_impl.rs
+++ b/crates/prek/src/cli/hook_impl.rs
@@ -118,6 +118,7 @@ pub(crate) async fn hook_impl(
     let Some(run_args) = to_run_args(hook_type, &args, &stdin).await? else {
         return Ok(legacy_code.into());
     };
+    let file_selection = run_args.file_selection.into();
 
     let status = cli::run(
         store,
@@ -127,12 +128,7 @@ pub(crate) async fn hook_impl(
         vec![],
         vec![],
         Some(hook_type.into()),
-        run_args.from_ref,
-        run_args.to_ref,
-        run_args.all_files,
-        vec![],
-        vec![],
-        false,
+        file_selection,
         false,
         flag(run_args.fail_fast, run_args.no_fail_fast),
         false,
@@ -254,9 +250,9 @@ async fn to_run_args(
             run_args.extra.remote_url = Some(args[1].to_string_lossy().into_owned());
 
             if let Some(push_info) = parse_pre_push_info(&args[0].to_string_lossy(), stdin).await? {
-                run_args.from_ref = push_info.from_ref;
-                run_args.to_ref = push_info.to_ref;
-                run_args.all_files = push_info.all_files;
+                run_args.file_selection.from_ref = push_info.from_ref;
+                run_args.file_selection.to_ref = push_info.to_ref;
+                run_args.file_selection.all_files = push_info.all_files;
                 run_args.extra.remote_branch = push_info.remote_branch;
                 run_args.extra.local_branch = push_info.local_branch;
             } else {
@@ -278,8 +274,8 @@ async fn to_run_args(
             }
         }
         HookType::PostCheckout => {
-            run_args.from_ref = Some(args[0].to_string_lossy().into_owned());
-            run_args.to_ref = Some(args[1].to_string_lossy().into_owned());
+            run_args.file_selection.from_ref = Some(args[0].to_string_lossy().into_owned());
+            run_args.file_selection.to_ref = Some(args[1].to_string_lossy().into_owned());
             run_args.extra.checkout_type = Some(args[2].to_string_lossy().into_owned());
         }
         HookType::PostMerge => run_args.extra.is_squash_merge = args[0] == "1",

--- a/crates/prek/src/cli/mod.rs
+++ b/crates/prek/src/cli/mod.rs
@@ -467,6 +467,112 @@ pub(crate) struct RunExtraArgs {
     pub(crate) rewrite_command: Option<String>,
 }
 
+#[derive(Debug, Clone, Default, Args)]
+pub(crate) struct FileSelectionArgs {
+    /// Run hooks on all tracked files in the repository.
+    #[arg(short, long, conflicts_with_all = ["files", "glob", "from_ref", "to_ref"])]
+    pub(crate) all_files: bool,
+
+    /// Run hooks on the specified file paths.
+    ///
+    /// Paths are resolved relative to the current working directory after applying `--cd`. They may
+    /// be tracked or untracked. This option accepts multiple paths and can be combined with
+    /// `--glob` and `--directory`.
+    #[arg(
+        long,
+        conflicts_with_all = ["all_files", "from_ref", "to_ref"],
+        num_args = 0..,
+        value_hint = ValueHint::AnyPath)
+    ]
+    pub(crate) files: Vec<String>,
+
+    /// Run hooks on tracked files matching the specified glob pattern.
+    ///
+    /// Patterns are matched against paths relative to the current working directory after applying
+    /// `--cd`. Quote patterns to prevent shell expansion. This option can be repeated and combined
+    /// with `--files` and `--directory`.
+    #[arg(
+        long,
+        value_name = "PATTERN",
+        conflicts_with_all = ["all_files", "from_ref", "to_ref"]
+    )]
+    pub(crate) glob: Vec<Glob>,
+
+    /// Run hooks on tracked files under the specified directory.
+    ///
+    /// Paths are resolved relative to the current working directory after applying `--cd`. This
+    /// option can be repeated and combined with `--files` and `--glob`.
+    #[arg(
+        short,
+        long,
+        value_name = "DIR",
+        conflicts_with_all = ["all_files", "from_ref", "to_ref"],
+        value_hint = ValueHint::DirPath
+    )]
+    pub(crate) directory: Vec<String>,
+
+    /// The original ref in a `<from_ref>...<to_ref>` diff expression.
+    /// Files changed in this diff will be run through the hooks.
+    #[arg(short = 's', long, alias = "source", value_hint = ValueHint::Other)]
+    pub(crate) from_ref: Option<String>,
+
+    /// The destination ref in a `from_ref...to_ref` diff expression.
+    /// Defaults to `HEAD` if `from_ref` is specified.
+    #[arg(
+        short = 'o',
+        long,
+        alias = "origin",
+        requires = "from_ref",
+        value_hint = ValueHint::Other,
+        default_value_if("from_ref", ArgPredicate::IsPresent, "HEAD")
+    )]
+    pub(crate) to_ref: Option<String>,
+
+    /// Run hooks against the last commit. Equivalent to `--from-ref HEAD~1 --to-ref HEAD`.
+    #[arg(long, conflicts_with_all = ["all_files", "files", "glob", "directory", "from_ref", "to_ref"])]
+    pub(crate) last_commit: bool,
+}
+
+impl From<FileSelectionArgs> for run::FileSelection {
+    fn from(args: FileSelectionArgs) -> Self {
+        let FileSelectionArgs {
+            all_files,
+            files,
+            glob,
+            directory,
+            from_ref,
+            to_ref,
+            last_commit,
+        } = args;
+
+        if last_commit {
+            return Self::Diff {
+                from_ref: "HEAD~1".to_string(),
+                to_ref: "HEAD".to_string(),
+            };
+        }
+
+        let (from_ref, to_ref) = match (from_ref, to_ref) {
+            (Some(from_ref), Some(to_ref)) => return Self::Diff { from_ref, to_ref },
+            refs => refs,
+        };
+
+        if !files.is_empty() || !glob.is_empty() || !directory.is_empty() {
+            return Self::Explicit {
+                files,
+                globs: glob,
+                directories: directory,
+            };
+        }
+
+        if all_files {
+            Self::All { from_ref, to_ref }
+        } else {
+            Self::Default
+        }
+    }
+}
+
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Default, Args)]
 pub(crate) struct RunOptions {
@@ -502,50 +608,8 @@ pub(crate) struct RunOptions {
     #[arg(long = "skip", value_name = "HOOK|PROJECT", add = ArgValueCompleter::new(selector_completer))]
     pub(crate) skips: Vec<String>,
 
-    /// Run on all files in the repo.
-    #[arg(short, long, conflicts_with_all = ["files", "from_ref", "to_ref"])]
-    pub(crate) all_files: bool,
-    /// Specific filenames to run hooks on.
-    #[arg(
-        long,
-        conflicts_with_all = ["all_files", "from_ref", "to_ref"],
-        num_args = 0..,
-        value_hint = ValueHint::AnyPath)
-    ]
-    pub(crate) files: Vec<String>,
-
-    /// Run hooks on all files in the specified directories.
-    ///
-    /// You can specify multiple directories. It can be used in conjunction with `--files`.
-    #[arg(
-        short,
-        long,
-        value_name = "DIR",
-        conflicts_with_all = ["all_files", "from_ref", "to_ref"],
-        value_hint = ValueHint::DirPath
-    )]
-    pub(crate) directory: Vec<String>,
-
-    /// The original ref in a `<from_ref>...<to_ref>` diff expression.
-    /// Files changed in this diff will be run through the hooks.
-    #[arg(short = 's', long, alias = "source", value_hint = ValueHint::Other)]
-    pub(crate) from_ref: Option<String>,
-
-    /// The destination ref in a `from_ref...to_ref` diff expression.
-    /// Defaults to `HEAD` if `from_ref` is specified.
-    #[arg(
-        short = 'o',
-        long,
-        alias = "origin",
-        requires = "from_ref",
-        value_hint = ValueHint::Other,
-        default_value_if("from_ref", ArgPredicate::IsPresent, "HEAD")
-    )]
-    pub(crate) to_ref: Option<String>,
-
-    /// Run hooks against the last commit. Equivalent to `--from-ref HEAD~1 --to-ref HEAD`.
-    #[arg(long, conflicts_with_all = ["all_files", "files", "directory", "from_ref", "to_ref"])]
-    pub(crate) last_commit: bool,
+    #[command(flatten)]
+    pub(crate) file_selection: FileSelectionArgs,
 
     /// When hooks fail, run `git diff` directly afterward.
     #[arg(long)]

--- a/crates/prek/src/cli/run/filter.rs
+++ b/crates/prek/src/cli/run/filter.rs
@@ -5,13 +5,13 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use itertools::{Either, Itertools};
+use globset::Glob;
 use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use prek_identify::{TagSet, tags_from_path};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::{debug, error, instrument};
 
-use crate::config::{FilePattern, Stage};
+use crate::config::{FilePattern, GlobPatterns, Stage};
 use crate::fs::PathClean;
 use crate::git::GIT_ROOT;
 use crate::hook::Hook;
@@ -420,21 +420,53 @@ impl<'a> RunFileIndex<'a> {
     }
 }
 
+#[derive(Debug, Default)]
+pub(crate) enum FileSelection {
+    #[default]
+    Default,
+    All {
+        from_ref: Option<String>,
+        to_ref: Option<String>,
+    },
+    Diff {
+        from_ref: String,
+        to_ref: String,
+    },
+    Explicit {
+        files: Vec<String>,
+        globs: Vec<Glob>,
+        directories: Vec<String>,
+    },
+}
+
+impl FileSelection {
+    pub(crate) const fn requires_clean_worktree(&self) -> bool {
+        matches!(self, Self::Default | Self::Diff { .. })
+    }
+
+    pub(crate) fn refs(&self) -> (Option<&str>, Option<&str>) {
+        match self {
+            Self::Diff { from_ref, to_ref } => (Some(from_ref), Some(to_ref)),
+            Self::All { from_ref, to_ref } => (from_ref.as_deref(), to_ref.as_deref()),
+            Self::Default | Self::Explicit { .. } => (None, None),
+        }
+    }
+}
+
 #[derive(Default)]
 pub(crate) struct CollectOptions {
     pub(crate) input_mode: RunInputMode,
-    pub(crate) from_ref: Option<String>,
-    pub(crate) to_ref: Option<String>,
-    pub(crate) all_files: bool,
-    pub(crate) files: Vec<String>,
-    pub(crate) directories: Vec<String>,
+    pub(crate) selection: FileSelection,
     pub(crate) commit_msg_filename: Option<String>,
 }
 
 impl CollectOptions {
     pub(crate) fn all_files() -> Self {
         Self {
-            all_files: true,
+            selection: FileSelection::All {
+                from_ref: None,
+                to_ref: None,
+            },
             ..Default::default()
         }
     }
@@ -488,11 +520,7 @@ impl RunInput {
 pub(crate) async fn collect_run_input(root: &Path, opts: CollectOptions) -> Result<RunInput> {
     let CollectOptions {
         input_mode,
-        from_ref,
-        to_ref,
-        all_files,
-        files,
-        directories,
+        selection,
         commit_msg_filename,
     } = opts;
 
@@ -516,16 +544,7 @@ pub(crate) async fn collect_run_input(root: &Path, opts: CollectOptions) -> Resu
         )
     })?;
 
-    let filenames = collect_files_from_args(
-        git_root,
-        root,
-        from_ref,
-        to_ref,
-        all_files,
-        files,
-        directories,
-    )
-    .await?;
+    let filenames = collect_files_for_selection(git_root, root, selection).await?;
 
     // Convert filenames to be relative to the workspace root.
     let mut filenames = filenames
@@ -552,89 +571,133 @@ fn adjust_relative_path(path: &str, new_cwd: &Path) -> Result<PathBuf, std::io::
     fs::relative_to(absolute, new_cwd)
 }
 
-/// Collect files to run hooks on.
-/// Returns a list of file paths relative to the git root.
-async fn collect_files_from_args(
+fn warn_missing_files(files: &[String]) {
+    match files {
+        [] => {}
+        [file] => {
+            warn_user!("This file does not exist and will be ignored: `{file}`");
+        }
+        files => {
+            warn_user!(
+                "These files do not exist and will be ignored: `{}`",
+                files.join(", ")
+            );
+        }
+    }
+}
+
+fn collect_file_arguments(files: Vec<String>, git_root: &Path) -> Result<FxHashSet<PathBuf>> {
+    let mut selected = FxHashSet::default();
+    let mut missing = Vec::new();
+
+    for file in files {
+        if fs_err::exists(&file)? {
+            selected.insert(fs::normalize_path(adjust_relative_path(&file, git_root)?));
+        } else {
+            missing.push(file);
+        }
+    }
+
+    warn_missing_files(&missing);
+    Ok(selected)
+}
+
+fn git_pathspec(path: &Path) -> &Path {
+    if path.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        path
+    }
+}
+
+async fn collect_explicit_files(
     git_root: &Path,
-    workspace_root: &Path,
-    from_ref: Option<String>,
-    to_ref: Option<String>,
-    all_files: bool,
     files: Vec<String>,
+    globs: Vec<Glob>,
     directories: Vec<String>,
 ) -> Result<Vec<PathBuf>> {
-    if let (Some(from_ref), Some(to_ref)) = (from_ref, to_ref) {
-        let files = git::get_changed_files(&from_ref, &to_ref, workspace_root).await?;
-        debug!(
-            "Files changed between {} and {}: {}",
-            from_ref,
-            to_ref,
-            files.len()
-        );
-        return Ok(files);
+    let mut selected = collect_file_arguments(files, git_root)?;
+    let patterns = GlobPatterns::from_globs(globs)?;
+    let cwd_relative = if patterns.is_empty() {
+        PathBuf::new()
+    } else {
+        fs::normalize_path(adjust_relative_path(".", git_root)?)
+    };
+    let directories = directories
+        .into_iter()
+        .map(|directory| adjust_relative_path(&directory, git_root).map(fs::normalize_path))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut pathspecs = directories
+        .iter()
+        .map(|directory| git_pathspec(directory))
+        .collect::<Vec<_>>();
+    if !patterns.is_empty() {
+        pathspecs.push(git_pathspec(&cwd_relative));
     }
 
-    if !files.is_empty() || !directories.is_empty() {
-        // By default, `pre-commit` add `types: [file]` for all hooks,
-        // so `pre-commit` will ignore user provided directories.
-        // We do the same here for compatibility.
-        // For `types: [directory]`, `pre-commit` passes the directory names to the hook directly.
-        let (exists, non_exists): (FxHashSet<_>, Vec<_>) =
-            files.into_iter().partition_map(|filename| {
-                if fs_err::exists(&filename).unwrap_or(false) {
-                    Either::Left(filename)
-                } else {
-                    Either::Right(filename)
-                }
-            });
-        if !non_exists.is_empty() {
-            if non_exists.len() == 1 {
-                warn_user!(
-                    "This file does not exist and will be ignored: `{}`",
-                    non_exists[0]
-                );
-            } else {
-                warn_user!(
-                    "These files do not exist and will be ignored: `{}`",
-                    non_exists.join(", ")
-                );
+    if !pathspecs.is_empty() {
+        for file in git::ls_files(git_root, pathspecs).await? {
+            let file = fs::normalize_path(file);
+            let matches_directory = directories
+                .iter()
+                .any(|directory| directory.as_os_str().is_empty() || file.starts_with(directory));
+            let matches_glob = !matches_directory
+                && !patterns.is_empty()
+                && file
+                    .strip_prefix(&cwd_relative)
+                    .is_ok_and(|relative| patterns.is_match(relative));
+
+            if matches_directory || matches_glob {
+                selected.insert(file);
             }
         }
+    }
 
-        let mut exists = exists
-            .into_iter()
-            .map(|filename| adjust_relative_path(&filename, git_root).map(fs::normalize_path))
-            .collect::<Result<FxHashSet<_>, _>>()?;
+    debug!("Files passed as arguments: {}", selected.len());
+    Ok(selected.into_iter().collect())
+}
 
-        for dir in directories {
-            let dir = adjust_relative_path(&dir, git_root)?;
-            let dir_files = git::ls_files(git_root, &dir).await?;
-            for file in dir_files {
-                let file = fs::normalize_path(file);
-                exists.insert(file);
-            }
+/// Collect files to run hooks on.
+/// Returns a list of file paths relative to the git root.
+async fn collect_files_for_selection(
+    git_root: &Path,
+    workspace_root: &Path,
+    selection: FileSelection,
+) -> Result<Vec<PathBuf>> {
+    match selection {
+        FileSelection::Diff { from_ref, to_ref } => {
+            let files = git::get_changed_files(&from_ref, &to_ref, workspace_root).await?;
+            debug!(
+                "Files changed between {} and {}: {}",
+                from_ref,
+                to_ref,
+                files.len()
+            );
+            Ok(files)
         }
+        FileSelection::Explicit {
+            files,
+            globs,
+            directories,
+        } => collect_explicit_files(git_root, files, globs, directories).await,
+        FileSelection::All { .. } => {
+            let files = git::ls_files(git_root, [workspace_root]).await?;
+            debug!("All files in the workspace: {}", files.len());
+            Ok(files)
+        }
+        FileSelection::Default => {
+            if git::is_in_merge_conflict().await? {
+                let files = git::get_conflicted_files(workspace_root).await?;
+                debug!("Conflicted files: {}", files.len());
+                return Ok(files);
+            }
 
-        debug!("Files passed as arguments: {}", exists.len());
-        return Ok(exists.into_iter().collect());
+            let files = git::get_staged_files(workspace_root).await?;
+            debug!("Staged files: {}", files.len());
+            Ok(files)
+        }
     }
-
-    if all_files {
-        let files = git::ls_files(git_root, workspace_root).await?;
-        debug!("All files in the workspace: {}", files.len());
-        return Ok(files);
-    }
-
-    if git::is_in_merge_conflict().await? {
-        let files = git::get_conflicted_files(workspace_root).await?;
-        debug!("Conflicted files: {}", files.len());
-        return Ok(files);
-    }
-
-    let files = git::get_staged_files(workspace_root).await?;
-    debug!("Staged files: {}", files.len());
-
-    Ok(files)
 }
 
 pub(super) const fn stage_uses_message_file_input(stage: Stage) -> bool {
@@ -644,7 +707,20 @@ pub(super) const fn stage_uses_message_file_input(stage: Stage) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::FileSelectionArgs;
     use crate::config::GlobPatterns;
+
+    #[test]
+    fn all_file_selection_preserves_partial_refs() {
+        let selection: FileSelection = FileSelectionArgs {
+            all_files: true,
+            to_ref: Some("local-sha".to_string()),
+            ..Default::default()
+        }
+        .into();
+
+        assert_eq!(selection.refs(), (None, Some("local-sha")));
+    }
 
     fn glob_pattern(pattern: &str) -> FilePattern {
         FilePattern::Glob(GlobPatterns::new(vec![pattern.to_string()]).unwrap())

--- a/crates/prek/src/cli/run/mod.rs
+++ b/crates/prek/src/cli/run/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) use filter::{
-    CollectOptions, FileTagCache, FileTagFilter, HookFileFilter, ProjectFiles, RunFileIndex,
-    RunInput, collect_run_input,
+    CollectOptions, FileSelection, FileTagCache, FileTagFilter, HookFileFilter, ProjectFiles,
+    RunFileIndex, RunInput, collect_run_input,
 };
 pub(crate) use install::{InstallCache, install_hooks};
 pub(crate) use reporter::{HookRunReporter, project_status_marker};

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -21,8 +21,8 @@ use crate::cli::run::filter::{RunInputMode, stage_uses_message_file_input};
 use crate::cli::run::install::{InstallCache, install_hooks};
 use crate::cli::run::keeper::WorkTreeKeeper;
 use crate::cli::run::{
-    CollectOptions, FileTagCache, GroupFilters, HookFileFilter, HookRunReporter, ProjectFiles,
-    RunFileIndex, RunInput, Selectors, collect_run_input, project_status_marker,
+    CollectOptions, FileSelection, FileTagCache, GroupFilters, HookFileFilter, HookRunReporter,
+    ProjectFiles, RunFileIndex, RunInput, Selectors, collect_run_input, project_status_marker,
 };
 use crate::cli::{ExitStatus, RunExtraArgs};
 use crate::config::{PassFilenames, Stage};
@@ -44,12 +44,7 @@ pub(crate) async fn run(
     groups: Vec<String>,
     no_groups: Vec<String>,
     hook_stage: Option<Stage>,
-    from_ref: Option<String>,
-    to_ref: Option<String>,
-    all_files: bool,
-    files: Vec<String>,
-    directories: Vec<String>,
-    last_commit: bool,
+    selection: FileSelection,
     show_diff_on_failure: bool,
     fail_fast: Option<bool>,
     dry_run: bool,
@@ -58,13 +53,6 @@ pub(crate) async fn run(
     verbose: bool,
     printer: Printer,
 ) -> Result<ExitStatus> {
-    // Convert `--last-commit` to `HEAD~1..HEAD`
-    let (from_ref, to_ref) = if last_commit {
-        (Some("HEAD~1".to_string()), Some("HEAD".to_string()))
-    } else {
-        (from_ref, to_ref)
-    };
-
     // Prevent recursive post-checkout hooks.
     if hook_stage == Some(Stage::PostCheckout)
         && EnvVars.is_set(EnvVars::PREK_INTERNAL__SKIP_POST_CHECKOUT)
@@ -75,7 +63,7 @@ pub(crate) async fn run(
     // Ensure we are in a git repository.
     LazyLock::force(&GIT_ROOT).as_ref()?;
 
-    let should_stash = !all_files && files.is_empty() && directories.is_empty();
+    let should_stash = selection.requires_clean_worktree();
 
     // Check if we have unresolved merge conflict files and fail fast.
     if should_stash && git::has_unmerged_paths().await? {
@@ -186,17 +174,14 @@ pub(crate) async fn run(
         );
     }
 
-    set_env_vars(from_ref.as_ref(), to_ref.as_ref(), &extra_args);
+    let (from_ref, to_ref) = selection.refs();
+    set_env_vars(from_ref, to_ref, &extra_args);
 
     let input = collect_run_input(
         workspace.root(),
         CollectOptions {
             input_mode,
-            from_ref,
-            to_ref,
-            all_files,
-            files,
-            directories,
+            selection,
             commit_msg_filename: extra_args.commit_msg_filename,
         },
     )
@@ -271,7 +256,7 @@ fn uses_only_message_file_input(hook: &Hook) -> bool {
 }
 
 // `pre-commit` sets these environment variables for other git hooks.
-fn set_env_vars(from_ref: Option<&String>, to_ref: Option<&String>, args: &RunExtraArgs) {
+fn set_env_vars(from_ref: Option<&str>, to_ref: Option<&str>, args: &RunExtraArgs) {
     unsafe {
         std::env::set_var("PRE_COMMIT", "1");
 

--- a/crates/prek/src/cli/try_repo.rs
+++ b/crates/prek/src/cli/try_repo.rs
@@ -273,6 +273,7 @@ pub(crate) async fn try_repo(
     )?;
     writeln!(printer.stdout(), "{}", display_config_str.dimmed())?;
 
+    let file_selection = run_args.file_selection.into();
     crate::cli::run(
         &store,
         Some(config_file),
@@ -281,12 +282,7 @@ pub(crate) async fn try_repo(
         vec![],
         vec![],
         stage,
-        run_args.from_ref,
-        run_args.to_ref,
-        run_args.all_files,
-        run_args.files,
-        run_args.directory,
-        run_args.last_commit,
+        file_selection,
         run_args.show_diff_on_failure,
         flag(run_args.fail_fast, run_args.no_fail_fast),
         run_args.dry_run,

--- a/crates/prek/src/git.rs
+++ b/crates/prek/src/git.rs
@@ -226,17 +226,24 @@ pub(crate) async fn get_changed_files(
     Ok(zsplit(&output.stdout)?)
 }
 
-#[instrument(level = "trace")]
-pub(crate) async fn ls_files(cwd: &Path, path: &Path) -> Result<Vec<PathBuf>, Error> {
-    let output = git_cmd()?
-        .current_dir(cwd)
+#[instrument(level = "trace", skip(paths))]
+pub(crate) async fn ls_files<P>(
+    cwd: &Path,
+    paths: impl IntoIterator<Item = P>,
+) -> Result<Vec<PathBuf>, Error>
+where
+    P: AsRef<Path>,
+{
+    let mut cmd = git_cmd()?;
+    cmd.current_dir(cwd)
+        .arg("--literal-pathspecs")
         .arg("ls-files")
         .arg("-z")
-        .arg("--")
-        .arg(path)
-        .check(true)
-        .output()
-        .await?;
+        .arg("--");
+    for path in paths {
+        cmd.arg(path.as_ref());
+    }
+    let output = cmd.check(true).output().await?;
 
     Ok(zsplit(&output.stdout)?)
 }

--- a/crates/prek/src/hooks/pre_commit_hooks/check_case_conflict.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_case_conflict.rs
@@ -16,7 +16,7 @@ pub(crate) async fn check_case_conflict(
     let work_dir = hook.work_dir();
 
     // Get all files in the repo.
-    let repo_files = git::ls_files(work_dir, Path::new(".")).await?;
+    let repo_files = git::ls_files(work_dir, [Path::new(".")]).await?;
     let mut repo_files_with_dirs: FxHashSet<&Path> = FxHashSet::default();
     for path in &repo_files {
         insert_path_and_parents(&mut repo_files_with_dirs, path);

--- a/crates/prek/src/main.rs
+++ b/crates/prek/src/main.rs
@@ -276,6 +276,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             show_settings!(args);
             let args = *args;
             let options = args.options;
+            let file_selection = options.file_selection.into();
 
             cli::run(
                 &store,
@@ -285,12 +286,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.groups,
                 args.no_groups,
                 args.stage,
-                options.from_ref,
-                options.to_ref,
-                options.all_files,
-                options.files,
-                options.directory,
-                options.last_commit,
+                file_selection,
                 options.show_diff_on_failure,
                 flag(options.fail_fast, options.no_fail_fast),
                 options.dry_run,

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -1708,12 +1708,15 @@ fn global_path_options_expand_tilde() -> Result<()> {
         options: RunOptions {
             includes: [],
             skips: [],
-            all_files: false,
-            files: [],
-            directory: [],
-            from_ref: None,
-            to_ref: None,
-            last_commit: false,
+            file_selection: FileSelectionArgs {
+                all_files: false,
+                files: [],
+                glob: [],
+                directory: [],
+                from_ref: None,
+                to_ref: None,
+                last_commit: false,
+            },
             show_diff_on_failure: false,
             fail_fast: false,
             no_fail_fast: false,
@@ -2531,6 +2534,81 @@ fn run_multiple_files() -> Result<()> {
     Ok(())
 }
 
+/// Test `prek run --glob` and its interaction with other explicit file selectors.
+#[test]
+fn run_glob() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+    context.write_pre_commit_config(indoc::indoc! {r"
+        repos:
+          - repo: local
+            hooks:
+              - id: glob
+                name: glob
+                language: system
+                entry: echo
+                verbose: true
+                types: [text]
+    "});
+
+    let cwd = context.work_dir();
+    cwd.child("root.rs").write_str("fn main() {}")?;
+    cwd.child("src/lib.rs").write_str("pub fn lib() {}")?;
+    cwd.child("src/lib.py").write_str("print('hello')")?;
+    cwd.child("src/nested/mod.rs")
+        .write_str("pub mod nested;")?;
+    cwd.child("docs/readme.md").write_str("# Readme")?;
+    context.git_add(".");
+    cwd.child("src/untracked.rs")
+        .write_str("pub fn untracked() {}")?;
+
+    cmd_snapshot!(context.filters(), context.run().arg("--glob").arg("src/**/*.rs"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    glob.....................................................................Passed
+    - hook id: glob
+    - duration: [TIME]
+
+      src/lib.rs src/nested/mod.rs
+
+    ----- stderr -----
+    "#);
+
+    cmd_snapshot!(context.filters(), context.run().arg("--cd").arg("src").arg("--files").arg("../root.rs").arg("--directory").arg("../docs").arg("--glob").arg("**/*.rs"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    glob.....................................................................Passed
+    - hook id: glob
+    - duration: [TIME]
+
+      docs/readme.md root.rs src/nested/mod.rs src/lib.rs
+
+    ----- stderr -----
+    "#);
+
+    cmd_snapshot!(context.filters(), context.run().arg("--cd").arg("src").arg("--glob").arg("../*.rs"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    glob.................................................(no files to check)Skipped
+
+    ----- stderr -----
+    ");
+
+    cmd_snapshot!(context.filters(), context.run().arg("--glob").arg("missing/**/*.rs"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    glob.................................................(no files to check)Skipped
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
 /// Test `prek run --files` with no files.
 #[test]
 fn run_no_files() {
@@ -3090,9 +3168,10 @@ fn selectors_completion() -> Result<()> {
     :lint:ruff	Ruff Lint
     root-hook	Root Hook
     --skip	Skip the specified hooks or projects
-    --all-files	Run on all files in the repo
-    --files	Specific filenames to run hooks on
-    --directory	Run hooks on all files in the specified directories
+    --all-files	Run hooks on all tracked files in the repository
+    --files	Run hooks on the specified file paths
+    --glob	Run hooks on tracked files matching the specified glob pattern
+    --directory	Run hooks on tracked files under the specified directory
     --from-ref	The original ref in a `<from_ref>...<to_ref>` diff expression. Files changed in this diff will be run through the hooks
     --to-ref	The destination ref in a `from_ref...to_ref` diff expression. Defaults to `HEAD` if `from_ref` is specified
     --last-commit	Run hooks against the last commit. Equivalent to `--from-ref HEAD~1 --to-ref HEAD`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -212,7 +212,7 @@ prek run [OPTIONS] [HOOK|PROJECT]...
 
 <h3 class="cli-reference">Options</h3>
 
-<dl class="cli-reference"><dt id="prek-run--all-files"><a href="#prek-run--all-files"><code>--all-files</code></a>, <code>-a</code></dt><dd><p>Run on all files in the repo</p>
+<dl class="cli-reference"><dt id="prek-run--all-files"><a href="#prek-run--all-files"><code>--all-files</code></a>, <code>-a</code></dt><dd><p>Run hooks on all tracked files in the repository</p>
 </dd><dt id="prek-run--cd"><a href="#prek-run--cd"><code>--cd</code></a>, <code>-C</code> <i>dir</i></dt><dd><p>Change to directory before running</p>
 </dd><dt id="prek-run--color"><a href="#prek-run--color"><code>--color</code></a> <i>color</i></dt><dd><p>Whether to use color in output</p>
 <p>May also be set with the <code>PREK_COLOR</code> environment variable.</p><p>[default: auto]</p><p>Possible values:</p>
@@ -221,12 +221,15 @@ prek run [OPTIONS] [HOOK|PROJECT]...
 <li><code>always</code>:  Enables colored output regardless of the detected environment</li>
 <li><code>never</code>:  Disables colored output</li>
 </ul></dd><dt id="prek-run--config"><a href="#prek-run--config"><code>--config</code></a>, <code>-c</code> <i>config</i></dt><dd><p>Path to alternate config file</p>
-</dd><dt id="prek-run--directory"><a href="#prek-run--directory"><code>--directory</code></a>, <code>-d</code> <i>dir</i></dt><dd><p>Run hooks on all files in the specified directories.</p>
-<p>You can specify multiple directories. It can be used in conjunction with <code>--files</code>.</p>
+</dd><dt id="prek-run--directory"><a href="#prek-run--directory"><code>--directory</code></a>, <code>-d</code> <i>dir</i></dt><dd><p>Run hooks on tracked files under the specified directory.</p>
+<p>Paths are resolved relative to the current working directory after applying <code>--cd</code>. This option can be repeated and combined with <code>--files</code> and <code>--glob</code>.</p>
 </dd><dt id="prek-run--dry-run"><a href="#prek-run--dry-run"><code>--dry-run</code></a></dt><dd><p>Do not run the hooks, but print the hooks that would have been run</p>
 </dd><dt id="prek-run--fail-fast"><a href="#prek-run--fail-fast"><code>--fail-fast</code></a></dt><dd><p>Stop running hooks after the first failure</p>
-</dd><dt id="prek-run--files"><a href="#prek-run--files"><code>--files</code></a> <i>files</i></dt><dd><p>Specific filenames to run hooks on</p>
+</dd><dt id="prek-run--files"><a href="#prek-run--files"><code>--files</code></a> <i>files</i></dt><dd><p>Run hooks on the specified file paths.</p>
+<p>Paths are resolved relative to the current working directory after applying <code>--cd</code>. They may be tracked or untracked. This option accepts multiple paths and can be combined with <code>--glob</code> and <code>--directory</code>.</p>
 </dd><dt id="prek-run--from-ref"><a href="#prek-run--from-ref"><code>--from-ref</code></a>, <code>--source</code>, <code>-s</code> <i>from-ref</i></dt><dd><p>The original ref in a <code>&lt;from_ref&gt;...&lt;to_ref&gt;</code> diff expression. Files changed in this diff will be run through the hooks</p>
+</dd><dt id="prek-run--glob"><a href="#prek-run--glob"><code>--glob</code></a> <i>pattern</i></dt><dd><p>Run hooks on tracked files matching the specified glob pattern.</p>
+<p>Patterns are matched against paths relative to the current working directory after applying <code>--cd</code>. Quote patterns to prevent shell expansion. This option can be repeated and combined with <code>--files</code> and <code>--directory</code>.</p>
 </dd><dt id="prek-run--group"><a href="#prek-run--group"><code>--group</code></a> <i>group</i></dt><dd><p>Run hooks belonging to the specified group.</p>
 <p>Can be specified multiple times.</p>
 </dd><dt id="prek-run--help"><a href="#prek-run--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Display the concise help for this command</p>
@@ -773,7 +776,7 @@ prek try-repo [OPTIONS] <REPO> [HOOK|PROJECT]...
 
 <h3 class="cli-reference">Options</h3>
 
-<dl class="cli-reference"><dt id="prek-try-repo--all-files"><a href="#prek-try-repo--all-files"><code>--all-files</code></a>, <code>-a</code></dt><dd><p>Run on all files in the repo</p>
+<dl class="cli-reference"><dt id="prek-try-repo--all-files"><a href="#prek-try-repo--all-files"><code>--all-files</code></a>, <code>-a</code></dt><dd><p>Run hooks on all tracked files in the repository</p>
 </dd><dt id="prek-try-repo--cd"><a href="#prek-try-repo--cd"><code>--cd</code></a>, <code>-C</code> <i>dir</i></dt><dd><p>Change to directory before running</p>
 </dd><dt id="prek-try-repo--color"><a href="#prek-try-repo--color"><code>--color</code></a> <i>color</i></dt><dd><p>Whether to use color in output</p>
 <p>May also be set with the <code>PREK_COLOR</code> environment variable.</p><p>[default: auto]</p><p>Possible values:</p>
@@ -782,12 +785,15 @@ prek try-repo [OPTIONS] <REPO> [HOOK|PROJECT]...
 <li><code>always</code>:  Enables colored output regardless of the detected environment</li>
 <li><code>never</code>:  Disables colored output</li>
 </ul></dd><dt id="prek-try-repo--config"><a href="#prek-try-repo--config"><code>--config</code></a>, <code>-c</code> <i>config</i></dt><dd><p>Path to alternate config file</p>
-</dd><dt id="prek-try-repo--directory"><a href="#prek-try-repo--directory"><code>--directory</code></a>, <code>-d</code> <i>dir</i></dt><dd><p>Run hooks on all files in the specified directories.</p>
-<p>You can specify multiple directories. It can be used in conjunction with <code>--files</code>.</p>
+</dd><dt id="prek-try-repo--directory"><a href="#prek-try-repo--directory"><code>--directory</code></a>, <code>-d</code> <i>dir</i></dt><dd><p>Run hooks on tracked files under the specified directory.</p>
+<p>Paths are resolved relative to the current working directory after applying <code>--cd</code>. This option can be repeated and combined with <code>--files</code> and <code>--glob</code>.</p>
 </dd><dt id="prek-try-repo--dry-run"><a href="#prek-try-repo--dry-run"><code>--dry-run</code></a></dt><dd><p>Do not run the hooks, but print the hooks that would have been run</p>
 </dd><dt id="prek-try-repo--fail-fast"><a href="#prek-try-repo--fail-fast"><code>--fail-fast</code></a></dt><dd><p>Stop running hooks after the first failure</p>
-</dd><dt id="prek-try-repo--files"><a href="#prek-try-repo--files"><code>--files</code></a> <i>files</i></dt><dd><p>Specific filenames to run hooks on</p>
+</dd><dt id="prek-try-repo--files"><a href="#prek-try-repo--files"><code>--files</code></a> <i>files</i></dt><dd><p>Run hooks on the specified file paths.</p>
+<p>Paths are resolved relative to the current working directory after applying <code>--cd</code>. They may be tracked or untracked. This option accepts multiple paths and can be combined with <code>--glob</code> and <code>--directory</code>.</p>
 </dd><dt id="prek-try-repo--from-ref"><a href="#prek-try-repo--from-ref"><code>--from-ref</code></a>, <code>--source</code>, <code>-s</code> <i>from-ref</i></dt><dd><p>The original ref in a <code>&lt;from_ref&gt;...&lt;to_ref&gt;</code> diff expression. Files changed in this diff will be run through the hooks</p>
+</dd><dt id="prek-try-repo--glob"><a href="#prek-try-repo--glob"><code>--glob</code></a> <i>pattern</i></dt><dd><p>Run hooks on tracked files matching the specified glob pattern.</p>
+<p>Patterns are matched against paths relative to the current working directory after applying <code>--cd</code>. Quote patterns to prevent shell expansion. This option can be repeated and combined with <code>--files</code> and <code>--directory</code>.</p>
 </dd><dt id="prek-try-repo--help"><a href="#prek-try-repo--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Display the concise help for this command</p>
 </dd><dt id="prek-try-repo--last-commit"><a href="#prek-try-repo--last-commit"><code>--last-commit</code></a></dt><dd><p>Run hooks against the last commit. Equivalent to <code>--from-ref HEAD~1 --to-ref HEAD</code></p>
 </dd><dt id="prek-try-repo--log-file"><a href="#prek-try-repo--log-file"><code>--log-file</code></a> <i>log-file</i></dt><dd><p>Write trace logs to the specified file. If not specified, trace logs will be written to <code>$PREK_HOME/prek.log</code></p>


### PR DESCRIPTION
Add a tracked-file `--glob` selector for `prek run` and unify explicit file collection.

Closes #729