### PR TITLE
Preserve hook output order with a shared pipe

### DIFF
--- a/crates/prek/src/languages/bun/bun.rs
+++ b/crates/prek/src/languages/bun/bun.rs
@@ -129,7 +129,7 @@ impl LanguageBackend for Bun {
 
         let entry = hook.entry.resolve(Some(&new_path), store)?;
         let run = async |batch: &[&Path]| {
-            let mut output = Cmd::new(&entry[0])
+            let output = Cmd::new(&entry[0])
                 .current_dir(hook.work_dir())
                 .args(&entry[1..])
                 .env(EnvVars::PATH, &new_path)
@@ -144,24 +144,13 @@ impl LanguageBackend for Bun {
 
             reporter.on_run_progress(progress, batch.len() as u64);
 
-            output.stdout.extend(output.stderr);
-            let code = output.status.code().unwrap_or(1);
-            anyhow::Ok((code, output.stdout))
+            anyhow::Ok(output)
         };
 
-        let results = run_by_batch(hook, filenames, entry.argv(), run).await?;
-
-        // Collect results
-        let mut combined_status = 0;
-        let mut combined_output = Vec::new();
-
-        for (code, output) in results {
-            combined_status |= code;
-            combined_output.extend(output);
-        }
+        let output = run_by_batch(hook, filenames, entry.argv(), run).await?;
 
         reporter.on_run_complete(progress);
 
-        Ok((combined_status, combined_output))
+        Ok(output)
     }
 }

--- a/crates/prek/src/languages/conda.rs
+++ b/crates/prek/src/languages/conda.rs
@@ -101,7 +101,7 @@ impl LanguageBackend for Conda {
         let entry = hook.entry.resolve(Some(&new_path), store)?;
 
         let run = async |batch: &[&Path]| {
-            let mut output = Cmd::new(&entry[0])
+            let output = Cmd::new(&entry[0])
                 .current_dir(hook.work_dir())
                 .args(&entry[1..])
                 .env(EnvVars::PATH, &new_path)
@@ -118,24 +118,14 @@ impl LanguageBackend for Conda {
 
             reporter.on_run_progress(progress, batch.len() as u64);
 
-            output.stdout.extend(output.stderr);
-            let code = output.status.code().unwrap_or(1);
-            anyhow::Ok((code, output.stdout))
+            anyhow::Ok(output)
         };
 
-        let results = run_by_batch(hook, filenames, entry.argv(), run).await?;
-
-        let mut combined_status = 0;
-        let mut combined_output = Vec::new();
-
-        for (code, output) in results {
-            combined_status |= code;
-            combined_output.extend(output);
-        }
+        let output = run_by_batch(hook, filenames, entry.argv(), run).await?;
 
         reporter.on_run_complete(progress);
 
-        Ok((combined_status, combined_output))
+        Ok(output)
     }
 }
 

--- a/crates/prek/src/languages/coursier.rs
+++ b/crates/prek/src/languages/coursier.rs
@@ -168,7 +168,7 @@ impl LanguageBackend for Coursier {
         let entry = hook.entry.resolve(Some(&path_env), store)?;
 
         let run = async |batch: &[&Path]| {
-            let mut output = Cmd::new(&entry[0])
+            let output = Cmd::new(&entry[0])
                 .current_dir(hook.work_dir())
                 .args(&entry[1..])
                 .envs(&hook.env)
@@ -183,24 +183,14 @@ impl LanguageBackend for Coursier {
 
             reporter.on_run_progress(progress, batch.len() as u64);
 
-            output.stdout.extend(output.stderr);
-            let code = output.status.code().unwrap_or(1);
-            anyhow::Ok((code, output.stdout))
+            anyhow::Ok(output)
         };
 
-        let results = run_by_batch(hook, filenames, entry.argv(), run).await?;
-
-        let mut combined_status = 0;
-        let mut combined_output = Vec::new();
-
-        for (code, output) in results {
-            combined_status |= code;
-            combined_output.extend(output);
-        }
+        let output = run_by_batch(hook, filenames, entry.argv(), run).await?;
 
         reporter.on_run_complete(progress);
 
-        Ok((combined_status, combined_output))
+        Ok(output)
     }
 }
 

--- a/crates/prek/src/languages/dart.rs
+++ b/crates/prek/src/languages/dart.rs
@@ -179,7 +179,7 @@ impl LanguageBackend for Dart {
         }
 
         let run = async |batch: &[&Path]| {
-            let mut output = Cmd::new(&entry[0])
+            let output = Cmd::new(&entry[0])
                 .current_dir(hook.work_dir())
                 .args(&entry[1..])
                 .env(EnvVars::PATH, &new_path)
@@ -194,23 +194,14 @@ impl LanguageBackend for Dart {
 
             reporter.on_run_progress(progress, batch.len() as u64);
 
-            output.stdout.extend(output.stderr);
-            let code = output.status.code().unwrap_or(1);
-            anyhow::Ok((code, output.stdout))
+            anyhow::Ok(output)
         };
 
-        let results = run_by_batch(hook, filenames, entry.argv(), run).await?;
-
-        let mut combined_status = 0;
-        let mut combined_output = Vec::new();
-        for (code, output) in results {
-            combined_status |= code;
-            combined_output.extend(output);
-        }
+        let output = run_by_batch(hook, filenames, entry.argv(), run).await?;
 
         reporter.on_run_complete(progress);
 
-        Ok((combined_status, combined_output))
+        Ok(output)
     }
 }
 

--- a/crates/prek/src/languages/deno/deno.rs
+++ b/crates/prek/src/languages/deno/deno.rs
@@ -194,7 +194,7 @@ impl LanguageBackend for Deno {
 
         let run = async |batch: &[&Path]| {
             let mut cmd = Cmd::new(&entry[0]);
-            let mut output = cmd
+            let output = cmd
                 .current_dir(hook.work_dir())
                 .env(EnvVars::PATH, &new_path)
                 .env(EnvVars::DENO_DIR, &deno_cache_dir)
@@ -210,25 +210,14 @@ impl LanguageBackend for Deno {
 
             reporter.on_run_progress(progress, batch.len() as u64);
 
-            output.stdout.extend(output.stderr);
-            let code = output.status.code().unwrap_or(1);
-            anyhow::Ok((code, output.stdout))
+            anyhow::Ok(output)
         };
 
-        let results = run_by_batch(hook, filenames, entry.argv(), run).await?;
-
-        // Collect results
-        let mut combined_status = 0;
-        let mut combined_output = Vec::new();
-
-        for (code, output) in results {
-            combined_status |= code;
-            combined_output.extend(output);
-        }
+        let output = run_by_batch(hook, filenames, entry.argv(), run).await?;
 
         reporter.on_run_complete(progress);
 
-        Ok((combined_status, combined_output))
+        Ok(output)
     }
 }
 

--- a/crates/prek/src/languages/docker.rs
+++ b/crates/prek/src/languages/docker.rs
@@ -498,7 +498,7 @@ impl LanguageBackend for Docker {
         let run = async |batch: &[&Path]| {
             // docker run [OPTIONS] IMAGE [COMMAND] [ARG...]
             let mut cmd = Docker::docker_run_cmd(hook.work_dir());
-            let mut output = cmd
+            let output = cmd
                 .current_dir(hook.work_dir())
                 .args(&env_args)
                 .arg("--entrypoint")
@@ -514,25 +514,14 @@ impl LanguageBackend for Docker {
 
             reporter.on_run_progress(progress, batch.len() as u64);
 
-            output.stdout.extend(output.stderr);
-            let code = output.status.code().unwrap_or(1);
-            anyhow::Ok((code, output.stdout))
+            anyhow::Ok(output)
         };
 
-        let results = run_by_batch(hook, filenames, &entry, run).await?;
-
-        // Collect results
-        let mut combined_status = 0;
-        let mut combined_output = Vec::new();
-
-        for (code, output) in results {
-            combined_status |= code;
-            combined_output.extend(output);
-        }
+        let output = run_by_batch(hook, filenames, &entry, run).await?;
 
         reporter.on_run_complete(progress);
 
-        Ok((combined_status, combined_output))
+        Ok(output)
     }
 }
 

--- a/crates/prek/src/languages/docker_image.rs
+++ b/crates/prek/src/languages/docker_image.rs
@@ -49,7 +49,7 @@ impl LanguageBackend for DockerImage {
         let entry = hook.entry.expect_direct().split()?;
         let run = async |batch: &[&Path]| {
             let mut cmd = Docker::docker_run_cmd(hook.work_dir());
-            let mut output = cmd
+            let output = cmd
                 .current_dir(hook.work_dir())
                 .args(&env_args)
                 .args(&entry[..])
@@ -62,24 +62,13 @@ impl LanguageBackend for DockerImage {
 
             reporter.on_run_progress(progress, batch.len() as u64);
 
-            output.stdout.extend(output.stderr);
-            let code = output.status.code().unwrap_or(1);
-            anyhow::Ok((code, output.stdout))
+            anyhow::Ok(output)
         };
 
-        let results = run_by_batch(hook, filenames, &entry, run).await?;
-
-        // Collect results
-        let mut combined_status = 0;
-        let mut combined_output = Vec::new();
-
-        for (code, output) in results {
-            combined_status |= code;
-            combined_output.extend(output);
-        }
+        let output = run_by_batch(hook, filenames, &entry, run).await?;
 
         reporter.on_run_complete(progress);
 
-        Ok((combined_status, combined_output))
+        Ok(output)
     }
 }

--- a/crates/prek/src/languages/dotnet/dotnet.rs
+++ b/crates/prek/src/languages/dotnet/dotnet.rs
@@ -128,7 +128,7 @@ impl LanguageBackend for Dotnet {
         let entry = hook.entry.resolve(Some(&new_path), store)?;
 
         let run = async |batch: &[&Path]| {
-            let mut output = Cmd::new(&entry[0])
+            let output = Cmd::new(&entry[0])
                 .current_dir(hook.work_dir())
                 .args(&entry[1..])
                 .env(EnvVars::PATH, &new_path)
@@ -143,24 +143,14 @@ impl LanguageBackend for Dotnet {
 
             reporter.on_run_progress(progress, batch.len() as u64);
 
-            output.stdout.extend(output.stderr);
-            let code = output.status.code().unwrap_or(1);
-            anyhow::Ok((code, output.stdout))
+            anyhow::Ok(output)
         };
 
-        let results = run_by_batch(hook, filenames, entry.argv(), run).await?;
-
-        let mut combined_status = 0;
-        let mut combined_output = Vec::new();
-
-        for (code, output) in results {
-            combined_status |= code;
-            combined_output.extend(output);
-        }
+        let output = run_by_batch(hook, filenames, entry.argv(), run).await?;
 
         reporter.on_run_complete(progress);
 
-        Ok((combined_status, combined_output))
+        Ok(output)
     }
 }
 

--- a/crates/prek/src/languages/golang/golang.rs
+++ b/crates/prek/src/languages/golang/golang.rs
@@ -147,7 +147,7 @@ impl LanguageBackend for Golang {
 
         let entry = hook.entry.resolve(Some(&new_path), store)?;
         let run = async |batch: &[&Path]| {
-            let mut output = Cmd::new(&entry[0])
+            let output = Cmd::new(&entry[0])
                 .current_dir(hook.work_dir())
                 .args(&entry[1..])
                 .env(EnvVars::PATH, &new_path)
@@ -165,24 +165,14 @@ impl LanguageBackend for Golang {
 
             reporter.on_run_progress(progress, batch.len() as u64);
 
-            output.stdout.extend(output.stderr);
-            let code = output.status.code().unwrap_or(1);
-            anyhow::Ok((code, output.stdout))
+            anyhow::Ok(output)
         };
 
-        let results = run_by_batch(hook, filenames, entry.argv(), run).await?;
-
-        let mut combined_status = 0;
-        let mut combined_output = Vec::new();
-
-        for (code, output) in results {
-            combined_status |= code;
-            combined_output.extend(output);
-        }
+        let output = run_by_batch(hook, filenames, entry.argv(), run).await?;
 
         reporter.on_run_complete(progress);
 
-        Ok((combined_status, combined_output))
+        Ok(output)
     }
 }
 

--- a/crates/prek/src/languages/haskell.rs
+++ b/crates/prek/src/languages/haskell.rs
@@ -125,7 +125,7 @@ impl LanguageBackend for Haskell {
         let entry = hook.entry.resolve(Some(&new_path), store)?;
 
         let run = async |batch: &[&Path]| {
-            let mut output = Cmd::new(&entry[0])
+            let output = Cmd::new(&entry[0])
                 .current_dir(hook.work_dir())
                 .args(&entry[1..])
                 .env(EnvVars::PATH, &new_path)
@@ -139,23 +139,13 @@ impl LanguageBackend for Haskell {
 
             reporter.on_run_progress(progress, batch.len() as u64);
 
-            output.stdout.extend(output.stderr);
-            let code = output.status.code().unwrap_or(1);
-            anyhow::Ok((code, output.stdout))
+            anyhow::Ok(output)
         };
 
-        let results = run_by_batch(hook, filenames, entry.argv(), run).await?;
-
-        let mut combined_status = 0;
-        let mut combined_output = Vec::new();
-
-        for (code, output) in results {
-            combined_status |= code;
-            combined_output.extend(output);
-        }
+        let output = run_by_batch(hook, filenames, entry.argv(), run).await?;
 
         reporter.on_run_complete(progress);
 
-        Ok((combined_status, combined_output))
+        Ok(output)
     }
 }

--- a/crates/prek/src/languages/julia.rs
+++ b/crates/prek/src/languages/julia.rs
@@ -115,7 +115,7 @@ impl LanguageBackend for Julia {
         }
 
         let run = async |batch: &[&Path]| {
-            let mut output = Cmd::new("julia")
+            let output = Cmd::new("julia")
                 .current_dir(hook.work_dir())
                 .arg("--startup-file=no")
                 .arg(format!("--project={}", env_dir.display()))
@@ -130,23 +130,13 @@ impl LanguageBackend for Julia {
 
             reporter.on_run_progress(progress, batch.len() as u64);
 
-            output.stdout.extend(output.stderr);
-            let code = output.status.code().unwrap_or(1);
-            anyhow::Ok((code, output.stdout))
+            anyhow::Ok(output)
         };
 
-        let results = run_by_batch(hook, filenames, &entry, run).await?;
-
-        let mut combined_status = 0;
-        let mut combined_output = Vec::new();
-
-        for (code, output) in results {
-            combined_status |= code;
-            combined_output.extend(output);
-        }
+        let output = run_by_batch(hook, filenames, &entry, run).await?;
 
         reporter.on_run_complete(progress);
 
-        Ok((combined_status, combined_output))
+        Ok(output)
     }
 }

--- a/crates/prek/src/languages/lua.rs
+++ b/crates/prek/src/languages/lua.rs
@@ -139,7 +139,7 @@ impl LanguageBackend for Lua {
         let lua_cpath = Lua::get_lua_cpath(env_dir, &version);
 
         let run = async |batch: &[&Path]| {
-            let mut output = Cmd::new(&entry[0])
+            let output = Cmd::new(&entry[0])
                 .current_dir(hook.work_dir())
                 .args(&entry[1..])
                 .env(EnvVars::PATH, &new_path)
@@ -155,24 +155,14 @@ impl LanguageBackend for Lua {
 
             reporter.on_run_progress(progress, batch.len() as u64);
 
-            output.stdout.extend(output.stderr);
-            let code = output.status.code().unwrap_or(1);
-            anyhow::Ok((code, output.stdout))
+            anyhow::Ok(output)
         };
 
-        let results = run_by_batch(hook, filenames, entry.argv(), run).await?;
-
-        let mut combined_status = 0;
-        let mut combined_output = Vec::new();
-
-        for (code, output) in results {
-            combined_status |= code;
-            combined_output.extend(output);
-        }
+        let output = run_by_batch(hook, filenames, entry.argv(), run).await?;
 
         reporter.on_run_complete(progress);
 
-        Ok((combined_status, combined_output))
+        Ok(output)
     }
 }
 

--- a/crates/prek/src/languages/node/node.rs
+++ b/crates/prek/src/languages/node/node.rs
@@ -170,7 +170,7 @@ impl LanguageBackend for Node {
                 .env(EnvVars::NODE_PATH, lib_dir(env_dir))
                 .envs(&hook.env);
             apply_npm_config_env(&mut cmd, env_dir, &npm_cache);
-            let mut output = cmd
+            let output = cmd
                 .args(&hook.args)
                 .file_args(batch)
                 .check(false)
@@ -180,25 +180,14 @@ impl LanguageBackend for Node {
 
             reporter.on_run_progress(progress, batch.len() as u64);
 
-            output.stdout.extend(output.stderr);
-            let code = output.status.code().unwrap_or(1);
-            anyhow::Ok((code, output.stdout))
+            anyhow::Ok(output)
         };
 
-        let results = run_by_batch(hook, filenames, entry.argv(), run).await?;
-
-        // Collect results
-        let mut combined_status = 0;
-        let mut combined_output = Vec::new();
-
-        for (code, output) in results {
-            combined_status |= code;
-            combined_output.extend(output);
-        }
+        let output = run_by_batch(hook, filenames, entry.argv(), run).await?;
 
         reporter.on_run_complete(progress);
 
-        Ok((combined_status, combined_output))
+        Ok(output)
     }
 }
 

--- a/crates/prek/src/languages/perl.rs
+++ b/crates/prek/src/languages/perl.rs
@@ -87,7 +87,7 @@ impl LanguageBackend for Perl {
         let entry = hook.entry.resolve(Some(&new_path), store)?;
 
         let run = async |batch: &[&Path]| {
-            let mut output = Cmd::new(&entry[0])
+            let output = Cmd::new(&entry[0])
                 .current_dir(hook.work_dir())
                 .args(&entry[1..])
                 .env(EnvVars::PATH, &new_path)
@@ -102,24 +102,14 @@ impl LanguageBackend for Perl {
 
             reporter.on_run_progress(progress, batch.len() as u64);
 
-            output.stdout.extend(output.stderr);
-            let code = output.status.code().unwrap_or(1);
-            anyhow::Ok((code, output.stdout))
+            anyhow::Ok(output)
         };
 
-        let results = run_by_batch(hook, filenames, entry.argv(), run).await?;
-
-        let mut combined_status = 0;
-        let mut combined_output = Vec::new();
-
-        for (code, output) in results {
-            combined_status |= code;
-            combined_output.extend(output);
-        }
+        let output = run_by_batch(hook, filenames, entry.argv(), run).await?;
 
         reporter.on_run_complete(progress);
 
-        Ok((combined_status, combined_output))
+        Ok(output)
     }
 }
 

--- a/crates/prek/src/languages/php.rs
+++ b/crates/prek/src/languages/php.rs
@@ -251,7 +251,7 @@ impl LanguageBackend for Php {
         let entry = hook.entry.resolve(Some(&path_env), store)?;
 
         let run = async |batch: &[&Path]| {
-            let mut output = Cmd::new(&entry[0])
+            let output = Cmd::new(&entry[0])
                 .current_dir(hook.work_dir())
                 .args(&entry[1..])
                 .env(EnvVars::PATH, &path_env)
@@ -265,23 +265,14 @@ impl LanguageBackend for Php {
 
             reporter.on_run_progress(progress, batch.len() as u64);
 
-            output.stdout.extend(output.stderr);
-            let code = output.status.code().unwrap_or(1);
-            anyhow::Ok((code, output.stdout))
+            anyhow::Ok(output)
         };
 
-        let results = run_by_batch(hook, filenames, entry.argv(), run).await?;
-        let mut combined_status = 0;
-        let mut combined_output = Vec::new();
-
-        for (code, output) in results {
-            combined_status |= code;
-            combined_output.extend(output);
-        }
+        let output = run_by_batch(hook, filenames, entry.argv(), run).await?;
 
         reporter.on_run_complete(progress);
 
-        Ok((combined_status, combined_output))
+        Ok(output)
     }
 }
 

--- a/crates/prek/src/languages/python/python.rs
+++ b/crates/prek/src/languages/python/python.rs
@@ -195,7 +195,7 @@ impl LanguageBackend for Python {
         let entry = hook.entry.resolve(Some(&new_path), store)?;
 
         let run = async |batch: &[&Path]| {
-            let mut output = Cmd::new(&entry[0])
+            let output = Cmd::new(&entry[0])
                 .current_dir(hook.work_dir())
                 .args(&entry[1..])
                 .env(EnvVars::VIRTUAL_ENV, env_dir)
@@ -211,25 +211,14 @@ impl LanguageBackend for Python {
 
             reporter.on_run_progress(progress, batch.len() as u64);
 
-            output.stdout.extend(output.stderr);
-            let code = output.status.code().unwrap_or(1);
-            anyhow::Ok((code, output.stdout))
+            anyhow::Ok(output)
         };
 
-        let results = run_by_batch(hook, filenames, entry.argv(), run).await?;
-
-        // Collect results
-        let mut combined_status = 0;
-        let mut combined_output = Vec::new();
-
-        for (code, output) in results {
-            combined_status |= code;
-            combined_output.extend(output);
-        }
+        let output = run_by_batch(hook, filenames, entry.argv(), run).await?;
 
         reporter.on_run_complete(progress);
 
-        Ok((combined_status, combined_output))
+        Ok(output)
     }
 }
 

--- a/crates/prek/src/languages/r.rs
+++ b/crates/prek/src/languages/r.rs
@@ -147,30 +147,20 @@ impl LanguageBackend for R {
                 .file_args(batch)
                 .check(false);
 
-            let mut output = cmd
+            let output = cmd
                 .pty_output_with_sink(reporter.output_sink(progress))
                 .await?;
 
             reporter.on_run_progress(progress, batch.len() as u64);
 
-            output.stdout.extend(output.stderr);
-            let code = output.status.code().unwrap_or(1);
-            anyhow::Ok((code, output.stdout))
+            anyhow::Ok(output)
         };
 
-        let results = run_by_batch(hook, filenames, &entry, run).await?;
-
-        let mut combined_status = 0;
-        let mut combined_output = Vec::new();
-
-        for (code, output) in results {
-            combined_status |= code;
-            combined_output.extend(output);
-        }
+        let output = run_by_batch(hook, filenames, &entry, run).await?;
 
         reporter.on_run_complete(progress);
 
-        Ok((combined_status, combined_output))
+        Ok(output)
     }
 }
 

--- a/crates/prek/src/languages/ruby/ruby.rs
+++ b/crates/prek/src/languages/ruby/ruby.rs
@@ -151,7 +151,7 @@ impl LanguageBackend for Ruby {
 
         // Execute in batches
         let run = async |batch: &[&Path]| {
-            let mut output = Cmd::new(&entry[0])
+            let output = Cmd::new(&entry[0])
                 .current_dir(hook.work_dir())
                 .env(EnvVars::PATH, &new_path)
                 .env(EnvVars::GEM_HOME, &gem_home)
@@ -169,25 +169,14 @@ impl LanguageBackend for Ruby {
 
             reporter.on_run_progress(progress, batch.len() as u64);
 
-            output.stdout.extend(output.stderr);
-            let code = output.status.code().unwrap_or(1);
-            anyhow::Ok((code, output.stdout))
+            anyhow::Ok(output)
         };
 
-        let results = run_by_batch(hook, filenames, entry.argv(), run).await?;
-
-        // Combine results
-        let mut combined_status = 0;
-        let mut combined_output = Vec::new();
-
-        for (code, output) in results {
-            combined_status |= code;
-            combined_output.extend(output);
-        }
+        let output = run_by_batch(hook, filenames, entry.argv(), run).await?;
 
         reporter.on_run_complete(progress);
 
-        Ok((combined_status, combined_output))
+        Ok(output)
     }
 }
 

--- a/crates/prek/src/languages/rust/rust.rs
+++ b/crates/prek/src/languages/rust/rust.rs
@@ -512,7 +512,7 @@ impl LanguageBackend for Rust {
 
         let entry = hook.entry.resolve(Some(&new_path), store)?;
         let run = async |batch: &[&Path]| {
-            let mut output = Cmd::new(&entry[0])
+            let output = Cmd::new(&entry[0])
                 .current_dir(hook.work_dir())
                 .args(&entry[1..])
                 .env(EnvVars::PATH, &new_path)
@@ -528,24 +528,14 @@ impl LanguageBackend for Rust {
 
             reporter.on_run_progress(progress, batch.len() as u64);
 
-            output.stdout.extend(output.stderr);
-            let code = output.status.code().unwrap_or(1);
-            anyhow::Ok((code, output.stdout))
+            anyhow::Ok(output)
         };
 
-        let results = run_by_batch(hook, filenames, entry.argv(), run).await?;
-
-        let mut combined_status = 0;
-        let mut combined_output = Vec::new();
-
-        for (code, output) in results {
-            combined_status |= code;
-            combined_output.extend(output);
-        }
+        let output = run_by_batch(hook, filenames, entry.argv(), run).await?;
 
         reporter.on_run_complete(progress);
 
-        Ok((combined_status, combined_output))
+        Ok(output)
     }
 }
 

--- a/crates/prek/src/languages/script.rs
+++ b/crates/prek/src/languages/script.rs
@@ -48,7 +48,7 @@ impl LanguageBackend for Script {
         let entry = hook.entry.resolve_script(repo_path, None, store)?;
 
         let run = async |batch: &[&Path]| {
-            let mut output = Cmd::new(&entry[0])
+            let output = Cmd::new(&entry[0])
                 .current_dir(hook.work_dir())
                 .envs(&hook.env)
                 .args(&entry[1..])
@@ -61,24 +61,13 @@ impl LanguageBackend for Script {
 
             reporter.on_run_progress(progress, batch.len() as u64);
 
-            output.stdout.extend(output.stderr);
-            let code = output.status.code().unwrap_or(1);
-            anyhow::Ok((code, output.stdout))
+            anyhow::Ok(output)
         };
 
-        let results = run_by_batch(hook, filenames, entry.argv(), run).await?;
-
-        // Collect results
-        let mut combined_status = 0;
-        let mut combined_output = Vec::new();
-
-        for (code, output) in results {
-            combined_status |= code;
-            combined_output.extend(output);
-        }
+        let output = run_by_batch(hook, filenames, entry.argv(), run).await?;
 
         reporter.on_run_complete(progress);
 
-        Ok((combined_status, combined_output))
+        Ok(output)
     }
 }

--- a/crates/prek/src/languages/swift.rs
+++ b/crates/prek/src/languages/swift.rs
@@ -190,7 +190,7 @@ impl LanguageBackend for Swift {
         let entry = hook.entry.resolve(Some(&new_path), store)?;
 
         let run = async |batch: &[&Path]| {
-            let mut output = Cmd::new(&entry[0])
+            let output = Cmd::new(&entry[0])
                 .current_dir(hook.work_dir())
                 .args(&entry[1..])
                 .env(EnvVars::PATH, &new_path)
@@ -204,24 +204,14 @@ impl LanguageBackend for Swift {
 
             reporter.on_run_progress(progress, batch.len() as u64);
 
-            output.stdout.extend(output.stderr);
-            let code = output.status.code().unwrap_or(1);
-            anyhow::Ok((code, output.stdout))
+            anyhow::Ok(output)
         };
 
-        let results = run_by_batch(hook, filenames, entry.argv(), run).await?;
-
-        let mut combined_status = 0;
-        let mut combined_output = Vec::new();
-
-        for (code, output) in results {
-            combined_status |= code;
-            combined_output.extend(output);
-        }
+        let output = run_by_batch(hook, filenames, entry.argv(), run).await?;
 
         reporter.on_run_complete(progress);
 
-        Ok((combined_status, combined_output))
+        Ok(output)
     }
 }
 

--- a/crates/prek/src/languages/system.rs
+++ b/crates/prek/src/languages/system.rs
@@ -42,7 +42,7 @@ impl LanguageBackend for System {
         let entry = hook.entry.resolve(None, store)?;
 
         let run = async |batch: &[&Path]| {
-            let mut output = Cmd::new(&entry[0])
+            let output = Cmd::new(&entry[0])
                 .current_dir(hook.work_dir())
                 .envs(&hook.env)
                 .args(&entry[1..])
@@ -55,24 +55,13 @@ impl LanguageBackend for System {
 
             reporter.on_run_progress(progress, batch.len() as u64);
 
-            output.stdout.extend(output.stderr);
-            let code = output.status.code().unwrap_or(1);
-            anyhow::Ok((code, output.stdout))
+            anyhow::Ok(output)
         };
 
-        let results = run_by_batch(hook, filenames, entry.argv(), run).await?;
-
-        // Collect results
-        let mut combined_status = 0;
-        let mut combined_output = Vec::new();
-
-        for (code, output) in results {
-            combined_status |= code;
-            combined_output.extend(output);
-        }
+        let output = run_by_batch(hook, filenames, entry.argv(), run).await?;
 
         reporter.on_run_complete(progress);
 
-        Ok((combined_status, combined_output))
+        Ok(output)
     }
 }

--- a/crates/prek/src/process.rs
+++ b/crates/prek/src/process.rs
@@ -27,6 +27,7 @@
 /// Adapt [axoprocess] to use [`tokio::process::Process`] instead of [`std::process::Command`].
 use std::ffi::OsStr;
 use std::fmt::Display;
+use std::io::PipeReader;
 use std::ops::Range;
 use std::path::Path;
 use std::process::Output;
@@ -36,6 +37,10 @@ use owo_colors::OwoColorize;
 use thiserror::Error;
 use tokio::io::AsyncReadExt;
 use tracing::{enabled, trace};
+
+use crate::run::HookRunOutput;
+#[cfg(not(windows))]
+use crate::run::USE_COLOR;
 
 /// An error from executing a command.
 #[derive(Debug, Error)]
@@ -114,9 +119,56 @@ pub(crate) trait OutputSink {
     fn write_chunk(&mut self, chunk: &[u8]);
 }
 
+#[derive(Debug)]
+pub(crate) struct MergedOutput {
+    status: ExitStatus,
+    bytes: Vec<u8>,
+}
+
+impl From<MergedOutput> for HookRunOutput {
+    fn from(output: MergedOutput) -> Self {
+        Self::new(output.status.code().unwrap_or(1), output.bytes)
+    }
+}
+
 fn write_output_chunk(output: &mut Vec<u8>, sink: &mut impl OutputSink, chunk: &[u8]) {
     output.extend_from_slice(chunk);
     sink.write_chunk(chunk);
+}
+
+struct AsyncPipeReader {
+    #[cfg(unix)]
+    inner: tokio::net::unix::pipe::Receiver,
+    #[cfg(windows)]
+    inner: tokio::fs::File,
+}
+
+impl AsyncPipeReader {
+    #[cfg(unix)]
+    fn new(reader: PipeReader) -> std::io::Result<Self> {
+        use std::os::fd::OwnedFd;
+
+        let inner = tokio::net::unix::pipe::Receiver::from_owned_fd(OwnedFd::from(reader))?;
+        Ok(Self { inner })
+    }
+
+    #[cfg(windows)]
+    #[expect(
+        clippy::unnecessary_wraps,
+        reason = "keep the constructor fallible on every platform"
+    )]
+    fn new(reader: PipeReader) -> std::io::Result<Self> {
+        use std::os::windows::io::OwnedHandle;
+
+        let file = std::fs::File::from(OwnedHandle::from(reader));
+        Ok(Self {
+            inner: tokio::fs::File::from_std(file),
+        })
+    }
+
+    async fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buffer).await
+    }
 }
 
 /// Constructors
@@ -188,75 +240,57 @@ impl Cmd {
         self.maybe_check_output(output)
     }
 
-    /// Like [`Cmd::output`], but streams stdout and stderr chunks into `sink` as
-    /// they are read. The sink receives both pipes in arrival order; the returned
-    /// output keeps stdout and stderr separated.
+    /// Captures stdout and stderr through the same pipe and streams chunks into
+    /// `sink` as they are read.
     pub(crate) async fn output_with_sink<S: OutputSink>(
         &mut self,
         mut sink: S,
-    ) -> Result<Output, Error> {
+    ) -> Result<MergedOutput, Error> {
         self.log_command();
+        let (mut child, mut reader) = self.spawn_with_output()?;
+
+        let mut buffer = [0u8; 4096];
+        let mut bytes = Vec::new();
+        loop {
+            let n = reader
+                .read(&mut buffer)
+                .await
+                .map_err(|cause| self.exec_error(cause))?;
+            if n == 0 {
+                break;
+            }
+            write_output_chunk(&mut bytes, &mut sink, &buffer[..n]);
+        }
+
+        let status = child.wait().await.map_err(|cause| self.exec_error(cause))?;
+        self.maybe_check_captured_output(MergedOutput { status, bytes })
+    }
+
+    fn spawn_with_output(&mut self) -> Result<(tokio::process::Child, AsyncPipeReader), Error> {
+        let (reader, writer) = std::io::pipe().map_err(|cause| self.exec_error(cause))?;
+        let reader = AsyncPipeReader::new(reader).map_err(|cause| self.exec_error(cause))?;
+        let stdout = writer.try_clone().map_err(|cause| self.exec_error(cause))?;
+
         self.inner.stdin(Stdio::null());
+        self.inner.stdout(stdout);
+        self.inner.stderr(writer);
+
+        let child = self.inner.spawn();
+
+        // Command retains configured handles for reuse. Drop the parent's pipe
+        // writers so EOF depends only on the child process tree.
         self.inner.stdout(Stdio::piped());
         self.inner.stderr(Stdio::piped());
 
-        let mut child = self.inner.spawn().map_err(|cause| self.exec_error(cause))?;
-
-        let mut stdout = child
-            .stdout
-            .take()
-            .expect("child stdout must be piped before spawn");
-        let mut stderr = child
-            .stderr
-            .take()
-            .expect("child stderr must be piped before spawn");
-        let mut stdout_done = false;
-        let mut stderr_done = false;
-        let mut stdout_buffer = [0u8; 4096];
-        let mut stderr_buffer = [0u8; 4096];
-        let mut stdout_output = Vec::new();
-        let mut stderr_output = Vec::new();
-
-        while !stdout_done || !stderr_done {
-            tokio::select! {
-                result = stdout.read(&mut stdout_buffer), if !stdout_done => {
-                    match result {
-                        Ok(0) => stdout_done = true,
-                        Ok(n) => write_output_chunk(&mut stdout_output, &mut sink, &stdout_buffer[..n]),
-                        Err(cause) => {
-                            return Err(self.exec_error(cause));
-                        }
-                    }
-                }
-                result = stderr.read(&mut stderr_buffer), if !stderr_done => {
-                    match result {
-                        Ok(0) => stderr_done = true,
-                        Ok(n) => write_output_chunk(&mut stderr_output, &mut sink, &stderr_buffer[..n]),
-                        Err(cause) => {
-                            return Err(self.exec_error(cause));
-                        }
-                    }
-                }
-            }
-        }
-
-        // For regular pipes, EOF on both streams is the point where output capture is complete.
-        // Waiting earlier must not make us return before trailing pipe bytes are read.
-        let status = child.wait().await.map_err(|cause| self.exec_error(cause))?;
-        let output = Output {
-            status,
-            stdout: stdout_output,
-            stderr: stderr_output,
-        };
-
-        self.maybe_check_output(output)
+        let child = child.map_err(|cause| self.exec_error(cause))?;
+        Ok((child, reader))
     }
 
     #[cfg(windows)]
     pub(crate) async fn pty_output_with_sink<S: OutputSink>(
         &mut self,
         sink: S,
-    ) -> Result<Output, Error> {
+    ) -> Result<MergedOutput, Error> {
         self.output_with_sink(sink).await
     }
 
@@ -264,9 +298,9 @@ impl Cmd {
     pub(crate) async fn pty_output_with_sink<S: OutputSink>(
         &mut self,
         sink: S,
-    ) -> Result<Output, Error> {
+    ) -> Result<MergedOutput, Error> {
         // If color is not used, fallback to piped output.
-        if !*crate::run::USE_COLOR {
+        if !*USE_COLOR {
             return self.output_with_sink(sink).await;
         }
 
@@ -274,7 +308,7 @@ impl Cmd {
     }
 
     #[cfg(not(windows))]
-    async fn run_on_pty<S: OutputSink>(&mut self, mut sink: S) -> Result<Output, Error> {
+    async fn run_on_pty<S: OutputSink>(&mut self, mut sink: S) -> Result<MergedOutput, Error> {
         let (mut pty, pts) = prek_pty::open()?;
         let (_, stdout, stderr) = pts.setup_subprocess()?;
 
@@ -303,14 +337,14 @@ impl Cmd {
         drop(pts);
 
         let mut buffer = [0u8; 4096];
-        let mut output = Vec::new();
+        let mut bytes = Vec::new();
 
         let status = loop {
             tokio::select! {
                 read_result = pty.read(&mut buffer) => {
                     match read_result {
                         Ok(0) => break child.wait().await.map_err(|cause| self.exec_error(cause))?,
-                        Ok(n) => write_output_chunk(&mut output, &mut sink, &buffer[..n]),
+                        Ok(n) => write_output_chunk(&mut bytes, &mut sink, &buffer[..n]),
                         // Linux reports PTY master EOF as EIO after all slave handles close.
                         Err(err) if err.raw_os_error() == Some(libc::EIO) => {
                             break child.wait().await.map_err(|cause| self.exec_error(cause))?;
@@ -325,7 +359,7 @@ impl Cmd {
                     loop {
                         match pty.try_read(&mut buffer) {
                             Ok(0) => break,
-                            Ok(n) => write_output_chunk(&mut output, &mut sink, &buffer[..n]),
+                            Ok(n) => write_output_chunk(&mut bytes, &mut sink, &buffer[..n]),
                             Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => break,
                             // Linux reports PTY master EOF as EIO after all slave handles close.
                             Err(err) if err.raw_os_error() == Some(libc::EIO) => break,
@@ -341,13 +375,7 @@ impl Cmd {
         child.stdout.take();
         child.stderr.take();
 
-        let output = Output {
-            status,
-            stdout: output,
-            stderr: Vec::new(),
-        };
-
-        self.maybe_check_output(output)
+        self.maybe_check_captured_output(MergedOutput { status, bytes })
     }
 
     /// Equivalent to [`std::process::Command::status`]
@@ -557,6 +585,20 @@ impl Cmd {
         }
     }
 
+    fn maybe_check_captured_output(&self, output: MergedOutput) -> Result<MergedOutput, Error> {
+        if self.check_status && !output.status.success() {
+            let status = output.status;
+            let output = Output {
+                status,
+                stdout: output.bytes,
+                stderr: Vec::new(),
+            };
+            Err(self.status_error(status, Some(output)))
+        } else {
+            Ok(output)
+        }
+    }
+
     /// Log the current command with [`tracing::trace!`].
     pub fn log_command(&self) {
         if !enabled!(tracing::Level::TRACE) {
@@ -760,27 +802,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn output_with_sink_streams_piped_stdout_and_stderr() {
-        let chunks = Arc::new(Mutex::new(0));
-        let output = Cmd::new("/bin/sh")
-            .arg("-c")
-            .arg("printf 'OUT\\n'; printf 'ERR\\n' >&2")
-            .check(false)
-            .output_with_sink(RecordingSink {
-                chunks: Arc::clone(&chunks),
-            })
-            .await
-            .expect("piped command should succeed");
-
-        assert!(output.status.success());
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        assert!(stdout.contains("OUT\n"));
-        assert!(stderr.contains("ERR\n"));
-        assert_ne!(*chunks.lock().unwrap(), 0);
-    }
-
-    #[tokio::test]
     async fn pty_output_captures_trailing_output_after_fast_exit() {
         for _ in 0..20 {
             let output = Cmd::new("/bin/sh")
@@ -792,9 +813,8 @@ mod tests {
                 .expect("pty command should succeed");
 
             assert!(output.status.success());
-            let stdout = String::from_utf8_lossy(&output.stdout).replace("\r\n", "\n");
-            assert_eq!(stdout, "FINAL\n");
-            assert!(output.stderr.is_empty());
+            let output = String::from_utf8_lossy(&output.bytes).replace("\r\n", "\n");
+            assert_eq!(output, "FINAL\n");
         }
     }
 }

--- a/crates/prek/src/run.rs
+++ b/crates/prek/src/run.rs
@@ -254,15 +254,32 @@ impl<'a> Iterator for Partitions<'a> {
     }
 }
 
+#[derive(Debug, Default)]
+pub(crate) struct HookRunOutput {
+    exit_code: i32,
+    output: Vec<u8>,
+}
+
+impl HookRunOutput {
+    pub(crate) fn new(exit_code: i32, output: Vec<u8>) -> Self {
+        Self { exit_code, output }
+    }
+
+    fn append(&mut self, output: Self) {
+        self.exit_code |= output.exit_code;
+        self.output.extend(output.output);
+    }
+}
+
 pub(crate) async fn run_by_batch<T, F>(
     hook: &Hook,
     filenames: &[&Path],
     entry: &[OsString],
     run: F,
-) -> anyhow::Result<Vec<T>>
+) -> anyhow::Result<(i32, Vec<u8>)>
 where
     F: for<'a> AsyncFn(&'a [&'a Path]) -> anyhow::Result<T>,
-    T: Send + 'static,
+    T: Into<HookRunOutput> + Send + 'static,
 {
     let concurrency = if hook.require_serial {
         1
@@ -280,19 +297,43 @@ where
     );
 
     #[allow(clippy::redundant_closure)]
-    let results: Vec<_> = futures_util::stream::iter(partitions)
+    let output = futures_util::stream::iter(partitions)
         .map(|batch| run(batch))
         .buffered(concurrency)
-        .try_collect()
+        .try_fold(
+            HookRunOutput::default(),
+            |mut combined, output| async move {
+                combined.append(output.into());
+                anyhow::Ok(combined)
+            },
+        )
         .await?;
 
-    Ok(results)
+    Ok((output.exit_code, output.output))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::path::{Path, PathBuf};
+
+    #[test]
+    fn hook_run_output_append_bitwise_ors_exit_codes() {
+        let mut output = HookRunOutput::new(1, Vec::new());
+
+        output.append(HookRunOutput::new(3, Vec::new()));
+
+        assert_eq!(output.exit_code, 3);
+    }
+
+    #[test]
+    fn hook_run_output_append_preserves_output_order() {
+        let mut output = HookRunOutput::new(0, b"first".to_vec());
+
+        output.append(HookRunOutput::new(0, b"second".to_vec()));
+
+        assert_eq!(output.output, b"firstsecond");
+    }
 
     fn resolve_concurrency_from_map(values: &[(&str, &str)], primary_env_var: &str) -> usize {
         resolve_concurrency(&EnvVars::from_map(values), primary_env_var)

--- a/crates/prek/tests/languages/docker_image.rs
+++ b/crates/prek/tests/languages/docker_image.rs
@@ -51,6 +51,12 @@ fn docker_image() -> Result<()> {
     - hook id: gitleaks-docker
     - exit code: 1
 
+      ○
+          │╲
+          │ ○
+          ○ ░
+          ░    gitleaks
+
       Finding:     aws_access_key_id = REDACTED
       Secret:      REDACTED
       RuleID:      generic-api-key
@@ -66,13 +72,6 @@ fn docker_image() -> Result<()> {
       File:        gitleaks_bad_01.txt
       Line:        2
       Fingerprint: gitleaks_bad_01.txt:generic-api-key:2
-
-
-          ○
-          │╲
-          │ ○
-          ○ ░
-          ░    gitleaks
 
       [TIME] INF 1 commits scanned.
       [TIME] INF scan completed in [TIME]

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -73,6 +73,55 @@ fn run_basic() -> Result<()> {
 }
 
 #[test]
+fn run_preserves_stdout_stderr_order() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    context
+        .work_dir()
+        .child("output.py")
+        .write_str(indoc::indoc! {r#"
+            import os
+
+            os.write(2, b"__PREK_STDERR_1__\n")
+            os.write(1, b"__PREK_STDOUT_1__\n")
+            os.write(2, b"__PREK_STDERR_2__\n")
+            os.write(1, b"__PREK_STDOUT_2__\n")
+        "#})?;
+    context.write_pre_commit_config(indoc::indoc! {r"
+        repos:
+          - repo: local
+            hooks:
+              - id: output-order
+                name: output-order
+                language: system
+                entry: python3 output.py
+                always_run: true
+                pass_filenames: false
+                verbose: true
+    "});
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run().args(["--all-files", "--color=never"]), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    output-order.............................................................Passed
+    - hook id: output-order
+    - duration: [TIME]
+
+      __PREK_STDERR_1__
+      __PREK_STDOUT_1__
+      __PREK_STDERR_2__
+      __PREK_STDOUT_2__
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[test]
 fn run_does_not_rewrite_unchanged_config_tracking_file() -> Result<()> {
     let context = TestContext::new();
     context.init_project();


### PR DESCRIPTION
Fix hook output ordering by capturing stdout and stderr through a shared pipe before spawning the process. Centralize merged batch output handling across language backends.

Closes #2382
