### PR TITLE
Add description for no-commit-to-branch

### DIFF
--- a/crates/prek/src/hooks/builtin_hooks/mod.rs
+++ b/crates/prek/src/hooks/builtin_hooks/mod.rs
@@ -456,6 +456,9 @@ impl BuiltinHook {
                 priority: None,
                 groups: None,
                 options: HookOptions {
+                    description: Some(
+                        "protects specific branches from direct commits.".to_string(),
+                    ),
                     pass_filenames: Some(PassFilenames::None),
                     always_run: Some(true),
                     ..Default::default()

--- a/crates/prek/tests/list_builtins.rs
+++ b/crates/prek/tests/list_builtins.rs
@@ -112,6 +112,7 @@ fn list_builtins_verbose() {
       replaces or checks mixed line ending.
 
     no-commit-to-branch
+      protects specific branches from direct commits.
 
     pretty-format-json
       checks that JSON files are pretty-formatted.
@@ -244,7 +245,7 @@ fn list_builtins_json() {
       {
         "id": "no-commit-to-branch",
         "name": "don't commit to branch",
-        "description": null
+        "description": "protects specific branches from direct commits."
       },
       {
         "id": "pretty-format-json",


### PR DESCRIPTION
Add the missing builtin description for `no-commit-to-branch` so verbose and JSON listings expose useful metadata.
