### PR TITLE
Add Jujutsu (jj) workspace support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ env:
   # jj-vcs/jj publishes no build attestations, so the archives are pinned by SHA-256.
   JJ_SHA256_LINUX_X86_64: "59e5588583ac82b623239929368c65b90735931c0f26b5a16c1f04d5bb97643d"
   JJ_SHA256_MACOS_AARCH64: "84336bbe5673a36ccc6395c494021ba632794da078eb8c8c513a60f8e1cc3083"
+  JJ_SHA256_MACOS_X86_64: "f1a7fec046b816132318c07a9c096680f7aae78b008709c7166a57efd9c579ec"
+  JJ_SHA256_WINDOWS_X86_64: "582f63e55310eaa397782fcb528c3feff5b943a4e2db70666d105972a381f80e"
 
 jobs:
   plan:
@@ -403,23 +405,31 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          case "$RUNNER_OS" in
-            Linux)
+          case "$RUNNER_OS-$RUNNER_ARCH" in
+            Linux-X64)
               target="x86_64-unknown-linux-musl"
               sha256="$JJ_SHA256_LINUX_X86_64"
               ;;
-            macOS)
+            macOS-ARM64)
               target="aarch64-apple-darwin"
               sha256="$JJ_SHA256_MACOS_AARCH64"
               ;;
+            macOS-X64)
+              target="x86_64-apple-darwin"
+              sha256="$JJ_SHA256_MACOS_X86_64"
+              ;;
             *)
-              echo "Unsupported runner OS for jj install: $RUNNER_OS" >&2
+              echo "Unsupported runner for jj install: $RUNNER_OS-$RUNNER_ARCH" >&2
               exit 1
               ;;
           esac
           asset="jj-v${JJ_VERSION}-${target}.tar.gz"
           gh release download "v${JJ_VERSION}" --repo jj-vcs/jj --pattern "${asset}" --dir /tmp --clobber
-          echo "${sha256}  /tmp/${asset}" | shasum -a 256 -c -
+          if command -v sha256sum >/dev/null 2>&1; then
+            echo "${sha256}  /tmp/${asset}" | sha256sum -c -
+          else
+            echo "${sha256}  /tmp/${asset}" | shasum -a 256 -c -
+          fi
           extracted="$(mktemp -d)"
           tar xzf "/tmp/${asset}" -C "${extracted}"
           mkdir -p "$HOME/.local/bin"
@@ -496,6 +506,28 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: "Install jj (Jujutsu)"
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $asset = "jj-v$env:JJ_VERSION-x86_64-pc-windows-msvc.zip"
+          gh release download "v$env:JJ_VERSION" --repo jj-vcs/jj --pattern $asset --dir $env:RUNNER_TEMP --clobber
+          $zip = Join-Path $env:RUNNER_TEMP $asset
+          $hash = (Get-FileHash -Algorithm SHA256 $zip).Hash.ToLower()
+          if ($hash -ne $env:JJ_SHA256_WINDOWS_X86_64) {
+            Write-Error "jj checksum mismatch: expected $env:JJ_SHA256_WINDOWS_X86_64, got $hash"
+            exit 1
+          }
+          $dest = Join-Path $env:USERPROFILE ".local\bin"
+          New-Item -ItemType Directory -Force -Path $dest | Out-Null
+          Expand-Archive -Path $zip -DestinationPath $dest -Force
+          Add-Content -Path $env:GITHUB_PATH -Value $dest
+          $jj = Join-Path $dest "jj.exe"
+          & $jj config set --user user.name "prek ci"
+          & $jj config set --user user.email "prek-ci@example.com"
+          & $jj --version
 
       - name: "Cargo test"
         working-directory: ${{ env.PREK_WORKSPACE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,6 +439,8 @@ jobs:
           jj config set --user user.name "prek ci" || true
           jj config set --user user.email "prek-ci@example.com" || true
           jj --version
+          # Fail the jj tests instead of silently skipping if jj ever goes missing.
+          echo "PREK_TEST_REQUIRE_JJ=1" >> "$GITHUB_ENV"
 
       - name: "Cargo test"
         env:
@@ -528,6 +530,8 @@ jobs:
           & $jj config set --user user.name "prek ci"
           & $jj config set --user user.email "prek-ci@example.com"
           & $jj --version
+          # Fail the jj tests instead of silently skipping if jj ever goes missing.
+          Add-Content -Path $env:GITHUB_ENV -Value "PREK_TEST_REQUIRE_JJ=1"
 
       - name: "Cargo test"
         working-directory: ${{ env.PREK_WORKSPACE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,17 @@ env:
   DENO_VERSION: "2"
   DART_VERSION: "3.10.4"
   R_VERSION: "4.6.0"
+  JJ_VERSION: "0.43.0"
 
   # Cargo env vars
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
+
+  # jj-vcs/jj publishes no build attestations, so the archives are pinned by SHA-256.
+  JJ_SHA256_LINUX_X86_64: "59e5588583ac82b623239929368c65b90735931c0f26b5a16c1f04d5bb97643d"
+  JJ_SHA256_MACOS_AARCH64: "84336bbe5673a36ccc6395c494021ba632794da078eb8c8c513a60f8e1cc3083"
 
 jobs:
   plan:
@@ -392,6 +397,38 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: "Install jj (Jujutsu)"
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          case "$RUNNER_OS" in
+            Linux)
+              target="x86_64-unknown-linux-musl"
+              sha256="$JJ_SHA256_LINUX_X86_64"
+              ;;
+            macOS)
+              target="aarch64-apple-darwin"
+              sha256="$JJ_SHA256_MACOS_AARCH64"
+              ;;
+            *)
+              echo "Unsupported runner OS for jj install: $RUNNER_OS" >&2
+              exit 1
+              ;;
+          esac
+          asset="jj-v${JJ_VERSION}-${target}.tar.gz"
+          gh release download "v${JJ_VERSION}" --repo jj-vcs/jj --pattern "${asset}" --dir /tmp --clobber
+          echo "${sha256}  /tmp/${asset}" | shasum -a 256 -c -
+          extracted="$(mktemp -d)"
+          tar xzf "/tmp/${asset}" -C "${extracted}"
+          mkdir -p "$HOME/.local/bin"
+          mv "${extracted}/jj" "$HOME/.local/bin/jj"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.local/bin:$PATH"
+          jj config set --user user.name "prek ci" || true
+          jj config set --user user.email "prek-ci@example.com" || true
+          jj --version
 
       - name: "Cargo test"
         env:

--- a/crates/prek/src/cli/hook_impl.rs
+++ b/crates/prek/src/cli/hook_impl.rs
@@ -14,10 +14,10 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use crate::cli::{self, ExitStatus, RunOptions, flag};
 use crate::config::HookType;
 use crate::fs::CWD;
-use crate::git::GIT_ROOT;
 use crate::languages::resolve_command;
 use crate::printer::Printer;
 use crate::process::Cmd;
+use crate::repo;
 use crate::store::Store;
 use crate::workspace;
 use crate::workspace::Project;
@@ -92,7 +92,7 @@ pub(crate) async fn hook_impl(
                 };
             }
             Ok(project) => {
-                if project.path() != GIT_ROOT.as_ref()? {
+                if project.path() != repo::root()? {
                     writeln!(
                         printer.stdout(),
                         "Running in workspace: `{}`",

--- a/crates/prek/src/cli/install.rs
+++ b/crates/prek/src/cli/install.rs
@@ -100,7 +100,9 @@ pub(crate) async fn install(
     let selectors = if let Some(project) = &project {
         Some(Selectors::load(&includes, &skips, project.path())?)
     } else if !includes.is_empty() || !skips.is_empty() {
-        anyhow::bail!("Cannot use `--include` or `--skip` outside of a git repository");
+        anyhow::bail!(
+            "Cannot use `--include` or `--skip` outside of a Git or Jujutsu (jj) repository"
+        );
     } else {
         None
     };

--- a/crates/prek/src/cli/run/filter.rs
+++ b/crates/prek/src/cli/run/filter.rs
@@ -15,8 +15,9 @@ use crate::config::{FilePattern, GlobPatterns, Stage};
 use crate::fs::PathClean;
 use crate::git::GIT_ROOT;
 use crate::hook::Hook;
+use crate::repo;
 use crate::workspace::Project;
-use crate::{fs, git, warn_user};
+use crate::{fs, warn_user};
 
 /// Filter filenames by include/exclude patterns.
 pub(crate) struct FilenameFilter<'a> {
@@ -637,7 +638,7 @@ async fn collect_explicit_files(
     }
 
     if !pathspecs.is_empty() {
-        for file in git::ls_files(git_root, pathspecs).await? {
+        for file in repo::ls_files(git_root, pathspecs).await? {
             let file = fs::normalize_path(file);
             let matches_directory = directories
                 .iter()
@@ -667,7 +668,7 @@ async fn collect_files_for_selection(
 ) -> Result<Vec<PathBuf>> {
     match selection {
         FileSelection::Diff { from_ref, to_ref } => {
-            let files = git::get_changed_files(&from_ref, &to_ref, workspace_root).await?;
+            let files = repo::changed_files_between(&from_ref, &to_ref, workspace_root).await?;
             debug!(
                 "Files changed between {} and {}: {}",
                 from_ref,
@@ -682,19 +683,18 @@ async fn collect_files_for_selection(
             directories,
         } => collect_explicit_files(git_root, files, globs, directories).await,
         FileSelection::All { .. } => {
-            let files = git::ls_files(git_root, [workspace_root]).await?;
+            let files = repo::ls_files(git_root, [workspace_root]).await?;
             debug!("All files in the workspace: {}", files.len());
             Ok(files)
         }
         FileSelection::Default => {
-            if git::is_in_merge_conflict().await? {
-                let files = git::get_conflicted_files(workspace_root).await?;
+            if let Some(files) = repo::conflicted_files(workspace_root).await? {
                 debug!("Conflicted files: {}", files.len());
                 return Ok(files);
             }
 
-            let files = git::get_staged_files(workspace_root).await?;
-            debug!("Staged files: {}", files.len());
+            let files = repo::default_files(workspace_root).await?;
+            debug!("Default files from repository backend: {}", files.len());
             Ok(files)
         }
     }

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -30,6 +30,7 @@ use crate::fs::CWD;
 use crate::git::GIT_ROOT;
 use crate::hook::{Hook, InstalledHook};
 use crate::printer::Printer;
+use crate::repo;
 use crate::run::{HOOK_CONCURRENCY, USE_COLOR};
 use crate::store::Store;
 use crate::workspace::{HookInitFilters, Project, Workspace};
@@ -60,10 +61,12 @@ pub(crate) async fn run(
         return Ok(ExitStatus::Success);
     }
 
-    // Ensure we are in a git repository.
+    // Ensure we are in a supported repository (Git or Jujutsu).
     LazyLock::force(&GIT_ROOT).as_ref()?;
 
-    let should_stash = selection.requires_clean_worktree();
+    // Jujutsu has no index/stash, so its default run mode operates on the working-copy
+    // changeset directly; the Git-only clean-worktree dance does not apply there.
+    let should_stash = selection.requires_clean_worktree() && repo::should_stash_by_default_run();
 
     // Check if we have unresolved merge conflict files and fail fast.
     if should_stash && git::has_unmerged_paths().await? {

--- a/crates/prek/src/cli/try_repo.rs
+++ b/crates/prek/src/cli/try_repo.rs
@@ -23,23 +23,6 @@ use crate::warn_user;
 // never the current workspace, so its git queries must be isolated from any
 // ambient repo env (e.g. the backing Git store injected in a jj workspace).
 
-/// Staged files in `repo`, isolated from the ambient repository env.
-async fn staged_files_isolated(repo: &Path) -> Result<Vec<PathBuf>> {
-    let output = git::git_cmd()?
-        .isolate_from_git_env()
-        .arg("diff")
-        .arg("--cached")
-        .arg("--name-only")
-        .arg("--diff-filter=ACMRTUXB") // Everything except for D
-        .hidden_args(["--no-ext-diff"])
-        .arg("-z")
-        .current_dir(repo)
-        .check(true)
-        .output()
-        .await?;
-    Ok(git::zsplit(&output.stdout)?)
-}
-
 /// Whether `repo` has a diff against `rev`, isolated from the ambient repo env.
 async fn has_diff_isolated(rev: &str, repo: &Path) -> Result<bool> {
     let status = git::git_cmd()?
@@ -89,7 +72,7 @@ async fn clone_and_commit(repo_path: &Path, head_rev: &str, tmp_dir: &Path) -> R
     let index_path = shadow.join(".git/index");
     let objects_path = shadow.join(".git/objects");
 
-    let staged_files = staged_files_isolated(repo_path).await?;
+    let staged_files = git::get_staged_files(repo_path, true).await?;
     if !staged_files.is_empty() {
         git::git_cmd()?
             .isolate_from_git_env()

--- a/crates/prek/src/cli/try_repo.rs
+++ b/crates/prek/src/cli/try_repo.rs
@@ -13,14 +13,50 @@ use crate::cli::run::Selectors;
 use crate::cli::{ExitStatus, RunOptions, flag};
 use crate::config::{self, Stage};
 use crate::git;
-use crate::git::GIT_ROOT;
+use crate::git::{GIT_ROOT, GitCommandExt};
 use crate::hooks::{BuiltinHooks, MetaHooks};
 use crate::printer::Printer;
 use crate::store::Store;
 use crate::warn_user;
 
+// try-repo always targets an external repo (a local path or the shadow copy),
+// never the current workspace, so its git queries must be isolated from any
+// ambient repo env (e.g. the backing Git store injected in a jj workspace).
+
+/// Staged files in `repo`, isolated from the ambient repository env.
+async fn staged_files_isolated(repo: &Path) -> Result<Vec<PathBuf>> {
+    let output = git::git_cmd()?
+        .isolate_from_git_env()
+        .arg("diff")
+        .arg("--cached")
+        .arg("--name-only")
+        .arg("--diff-filter=ACMRTUXB") // Everything except for D
+        .hidden_args(["--no-ext-diff"])
+        .arg("-z")
+        .current_dir(repo)
+        .check(true)
+        .output()
+        .await?;
+    Ok(git::zsplit(&output.stdout)?)
+}
+
+/// Whether `repo` has a diff against `rev`, isolated from the ambient repo env.
+async fn has_diff_isolated(rev: &str, repo: &Path) -> Result<bool> {
+    let status = git::git_cmd()?
+        .isolate_from_git_env()
+        .arg("diff")
+        .arg("--quiet")
+        .arg(rev)
+        .current_dir(repo)
+        .check(false)
+        .status()
+        .await?;
+    Ok(status.code() == Some(1))
+}
+
 async fn get_head_rev(repo: &Path) -> Result<String> {
     let head_rev = git::git_cmd()?
+        .isolate_from_git_env()
         .arg("rev-parse")
         .arg("HEAD")
         .current_dir(repo)
@@ -34,12 +70,14 @@ async fn get_head_rev(repo: &Path) -> Result<String> {
 async fn clone_and_commit(repo_path: &Path, head_rev: &str, tmp_dir: &Path) -> Result<PathBuf> {
     let shadow = tmp_dir.join("shadow-repo");
     git::git_cmd()?
+        .isolate_from_git_env()
         .arg("clone")
         .arg(repo_path)
         .arg(&shadow)
         .output()
         .await?;
     git::git_cmd()?
+        .isolate_from_git_env()
         .arg("checkout")
         .arg(head_rev)
         .arg("-b")
@@ -51,9 +89,10 @@ async fn clone_and_commit(repo_path: &Path, head_rev: &str, tmp_dir: &Path) -> R
     let index_path = shadow.join(".git/index");
     let objects_path = shadow.join(".git/objects");
 
-    let staged_files = git::get_staged_files(repo_path).await?;
+    let staged_files = staged_files_isolated(repo_path).await?;
     if !staged_files.is_empty() {
         git::git_cmd()?
+            .isolate_from_git_env()
             .arg("add")
             .arg("--")
             .file_args(&staged_files)
@@ -66,6 +105,7 @@ async fn clone_and_commit(repo_path: &Path, head_rev: &str, tmp_dir: &Path) -> R
 
     let mut add_u_cmd = git::git_cmd()?;
     add_u_cmd
+        .isolate_from_git_env()
         .arg("add")
         .arg("--update") // Update tracked files
         .current_dir(repo_path)
@@ -75,6 +115,7 @@ async fn clone_and_commit(repo_path: &Path, head_rev: &str, tmp_dir: &Path) -> R
         .await?;
 
     git::git_cmd()?
+        .isolate_from_git_env()
         .arg("commit")
         .arg("-m")
         .arg("Temporary commit by prek try-repo")
@@ -131,6 +172,7 @@ async fn prepare_repo<'a>(
     } else {
         // For remote repositories, use ls-remote
         let head_rev = git::git_cmd()?
+            .isolate_from_git_env()
             .arg("ls-remote")
             .arg("--exit-code")
             .arg(runtime_source.as_ref())
@@ -146,7 +188,7 @@ async fn prepare_repo<'a>(
     };
 
     // If repo is a local repo with uncommitted changes, create a shadow repo to commit the changes.
-    if is_local && git::has_diff("HEAD", repo_path).await? {
+    if is_local && has_diff_isolated("HEAD", repo_path).await? {
         warn_user!("Local repository has uncommitted changes. Creating a temporary copy...");
         let shadow = clone_and_commit(repo_path, &head_rev, tmp_dir).await?;
         let head_rev = get_head_rev(&shadow).await?;

--- a/crates/prek/src/git.rs
+++ b/crates/prek/src/git.rs
@@ -148,7 +148,7 @@ pub(crate) fn git_cmd() -> Result<Cmd, Error> {
     Ok(cmd)
 }
 
-fn zsplit(s: &[u8]) -> Result<Vec<PathBuf>, Utf8Error> {
+pub(crate) fn zsplit(s: &[u8]) -> Result<Vec<PathBuf>, Utf8Error> {
     s.split(|&b| b == b'\0')
         .filter(|slice| !slice.is_empty())
         .map(path_from_git_bytes)
@@ -362,18 +362,6 @@ pub(crate) async fn has_unmerged_paths() -> Result<bool, Error> {
         .output()
         .await?;
     Ok(!output.stdout.trim_ascii().is_empty())
-}
-
-pub(crate) async fn has_diff(rev: &str, path: &Path) -> Result<bool> {
-    let status = git_cmd()?
-        .arg("diff")
-        .arg("--quiet")
-        .arg(rev)
-        .current_dir(path)
-        .check(false)
-        .status()
-        .await?;
-    Ok(status.code() == Some(1))
 }
 
 pub(crate) async fn is_in_merge_conflict() -> Result<bool, Error> {

--- a/crates/prek/src/git.rs
+++ b/crates/prek/src/git.rs
@@ -148,7 +148,7 @@ pub(crate) fn git_cmd() -> Result<Cmd, Error> {
     Ok(cmd)
 }
 
-pub(crate) fn zsplit(s: &[u8]) -> Result<Vec<PathBuf>, Utf8Error> {
+fn zsplit(s: &[u8]) -> Result<Vec<PathBuf>, Utf8Error> {
     s.split(|&b| b == b'\0')
         .filter(|slice| !slice.is_empty())
         .map(path_from_git_bytes)
@@ -320,8 +320,15 @@ pub(crate) async fn get_git_hooks_dir() -> Result<PathBuf, Error> {
     }
 }
 
-pub(crate) async fn get_staged_files(root: &Path) -> Result<Vec<PathBuf>, Error> {
-    let output = git_cmd()?
+/// Staged files under `root`. Set `isolated` to detach from any ambient repository
+/// env (e.g. the backing Git store injected in a jj workspace) when `root` is an
+/// external repo, as `try-repo` does.
+pub(crate) async fn get_staged_files(root: &Path, isolated: bool) -> Result<Vec<PathBuf>, Error> {
+    let mut cmd = git_cmd()?;
+    if isolated {
+        cmd.isolate_from_git_env();
+    }
+    let output = cmd
         .current_dir(root)
         .arg("diff")
         .arg("--cached")

--- a/crates/prek/src/git.rs
+++ b/crates/prek/src/git.rs
@@ -32,6 +32,9 @@ pub(crate) enum Error {
         "Git resolved hooks directory to the current directory (`{0}`). Unset `core.hooksPath` or set it to a real directory path."
     )]
     InvalidHooksPath(PathBuf),
+
+    #[error("{0}")]
+    Message(String),
 }
 
 pub(crate) static GIT: LazyLock<Result<PathBuf, which::Error>> =
@@ -61,13 +64,18 @@ fn git_work_tree() -> Option<&'static Path> {
     GIT_WORK_TREE.get().and_then(Option::as_deref)
 }
 
-pub(crate) static GIT_ROOT: LazyLock<Result<PathBuf, Error>> = LazyLock::new(|| {
-    get_root()
-        .map(|root| dunce::canonicalize(&root).unwrap_or(root))
-        .inspect(|root| {
-            debug!("Git root: {}", root.display());
-        })
-});
+// Delegates to the repository backend so Git and Jujutsu workspaces share a single
+// notion of "the workspace root". `get_root()` still does the raw Git detection that
+// `RepoContext` builds on, so this never re-enters the backend during initialization.
+pub(crate) static GIT_ROOT: LazyLock<Result<PathBuf, Error>> =
+    LazyLock::new(|| match crate::repo::REPO_CONTEXT.as_ref() {
+        Ok(repo) => {
+            let root = repo.root().to_path_buf();
+            debug!("Repository root: {}", root.display());
+            Ok(root)
+        }
+        Err(err) => Err(Error::Message(format!("{err:#}"))),
+    });
 
 /// Remove some `GIT_` environment variables exposed by `git`.
 ///
@@ -112,13 +120,14 @@ pub(crate) fn apply_git_work_tree(cmd: &mut Command) -> &mut Command {
 
 impl GitCommandExt for Cmd {
     fn isolate_from_git_env(&mut self) -> &mut Self {
-        // `git_cmd()` adds this synthetic value as a command-local env. Commands
-        // that call `isolate_from_git_env()` are intentionally detached from the
-        // current repo, so remove it here; inherited `GIT_WORK_TREE` is handled
-        // by `GIT_ENVS_TO_REMOVE`.
-        if git_work_tree().is_some() {
-            self.env_remove(EnvVars::GIT_WORK_TREE);
-        }
+        // `git_cmd()` may inject command-local `GIT_DIR`/`GIT_WORK_TREE` values:
+        // the synthetic work tree derived from an inherited `GIT_DIR`, and, in a
+        // Jujutsu workspace, the backing Git store pointers set by
+        // `repo::apply_git_env()`. Commands that call `isolate_from_git_env()` are
+        // intentionally detached from the current repo, so strip both here;
+        // inherited env vars are handled by `GIT_ENVS_TO_REMOVE`.
+        self.env_remove(EnvVars::GIT_DIR);
+        self.env_remove(EnvVars::GIT_WORK_TREE);
         for (key, _) in GIT_ENVS_TO_REMOVE.iter() {
             self.env_remove(key);
         }
@@ -132,6 +141,9 @@ pub(crate) fn git_cmd() -> Result<Cmd, Error> {
     if let Some(work_tree) = git_work_tree() {
         cmd.env(EnvVars::GIT_WORK_TREE, work_tree);
     }
+    // For a Jujutsu workspace this points Git at the backing Git store; for a plain
+    // Git repo it is a no-op.
+    crate::repo::apply_git_env(&mut cmd);
 
     Ok(cmd)
 }
@@ -997,10 +1009,13 @@ mod tests {
     #[cfg(unix)]
     use super::zsplit;
     use super::{
-        Error, GIT, TerminalPrompt, full_clone, init_repo, shared_repository_file_mode,
-        should_update_submodules, update_submodules,
+        Error, GIT, GitCommandExt, TerminalPrompt, full_clone, init_repo,
+        shared_repository_file_mode, should_update_submodules, update_submodules,
     };
+    use crate::process::Cmd;
     use assert_cmd::assert::OutputAssertExt;
+    use prek_consts::env_vars::EnvVars;
+    use std::collections::BTreeMap;
     use std::path::Path;
     use std::process::Command;
 
@@ -1009,6 +1024,30 @@ mod tests {
         command.current_dir(path).args(args);
 
         command.assert().success();
+    }
+
+    // A Jujutsu workspace injects `GIT_DIR`/`GIT_WORK_TREE` as command-local env vars
+    // (via `repo::apply_git_env`). Commands that isolate themselves from the current
+    // repo must strip those overrides, not just inherited env vars.
+    #[test]
+    fn isolate_from_git_env_clears_repo_context_overrides() {
+        let mut cmd = Cmd::new("/bin/sh");
+        cmd.env(EnvVars::GIT_DIR, "/tmp/repo/.git")
+            .env(EnvVars::GIT_WORK_TREE, "/tmp/repo")
+            .isolate_from_git_env();
+
+        let envs = cmd
+            .get_envs()
+            .map(|(key, value)| {
+                (
+                    key.to_string_lossy().into_owned(),
+                    value.map(|v| v.to_string_lossy().into_owned()),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+
+        assert_eq!(envs.get(EnvVars::GIT_DIR), Some(&None));
+        assert_eq!(envs.get(EnvVars::GIT_WORK_TREE), Some(&None));
     }
 
     #[tokio::test]

--- a/crates/prek/src/hooks/pre_commit_hooks/check_added_large_files.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_added_large_files.rs
@@ -3,10 +3,11 @@ use std::path::{Path, PathBuf};
 use clap::Parser;
 use rustc_hash::FxHashSet;
 
-use crate::git::{get_added_files, get_lfs_files};
+use crate::git::get_lfs_files;
 use crate::hook::Hook;
 use crate::hooks::pre_commit_hooks::{hook_filenames, parse_hook_args};
 use crate::hooks::run_concurrent_file_checks;
+use crate::repo;
 use crate::run::INTERNAL_CONCURRENCY;
 
 #[derive(Parser)]
@@ -34,7 +35,7 @@ pub(crate) async fn check_added_large_files(
     let filenames = if args.enforce_all {
         filenames
     } else {
-        let added_files = get_added_files(hook.work_dir())
+        let added_files = repo::added_files(hook.work_dir())
             .await?
             .into_iter()
             .collect::<FxHashSet<_>>();

--- a/crates/prek/src/hooks/pre_commit_hooks/check_case_conflict.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_case_conflict.rs
@@ -6,9 +6,9 @@ use anyhow::Result;
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
-use crate::git;
 use crate::hook::Hook;
 use crate::hooks::pre_commit_hooks::{FilenamesArgs, hook_filenames, parse_hook_args};
+use crate::repo;
 
 pub(crate) async fn check_case_conflict(
     hook: &Hook,
@@ -19,14 +19,14 @@ pub(crate) async fn check_case_conflict(
     let work_dir = hook.work_dir();
 
     // Get all files in the repo.
-    let repo_files = git::ls_files(work_dir, [Path::new(".")]).await?;
+    let repo_files = repo::ls_files(work_dir, [Path::new(".")]).await?;
     let mut repo_files_with_dirs: FxHashSet<&Path> = FxHashSet::default();
     for path in &repo_files {
         insert_path_and_parents(&mut repo_files_with_dirs, path);
     }
 
     // Get relevant files (filenames + added files) and include their parent directories.
-    let added = git::get_added_files(work_dir).await?;
+    let added = repo::added_files(work_dir).await?;
     let mut relevant_files_with_dirs: FxHashSet<&Path> = FxHashSet::default();
     for filename in &filenames {
         insert_path_and_parents(&mut relevant_files_with_dirs, filename);

--- a/crates/prek/src/hooks/pre_commit_hooks/no_commit_to_branch.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/no_commit_to_branch.rs
@@ -36,6 +36,13 @@ impl Args {
 pub(crate) async fn no_commit_to_branch(hook: &Hook) -> Result<(i32, Vec<u8>)> {
     let args = Args::try_parse_from(hook.entry.expect_direct().split_with_args(&hook.args)?)?;
 
+    // jj has no "current branch" mapping to Git's HEAD: colocated repos keep HEAD
+    // detached and non-colocated backing stores have an unborn HEAD pointing at
+    // `main`, which would otherwise block every run. Skip rather than false-fail.
+    if crate::repo::is_jujutsu() {
+        return Ok((0, Vec::new()));
+    }
+
     let output = git_cmd()?
         .arg("symbolic-ref")
         .arg("HEAD")

--- a/crates/prek/src/jj.rs
+++ b/crates/prek/src/jj.rs
@@ -1,0 +1,285 @@
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+use tracing::instrument;
+
+use crate::process;
+use crate::process::Cmd;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum Error {
+    #[error(transparent)]
+    Command(#[from] process::Error),
+
+    #[error("Failed to find Jujutsu (jj): {0}")]
+    JjNotFound(#[from] which::Error),
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+/// Path to the `jj` executable, resolved via `PATH`.
+pub(crate) static JJ: LazyLock<Result<PathBuf, which::Error>> =
+    LazyLock::new(|| which::which("jj"));
+
+/// Walk up from `start` looking for a directory containing `.jj/`.
+pub(crate) fn find_workspace_root(start: &Path) -> Option<PathBuf> {
+    let mut current = start.to_path_buf();
+    loop {
+        if current.join(".jj").is_dir() {
+            return Some(current);
+        }
+        if !current.pop() {
+            return None;
+        }
+    }
+}
+
+fn resolve_repo_dir(workspace_root: &Path) -> Result<Option<PathBuf>, Error> {
+    let repo_dir_candidate = workspace_root.join(".jj").join("repo");
+    if repo_dir_candidate.is_file() {
+        let content = fs_err::read_to_string(&repo_dir_candidate)?;
+        let path = PathBuf::from(content.trim());
+        let repo_dir = if path.is_absolute() {
+            path
+        } else {
+            workspace_root.join(".jj").join(path)
+        };
+        return Ok(Some(repo_dir));
+    }
+    if repo_dir_candidate.is_dir() {
+        return Ok(Some(repo_dir_candidate));
+    }
+    Ok(None)
+}
+
+/// Resolve the backing Git directory for a Jujutsu workspace.
+///
+/// For a primary (colocated) workspace, `.jj/repo` is a directory.
+/// For a secondary workspace (created with `jj workspace add`), `.jj/repo` is a file
+/// containing the absolute path to the main repo's `.jj/repo` directory.
+pub(crate) fn resolve_backing_git_dir(workspace_root: &Path) -> Result<Option<PathBuf>, Error> {
+    let Some(repo_dir) = resolve_repo_dir(workspace_root)? else {
+        return Ok(None);
+    };
+
+    let git_target_file = repo_dir.join("store").join("git_target");
+    if !git_target_file.try_exists()? {
+        // No `git_target` means this is not a Git-backed jj repo (e.g. the native
+        // backend), which prek cannot drive. Treat it as "no backing Git dir".
+        return Ok(None);
+    }
+    let git_target = fs_err::read_to_string(&git_target_file)?;
+    let git_target = git_target.trim();
+
+    let git_path = PathBuf::from(git_target);
+    let git_dir = if git_path.is_absolute() {
+        git_path
+    } else {
+        repo_dir.join("store").join(git_path)
+    };
+
+    // Check existence before canonicalizing: `canonicalize()` errors on a missing
+    // path, but a dangling `git_target` should surface as `Ok(None)`, not an error.
+    if !git_dir.try_exists()? {
+        return Ok(None);
+    }
+
+    // Canonicalize to resolve any `..` components now that we know it exists.
+    let git_dir = git_dir.canonicalize()?;
+    Ok(Some(git_dir))
+}
+
+/// Create a new `Cmd` for running Jujutsu.
+pub(crate) fn jj_cmd() -> Result<Cmd, Error> {
+    let cmd = Cmd::new(JJ.as_ref().map_err(|&e| Error::JjNotFound(e))?);
+    Ok(cmd)
+}
+
+fn relative_to_cwd<'a>(cwd: &'a Path, path: &'a Path) -> &'a Path {
+    path.strip_prefix(cwd)
+        .ok()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or(path)
+}
+
+fn parse_path_lines(output: &[u8]) -> Vec<PathBuf> {
+    String::from_utf8_lossy(output)
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(PathBuf::from)
+        .collect()
+}
+
+/// List tracked files in the current Jujutsu workspace revision under `paths`.
+///
+/// Paths are interpreted relative to `cwd`, mirroring `git::ls_files`. `jj file list`
+/// prints paths relative to `cwd`, so the results line up with the Git backend.
+#[instrument(level = "trace", skip(paths))]
+pub(crate) async fn ls_files<P>(
+    cwd: &Path,
+    paths: impl IntoIterator<Item = P>,
+) -> Result<Vec<PathBuf>, Error>
+where
+    P: AsRef<Path>,
+{
+    let mut cmd = jj_cmd()?;
+    cmd.current_dir(cwd).arg("file").arg("list");
+    for path in paths {
+        let relative = relative_to_cwd(cwd, path.as_ref());
+        if !relative.as_os_str().is_empty() && relative != Path::new(".") {
+            cmd.arg(relative);
+        }
+    }
+
+    let output = cmd.check(true).output().await?;
+    Ok(parse_path_lines(&output.stdout))
+}
+
+/// Get the list of changed files in the current Jujutsu working copy.
+#[instrument(level = "trace")]
+pub(crate) async fn get_changed_files(root: &Path) -> Result<Vec<PathBuf>, Error> {
+    let output = jj_cmd()?
+        .current_dir(root)
+        .arg("diff")
+        .arg("-r")
+        .arg("@")
+        .arg("--name-only")
+        .check(true)
+        .output()
+        .await?;
+    Ok(parse_path_lines(&output.stdout))
+}
+
+/// Get the list of changed files between two Jujutsu revisions.
+#[instrument(level = "trace")]
+pub(crate) async fn get_changed_files_between(
+    old: &str,
+    new: &str,
+    root: &Path,
+) -> Result<Vec<PathBuf>, Error> {
+    let output = jj_cmd()?
+        .current_dir(root)
+        .arg("diff")
+        .arg("--from")
+        .arg(old)
+        .arg("--to")
+        .arg(new)
+        .arg("--name-only")
+        .check(true)
+        .output()
+        .await?;
+    Ok(parse_path_lines(&output.stdout))
+}
+
+/// Get conflicted files in the current Jujutsu working copy.
+#[instrument(level = "trace")]
+pub(crate) async fn get_conflicted_files(root: &Path) -> Result<Vec<PathBuf>, Error> {
+    let output = jj_cmd()?
+        .current_dir(root)
+        .arg("diff")
+        .arg("-r")
+        .arg("@")
+        .arg("--types")
+        .check(true)
+        .output()
+        .await?;
+
+    let files = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            if line.is_empty() {
+                return None;
+            }
+
+            let mut parts = line.splitn(2, char::is_whitespace);
+            let status = parts.next()?;
+            let path = parts.next()?.trim_start();
+            if status.contains('C') && !path.is_empty() {
+                Some(PathBuf::from(path))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    Ok(files)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_workspace_root_returns_none_for_non_jj_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(find_workspace_root(dir.path()).is_none());
+    }
+
+    #[test]
+    fn find_workspace_root_finds_current_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        fs_err::create_dir(dir.path().join(".jj")).unwrap();
+        let result = find_workspace_root(dir.path());
+        assert_eq!(result, Some(dir.path().to_path_buf()));
+    }
+
+    #[test]
+    fn find_workspace_root_finds_parent_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        fs_err::create_dir(dir.path().join(".jj")).unwrap();
+        let child = dir.path().join("subdir");
+        fs_err::create_dir(&child).unwrap();
+        let result = find_workspace_root(&child);
+        assert_eq!(result, Some(dir.path().to_path_buf()));
+    }
+
+    #[test]
+    fn resolve_backing_git_dir_returns_none_without_repo_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        fs_err::create_dir(dir.path().join(".jj")).unwrap();
+        let result = resolve_backing_git_dir(dir.path()).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn resolve_backing_git_dir_resolves_colocated_workspace() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        let store_dir = root.join(".jj").join("repo").join("store");
+        fs_err::create_dir_all(&store_dir).unwrap();
+        fs_err::write(store_dir.join("git_target"), "../../../.git").unwrap();
+        let git_dir = root.join(".git");
+        fs_err::create_dir(&git_dir).unwrap();
+
+        let resolved = resolve_backing_git_dir(root).unwrap();
+        assert_eq!(resolved, Some(git_dir.canonicalize().unwrap()));
+    }
+
+    #[test]
+    fn resolve_backing_git_dir_resolves_secondary_workspace() {
+        let dir = tempfile::tempdir().unwrap();
+        let main_root = dir.path().join("main");
+        let secondary_root = dir.path().join("secondary");
+
+        let main_store = main_root.join(".jj").join("repo").join("store");
+        fs_err::create_dir_all(&main_store).unwrap();
+        fs_err::write(main_store.join("git_target"), "../../../.git").unwrap();
+        let main_git = main_root.join(".git");
+        fs_err::create_dir(&main_git).unwrap();
+
+        let secondary_jj = secondary_root.join(".jj");
+        fs_err::create_dir_all(&secondary_jj).unwrap();
+        let main_repo_abs = main_root.join(".jj").join("repo").canonicalize().unwrap();
+        fs_err::write(
+            secondary_jj.join("repo"),
+            main_repo_abs.to_string_lossy().as_ref(),
+        )
+        .unwrap();
+
+        let resolved = resolve_backing_git_dir(&secondary_root).unwrap();
+        assert_eq!(resolved, Some(main_git.canonicalize().unwrap()));
+    }
+}

--- a/crates/prek/src/jj.rs
+++ b/crates/prek/src/jj.rs
@@ -86,7 +86,8 @@ pub(crate) fn resolve_backing_git_dir(workspace_root: &Path) -> Result<Option<Pa
     }
 
     // Canonicalize to resolve any `..` components now that we know it exists.
-    let git_dir = git_dir.canonicalize()?;
+    // `dunce` avoids Windows `\\?\` UNC paths, which git handles poorly.
+    let git_dir = dunce::canonicalize(&git_dir)?;
     Ok(Some(git_dir))
 }
 
@@ -111,6 +112,49 @@ fn parse_path_lines(output: &[u8]) -> Vec<PathBuf> {
         .collect()
 }
 
+/// Build a jj fileset expression matching `path` literally, relative to the
+/// command's working directory. jj interprets bare path arguments as fileset
+/// expressions, so metacharacters like `[` must be quoted; this mirrors git's
+/// `--literal-pathspecs`.
+fn literal_fileset(path: &Path) -> String {
+    // jj uses forward slashes in filesets, and string literals use double quotes
+    // with backslash escaping (matching Rust's debug formatting).
+    let path = path.to_string_lossy().replace('\\', "/");
+    format!("cwd:{path:?}")
+}
+
+/// A single entry from `jj diff --types`: the file's kind before and after the
+/// change, plus its path (relative to the command's working directory). The kind
+/// bytes are jj's status letters, e.g. `F` file, `L` symlink, `C` conflict, `-`
+/// absent.
+struct TypedChange {
+    before: u8,
+    after: u8,
+    path: PathBuf,
+}
+
+fn parse_typed_changes(output: &[u8]) -> Vec<TypedChange> {
+    String::from_utf8_lossy(output)
+        .lines()
+        .filter_map(|line| {
+            let (types, path) = line.trim_end().split_once(char::is_whitespace)?;
+            let bytes = types.as_bytes();
+            if bytes.len() < 2 {
+                return None;
+            }
+            let path = path.trim_start();
+            if path.is_empty() {
+                return None;
+            }
+            Some(TypedChange {
+                before: bytes[0],
+                after: bytes[1],
+                path: PathBuf::from(path),
+            })
+        })
+        .collect()
+}
+
 /// List tracked files in the current Jujutsu workspace revision under `paths`.
 ///
 /// Paths are interpreted relative to `cwd`, mirroring `git::ls_files`. `jj file list`
@@ -127,16 +171,22 @@ where
     cmd.current_dir(cwd).arg("file").arg("list");
     for path in paths {
         let relative = relative_to_cwd(cwd, path.as_ref());
-        if !relative.as_os_str().is_empty() && relative != Path::new(".") {
-            cmd.arg(relative);
-        }
+        let relative = if relative.as_os_str().is_empty() {
+            Path::new(".")
+        } else {
+            relative
+        };
+        cmd.arg(literal_fileset(relative));
     }
 
     let output = cmd.check(true).output().await?;
     Ok(parse_path_lines(&output.stdout))
 }
 
-/// Get the list of changed files in the current Jujutsu working copy.
+/// Files changed in the current working-copy revision, excluding deletions.
+///
+/// Deletions are dropped to match the Git backend, whose `--diff-filter` never
+/// reports deleted paths (running hooks on nonexistent files is pointless).
 #[instrument(level = "trace")]
 pub(crate) async fn get_changed_files(root: &Path) -> Result<Vec<PathBuf>, Error> {
     let output = jj_cmd()?
@@ -144,14 +194,37 @@ pub(crate) async fn get_changed_files(root: &Path) -> Result<Vec<PathBuf>, Error
         .arg("diff")
         .arg("-r")
         .arg("@")
-        .arg("--name-only")
+        .arg("--types")
         .check(true)
         .output()
         .await?;
-    Ok(parse_path_lines(&output.stdout))
+    Ok(changed_paths(&output.stdout))
 }
 
-/// Get the list of changed files between two Jujutsu revisions.
+/// Files newly added in the current working-copy revision (absent before).
+///
+/// Mirrors `git diff --staged --diff-filter=A`: only files that did not exist in
+/// the parent, so hooks like `check-added-large-files` do not flag pre-existing
+/// files that were merely modified.
+#[instrument(level = "trace")]
+pub(crate) async fn get_added_files(root: &Path) -> Result<Vec<PathBuf>, Error> {
+    let output = jj_cmd()?
+        .current_dir(root)
+        .arg("diff")
+        .arg("-r")
+        .arg("@")
+        .arg("--types")
+        .check(true)
+        .output()
+        .await?;
+    Ok(parse_typed_changes(&output.stdout)
+        .into_iter()
+        .filter(|change| change.before == b'-' && change.after != b'-')
+        .map(|change| change.path)
+        .collect())
+}
+
+/// Get the list of changed files between two Jujutsu revisions (excluding deletions).
 #[instrument(level = "trace")]
 pub(crate) async fn get_changed_files_between(
     old: &str,
@@ -165,41 +238,50 @@ pub(crate) async fn get_changed_files_between(
         .arg(old)
         .arg("--to")
         .arg(new)
-        .arg("--name-only")
-        .check(true)
-        .output()
-        .await?;
-    Ok(parse_path_lines(&output.stdout))
-}
-
-/// Get conflicted files in the current Jujutsu working copy.
-#[instrument(level = "trace")]
-pub(crate) async fn get_conflicted_files(root: &Path) -> Result<Vec<PathBuf>, Error> {
-    let output = jj_cmd()?
-        .current_dir(root)
-        .arg("diff")
-        .arg("-r")
-        .arg("@")
         .arg("--types")
         .check(true)
         .output()
         .await?;
+    Ok(changed_paths(&output.stdout))
+}
 
+fn changed_paths(output: &[u8]) -> Vec<PathBuf> {
+    parse_typed_changes(output)
+        .into_iter()
+        .filter(|change| change.after != b'-')
+        .map(|change| change.path)
+        .collect()
+}
+
+/// Get files with unresolved conflicts in the current Jujutsu working copy.
+///
+/// Uses `jj resolve --list`, which is the authoritative list of unresolved
+/// conflicts. It exits non-zero when there are none, so failures are treated as
+/// "no conflicts".
+#[instrument(level = "trace")]
+pub(crate) async fn get_conflicted_files(root: &Path) -> Result<Vec<PathBuf>, Error> {
+    let output = jj_cmd()?
+        .current_dir(root)
+        .arg("resolve")
+        .arg("--list")
+        .check(false)
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        return Ok(Vec::new());
+    }
+
+    // Each line is `<path><padding><N>-sided conflict`. Paths do not contain runs
+    // of two or more spaces, so split on the first such run.
     let files = String::from_utf8_lossy(&output.stdout)
         .lines()
         .filter_map(|line| {
-            let line = line.trim();
-            if line.is_empty() {
-                return None;
-            }
-
-            let mut parts = line.splitn(2, char::is_whitespace);
-            let status = parts.next()?;
-            let path = parts.next()?.trim_start();
-            if status.contains('C') && !path.is_empty() {
-                Some(PathBuf::from(path))
-            } else {
+            let path = line.split("  ").next()?.trim();
+            if path.is_empty() {
                 None
+            } else {
+                Some(PathBuf::from(path))
             }
         })
         .collect();
@@ -281,5 +363,62 @@ mod tests {
 
         let resolved = resolve_backing_git_dir(&secondary_root).unwrap();
         assert_eq!(resolved, Some(main_git.canonicalize().unwrap()));
+    }
+
+    #[test]
+    fn resolve_backing_git_dir_returns_none_without_git_target() {
+        // A non-Git jj backend has a store directory but no `git_target` file.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        fs_err::create_dir_all(root.join(".jj").join("repo").join("store")).unwrap();
+
+        let resolved = resolve_backing_git_dir(root).unwrap();
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn resolve_backing_git_dir_returns_none_for_dangling_git_target() {
+        // `git_target` points at a path that does not exist; this should be reported
+        // as "no backing dir", not surface as an error from `canonicalize`.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let store_dir = root.join(".jj").join("repo").join("store");
+        fs_err::create_dir_all(&store_dir).unwrap();
+        fs_err::write(store_dir.join("git_target"), "../../../.git").unwrap();
+        // Note: no `.git` directory is created.
+
+        let resolved = resolve_backing_git_dir(root).unwrap();
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn literal_fileset_quotes_paths() {
+        assert_eq!(literal_fileset(Path::new("foo.txt")), r#"cwd:"foo.txt""#);
+        assert_eq!(literal_fileset(Path::new(".")), r#"cwd:".""#);
+        // Fileset metacharacters must be preserved literally, not treated as globs.
+        assert_eq!(
+            literal_fileset(Path::new("glob[1].txt")),
+            r#"cwd:"glob[1].txt""#
+        );
+    }
+
+    #[test]
+    fn parse_typed_changes_reads_status_and_path() {
+        let changes = parse_typed_changes(b"-F added.txt\nFF modified.txt\nF- deleted.txt\n");
+        assert_eq!(changes.len(), 3);
+        assert_eq!(changes[0].before, b'-');
+        assert_eq!(changes[0].after, b'F');
+        assert_eq!(changes[0].path, PathBuf::from("added.txt"));
+        assert_eq!(changes[2].before, b'F');
+        assert_eq!(changes[2].after, b'-');
+    }
+
+    #[test]
+    fn changed_paths_excludes_deletions() {
+        let paths = changed_paths(b"-F added.txt\nFF modified.txt\nF- deleted.txt\n");
+        assert_eq!(
+            paths,
+            vec![PathBuf::from("added.txt"), PathBuf::from("modified.txt")]
+        );
     }
 }

--- a/crates/prek/src/jj.rs
+++ b/crates/prek/src/jj.rs
@@ -139,10 +139,44 @@ fn scope_fileset(cwd: &Path, path: &Path) -> String {
     literal_fileset(relative_to_cwd(cwd, path))
 }
 
-/// A single entry from `jj diff --types`: the file's kind before and after the
-/// change, plus its path (relative to the command's working directory). The kind
-/// bytes are jj's status letters, e.g. `F` file, `L` symlink, `C` conflict, `-`
-/// absent.
+/// Template for `jj diff` that emits one `<status> <path>` line per changed file.
+/// This avoids `--types`, whose git-style `{a => b}` rename compaction yields a
+/// "path" that names no real file; `path` here is always the real target path.
+///
+/// Note `path` is repo-root-relative (a `RepoPath`), regardless of the command's
+/// working directory. Use this only where output is consumed repo-root-relative
+/// (the changed-file queries run from the repo root); `--types` is cwd-relative.
+const DIFF_TEMPLATE: &str = r#"status_char ++ " " ++ path ++ "\n""#;
+
+/// One entry from a `jj diff` rendered with `DIFF_TEMPLATE`: the status letter
+/// (`A`/`D`/`M`/`R`/`C`) and the target path.
+struct DiffEntry {
+    status: u8,
+    path: PathBuf,
+}
+
+fn parse_diff_entries(output: &[u8]) -> Vec<DiffEntry> {
+    String::from_utf8_lossy(output)
+        .lines()
+        .filter_map(|line| {
+            let (status, path) = line.split_once(' ')?;
+            let &status = status.as_bytes().first()?;
+            if path.is_empty() {
+                return None;
+            }
+            Some(DiffEntry {
+                status,
+                path: PathBuf::from(path),
+            })
+        })
+        .collect()
+}
+
+/// One entry from `jj diff --types`: the file kind before and after the change, and
+/// its path *relative to the command's working directory* (unlike `DIFF_TEMPLATE`).
+/// Kind bytes are jj status letters: `F` file, `L` symlink, `C` conflict, `-` absent.
+/// Renames render as the compacted `{a => b}` form, so only use this where renames
+/// are filtered out (added-file detection keys on `before == '-'`).
 struct TypedChange {
     before: u8,
     after: u8,
@@ -213,7 +247,8 @@ pub(crate) async fn get_changed_files(
         .arg("diff")
         .arg("-r")
         .arg("@")
-        .arg("--types");
+        .arg("-T")
+        .arg(DIFF_TEMPLATE);
     if let Some(scope_path) = scope {
         cmd.arg(scope_fileset(root, scope_path));
     }
@@ -223,9 +258,12 @@ pub(crate) async fn get_changed_files(
 
 /// Files newly added in the current working-copy revision (absent before).
 ///
-/// Mirrors `git diff --staged --diff-filter=A`: only files that did not exist in
-/// the parent, so hooks like `check-added-large-files` do not flag pre-existing
-/// files that were merely modified.
+/// Mirrors `git diff --staged --relative --diff-filter=A`: only files absent in the
+/// parent, reported relative to and scoped under `root`, so hooks like
+/// `check-added-large-files` and `check-case-conflict` (which compare against
+/// `root`-relative filenames) match in nested projects. Uses `--types` rather than
+/// `DIFF_TEMPLATE` because its output is cwd-relative; renames are `FF`, so the
+/// `before == '-'` filter naturally excludes them (no compacted paths leak through).
 #[instrument(level = "trace")]
 pub(crate) async fn get_added_files(root: &Path) -> Result<Vec<PathBuf>, Error> {
     let output = jj_cmd()?
@@ -234,6 +272,9 @@ pub(crate) async fn get_added_files(root: &Path) -> Result<Vec<PathBuf>, Error> 
         .arg("-r")
         .arg("@")
         .arg("--types")
+        // Scope to the `root` subtree so out-of-project files are excluded, matching
+        // git's `--relative`.
+        .arg(literal_fileset(Path::new(".")))
         .check(true)
         .output()
         .await?;
@@ -276,7 +317,8 @@ pub(crate) async fn get_changed_files_between(
         .arg(&from)
         .arg("--to")
         .arg(new)
-        .arg("--types");
+        .arg("-T")
+        .arg(DIFF_TEMPLATE);
     if let Some(scope_path) = scope {
         cmd.arg(scope_fileset(root, scope_path));
     }
@@ -285,10 +327,10 @@ pub(crate) async fn get_changed_files_between(
 }
 
 fn changed_paths(output: &[u8]) -> Vec<PathBuf> {
-    parse_typed_changes(output)
+    parse_diff_entries(output)
         .into_iter()
-        .filter(|change| change.after != b'-')
-        .map(|change| change.path)
+        .filter(|entry| entry.status != b'D') // exclude deletions, like git's --diff-filter
+        .map(|entry| entry.path)
         .collect()
 }
 
@@ -463,23 +505,39 @@ mod tests {
     }
 
     #[test]
-    fn parse_typed_changes_reads_status_and_path() {
-        let changes = parse_typed_changes(b"-F added.txt\nFF modified.txt\nF- deleted.txt\n");
-        assert_eq!(changes.len(), 3);
-        assert_eq!(changes[0].before, b'-');
-        assert_eq!(changes[0].after, b'F');
-        assert_eq!(changes[0].path, PathBuf::from("added.txt"));
-        assert_eq!(changes[2].before, b'F');
-        assert_eq!(changes[2].after, b'-');
+    fn parse_diff_entries_reads_status_and_path() {
+        // Renames render as the real target path (not the `{a => b}` compaction).
+        let entries =
+            parse_diff_entries(b"A added.txt\nM modified.txt\nD deleted.txt\nR dir/renamed.txt\n");
+        assert_eq!(entries.len(), 4);
+        assert_eq!(entries[0].status, b'A');
+        assert_eq!(entries[0].path, PathBuf::from("added.txt"));
+        assert_eq!(entries[3].status, b'R');
+        assert_eq!(entries[3].path, PathBuf::from("dir/renamed.txt"));
     }
 
     #[test]
-    fn changed_paths_excludes_deletions() {
-        let paths = changed_paths(b"-F added.txt\nFF modified.txt\nF- deleted.txt\n");
+    fn changed_paths_excludes_deletions_and_keeps_renames() {
+        let paths =
+            changed_paths(b"A added.txt\nM modified.txt\nD deleted.txt\nR dir/renamed.txt\n");
         assert_eq!(
             paths,
-            vec![PathBuf::from("added.txt"), PathBuf::from("modified.txt")]
+            vec![
+                PathBuf::from("added.txt"),
+                PathBuf::from("modified.txt"),
+                PathBuf::from("dir/renamed.txt"),
+            ]
         );
+    }
+
+    #[test]
+    fn parse_typed_changes_reads_kinds() {
+        // `--types` powers added-file detection (`before == '-'`).
+        let changes = parse_typed_changes(b"-F added.txt\nFF modified.txt\nF- deleted.txt\n");
+        assert_eq!(changes.len(), 3);
+        assert_eq!((changes[0].before, changes[0].after), (b'-', b'F'));
+        assert_eq!(changes[0].path, PathBuf::from("added.txt"));
+        assert_eq!((changes[2].before, changes[2].after), (b'F', b'-'));
     }
 
     #[test]

--- a/crates/prek/src/jj.rs
+++ b/crates/prek/src/jj.rs
@@ -64,19 +64,26 @@ pub(crate) fn resolve_backing_git_dir(workspace_root: &Path) -> Result<Option<Pa
     };
 
     let git_target_file = repo_dir.join("store").join("git_target");
-    if !git_target_file.try_exists()? {
-        // No `git_target` means this is not a Git-backed jj repo (e.g. the native
-        // backend), which prek cannot drive. Treat it as "no backing Git dir".
-        return Ok(None);
-    }
-    let git_target = fs_err::read_to_string(&git_target_file)?;
-    let git_target = git_target.trim();
+    let git_dir = if git_target_file.try_exists()? {
+        let git_target = fs_err::read_to_string(&git_target_file)?;
+        let git_target = git_target.trim();
 
-    let git_path = PathBuf::from(git_target);
-    let git_dir = if git_path.is_absolute() {
-        git_path
+        let git_path = PathBuf::from(git_target);
+        if git_path.is_absolute() {
+            git_path
+        } else {
+            repo_dir.join("store").join(git_path)
+        }
     } else {
-        repo_dir.join("store").join(git_path)
+        // Fall back to `.jj/repo/store/git` for `jj git init --no-colocate` repositories.
+        let store_git = repo_dir.join("store").join("git");
+        if store_git.is_dir() {
+            store_git
+        } else {
+            // Not a Git-backed jj repo (e.g. the native backend), which prek cannot drive.
+            // Treat it as "no backing Git dir".
+            return Ok(None);
+        }
     };
 
     // Check existence before canonicalizing: `canonicalize()` errors on a missing
@@ -104,6 +111,10 @@ fn relative_to_cwd<'a>(cwd: &'a Path, path: &'a Path) -> &'a Path {
         .unwrap_or(path)
 }
 
+/// Template that makes `jj file list` print one path per line regardless of the
+/// user's `templates.file_list` configuration.
+const FILE_LIST_TEMPLATE: &str = r#"path ++ "\n""#;
+
 fn parse_path_lines(output: &[u8]) -> Vec<PathBuf> {
     String::from_utf8_lossy(output)
         .lines()
@@ -121,6 +132,11 @@ fn literal_fileset(path: &Path) -> String {
     // with backslash escaping (matching Rust's debug formatting).
     let path = path.to_string_lossy().replace('\\', "/");
     format!("cwd:{path:?}")
+}
+
+/// Build a literal fileset that scopes a query to `path`, expressed relative to `cwd`.
+fn scope_fileset(cwd: &Path, path: &Path) -> String {
+    literal_fileset(relative_to_cwd(cwd, path))
 }
 
 /// A single entry from `jj diff --types`: the file's kind before and after the
@@ -168,15 +184,15 @@ where
     P: AsRef<Path>,
 {
     let mut cmd = jj_cmd()?;
-    cmd.current_dir(cwd).arg("file").arg("list");
+    cmd.current_dir(cwd)
+        .arg("file")
+        .arg("list")
+        // Pin the output format: `jj file list`'s default template is user-overridable
+        // via `templates.file_list`, which would otherwise break path parsing.
+        .arg("-T")
+        .arg(FILE_LIST_TEMPLATE);
     for path in paths {
-        let relative = relative_to_cwd(cwd, path.as_ref());
-        let relative = if relative.as_os_str().is_empty() {
-            Path::new(".")
-        } else {
-            relative
-        };
-        cmd.arg(literal_fileset(relative));
+        cmd.arg(scope_fileset(cwd, path.as_ref()));
     }
 
     let output = cmd.check(true).output().await?;
@@ -188,16 +204,20 @@ where
 /// Deletions are dropped to match the Git backend, whose `--diff-filter` never
 /// reports deleted paths (running hooks on nonexistent files is pointless).
 #[instrument(level = "trace")]
-pub(crate) async fn get_changed_files(root: &Path) -> Result<Vec<PathBuf>, Error> {
-    let output = jj_cmd()?
-        .current_dir(root)
+pub(crate) async fn get_changed_files(
+    root: &Path,
+    scope: Option<&Path>,
+) -> Result<Vec<PathBuf>, Error> {
+    let mut cmd = jj_cmd()?;
+    cmd.current_dir(root)
         .arg("diff")
         .arg("-r")
         .arg("@")
-        .arg("--types")
-        .check(true)
-        .output()
-        .await?;
+        .arg("--types");
+    if let Some(scope_path) = scope {
+        cmd.arg(scope_fileset(root, scope_path));
+    }
+    let output = cmd.check(true).output().await?;
     Ok(changed_paths(&output.stdout))
 }
 
@@ -225,23 +245,42 @@ pub(crate) async fn get_added_files(root: &Path) -> Result<Vec<PathBuf>, Error> 
 }
 
 /// Get the list of changed files between two Jujutsu revisions (excluding deletions).
+///
+/// This mirrors the Git backend's `old...new` (merge-base) semantics, which is what
+/// `--from-ref`/`--to-ref` document: diff from the fork point of the two revisions to
+/// `new`, so edits made only on `old` since it diverged are not included.
 #[instrument(level = "trace")]
 pub(crate) async fn get_changed_files_between(
     old: &str,
     new: &str,
     root: &Path,
+    scope: Option<&Path>,
 ) -> Result<Vec<PathBuf>, Error> {
-    let output = jj_cmd()?
-        .current_dir(root)
+    // Map git's "HEAD" to jj's "@" for the working-copy commit.
+    let old = match old {
+        "HEAD" => "@",
+        "HEAD~1" => "@-",
+        _ => old,
+    };
+    let new = match new {
+        "HEAD" => "@",
+        "HEAD~1" => "@-",
+        _ => new,
+    };
+
+    let from = format!("fork_point(({old}) | ({new}))");
+    let mut cmd = jj_cmd()?;
+    cmd.current_dir(root)
         .arg("diff")
         .arg("--from")
-        .arg(old)
+        .arg(&from)
         .arg("--to")
         .arg(new)
-        .arg("--types")
-        .check(true)
-        .output()
-        .await?;
+        .arg("--types");
+    if let Some(scope_path) = scope {
+        cmd.arg(scope_fileset(root, scope_path));
+    }
+    let output = cmd.check(true).output().await?;
     Ok(changed_paths(&output.stdout))
 }
 
@@ -256,8 +295,8 @@ fn changed_paths(output: &[u8]) -> Vec<PathBuf> {
 /// Get files with unresolved conflicts in the current Jujutsu working copy.
 ///
 /// Uses `jj resolve --list`, which is the authoritative list of unresolved
-/// conflicts. It exits non-zero when there are none, so failures are treated as
-/// "no conflicts".
+/// conflicts. It exits with code 2 and a specific stderr message when there
+/// are none, which we handle; other errors are propagated.
 #[instrument(level = "trace")]
 pub(crate) async fn get_conflicted_files(root: &Path) -> Result<Vec<PathBuf>, Error> {
     let output = jj_cmd()?
@@ -269,24 +308,45 @@ pub(crate) async fn get_conflicted_files(root: &Path) -> Result<Vec<PathBuf>, Er
         .await?;
 
     if !output.status.success() {
-        return Ok(Vec::new());
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // jj resolve --list returns exit code 2 and "No conflicts found" on success-no-conflicts.
+        if output.status.code() == Some(2) && stderr.contains("No conflicts found") {
+            return Ok(Vec::new());
+        }
+        return Err(process::Error::Status {
+            command: "jj resolve --list".to_string(),
+            error: process::StatusError {
+                status: output.status,
+                output: Some(output),
+            },
+        }
+        .into());
     }
 
-    // Each line is `<path><padding><N>-sided conflict`. Paths do not contain runs
-    // of two or more spaces, so split on the first such run.
-    let files = String::from_utf8_lossy(&output.stdout)
+    Ok(parse_conflict_list(&output.stdout))
+}
+
+/// Parse `jj resolve --list` output into conflicted paths.
+///
+/// Each line is `<path><padding><N>-sided conflict`, where `<padding>` is a run of
+/// two or more spaces. Split on the LAST such run so a path that itself contains
+/// spaces (even consecutive ones) is preserved.
+fn parse_conflict_list(output: &[u8]) -> Vec<PathBuf> {
+    String::from_utf8_lossy(output)
         .lines()
         .filter_map(|line| {
-            let path = line.split("  ").next()?.trim();
+            let line = line.trim_end();
+            let path = line
+                .rsplit_once("  ")
+                .map_or(line, |(path, _)| path)
+                .trim_end();
             if path.is_empty() {
                 None
             } else {
                 Some(PathBuf::from(path))
             }
         })
-        .collect();
-
-    Ok(files)
+        .collect()
 }
 
 #[cfg(test)]
@@ -337,7 +397,7 @@ mod tests {
         fs_err::create_dir(&git_dir).unwrap();
 
         let resolved = resolve_backing_git_dir(root).unwrap();
-        assert_eq!(resolved, Some(git_dir.canonicalize().unwrap()));
+        assert_eq!(resolved, Some(dunce::canonicalize(&git_dir).unwrap()));
     }
 
     #[test]
@@ -354,7 +414,7 @@ mod tests {
 
         let secondary_jj = secondary_root.join(".jj");
         fs_err::create_dir_all(&secondary_jj).unwrap();
-        let main_repo_abs = main_root.join(".jj").join("repo").canonicalize().unwrap();
+        let main_repo_abs = dunce::canonicalize(main_root.join(".jj").join("repo")).unwrap();
         fs_err::write(
             secondary_jj.join("repo"),
             main_repo_abs.to_string_lossy().as_ref(),
@@ -362,7 +422,7 @@ mod tests {
         .unwrap();
 
         let resolved = resolve_backing_git_dir(&secondary_root).unwrap();
-        assert_eq!(resolved, Some(main_git.canonicalize().unwrap()));
+        assert_eq!(resolved, Some(dunce::canonicalize(&main_git).unwrap()));
     }
 
     #[test]
@@ -419,6 +479,21 @@ mod tests {
         assert_eq!(
             paths,
             vec![PathBuf::from("added.txt"), PathBuf::from("modified.txt")]
+        );
+    }
+
+    #[test]
+    fn parse_conflict_list_extracts_paths_with_spaces() {
+        // `jj resolve --list` pads the path with 2+ spaces before the description.
+        let out = b"src/a.txt    2-sided conflict\nwith space.txt    2-sided conflict\ntwo  spaces.txt    3-sided conflict\n";
+        let paths = parse_conflict_list(out);
+        assert_eq!(
+            paths,
+            vec![
+                PathBuf::from("src/a.txt"),
+                PathBuf::from("with space.txt"),
+                PathBuf::from("two  spaces.txt"),
+            ]
         );
     }
 }

--- a/crates/prek/src/main.rs
+++ b/crates/prek/src/main.rs
@@ -40,11 +40,13 @@ mod hook_entry;
 mod hooks;
 mod http;
 mod install_source;
+mod jj;
 mod languages;
 mod printer;
 mod process;
 #[cfg(all(unix, feature = "profiler"))]
 mod profiler;
+mod repo;
 #[cfg(unix)]
 mod resource_limit;
 mod run;

--- a/crates/prek/src/repo.rs
+++ b/crates/prek/src/repo.rs
@@ -1,0 +1,241 @@
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+use anyhow::{Context, Result};
+use prek_consts::env_vars::EnvVars;
+use tracing::debug;
+
+use crate::git;
+use crate::jj;
+use crate::process::Cmd;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RepoKind {
+    Git,
+    Jujutsu,
+}
+
+#[derive(Debug)]
+pub(crate) struct RepoContext {
+    kind: RepoKind,
+    root: PathBuf,
+    backing_git_dir: Option<PathBuf>,
+}
+
+impl RepoContext {
+    /// Detect the repository model for the current working directory once at startup.
+    ///
+    /// The intent here is to give the rest of the codebase a single answer to
+    /// "what kind of repo am I in?" after `--cd` and other cwd changes have already
+    /// taken effect. Jujutsu is checked first because a Jujutsu workspace may not be
+    /// discoverable via plain Git root detection from the current directory.
+    fn detect_current() -> Result<Self> {
+        let cwd = std::env::current_dir().context("Failed to get current directory")?;
+        if let Some(root) = jj::find_workspace_root(&cwd) {
+            let git_dir = jj::resolve_backing_git_dir(&root)
+                .context("Failed to resolve backing Git directory for Jujutsu workspace")?
+                .context(
+                    "Detected a Jujutsu workspace, but could not resolve its backing Git directory",
+                )?;
+            let root = canonicalize_root(root);
+            debug!(
+                root = %root.display(),
+                git_dir = %git_dir.display(),
+                "Detected Jujutsu workspace",
+            );
+            return Ok(Self {
+                kind: RepoKind::Jujutsu,
+                root,
+                backing_git_dir: Some(git_dir),
+            });
+        }
+
+        let root = git::get_root()
+            .map_err(|err| anyhow::anyhow!("Not inside a Git or Jujutsu repository: {err}"))?;
+        let root = canonicalize_root(root);
+        debug!(root = %root.display(), "Detected Git repository");
+
+        Ok(Self {
+            kind: RepoKind::Git,
+            root,
+            backing_git_dir: None,
+        })
+    }
+
+    pub(crate) fn kind(&self) -> RepoKind {
+        self.kind
+    }
+
+    pub(crate) fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Apply per-command Git environment needed to talk to the backing Git repo.
+    ///
+    /// This is intentionally scoped to the specific command being built. We do not
+    /// mutate process-wide `GIT_DIR` / `GIT_WORK_TREE`, because that would make
+    /// Jujutsu support an ambient global side effect rather than an explicit repo
+    /// backend behavior.
+    fn apply_git_env(&self, cmd: &mut Cmd) {
+        if let Some(git_dir) = &self.backing_git_dir {
+            cmd.env(EnvVars::GIT_DIR, git_dir);
+            cmd.env(EnvVars::GIT_WORK_TREE, &self.root);
+        }
+    }
+}
+
+/// Canonicalize the workspace root so `GIT_ROOT` and `repo::root()` agree on a single
+/// path spelling (this mirrors the historic `GIT_ROOT` behavior). Falls back to the
+/// original path if canonicalization fails.
+fn canonicalize_root(root: PathBuf) -> PathBuf {
+    dunce::canonicalize(&root).unwrap_or(root)
+}
+
+pub(crate) static REPO_CONTEXT: LazyLock<Result<RepoContext>> =
+    LazyLock::new(RepoContext::detect_current);
+
+/// Access the cached repository context with a normal `Result` API.
+///
+/// `LazyLock<Result<_>>` is convenient for one-time detection, but most callers
+/// want error propagation instead of reasoning about the lazy container directly.
+fn current() -> Result<&'static RepoContext> {
+    match REPO_CONTEXT.as_ref() {
+        Ok(repo) => Ok(repo),
+        Err(err) => Err(anyhow::anyhow!("{err:#}")),
+    }
+}
+
+/// Apply repository-specific Git environment to a single command if needed.
+///
+/// For plain Git repositories this is a no-op. For Jujutsu workspaces this points
+/// Git commands at the backing Git store so the rest of prek can keep using a
+/// small number of Git-backed primitives without leaking that setup everywhere.
+pub(crate) fn apply_git_env(cmd: &mut Cmd) {
+    if let Ok(repo) = REPO_CONTEXT.as_ref() {
+        repo.apply_git_env(cmd);
+    }
+}
+
+/// Return the repository root that prek should treat as the workspace boundary.
+///
+/// This is the Jujutsu workspace root for Jujutsu repos and the Git root for
+/// plain Git repos. Callers should prefer this instead of reaching into Git/JJ
+/// discovery directly.
+pub(crate) fn root() -> Result<&'static Path> {
+    Ok(current()?.root())
+}
+
+/// Whether `prek run` should preserve Git's stash/clean-worktree behavior by default.
+///
+/// Git's default mode is index-driven, so stashing protects unstaged changes from
+/// bleeding into hook execution. Jujutsu's default mode is working-copy based, so
+/// that Git-specific hygiene step does not apply.
+pub(crate) fn should_stash_by_default_run() -> bool {
+    current()
+        .map(|repo| repo.kind() == RepoKind::Git)
+        .unwrap_or(true)
+}
+
+/// Whether config files must be staged before they are considered authoritative.
+///
+/// This is a Git-specific rule because prek historically reads config from the
+/// staged snapshot. Jujutsu has no staging area, so enforcing that rule there
+/// would be both confusing and wrong.
+pub(crate) fn requires_staged_configs() -> bool {
+    current()
+        .map(|repo| repo.kind() == RepoKind::Git)
+        .unwrap_or(true)
+}
+
+/// Return files that should be treated as newly introduced for hook logic.
+///
+/// In Git this maps to added files in the index. In Jujutsu there is no staging
+/// area, so the closest useful intent is "files changed in the current working
+/// copy changeset".
+pub(crate) async fn added_files(workspace_root: &Path) -> Result<Vec<PathBuf>> {
+    match current()?.kind() {
+        RepoKind::Git => git::get_added_files(workspace_root)
+            .await
+            .map_err(Into::into),
+        RepoKind::Jujutsu => jj::get_changed_files(workspace_root)
+            .await
+            .map_err(Into::into),
+    }
+}
+
+/// Return the default file set for `prek run` when the user did not specify one.
+///
+/// The goal is to preserve each VCS's natural workflow:
+/// Git uses staged files, while Jujutsu uses the current working-copy changeset.
+pub(crate) async fn default_files(workspace_root: &Path) -> Result<Vec<PathBuf>> {
+    match current()?.kind() {
+        RepoKind::Git => git::get_staged_files(workspace_root)
+            .await
+            .map_err(Into::into),
+        RepoKind::Jujutsu => jj::get_changed_files(workspace_root)
+            .await
+            .map_err(Into::into),
+    }
+}
+
+/// Return files changed between two user-supplied revisions.
+///
+/// The caller does not need to care whether those revision strings are Git refs or
+/// Jujutsu revsets/bookmarks; each backend interprets them using its own native
+/// revision syntax.
+pub(crate) async fn changed_files_between(
+    old: &str,
+    new: &str,
+    workspace_root: &Path,
+) -> Result<Vec<PathBuf>> {
+    match current()?.kind() {
+        RepoKind::Git => git::get_changed_files(old, new, workspace_root)
+            .await
+            .map_err(Into::into),
+        RepoKind::Jujutsu => jj::get_changed_files_between(old, new, workspace_root)
+            .await
+            .map_err(Into::into),
+    }
+}
+
+/// List tracked files under the given pathspecs using the active repository backend.
+///
+/// This keeps callers focused on "which files belong to the repo here?" rather
+/// than the mechanics of `git ls-files` versus the Jujutsu equivalent.
+pub(crate) async fn ls_files<P>(
+    cwd: &Path,
+    paths: impl IntoIterator<Item = P>,
+) -> Result<Vec<PathBuf>>
+where
+    P: AsRef<Path>,
+{
+    match current()?.kind() {
+        RepoKind::Git => git::ls_files(cwd, paths).await.map_err(Into::into),
+        RepoKind::Jujutsu => jj::ls_files(cwd, paths).await.map_err(Into::into),
+    }
+}
+
+/// Return conflicted files if the current repo backend reports a conflict state.
+///
+/// Git exposes a repo-wide merge-conflict mode, while Jujutsu exposes conflicted
+/// paths in the working copy. This helper normalizes both into "Some(files)" or
+/// `None` so higher-level run logic can stay backend-agnostic.
+pub(crate) async fn conflicted_files(workspace_root: &Path) -> Result<Option<Vec<PathBuf>>> {
+    match current()?.kind() {
+        RepoKind::Git => {
+            if git::is_in_merge_conflict().await? {
+                Ok(Some(git::get_conflicted_files(workspace_root).await?))
+            } else {
+                Ok(None)
+            }
+        }
+        RepoKind::Jujutsu => {
+            let files = jj::get_conflicted_files(workspace_root).await?;
+            if files.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(files))
+            }
+        }
+    }
+}

--- a/crates/prek/src/repo.rs
+++ b/crates/prek/src/repo.rs
@@ -23,36 +23,68 @@ pub(crate) struct RepoContext {
 }
 
 impl RepoContext {
-    /// Detect the repository model for the current working directory once at startup.
+    /// Detect the repository model for the current working directory, once at startup.
     ///
-    /// The intent here is to give the rest of the codebase a single answer to
-    /// "what kind of repo am I in?" after `--cd` and other cwd changes have already
-    /// taken effect. Jujutsu is checked first because a Jujutsu workspace may not be
-    /// discoverable via plain Git root detection from the current directory.
+    /// Resolves both a `.jj` workspace root and a `.git` root and picks the nearest
+    /// (deepest): a Git repo nested inside a jj workspace is treated as Git; equal
+    /// roots are a colocated jj repo, so Jujutsu wins.
     fn detect_current() -> Result<Self> {
         let cwd = std::env::current_dir().context("Failed to get current directory")?;
-        if let Some(root) = jj::find_workspace_root(&cwd) {
-            let git_dir = jj::resolve_backing_git_dir(&root)
+
+        let jj_root = jj::find_workspace_root(&cwd).map(canonicalize_root);
+        let git_root_result = git::get_root();
+        let git_root = git_root_result
+            .as_ref()
+            .ok()
+            .map(|root| canonicalize_root(root.clone()));
+
+        // Prefer jj unless the Git root is strictly deeper than the jj workspace root
+        // (a nested Git repo inside a jj workspace).
+        let prefer_jj = match (&jj_root, &git_root) {
+            (Some(jj), Some(git)) => {
+                let git_is_strictly_deeper = git.starts_with(jj) && git != jj;
+                !git_is_strictly_deeper
+            }
+            (Some(_), None) => true,
+            (None, _) => false,
+        };
+
+        if let Some(root) = jj_root.filter(|_| prefer_jj) {
+            match jj::resolve_backing_git_dir(&root)
                 .context("Failed to resolve backing Git directory for Jujutsu workspace")?
-                .context(
-                    "Detected a Jujutsu workspace, but could not resolve its backing Git directory",
-                )?;
-            let root = canonicalize_root(root);
-            debug!(
-                root = %root.display(),
-                git_dir = %git_dir.display(),
-                "Detected Jujutsu workspace",
-            );
-            return Ok(Self {
-                kind: RepoKind::Jujutsu,
-                root,
-                backing_git_dir: Some(git_dir),
-            });
+            {
+                Some(git_dir) => {
+                    debug!(
+                        root = %root.display(),
+                        git_dir = %git_dir.display(),
+                        "Detected Jujutsu workspace",
+                    );
+                    return Ok(Self {
+                        kind: RepoKind::Jujutsu,
+                        root,
+                        backing_git_dir: Some(git_dir),
+                    });
+                }
+                // jj metadata exists but has no usable backing Git store (native backend
+                // or a broken `.jj`). Fall back to the Git backend when a Git root was
+                // found, so an otherwise-valid Git checkout keeps working.
+                None if git_root.is_none() => {
+                    return Err(anyhow::anyhow!(
+                        "Detected a Jujutsu workspace, but could not resolve its backing Git directory"
+                    ));
+                }
+                None => {
+                    debug!("Jujutsu metadata is unusable; falling back to the Git backend");
+                }
+            }
         }
 
-        let root = git::get_root()
-            .map_err(|err| anyhow::anyhow!("Not inside a Git or Jujutsu repository: {err}"))?;
-        let root = canonicalize_root(root);
+        let Some(root) = git_root else {
+            let err = git_root_result.expect_err("git_root is None only when detection failed");
+            return Err(anyhow::anyhow!(
+                "Not inside a Git or Jujutsu repository: {err}"
+            ));
+        };
         debug!(root = %root.display(), "Detected Git repository");
 
         Ok(Self {
@@ -147,11 +179,8 @@ pub(crate) fn requires_staged_configs() -> bool {
         .unwrap_or(true)
 }
 
-/// Return files that should be treated as newly introduced for hook logic.
-///
-/// In Git this maps to added files in the index. In Jujutsu there is no staging
-/// area, so the closest useful intent is "files changed in the current working
-/// copy changeset".
+/// Files to treat as newly introduced: added-in-index for Git, absent-in-parent
+/// for Jujutsu (which has no staging area).
 pub(crate) async fn added_files(workspace_root: &Path) -> Result<Vec<PathBuf>> {
     // Both backends report paths relative to `workspace_root` here (git via
     // `--relative`, jj by running in that directory), matching the project-relative
@@ -166,19 +195,19 @@ pub(crate) async fn added_files(workspace_root: &Path) -> Result<Vec<PathBuf>> {
     }
 }
 
-/// Return the default file set for `prek run` when the user did not specify one.
-///
-/// The goal is to preserve each VCS's natural workflow:
-/// Git uses staged files, while Jujutsu uses the current working-copy changeset.
+/// Default file set for `prek run`: staged files for Git, the working-copy
+/// changeset for Jujutsu.
 pub(crate) async fn default_files(workspace_root: &Path) -> Result<Vec<PathBuf>> {
     let repo = current()?;
     match repo.kind() {
-        RepoKind::Git => git::get_staged_files(workspace_root)
+        RepoKind::Git => git::get_staged_files(workspace_root, false)
             .await
             .map_err(Into::into),
-        // Run jj from the workspace root so paths are root-relative, matching git's
+        // Run jj from the repository root (`repo.root()`) so paths are repo-relative, matching git's
         // output; `collect_run_input` then strips the project prefix.
-        RepoKind::Jujutsu => jj::get_changed_files(repo.root()).await.map_err(Into::into),
+        RepoKind::Jujutsu => jj::get_changed_files(repo.root(), Some(workspace_root))
+            .await
+            .map_err(Into::into),
     }
 }
 
@@ -197,16 +226,15 @@ pub(crate) async fn changed_files_between(
         RepoKind::Git => git::get_changed_files(old, new, workspace_root)
             .await
             .map_err(Into::into),
-        RepoKind::Jujutsu => jj::get_changed_files_between(old, new, repo.root())
-            .await
-            .map_err(Into::into),
+        RepoKind::Jujutsu => {
+            jj::get_changed_files_between(old, new, repo.root(), Some(workspace_root))
+                .await
+                .map_err(Into::into)
+        }
     }
 }
 
-/// List tracked files under the given pathspecs using the active repository backend.
-///
-/// This keeps callers focused on "which files belong to the repo here?" rather
-/// than the mechanics of `git ls-files` versus the Jujutsu equivalent.
+/// List tracked files under `paths` using the active repository backend.
 pub(crate) async fn ls_files<P>(
     cwd: &Path,
     paths: impl IntoIterator<Item = P>,
@@ -220,11 +248,8 @@ where
     }
 }
 
-/// Return conflicted files if the current repo backend reports a conflict state.
-///
-/// Git exposes a repo-wide merge-conflict mode, while Jujutsu exposes conflicted
-/// paths in the working copy. This helper normalizes both into "Some(files)" or
-/// `None` so higher-level run logic can stay backend-agnostic.
+/// Conflicted files for the active backend, or `None` when not in a conflict state.
+/// Git uses its repo-wide merge-conflict mode; Jujutsu uses working-copy conflicts.
 pub(crate) async fn conflicted_files(workspace_root: &Path) -> Result<Option<Vec<PathBuf>>> {
     let repo = current()?;
     match repo.kind() {

--- a/crates/prek/src/repo.rs
+++ b/crates/prek/src/repo.rs
@@ -153,11 +153,14 @@ pub(crate) fn requires_staged_configs() -> bool {
 /// area, so the closest useful intent is "files changed in the current working
 /// copy changeset".
 pub(crate) async fn added_files(workspace_root: &Path) -> Result<Vec<PathBuf>> {
+    // Both backends report paths relative to `workspace_root` here (git via
+    // `--relative`, jj by running in that directory), matching the project-relative
+    // filenames hooks expect.
     match current()?.kind() {
         RepoKind::Git => git::get_added_files(workspace_root)
             .await
             .map_err(Into::into),
-        RepoKind::Jujutsu => jj::get_changed_files(workspace_root)
+        RepoKind::Jujutsu => jj::get_added_files(workspace_root)
             .await
             .map_err(Into::into),
     }
@@ -168,13 +171,14 @@ pub(crate) async fn added_files(workspace_root: &Path) -> Result<Vec<PathBuf>> {
 /// The goal is to preserve each VCS's natural workflow:
 /// Git uses staged files, while Jujutsu uses the current working-copy changeset.
 pub(crate) async fn default_files(workspace_root: &Path) -> Result<Vec<PathBuf>> {
-    match current()?.kind() {
+    let repo = current()?;
+    match repo.kind() {
         RepoKind::Git => git::get_staged_files(workspace_root)
             .await
             .map_err(Into::into),
-        RepoKind::Jujutsu => jj::get_changed_files(workspace_root)
-            .await
-            .map_err(Into::into),
+        // Run jj from the workspace root so paths are root-relative, matching git's
+        // output; `collect_run_input` then strips the project prefix.
+        RepoKind::Jujutsu => jj::get_changed_files(repo.root()).await.map_err(Into::into),
     }
 }
 
@@ -188,11 +192,12 @@ pub(crate) async fn changed_files_between(
     new: &str,
     workspace_root: &Path,
 ) -> Result<Vec<PathBuf>> {
-    match current()?.kind() {
+    let repo = current()?;
+    match repo.kind() {
         RepoKind::Git => git::get_changed_files(old, new, workspace_root)
             .await
             .map_err(Into::into),
-        RepoKind::Jujutsu => jj::get_changed_files_between(old, new, workspace_root)
+        RepoKind::Jujutsu => jj::get_changed_files_between(old, new, repo.root())
             .await
             .map_err(Into::into),
     }
@@ -221,7 +226,8 @@ where
 /// paths in the working copy. This helper normalizes both into "Some(files)" or
 /// `None` so higher-level run logic can stay backend-agnostic.
 pub(crate) async fn conflicted_files(workspace_root: &Path) -> Result<Option<Vec<PathBuf>>> {
-    match current()?.kind() {
+    let repo = current()?;
+    match repo.kind() {
         RepoKind::Git => {
             if git::is_in_merge_conflict().await? {
                 Ok(Some(git::get_conflicted_files(workspace_root).await?))
@@ -230,7 +236,7 @@ pub(crate) async fn conflicted_files(workspace_root: &Path) -> Result<Option<Vec
             }
         }
         RepoKind::Jujutsu => {
-            let files = jj::get_conflicted_files(workspace_root).await?;
+            let files = jj::get_conflicted_files(repo.root()).await?;
             if files.is_empty() {
                 Ok(None)
             } else {

--- a/crates/prek/src/repo.rs
+++ b/crates/prek/src/repo.rs
@@ -157,6 +157,13 @@ pub(crate) fn root() -> Result<&'static Path> {
     Ok(current()?.root())
 }
 
+/// Whether the active repository backend is Jujutsu.
+pub(crate) fn is_jujutsu() -> bool {
+    current()
+        .map(|repo| repo.kind() == RepoKind::Jujutsu)
+        .unwrap_or(false)
+}
+
 /// Whether `prek run` should preserve Git's stash/clean-worktree behavior by default.
 ///
 /// Git's default mode is index-driven, so stashing protects unstaged changes from

--- a/crates/prek/src/workspace.rs
+++ b/crates/prek/src/workspace.rs
@@ -22,7 +22,7 @@ use crate::git::GIT_ROOT;
 use crate::hook::HookSpec;
 use crate::hook::{self, Hook, HookBuilder, Repo};
 use crate::store::{CacheBucket, Store};
-use crate::{git, store, warn_user};
+use crate::{git, repo, store, warn_user};
 
 #[derive(Error, Debug)]
 pub(crate) enum Error {
@@ -1028,8 +1028,15 @@ impl Workspace {
         Ok(hooks)
     }
 
-    /// Check if all configuration files are staged in git.
+    /// Check that all configuration files are staged.
+    ///
+    /// This only applies to backends with a staging area (Git). Jujutsu has no
+    /// index, so the check is skipped there.
     pub(crate) async fn check_configs_staged(&self) -> Result<()> {
+        if !repo::requires_staged_configs() {
+            return Ok(());
+        }
+
         let config_files = self
             .projects
             .iter()

--- a/crates/prek/tests/builtin_hooks.rs
+++ b/crates/prek/tests/builtin_hooks.rs
@@ -3257,6 +3257,55 @@ fn check_case_conflict_in_non_colocated_jujutsu_workspace() -> Result<()> {
     Ok(())
 }
 
+/// In a jj workspace, `check-added-large-files` must only flag newly added files,
+/// not pre-existing ones that were merely modified (jj has no staging area, so
+/// "added" is derived from the working-copy changeset).
+#[test]
+fn check_added_large_files_ignores_modified_in_jj_workspace() -> Result<()> {
+    let Some(mut init) = jj_cmd(".") else {
+        return Ok(());
+    };
+    let context = TestContext::new();
+
+    init.current_dir(context.work_dir())
+        .args(["git", "init", "--colocate"])
+        .assert()
+        .success();
+
+    let cwd = context.work_dir();
+    // Commit a large file as a pre-existing baseline.
+    cwd.child("large_file.txt").write_binary(&[0; 2048])?; // 2 KB
+    jj_cmd(cwd.path())
+        .unwrap()
+        .args(["commit", "-m", "baseline"])
+        .assert()
+        .success();
+
+    context.write_pre_commit_config(indoc::indoc! {r"
+        repos:
+          - repo: builtin
+            hooks:
+              - id: check-added-large-files
+                args: ['--maxkb', '1']
+    "});
+
+    // Modify the pre-existing large file (still over the limit) and add a small file.
+    cwd.child("large_file.txt").write_binary(&[1; 2048])?;
+    cwd.child("small.txt").write_str("hello\n")?;
+
+    // large_file.txt is modified, not added, so it must not be flagged.
+    cmd_snapshot!(context.filters(), context.run(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    check for added large files..............................................Passed
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
 #[test]
 fn check_case_conflict_among_new_files() -> Result<()> {
     let context = TestContext::new();

--- a/crates/prek/tests/builtin_hooks.rs
+++ b/crates/prek/tests/builtin_hooks.rs
@@ -2510,6 +2510,41 @@ fn no_commit_to_branch_hook() -> Result<()> {
     Ok(())
 }
 
+/// `no-commit-to-branch` is skipped in a jj workspace: jj has no "current branch"
+/// mapping to Git's HEAD, and the backing store's unborn HEAD would otherwise make
+/// the hook block every run. Regression test for that false positive.
+#[test]
+fn no_commit_to_branch_skipped_in_jj_workspace() -> Result<()> {
+    let Some(mut init) = jj_cmd(".") else {
+        return Ok(());
+    };
+    let context = TestContext::new();
+
+    init.current_dir(context.work_dir())
+        .args(["git", "init", "--colocate"])
+        .assert()
+        .success();
+
+    context.write_pre_commit_config(indoc::indoc! {r"
+        repos:
+          - repo: builtin
+            hooks:
+              - id: no-commit-to-branch
+    "});
+    context.work_dir().child("test.txt").write_str("hello")?;
+
+    cmd_snapshot!(context.filters(), context.run(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    don't commit to branch...................................................Passed
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
 #[test]
 fn no_commit_to_branch_hook_with_custom_branches() -> Result<()> {
     let context = TestContext::new();
@@ -3290,6 +3325,52 @@ fn check_added_large_files_ignores_modified_in_jj_workspace() -> Result<()> {
     exit_code: 0
     ----- stdout -----
     check for added large files..............................................Passed
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+/// In a nested jj project (config in a subdirectory), added files must be reported
+/// relative to the project directory so `check-added-large-files` matches them. The
+/// jj diff template's paths are repo-root-relative, so `added_files` uses `--types`
+/// (cwd-relative) instead; this guards against that regressing.
+#[test]
+fn check_added_large_files_in_nested_jj_workspace() -> Result<()> {
+    let Some(mut init) = jj_cmd(".") else {
+        return Ok(());
+    };
+    let context = TestContext::new();
+
+    init.current_dir(context.work_dir())
+        .args(["git", "init", "--colocate"])
+        .assert()
+        .success();
+
+    let project = context.work_dir().child("project");
+    project.create_dir_all()?;
+    project
+        .child(".pre-commit-config.yaml")
+        .write_str(indoc::indoc! {r"
+        repos:
+          - repo: builtin
+            hooks:
+              - id: check-added-large-files
+                args: ['--maxkb', '1']
+    "})?;
+    // A newly added >1 KB file inside the nested project.
+    project.child("big.txt").write_binary(&[0; 2048])?;
+
+    cmd_snapshot!(context.filters(), context.run().current_dir(project.path()), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    check for added large files..............................................Failed
+    - hook id: check-added-large-files
+    - exit code: 1
+
+      big.txt (2 KB) exceeds 1 KB
 
     ----- stderr -----
     ");

--- a/crates/prek/tests/builtin_hooks.rs
+++ b/crates/prek/tests/builtin_hooks.rs
@@ -2,6 +2,8 @@
 use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::Command;
 
 use anyhow::Result;
 use assert_cmd::assert::OutputAssertExt;
@@ -12,6 +14,13 @@ use prek_consts::PRE_COMMIT_CONFIG_YAML;
 use crate::common::{TestContext, cmd_snapshot, git_cmd};
 
 mod common;
+
+fn jj_cmd(dir: impl AsRef<Path>) -> Option<Command> {
+    let jj = which::which("jj").ok()?;
+    let mut cmd = Command::new(jj);
+    cmd.current_dir(dir);
+    Some(cmd)
+}
 
 /// Tests that `repo: builtin` hooks doesn't create hook env.
 #[test]
@@ -3196,6 +3205,51 @@ fn check_case_conflict_directory() -> Result<()> {
 
       Case-insensitivity conflict found: src/UTILS
       Case-insensitivity conflict found: src/utils
+
+    ----- stderr -----
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn check_case_conflict_in_non_colocated_jujutsu_workspace() -> Result<()> {
+    let Some(mut init) = jj_cmd(".") else {
+        return Ok(());
+    };
+    let context = TestContext::new();
+
+    if !is_case_sensitive_filesystem(&context)? {
+        return Ok(());
+    }
+
+    init.current_dir(context.work_dir())
+        .args(["git", "init", "--no-colocate"])
+        .assert()
+        .success();
+
+    let cwd = context.work_dir();
+    cwd.child("src/foo.txt").write_str("existing file")?;
+
+    context.write_pre_commit_config(indoc::indoc! {r"
+        repos:
+          - repo: builtin
+            hooks:
+              - id: check-case-conflict
+    "});
+
+    cwd.child("src/FOO.txt").write_str("conflicting case")?;
+
+    cmd_snapshot!(context.filters(), context.run(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    check for case conflicts.................................................Failed
+    - hook id: check-case-conflict
+    - exit code: 1
+
+      Case-insensitivity conflict found: src/FOO.txt
+      Case-insensitivity conflict found: src/foo.txt
 
     ----- stderr -----
     "#);

--- a/crates/prek/tests/builtin_hooks.rs
+++ b/crates/prek/tests/builtin_hooks.rs
@@ -2,8 +2,6 @@
 use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
-use std::process::Command;
 
 use anyhow::Result;
 use assert_cmd::assert::OutputAssertExt;
@@ -11,16 +9,9 @@ use assert_fs::prelude::*;
 use insta::assert_snapshot;
 use prek_consts::PRE_COMMIT_CONFIG_YAML;
 
-use crate::common::{TestContext, cmd_snapshot, git_cmd};
+use crate::common::{TestContext, cmd_snapshot, git_cmd, jj_cmd};
 
 mod common;
-
-fn jj_cmd(dir: impl AsRef<Path>) -> Option<Command> {
-    let jj = which::which("jj").ok()?;
-    let mut cmd = Command::new(jj);
-    cmd.current_dir(dir);
-    Some(cmd)
-}
 
 /// Tests that `repo: builtin` hooks doesn't create hook env.
 #[test]

--- a/crates/prek/tests/common/mod.rs
+++ b/crates/prek/tests/common/mod.rs
@@ -42,6 +42,18 @@ pub fn git_cmd(dir: impl AsRef<Path>) -> Command {
     cmd
 }
 
+/// Build a `jj` command in `dir`, or `None` when `jj` is not installed so tests can
+/// skip gracefully on machines without Jujutsu.
+pub fn jj_cmd(dir: impl AsRef<Path>) -> Option<Command> {
+    let jj = which::which("jj").ok()?;
+    let mut cmd = Command::new(jj);
+    cmd.current_dir(dir);
+    // Give jj a deterministic identity so `jj commit` does not depend on host config.
+    cmd.env("JJ_USER", "prek test");
+    cmd.env("JJ_EMAIL", "prek-test@example.com");
+    Some(cmd)
+}
+
 pub struct TestContext {
     temp_dir: ChildPath,
     home_dir: ChildPath,

--- a/crates/prek/tests/common/mod.rs
+++ b/crates/prek/tests/common/mod.rs
@@ -44,8 +44,17 @@ pub fn git_cmd(dir: impl AsRef<Path>) -> Command {
 
 /// Build a `jj` command in `dir`, or `None` when `jj` is not installed so tests can
 /// skip gracefully on machines without Jujutsu.
+///
+/// Set `PREK_TEST_REQUIRE_JJ` (CI does this after installing jj) to turn a missing
+/// `jj` into a hard failure, so the jj tests can never silently no-op.
 pub fn jj_cmd(dir: impl AsRef<Path>) -> Option<Command> {
-    let jj = which::which("jj").ok()?;
+    let Ok(jj) = which::which("jj") else {
+        assert!(
+            !EnvVars.is_set("PREK_TEST_REQUIRE_JJ"),
+            "PREK_TEST_REQUIRE_JJ is set but `jj` was not found on PATH"
+        );
+        return None;
+    };
     let mut cmd = Command::new(jj);
     cmd.current_dir(dir);
     // Give jj a deterministic identity so `jj commit` does not depend on host config.

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-use std::process::Command;
 use std::time::SystemTime;
 
 use anyhow::Result;
@@ -12,21 +11,9 @@ use prek_consts::{
     PRE_COMMIT_CONFIG_YAML, PRE_COMMIT_CONFIG_YML, PRE_COMMIT_HOOKS_YAML, PREK_TOML,
 };
 
-use crate::common::{TestContext, cmd_snapshot, git_cmd};
+use crate::common::{TestContext, cmd_snapshot, git_cmd, jj_cmd};
 
 mod common;
-
-/// Build a `jj` command in `dir`, or `None` when `jj` is not installed so tests can
-/// skip gracefully on machines without Jujutsu.
-fn jj_cmd(dir: impl AsRef<Path>) -> Option<Command> {
-    let jj = which::which("jj").ok()?;
-    let mut cmd = Command::new(jj);
-    cmd.current_dir(dir);
-    // Give jj a deterministic identity so `jj commit` does not depend on host config.
-    cmd.env("JJ_USER", "prek test");
-    cmd.env("JJ_EMAIL", "prek-test@example.com");
-    Some(cmd)
-}
 
 #[test]
 fn run_basic() -> Result<()> {
@@ -386,7 +373,8 @@ fn run_selects_conflicted_files_in_jj_workspace() -> Result<()> {
 }
 
 /// `--from-ref`/`--to-ref` in a jj workspace selects files changed between two
-/// revisions via `jj diff --from --to`.
+/// revisions using merge-base (`from...to`) semantics, matching the Git backend.
+/// With divergent refs, edits made only on the `from` side must NOT be selected.
 #[test]
 fn run_from_ref_to_ref_in_jj_workspace() -> Result<()> {
     let Some(mut init) = jj_cmd(".") else {
@@ -416,15 +404,22 @@ fn run_from_ref_to_ref_in_jj_workspace() -> Result<()> {
         jj_cmd(cwd.path()).unwrap().args(args).assert().success();
     };
 
-    cwd.child("x.txt").write_str("1")?;
-    jj(&["describe", "-m", "c1"]);
-    jj(&["bookmark", "create", "r1", "-r", "@"]);
-    jj(&["new", "-m", "c2"]);
-    cwd.child("y.txt").write_str("2")?;
-    jj(&["bookmark", "create", "r2", "-r", "@"]);
+    // base, then two divergent branches from it.
+    cwd.child("base.txt").write_str("base")?;
+    jj(&["describe", "-m", "base"]);
+    jj(&["bookmark", "create", "base", "-r", "@"]);
+    // `from` branch adds a file that only exists on its side.
+    jj(&["new", "-m", "from"]);
+    cwd.child("from_only.txt").write_str("from")?;
+    jj(&["bookmark", "create", "from", "-r", "@"]);
+    // `to` branch diverges from base with its own file.
+    jj(&["new", "base", "-m", "to"]);
+    cwd.child("to_only.txt").write_str("to")?;
+    jj(&["bookmark", "create", "to", "-r", "@"]);
 
-    // Only y.txt changed between r1 and r2; x.txt and the config are unchanged.
-    cmd_snapshot!(context.filters(), context.run().arg("--from-ref").arg("r1").arg("--to-ref").arg("r2"), @r"
+    // Merge-base semantics: only to_only.txt is in `from...to`. A direct from->to
+    // diff would also report from_only.txt (as a deletion), which must not happen.
+    cmd_snapshot!(context.filters(), context.run().arg("--from-ref").arg("from").arg("--to-ref").arg("to"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -432,7 +427,7 @@ fn run_from_ref_to_ref_in_jj_workspace() -> Result<()> {
     - hook id: echo-files
     - duration: [TIME]
 
-      y.txt
+      to_only.txt
 
     ----- stderr -----
     ");

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -435,6 +435,128 @@ fn run_from_ref_to_ref_in_jj_workspace() -> Result<()> {
     Ok(())
 }
 
+/// A renamed file must be selected by its real (new) path. `jj diff --types` renders
+/// renames with git-style `{a => b}` compaction, which would produce a bogus path
+/// that names no file and silently bypass hooks; the diff template avoids that.
+#[test]
+fn run_selects_renamed_file_in_jj_workspace() -> Result<()> {
+    let Some(mut init) = jj_cmd(".") else {
+        return Ok(());
+    };
+    let context = TestContext::new();
+
+    init.current_dir(context.work_dir())
+        .args(["git", "init", "--colocate"])
+        .assert()
+        .success();
+
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: echo-files
+                name: echo-files
+                entry: python3 -c "import sys; print(chr(10).join(sorted(sys.argv[1:])))"
+                language: system
+                files: \.txt$
+                verbose: true
+    "#});
+
+    let cwd = context.work_dir();
+    cwd.child("orig.txt").write_str("content\n")?;
+    jj_cmd(cwd.path())
+        .unwrap()
+        .args(["commit", "-m", "baseline"])
+        .assert()
+        .success();
+
+    // Rename the tracked file in the working copy.
+    fs_err::rename(
+        cwd.child("orig.txt").path(),
+        cwd.child("renamed.txt").path(),
+    )?;
+
+    cmd_snapshot!(context.filters(), context.run(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    echo-files...............................................................Passed
+    - hook id: echo-files
+    - duration: [TIME]
+
+      renamed.txt
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+/// End-to-end coverage for a real secondary workspace (`jj workspace add`), which has
+/// a `.jj` but no `.git`: the backing Git directory must be resolved from the main
+/// workspace so `prek run` works with no `.git` present.
+#[test]
+fn run_in_secondary_jj_workspace() -> Result<()> {
+    let Some(mut init) = jj_cmd(".") else {
+        return Ok(());
+    };
+    let context = TestContext::new();
+    let main = context.work_dir();
+
+    init.current_dir(main.path())
+        .args(["git", "init", "--colocate"])
+        .assert()
+        .success();
+
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: echo-files
+                name: echo-files
+                entry: python3 -c "import sys; print(chr(10).join(sorted(sys.argv[1:])))"
+                language: system
+                files: \.txt$
+                verbose: true
+    "#});
+    // Commit so the config is on an ancestor the secondary workspace checks out.
+    jj_cmd(main.path())
+        .unwrap()
+        .args(["commit", "-m", "baseline"])
+        .assert()
+        .success();
+
+    // Add a secondary workspace as a sibling directory (no `.git` of its own).
+    let secondary = main.path().parent().unwrap().join(format!(
+        "{}-secondary",
+        main.path().file_name().unwrap().to_string_lossy()
+    ));
+    jj_cmd(main.path())
+        .unwrap()
+        .args(["workspace", "add", &secondary.to_string_lossy()])
+        .assert()
+        .success();
+    assert!(secondary.join(".jj").exists());
+    assert!(!secondary.join(".git").exists());
+
+    fs_err::write(secondary.join("second.txt"), "hi\n")?;
+
+    cmd_snapshot!(context.filters(), context.run().current_dir(&secondary), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    echo-files...............................................................Passed
+    - hook id: echo-files
+    - duration: [TIME]
+
+      second.txt
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
 #[test]
 fn fast_path_checks_filenames_from_entry_and_args() -> Result<()> {
     let context = TestContext::new();

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::process::Command;
 use std::time::SystemTime;
 
 use anyhow::Result;
@@ -14,6 +15,15 @@ use prek_consts::{
 use crate::common::{TestContext, cmd_snapshot, git_cmd};
 
 mod common;
+
+/// Build a `jj` command in `dir`, or `None` when `jj` is not installed so tests can
+/// skip gracefully on machines without Jujutsu.
+fn jj_cmd(dir: impl AsRef<Path>) -> Option<Command> {
+    let jj = which::which("jj").ok()?;
+    let mut cmd = Command::new(jj);
+    cmd.current_dir(dir);
+    Some(cmd)
+}
 
 #[test]
 fn run_basic() -> Result<()> {
@@ -68,6 +78,142 @@ fn run_basic() -> Result<()> {
 
     ----- stderr -----
     "#);
+
+    Ok(())
+}
+
+/// A secondary (non-colocated) jj workspace has no `.git` directory at all; prek must
+/// still resolve the backing Git store and select the working-copy changeset.
+#[test]
+fn run_in_non_colocated_jj_workspace() -> Result<()> {
+    let Some(mut init) = jj_cmd(".") else {
+        return Ok(());
+    };
+    let context = TestContext::new();
+
+    init.current_dir(context.work_dir())
+        .args(["git", "init", "--no-colocate"])
+        .assert()
+        .success();
+
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: echo-files
+                name: echo-files
+                entry: python3 -c "import sys; print('ARGS:' + ' '.join(sys.argv[1:]))"
+                language: system
+                files: \.txt$
+                verbose: true
+    "#});
+
+    context.work_dir().child("file.txt").write_str("hello")?;
+    context.work_dir().child("ignored.md").write_str("nope")?;
+
+    cmd_snapshot!(context.filters(), context.run(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    echo-files...............................................................Passed
+    - hook id: echo-files
+    - duration: [TIME]
+
+      ARGS:file.txt
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+/// In a colocated jj workspace the default `prek run` mode must select the working-copy
+/// changeset. Git's index is empty (jj does not stage), so the old staged-files path
+/// would run on nothing.
+#[test]
+fn run_default_in_colocated_jj_workspace() -> Result<()> {
+    let Some(mut init) = jj_cmd(".") else {
+        return Ok(());
+    };
+    let context = TestContext::new();
+
+    init.current_dir(context.work_dir())
+        .args(["git", "init", "--colocate"])
+        .assert()
+        .success();
+
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: echo-files
+                name: echo-files
+                entry: python3 -c "import sys; print('ARGS:' + ' '.join(sys.argv[1:]))"
+                language: system
+                files: \.txt$
+                verbose: true
+    "#});
+
+    context.work_dir().child("file.txt").write_str("hello")?;
+
+    cmd_snapshot!(context.filters(), context.run(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    echo-files...............................................................Passed
+    - hook id: echo-files
+    - duration: [TIME]
+
+      ARGS:file.txt
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+/// `--all-files` in a jj workspace must list every tracked file via the jj backend.
+#[test]
+fn run_all_files_in_jj_workspace() -> Result<()> {
+    let Some(mut init) = jj_cmd(".") else {
+        return Ok(());
+    };
+    let context = TestContext::new();
+
+    init.current_dir(context.work_dir())
+        .args(["git", "init", "--colocate"])
+        .assert()
+        .success();
+
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: echo-files
+                name: echo-files
+                entry: python3 -c "import sys; print('ARGS:' + ' '.join(sorted(sys.argv[1:])))"
+                language: system
+                files: \.txt$
+                verbose: true
+    "#});
+
+    context.work_dir().child("a.txt").write_str("a")?;
+    context.work_dir().child("b.txt").write_str("b")?;
+
+    // `jj file list` auto-snapshots the working copy, so newly written files are
+    // tracked without an explicit commit.
+    cmd_snapshot!(context.filters(), context.run().arg("--all-files"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    echo-files...............................................................Passed
+    - hook id: echo-files
+    - duration: [TIME]
+
+      ARGS:a.txt b.txt
+
+    ----- stderr -----
+    ");
 
     Ok(())
 }
@@ -276,7 +422,7 @@ fn run_in_non_git_repo() {
     ----- stdout -----
 
     ----- stderr -----
-    error: Command `[GIT] rev-parse --show-toplevel` exited with an error:
+    error: Not inside a Git or Jujutsu repository: Command `[GIT] rev-parse --show-toplevel` exited with an error:
 
     [status]
     exit status: 128

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -22,6 +22,9 @@ fn jj_cmd(dir: impl AsRef<Path>) -> Option<Command> {
     let jj = which::which("jj").ok()?;
     let mut cmd = Command::new(jj);
     cmd.current_dir(dir);
+    // Give jj a deterministic identity so `jj commit` does not depend on host config.
+    cmd.env("JJ_USER", "prek test");
+    cmd.env("JJ_EMAIL", "prek-test@example.com");
     Some(cmd)
 }
 
@@ -211,6 +214,225 @@ fn run_all_files_in_jj_workspace() -> Result<()> {
     - duration: [TIME]
 
       ARGS:a.txt b.txt
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+/// When the prek workspace root is a subdirectory of the jj workspace root, jj
+/// reports repo-root-relative paths that must be stripped to project-relative
+/// ones. Regression test for running with the config in a nested directory.
+#[test]
+fn run_in_nested_jj_workspace() -> Result<()> {
+    let Some(mut init) = jj_cmd(".") else {
+        return Ok(());
+    };
+    let context = TestContext::new();
+
+    init.current_dir(context.work_dir())
+        .args(["git", "init", "--colocate"])
+        .assert()
+        .success();
+
+    let project = context.work_dir().child("project");
+    project.create_dir_all()?;
+    project
+        .child(".pre-commit-config.yaml")
+        .write_str(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: echo-files
+                name: echo-files
+                entry: python3 -c "import sys; print(chr(10).join(sorted(sys.argv[1:])))"
+                language: system
+                files: \.txt$
+                verbose: true
+    "#})?;
+    project.child("app.txt").write_str("in project")?;
+    context.work_dir().child("root.txt").write_str("outside")?;
+
+    cmd_snapshot!(context.filters(), context.run().current_dir(project.path()), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    echo-files...............................................................Passed
+    - hook id: echo-files
+    - duration: [TIME]
+
+      app.txt
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+/// Deleted files must not be passed to hooks in a jj workspace, matching git's
+/// `--diff-filter` which drops deletions.
+#[test]
+fn run_excludes_deleted_files_in_jj_workspace() -> Result<()> {
+    let Some(mut init) = jj_cmd(".") else {
+        return Ok(());
+    };
+    let context = TestContext::new();
+
+    init.current_dir(context.work_dir())
+        .args(["git", "init", "--colocate"])
+        .assert()
+        .success();
+
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: echo-files
+                name: echo-files
+                entry: python3 -c "import sys; print(chr(10).join(sorted(sys.argv[1:])))"
+                language: system
+                files: \.txt$
+                verbose: true
+    "#});
+
+    context.work_dir().child("keep.txt").write_str("keep")?;
+    context.work_dir().child("del.txt").write_str("gone")?;
+
+    // Commit the baseline so the deletion below is a real change against the parent.
+    jj_cmd(context.work_dir())
+        .unwrap()
+        .args(["commit", "-m", "baseline"])
+        .assert()
+        .success();
+
+    fs_err::remove_file(context.work_dir().child("del.txt").path())?;
+    context.work_dir().child("keep.txt").write_str("changed")?;
+
+    cmd_snapshot!(context.filters(), context.run(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    echo-files...............................................................Passed
+    - hook id: echo-files
+    - duration: [TIME]
+
+      keep.txt
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+/// The default run must select files with unresolved conflicts in a jj workspace,
+/// which are reported by `jj resolve --list` (not by `jj diff`, since the merge
+/// commit auto-merges cleanly against its parents).
+#[test]
+fn run_selects_conflicted_files_in_jj_workspace() -> Result<()> {
+    let Some(mut init) = jj_cmd(".") else {
+        return Ok(());
+    };
+    let context = TestContext::new();
+
+    init.current_dir(context.work_dir())
+        .args(["git", "init", "--colocate"])
+        .assert()
+        .success();
+
+    let cwd = context.work_dir();
+    let jj = |args: &[&str]| {
+        jj_cmd(cwd.path()).unwrap().args(args).assert().success();
+    };
+
+    // Build a real conflict: a base revision and two divergent edits, then merge.
+    cwd.child("c.txt").write_str("line1\nline2\nline3\n")?;
+    jj(&["describe", "-m", "base"]);
+    jj(&["bookmark", "create", "base", "-r", "@"]);
+    jj(&["new", "-m", "x"]);
+    cwd.child("c.txt").write_str("line1\nXXX\nline3\n")?;
+    jj(&["bookmark", "create", "x", "-r", "@"]);
+    jj(&["new", "base", "-m", "y"]);
+    cwd.child("c.txt").write_str("line1\nYYY\nline3\n")?;
+    jj(&["bookmark", "create", "y", "-r", "@"]);
+    jj(&["new", "x", "y", "-m", "merge"]);
+
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: echo-files
+                name: echo-files
+                entry: python3 -c "import sys; print(chr(10).join(sorted(sys.argv[1:])))"
+                language: system
+                files: \.txt$
+                verbose: true
+    "#});
+
+    cmd_snapshot!(context.filters(), context.run(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    echo-files...............................................................Passed
+    - hook id: echo-files
+    - duration: [TIME]
+
+      c.txt
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+/// `--from-ref`/`--to-ref` in a jj workspace selects files changed between two
+/// revisions via `jj diff --from --to`.
+#[test]
+fn run_from_ref_to_ref_in_jj_workspace() -> Result<()> {
+    let Some(mut init) = jj_cmd(".") else {
+        return Ok(());
+    };
+    let context = TestContext::new();
+
+    init.current_dir(context.work_dir())
+        .args(["git", "init", "--colocate"])
+        .assert()
+        .success();
+
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: echo-files
+                name: echo-files
+                entry: python3 -c "import sys; print(chr(10).join(sorted(sys.argv[1:])))"
+                language: system
+                files: \.txt$
+                verbose: true
+    "#});
+
+    let cwd = context.work_dir();
+    let jj = |args: &[&str]| {
+        jj_cmd(cwd.path()).unwrap().args(args).assert().success();
+    };
+
+    cwd.child("x.txt").write_str("1")?;
+    jj(&["describe", "-m", "c1"]);
+    jj(&["bookmark", "create", "r1", "-r", "@"]);
+    jj(&["new", "-m", "c2"]);
+    cwd.child("y.txt").write_str("2")?;
+    jj(&["bookmark", "create", "r2", "-r", "@"]);
+
+    // Only y.txt changed between r1 and r2; x.txt and the config are unchanged.
+    cmd_snapshot!(context.filters(), context.run().arg("--from-ref").arg("r1").arg("--to-ref").arg("r2"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    echo-files...............................................................Passed
+    - hook id: echo-files
+    - duration: [TIME]
+
+      y.txt
 
     ----- stderr -----
     ");

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -27,6 +27,18 @@ Running `prek install` installs the first type: it writes the Git shim so that G
 
 Adding `--prepare-hooks` tells prek to do that **and** proactively create the environments and caches required by the hooks that prek manages. That way, the next time Git invokes prek through the shim, the managed hooks are ready to run without additional setup. The older `--install-hooks` spelling remains as an alias.
 
+## Does prek work with Jujutsu (jj)?
+
+Yes. prek detects [Jujutsu](https://jj-vcs.github.io/jj/) workspaces automatically, including secondary workspaces created with `jj workspace add`. No extra configuration is needed.
+
+When running inside a jj workspace, prek:
+
+- Resolves the backing Git directory from `.jj/repo/store/git_target`, so all internal git commands work even when there is no `.git` directory.
+- Selects the files changed in the current working-copy changeset (via `jj diff --name-only`) for the default `prek run`, because jj has no separate staging area like `git diff --staged`.
+- Disables git-index stashing, which does not apply to jj.
+
+The `--all-files`, `--files`, and `--from-ref`/`--to-ref` modes work the same way as in a regular git repository.
+
 ## How does `prek install` interact with `core.hooksPath` and worktrees?
 
 If `core.hooksPath` is set in repo-local (`git config --local`) or worktree-local (`git config --worktree`) config, `prek install` and `prek uninstall` will honor it and operate on Git's effective hooks directory.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -39,9 +39,17 @@ When running inside a jj workspace, prek:
 
 The `--all-files`, `--files`, and `--from-ref`/`--to-ref` modes work the same way as in a regular git repository.
 
+In a colocated workspace, prek detects jj, so even when invoked as an installed Git hook it checks the jj working-copy changeset rather than Git's staged files.
+
 !!! note
 
-    Hooks that inspect Git index or merge state directly rather than a file list have limited support in jj workspaces, because jj has no staging area and records conflicts in the working-copy commit rather than as a Git merge. In particular, `forbid-new-submodules` relies on `git diff --staged` and will not detect newly added submodules, and `check-merge-conflict` relies on Git merge-state files and will not fire during a jj conflict unless run with `--assume-in-merge`.
+    A few checks that read Git's index or merge state directly (rather than a file list) have limited support in jj workspaces, because jj has no staging area and records conflicts in the working-copy commit rather than as a Git merge:
+
+    - `no-commit-to-branch` is skipped, since jj has no single "current branch" mapping to Git's `HEAD`.
+    - `forbid-new-submodules` does not detect newly added submodules (it reads `git diff --staged`).
+    - `check-merge-conflict` does not fire during a jj conflict unless run with `--assume-in-merge` (it reads Git merge-state files).
+
+    In a non-colocated workspace (no `.git`), the backing Git index is empty, so more behavior degrades: `destroyed-symlinks` and the Windows fallback of the shebang checks no-op, and prek cannot report files modified by a hook or show the diff on failure (`--show-diff-on-failure`). Colocated workspaces keep the Git index in sync and are unaffected.
 
 ## How does `prek install` interact with `core.hooksPath` and worktrees?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -34,10 +34,14 @@ Yes. prek detects [Jujutsu](https://jj-vcs.github.io/jj/) workspaces automatical
 When running inside a jj workspace, prek:
 
 - Resolves the backing Git directory from `.jj/repo/store/git_target`, so all internal git commands work even when there is no `.git` directory.
-- Selects the files changed in the current working-copy changeset (via `jj diff --name-only`) for the default `prek run`, because jj has no separate staging area like `git diff --staged`.
+- Selects the files changed in the current working-copy changeset (via `jj diff`) for the default `prek run`, because jj has no separate staging area like `git diff --staged`.
 - Disables git-index stashing, which does not apply to jj.
 
 The `--all-files`, `--files`, and `--from-ref`/`--to-ref` modes work the same way as in a regular git repository.
+
+!!! note
+
+    Hooks that inspect Git index or merge state directly rather than a file list have limited support in jj workspaces, because jj has no staging area and records conflicts in the working-copy commit rather than as a Git merge. In particular, `forbid-new-submodules` relies on `git diff --staged` and will not detect newly added submodules, and `check-merge-conflict` relies on Git merge-state files and will not fire during a jj conflict unless run with `--assume-in-merge`.
 
 ## How does `prek install` interact with `core.hooksPath` and worktrees?
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -59,7 +59,7 @@ Once you’re happy with your setup, you can stage the config file with `git add
 
 ### 2. Run hooks on demand
 
-Use `prek run` to execute all configured hooks on the files in your current git staging area:
+Use `prek run` to execute all configured hooks on the files in your current git staging area (or jj working copy, if you use [Jujutsu](https://jj-vcs.github.io/jj/)):
 
 ```bash
 prek run

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -19,7 +19,7 @@ When you run `prek run` without the `--config` option, `prek` automatically disc
 
 2. **Discover all projects**: From the workspace root, `prek` recursively searches all subdirectories for additional `.pre-commit-config.yaml` files. Each one becomes a separate project.
 
-3. **Git repository boundary**: The search stops at the git repository root (`.git` directory) to avoid including unrelated projects.
+3. **Repository boundary**: The search stops at the repository root (`.git` or `.jj` directory) to avoid including unrelated projects.
 
 !!! note
 

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -25,7 +25,7 @@ When you run `prek run` without the `--config` option, `prek` automatically disc
 
     **Workspace root**
 
-    - The workspace root is not necessarily the same as the git repository root, a workspace can exist within a subdirectory of a git repository.
+    - The workspace root is not necessarily the same as the repository root; a workspace can exist within a subdirectory of a Git or Jujutsu repository.
     - The current working directory determines the workspace root discovery. `prek` starts searching from your current location and stops at the first `.pre-commit-config.yaml` file found while traversing up the directory tree. Running from different directories may discover different workspace roots. Use `prek -C <dir>` to change the working directory before execution.
 
     **Discovery exclusions**


### PR DESCRIPTION
Adds Jujutsu (jj) workspace support so `prek run` works inside jj workspaces, including secondary workspaces created with `jj workspace add` that have no `.git` directory.

Builds on #1677 by @martijnberger, rebased onto current master. The first commit preserves the original work (and its authorship); a second commit holds the follow-up review fixes.

- Detect the repo backend (Git or jj) once at startup and route file selection, stashing, and staged-config checks through it. Git behavior is unchanged.
- In a jj workspace, resolve the backing Git dir from `.jj/repo/store/git_target` and point git commands at it per-command, so no `.git` is required.
- Default `prek run` uses the working-copy changeset; `--all-files`, `--from-ref`/`--to-ref`, and conflict detection (`jj resolve --list`) use jj equivalents. Deleted paths are excluded, matching git's `--diff-filter`.
- Skip the git-index stash and the staged-config check for jj (no staging area).
- Isolate `try-repo`'s git commands so they target the external/shadow repo, not the jj backing store.
- CI installs a pinned, checksum-verified jj on Linux and macOS to run the new integration tests.

Supersedes #1677.
