### PR TITLE
Track builtin hook file changes directly

### DIFF
--- a/crates/prek/src/cli/run/diff.rs
+++ b/crates/prek/src/cli/run/diff.rs
@@ -4,7 +4,8 @@ use anyhow::Result;
 
 use crate::git;
 
-pub(super) struct DiffTracker<'a> {
+/// Tracks project worktree changes across hook priority groups.
+pub(crate) struct DiffTracker<'a> {
     path: &'a Path,
     baseline: DiffBaseline,
 }
@@ -16,28 +17,32 @@ enum DiffBaseline {
 }
 
 impl<'a> DiffTracker<'a> {
-    pub(super) fn clean_baseline(path: &'a Path) -> Self {
+    /// Creates a tracker for a worktree known to have no unstaged changes.
+    pub(crate) fn clean_baseline(path: &'a Path) -> Self {
         Self {
             path,
             baseline: DiffBaseline::Clean,
         }
     }
 
-    pub(super) fn unknown_baseline(path: &'a Path) -> Self {
+    /// Creates a tracker whose initial worktree state is unknown.
+    pub(crate) fn unknown_baseline(path: &'a Path) -> Self {
         Self {
             path,
             baseline: DiffBaseline::Unknown,
         }
     }
 
-    pub(super) async fn prepare_for_group(&mut self, track_changes: bool) -> Result<()> {
+    /// Captures an unknown baseline before a group that requires diff tracking.
+    pub(crate) async fn prepare_for_group(&mut self, track_changes: bool) -> Result<()> {
         if track_changes && let DiffBaseline::Unknown = self.baseline {
             self.baseline = DiffBaseline::Snapshot(git::diff_worktree(self.path).await?);
         }
         Ok(())
     }
 
-    pub(super) async fn changed_after_group(&mut self, track_changes: bool) -> Result<bool> {
+    /// Checks for worktree changes and advances the tracked baseline.
+    pub(crate) async fn changed_after_group(&mut self, track_changes: bool) -> Result<bool> {
         if !track_changes {
             return Ok(false);
         }
@@ -78,7 +83,8 @@ impl<'a> DiffTracker<'a> {
         }
     }
 
-    pub(super) fn invalidate(&mut self) {
+    /// Discards the baseline after a hook reports a modification directly.
+    pub(crate) fn invalidate(&mut self) {
         self.baseline = DiffBaseline::Unknown;
     }
 }

--- a/crates/prek/src/cli/run/diff.rs
+++ b/crates/prek/src/cli/run/diff.rs
@@ -30,21 +30,15 @@ impl<'a> DiffTracker<'a> {
         }
     }
 
-    pub(super) async fn prepare_for_group(&mut self, may_modify_files: bool) -> Result<()> {
-        if may_modify_files && let DiffBaseline::Unknown = self.baseline {
-            self.baseline = DiffBaseline::Snapshot(git::get_diff(self.path).await?);
+    pub(super) async fn prepare_for_group(&mut self, track_changes: bool) -> Result<()> {
+        if track_changes && let DiffBaseline::Unknown = self.baseline {
+            self.baseline = DiffBaseline::Snapshot(git::diff_worktree(self.path).await?);
         }
         Ok(())
     }
 
-    pub(super) async fn changed_after_group(
-        &mut self,
-        may_modify_files: bool,
-        all_skipped: bool,
-    ) -> Result<bool> {
-        // Read-only groups and fully skipped groups cannot change files, so avoid
-        // asking git about the working tree.
-        if !may_modify_files || all_skipped {
+    pub(super) async fn changed_after_group(&mut self, track_changes: bool) -> Result<bool> {
+        if !track_changes {
             return Ok(false);
         }
 
@@ -59,7 +53,7 @@ impl<'a> DiffTracker<'a> {
                 // can look dirty even when the content is unchanged. Do a full
                 // diff here to ignore stat-only changes and reuse the content
                 // diff as the baseline if the hook really modified files.
-                let curr_diff = git::get_diff(self.path).await?;
+                let curr_diff = git::diff_worktree(self.path).await?;
                 if curr_diff.is_empty() {
                     return Ok(false);
                 }
@@ -73,7 +67,7 @@ impl<'a> DiffTracker<'a> {
                 // Unknown initial state, `--all-files`, and later dirty groups
                 // need a full before/after diff comparison to avoid confusing
                 // pre-existing user changes with hook changes.
-                let curr_diff = git::get_diff(self.path).await?;
+                let curr_diff = git::diff_worktree(self.path).await?;
                 let modified = curr_diff != *prev_diff;
                 *prev_diff = curr_diff;
                 Ok(modified)
@@ -82,5 +76,9 @@ impl<'a> DiffTracker<'a> {
                 unreachable!("diff baseline must be captured before hooks can modify files")
             }
         }
+    }
+
+    pub(super) fn invalidate(&mut self) {
+        self.baseline = DiffBaseline::Unknown;
     }
 }

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -719,6 +719,7 @@ impl<'a> HookRunSession<'a> {
                     Rc::clone(&semaphore),
                 )
                 .await?;
+
             let needs_diff = group_results
                 .iter()
                 .any(|result| result.file_changes == hooks::FileChanges::Unknown);

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -703,10 +703,12 @@ impl<'a> HookRunSession<'a> {
         let mut stop_after_level = false;
 
         for group_hooks in project_run.groups {
-            let group_may_modify_files =
-                !self.dry_run && group_hooks.iter().any(|hook| hooks::may_modify_files(hook));
+            let group_requires_diff_tracking = !self.dry_run
+                && group_hooks
+                    .iter()
+                    .any(|hook| hooks::requires_diff_tracking(hook));
             diff_tracker
-                .prepare_for_group(group_may_modify_files)
+                .prepare_for_group(group_requires_diff_tracking)
                 .await?;
 
             let group_results = self
@@ -717,12 +719,20 @@ impl<'a> HookRunSession<'a> {
                     Rc::clone(&semaphore),
                 )
                 .await?;
-            let all_skipped = group_results
+            let needs_diff = group_results
                 .iter()
-                .all(|result| result.status.is_skipped());
-            let group_modified_files = diff_tracker
-                .changed_after_group(group_may_modify_files, all_skipped)
-                .await?;
+                .any(|result| result.file_changes == hooks::FileChanges::Unknown);
+            let known_modified_files = group_results
+                .iter()
+                .any(|result| result.file_changes == hooks::FileChanges::Modified);
+            let diff_detected_modifications = diff_tracker.changed_after_group(needs_diff).await?;
+            if known_modified_files && !needs_diff {
+                // Native hooks report modifications directly, so no Git snapshot
+                // was taken. Force one before a later external hook needs a
+                // before/after comparison.
+                diff_tracker.invalidate();
+            }
+            let group_modified_files = known_modified_files || diff_detected_modifications;
 
             let group = ProjectGroupRunResult {
                 results: group_results,
@@ -1286,6 +1296,7 @@ struct RunResult {
     duration: std::time::Duration,
     exit_status: i32,
     output: Vec<u8>,
+    file_changes: hooks::FileChanges,
 }
 
 impl RunResult {
@@ -1296,6 +1307,7 @@ impl RunResult {
             duration: std::time::Duration::ZERO,
             exit_status: 0,
             output: Vec::new(),
+            file_changes: hooks::FileChanges::Unchanged,
         }
     }
 }
@@ -1331,8 +1343,8 @@ async fn run_hook(
     let start = std::time::Instant::now();
     input.shuffle();
 
-    let (exit_status, hook_output) = if dry_run {
-        (0, dry_run_hook(&hook, &input)?)
+    let hook_output = if dry_run {
+        hooks::HookOutput::unchanged(0, dry_run_hook(&hook, &input)?)
     } else {
         match &input {
             HookRunInput::Filenames(filenames) => {
@@ -1348,6 +1360,11 @@ async fn run_hook(
         }
         .with_context(|| format!("Failed to run hook `{hook}`"))?
     };
+    let hooks::HookOutput {
+        exit_status,
+        output,
+        file_changes,
+    } = hook_output;
 
     let duration = start.elapsed();
 
@@ -1364,7 +1381,8 @@ async fn run_hook(
         status: run_status,
         duration,
         exit_status,
-        output: hook_output,
+        output,
+        file_changes,
     })
 }
 

--- a/crates/prek/src/git.rs
+++ b/crates/prek/src/git.rs
@@ -435,7 +435,7 @@ pub(crate) async fn has_worktree_diff(path: &Path) -> Result<bool, Error> {
 }
 
 #[instrument(level = "trace")]
-pub(crate) async fn get_diff(path: &Path) -> Result<Vec<u8>, Error> {
+pub(crate) async fn diff_worktree(path: &Path) -> Result<Vec<u8>, Error> {
     let output = git_cmd()?
         .arg("diff")
         .hidden_args(["--no-ext-diff", "--no-textconv", "--ignore-submodules"])

--- a/crates/prek/src/hooks/builtin_hooks/check_illegal_windows_names.rs
+++ b/crates/prek/src/hooks/builtin_hooks/check_illegal_windows_names.rs
@@ -2,6 +2,7 @@ use std::io::Write;
 use std::path::Path;
 
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 
 pub(super) const ILLEGAL_WINDOWS_PATTERN: &str = r"(?i)((^|/)(CON|PRN|AUX|NUL|COM[\d\x{00B9}\x{00B2}\x{00B3}]|LPT[\d\x{00B9}\x{00B2}\x{00B3}])(\.|/|$)|[<>:\x22\\|?*\x00-\x1F]|/[^/]*[\.\s]/|[^/]*[\.\s]$)";
 
@@ -12,12 +13,12 @@ pub(super) const ILLEGAL_WINDOWS_PATTERN: &str = r"(?i)((^|/)(CON|PRN|AUX|NUL|CO
 // `fail` language in Rust, so there is no dedicated fast-path implementation to
 // add here. This module only exists to provide the builtin-hook equivalent:
 // reuse the same regex for matching, then emit a simple fail-style message.
-pub(crate) fn check_illegal_windows_names(_hook: &Hook, filenames: &[&Path]) -> (i32, Vec<u8>) {
+pub(crate) fn check_illegal_windows_names(_hook: &Hook, filenames: &[&Path]) -> HookOutput {
     if filenames.is_empty() {
-        return (0, Vec::new());
+        return HookOutput::unchanged(0, Vec::new());
     }
 
-    (1, illegal_windows_names_output(filenames))
+    HookOutput::unchanged(1, illegal_windows_names_output(filenames))
 }
 
 fn illegal_windows_names_output(filenames: &[&Path]) -> Vec<u8> {

--- a/crates/prek/src/hooks/builtin_hooks/check_json5.rs
+++ b/crates/prek/src/hooks/builtin_hooks/check_json5.rs
@@ -1,14 +1,12 @@
 use std::path::Path;
 
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::check_json::JsonDuplicateKeyChecker;
 use crate::hooks::run_concurrent_file_checks;
 use crate::run::INTERNAL_CONCURRENCY;
 
-pub(crate) async fn check_json5(
-    hook: &Hook,
-    filenames: &[&Path],
-) -> anyhow::Result<(i32, Vec<u8>)> {
+pub(crate) async fn check_json5(hook: &Hook, filenames: &[&Path]) -> anyhow::Result<HookOutput> {
     run_concurrent_file_checks(
         filenames.iter().copied(),
         *INTERNAL_CONCURRENCY,
@@ -17,18 +15,18 @@ pub(crate) async fn check_json5(
     .await
 }
 
-async fn check_file(file_base: &Path, filename: &Path) -> anyhow::Result<(i32, Vec<u8>)> {
+async fn check_file(file_base: &Path, filename: &Path) -> anyhow::Result<HookOutput> {
     let file_path = file_base.join(filename);
     let content = fs_err::tokio::read_to_string(file_path).await?;
     if content.is_empty() {
-        return Ok((0, Vec::new()));
+        return Ok(HookOutput::unchanged(0, Vec::new()));
     }
 
     match json5::from_str::<JsonDuplicateKeyChecker>(&content) {
-        Ok(_) => Ok((0, Vec::new())),
+        Ok(_) => Ok(HookOutput::unchanged(0, Vec::new())),
         Err(e) => {
             let error_message = format!("{}: Failed to json5 decode ({})\n", filename.display(), e);
-            Ok((1, error_message.into_bytes()))
+            Ok(HookOutput::unchanged(1, error_message.into_bytes()))
         }
     }
 }
@@ -69,9 +67,9 @@ mod tests {
         }
         "#};
         let file_path = create_test_file(&dir, "valid.json5", content.as_bytes()).await?;
-        let (code, output) = check_file(dir.path(), &file_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(dir.path(), &file_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
 
         Ok(())
     }
@@ -89,9 +87,9 @@ mod tests {
         }
         "#};
         let file_path = create_test_file(&dir, "duplicate.json5", content.as_bytes()).await?;
-        let (code, output) = check_file(dir.path(), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(String::from_utf8_lossy(&output).contains("duplicate key"));
+        let result = check_file(dir.path(), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(String::from_utf8_lossy(&result.output).contains("duplicate key"));
 
         Ok(())
     }
@@ -100,9 +98,9 @@ mod tests {
     async fn test_invalid_json5() -> anyhow::Result<()> {
         let dir = tempdir()?;
         let file_path = create_test_file(&dir, "invalid.json5", b"{ key: 'value' ").await?;
-        let (code, output) = check_file(dir.path(), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
+        let result = check_file(dir.path(), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
 
         Ok(())
     }

--- a/crates/prek/src/hooks/builtin_hooks/mod.rs
+++ b/crates/prek/src/hooks/builtin_hooks/mod.rs
@@ -11,7 +11,7 @@ use crate::hook::Hook;
 use crate::hooks::pre_commit_hooks;
 use crate::store::Store;
 
-use super::HookFuture;
+use super::{HookFuture, HookOutput};
 
 mod check_illegal_windows_names;
 mod check_json5;
@@ -85,45 +85,13 @@ impl BuiltinHooks {
         if help.is_empty() { None } else { Some(help) }
     }
 
-    pub(crate) fn may_modify_files(self) -> bool {
-        match self {
-            Self::EndOfFileFixer
-            | Self::FileContentsSorter
-            | Self::FixByteOrderMarker
-            | Self::MixedLineEnding
-            | Self::PrettyFormatJson
-            | Self::RequirementsTxtFixer
-            | Self::TrailingWhitespace => true,
-
-            Self::CheckAddedLargeFiles
-            | Self::CheckCaseConflict
-            | Self::CheckExecutablesHaveShebangs
-            | Self::CheckIllegalWindowsNames
-            | Self::CheckJson
-            | Self::CheckJson5
-            | Self::CheckMergeConflict
-            | Self::CheckShebangScriptsAreExecutable
-            | Self::CheckSymlinks
-            | Self::CheckToml
-            | Self::CheckVcsPermalinks
-            | Self::CheckXml
-            | Self::CheckYaml
-            | Self::DenyPattern
-            | Self::DestroyedSymlinks
-            | Self::DetectPrivateKey
-            | Self::ForbidNewSubmodules
-            | Self::NoCommitToBranch
-            | Self::RequirePattern => false,
-        }
-    }
-
     pub(crate) async fn run(
         self,
         _store: &Store,
         hook: &Hook,
         filenames: &[&Path],
         reporter: &HookRunReporter,
-    ) -> Result<(i32, Vec<u8>)> {
+    ) -> Result<HookOutput> {
         let progress = reporter.on_run_start(hook, filenames.len());
         let future: HookFuture<'_> = match self {
             Self::CheckAddedLargeFiles => {

--- a/crates/prek/src/hooks/builtin_hooks/mod.rs
+++ b/crates/prek/src/hooks/builtin_hooks/mod.rs
@@ -8,7 +8,14 @@ use prek_identify::tags;
 use crate::cli::run::HookRunReporter;
 use crate::config::{BuiltinHook, FilePattern, HookOptions, PassFilenames, Stage};
 use crate::hook::Hook;
-use crate::hooks::pre_commit_hooks;
+use crate::hooks::pre_commit_hooks::{
+    check_added_large_files, check_case_conflict, check_executables_have_shebangs, check_json,
+    check_merge_conflict, check_shebang_scripts_are_executable, check_symlinks, check_toml,
+    check_vcs_permalinks, check_xml, check_yaml, destroyed_symlinks, detect_private_key,
+    file_contents_sorter, fix_byte_order_marker, fix_end_of_file, fix_trailing_whitespace,
+    forbid_new_submodules, mixed_line_ending, no_commit_to_branch, pretty_format_json,
+    requirements_txt_fixer,
+};
 use crate::store::Store;
 
 use super::{HookFuture, HookOutput};
@@ -63,18 +70,16 @@ pub(crate) enum BuiltinHooks {
 impl BuiltinHooks {
     fn flags_command(self) -> Option<Command> {
         Some(match self {
-            Self::CheckAddedLargeFiles => {
-                pre_commit_hooks::check_added_large_files::Args::command()
-            }
-            Self::CheckMergeConflict => pre_commit_hooks::check_merge_conflict::Args::command(),
-            Self::CheckVcsPermalinks => pre_commit_hooks::check_vcs_permalinks::Args::command(),
-            Self::CheckYaml => pre_commit_hooks::check_yaml::Args::command(),
+            Self::CheckAddedLargeFiles => check_added_large_files::Args::command(),
+            Self::CheckMergeConflict => check_merge_conflict::Args::command(),
+            Self::CheckVcsPermalinks => check_vcs_permalinks::Args::command(),
+            Self::CheckYaml => check_yaml::Args::command(),
             Self::DenyPattern | Self::RequirePattern => pattern::Args::command(),
-            Self::FileContentsSorter => pre_commit_hooks::file_contents_sorter::Args::command(),
-            Self::MixedLineEnding => pre_commit_hooks::mixed_line_ending::Args::command(),
-            Self::NoCommitToBranch => pre_commit_hooks::no_commit_to_branch::Args::command(),
-            Self::PrettyFormatJson => pre_commit_hooks::pretty_format_json::Args::command(),
-            Self::TrailingWhitespace => pre_commit_hooks::fix_trailing_whitespace::Args::command(),
+            Self::FileContentsSorter => file_contents_sorter::Args::command(),
+            Self::MixedLineEnding => mixed_line_ending::Args::command(),
+            Self::NoCommitToBranch => no_commit_to_branch::Args::command(),
+            Self::PrettyFormatJson => pretty_format_json::Args::command(),
+            Self::TrailingWhitespace => fix_trailing_whitespace::Args::command(),
             _ => return None,
         })
     }
@@ -94,62 +99,38 @@ impl BuiltinHooks {
     ) -> Result<HookOutput> {
         let progress = reporter.on_run_start(hook, filenames.len());
         let future: HookFuture<'_> = match self {
-            Self::CheckAddedLargeFiles => {
-                Box::pin(pre_commit_hooks::check_added_large_files(hook, filenames))
+            Self::CheckAddedLargeFiles => Box::pin(check_added_large_files::run(hook, filenames)),
+            Self::CheckCaseConflict => Box::pin(check_case_conflict::run(hook, filenames)),
+            Self::CheckExecutablesHaveShebangs => {
+                Box::pin(check_executables_have_shebangs::run(hook, filenames))
             }
-            Self::CheckCaseConflict => {
-                Box::pin(pre_commit_hooks::check_case_conflict(hook, filenames))
-            }
-            Self::CheckExecutablesHaveShebangs => Box::pin(
-                pre_commit_hooks::check_executables_have_shebangs(hook, filenames),
-            ),
             Self::CheckIllegalWindowsNames => Box::pin(std::future::ready(Ok(
                 check_illegal_windows_names::check_illegal_windows_names(hook, filenames),
             ))),
-            Self::CheckJson => Box::pin(pre_commit_hooks::check_json(hook, filenames)),
+            Self::CheckJson => Box::pin(check_json::run(hook, filenames)),
             Self::CheckJson5 => Box::pin(check_json5::check_json5(hook, filenames)),
-            Self::CheckMergeConflict => {
-                Box::pin(pre_commit_hooks::check_merge_conflict(hook, filenames))
+            Self::CheckMergeConflict => Box::pin(check_merge_conflict::run(hook, filenames)),
+            Self::CheckShebangScriptsAreExecutable => {
+                Box::pin(check_shebang_scripts_are_executable::run(hook, filenames))
             }
-            Self::CheckShebangScriptsAreExecutable => Box::pin(
-                pre_commit_hooks::check_shebang_scripts_are_executable(hook, filenames),
-            ),
-            Self::CheckSymlinks => Box::pin(pre_commit_hooks::check_symlinks(hook, filenames)),
-            Self::CheckToml => Box::pin(pre_commit_hooks::check_toml(hook, filenames)),
-            Self::CheckVcsPermalinks => {
-                Box::pin(pre_commit_hooks::check_vcs_permalinks(hook, filenames))
-            }
-            Self::CheckXml => Box::pin(pre_commit_hooks::check_xml(hook, filenames)),
-            Self::CheckYaml => Box::pin(pre_commit_hooks::check_yaml(hook, filenames)),
+            Self::CheckSymlinks => Box::pin(check_symlinks::run(hook, filenames)),
+            Self::CheckToml => Box::pin(check_toml::run(hook, filenames)),
+            Self::CheckVcsPermalinks => Box::pin(check_vcs_permalinks::run(hook, filenames)),
+            Self::CheckXml => Box::pin(check_xml::run(hook, filenames)),
+            Self::CheckYaml => Box::pin(check_yaml::run(hook, filenames)),
             Self::DenyPattern => Box::pin(pattern::deny_pattern(hook, filenames)),
-            Self::DestroyedSymlinks => {
-                Box::pin(pre_commit_hooks::destroyed_symlinks(hook, filenames))
-            }
-            Self::DetectPrivateKey => {
-                Box::pin(pre_commit_hooks::detect_private_key(hook, filenames))
-            }
-            Self::EndOfFileFixer => Box::pin(pre_commit_hooks::fix_end_of_file(hook, filenames)),
-            Self::FileContentsSorter => {
-                Box::pin(pre_commit_hooks::file_contents_sorter(hook, filenames))
-            }
-            Self::FixByteOrderMarker => {
-                Box::pin(pre_commit_hooks::fix_byte_order_marker(hook, filenames))
-            }
-            Self::ForbidNewSubmodules => {
-                Box::pin(pre_commit_hooks::forbid_new_submodules(hook, filenames))
-            }
-            Self::MixedLineEnding => Box::pin(pre_commit_hooks::mixed_line_ending(hook, filenames)),
-            Self::NoCommitToBranch => Box::pin(pre_commit_hooks::no_commit_to_branch(hook)),
-            Self::PrettyFormatJson => {
-                Box::pin(pre_commit_hooks::pretty_format_json(hook, filenames))
-            }
+            Self::DestroyedSymlinks => Box::pin(destroyed_symlinks::run(hook, filenames)),
+            Self::DetectPrivateKey => Box::pin(detect_private_key::run(hook, filenames)),
+            Self::EndOfFileFixer => Box::pin(fix_end_of_file::run(hook, filenames)),
+            Self::FileContentsSorter => Box::pin(file_contents_sorter::run(hook, filenames)),
+            Self::FixByteOrderMarker => Box::pin(fix_byte_order_marker::run(hook, filenames)),
+            Self::ForbidNewSubmodules => Box::pin(forbid_new_submodules::run(hook, filenames)),
+            Self::MixedLineEnding => Box::pin(mixed_line_ending::run(hook, filenames)),
+            Self::NoCommitToBranch => Box::pin(no_commit_to_branch::run(hook)),
+            Self::PrettyFormatJson => Box::pin(pretty_format_json::run(hook, filenames)),
             Self::RequirePattern => Box::pin(pattern::require_pattern(hook, filenames)),
-            Self::RequirementsTxtFixer => {
-                Box::pin(pre_commit_hooks::requirements_txt_fixer(hook, filenames))
-            }
-            Self::TrailingWhitespace => {
-                Box::pin(pre_commit_hooks::fix_trailing_whitespace(hook, filenames))
-            }
+            Self::RequirementsTxtFixer => Box::pin(requirements_txt_fixer::run(hook, filenames)),
+            Self::TrailingWhitespace => Box::pin(fix_trailing_whitespace::run(hook, filenames)),
         };
         let result = future.await;
         reporter.on_run_complete(progress);

--- a/crates/prek/src/hooks/builtin_hooks/pattern.rs
+++ b/crates/prek/src/hooks/builtin_hooks/pattern.rs
@@ -8,6 +8,7 @@ use memchr::memchr_iter;
 use regex_automata::{MatchKind, meta::Regex, util::syntax};
 
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 use crate::hooks::run_concurrent_file_checks;
 use crate::run::INTERNAL_CONCURRENCY;
 
@@ -79,15 +80,15 @@ impl Matcher {
     }
 }
 
-pub(crate) async fn deny_pattern(hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
+pub(crate) async fn deny_pattern(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     run(hook, filenames, MatchPolicy::Deny).await
 }
 
-pub(crate) async fn require_pattern(hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
+pub(crate) async fn require_pattern(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     run(hook, filenames, MatchPolicy::Require).await
 }
 
-async fn run(hook: &Hook, filenames: &[&Path], policy: MatchPolicy) -> Result<(i32, Vec<u8>)> {
+async fn run(hook: &Hook, filenames: &[&Path], policy: MatchPolicy) -> Result<HookOutput> {
     let args = Args::try_parse_from(hook.entry.expect_direct().split_with_args(&hook.args)?)?;
     let matcher = Matcher::new(&args)?;
     let file_base = hook.project().relative_path();
@@ -105,11 +106,12 @@ async fn check_file(
     filename: &Path,
     matcher: &Matcher,
     policy: MatchPolicy,
-) -> Result<(i32, Vec<u8>)> {
-    match matcher.scan_mode {
+) -> Result<HookOutput> {
+    let (exit_status, output) = match matcher.scan_mode {
         ScanMode::Lines => check_lines(file_base, filename, &matcher.regex, policy).await,
         ScanMode::Multiline => check_multiline(file_base, filename, &matcher.regex, policy).await,
-    }
+    }?;
+    Ok(HookOutput::unchanged(exit_status, output))
 }
 
 async fn check_lines(

--- a/crates/prek/src/hooks/meta_hooks.rs
+++ b/crates/prek/src/hooks/meta_hooks.rs
@@ -13,6 +13,7 @@ use crate::cli::run::{
 };
 use crate::config::{self, FilePattern, HookOptions, Language, MetaHook};
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 use crate::store::Store;
 use crate::workspace::{HookInitFilters, Project};
 
@@ -50,7 +51,7 @@ impl MetaHooks {
         hook: &Hook,
         filenames: &[&Path],
         reporter: &HookRunReporter,
-    ) -> Result<(i32, Vec<u8>)> {
+    ) -> Result<HookOutput> {
         let progress = reporter.on_run_start(hook, filenames.len());
         let result = match self {
             Self::CheckHooksApply => check_hooks_apply(store, hook, filenames).await,
@@ -108,10 +109,10 @@ pub(crate) async fn check_hooks_apply(
     store: &Store,
     hook: &Hook,
     filenames: &[&Path],
-) -> Result<(i32, Vec<u8>)> {
+) -> Result<HookOutput> {
     let projects = load_meta_projects(hook, filenames)?;
     if projects.is_empty() {
-        return Ok((0, Vec::new()));
+        return Ok(HookOutput::unchanged(0, Vec::new()));
     }
 
     let relative_path = hook.project().relative_path();
@@ -177,7 +178,7 @@ pub(crate) async fn check_hooks_apply(
         }
     }
 
-    Ok((code, output))
+    Ok(HookOutput::unchanged(code, output))
 }
 
 fn load_meta_projects(hook: &Hook, filenames: &[&Path]) -> Result<Vec<Project>> {
@@ -247,13 +248,10 @@ fn excludes_any(
 }
 
 /// Ensures that exclude directives apply to any file in the repository.
-pub(crate) async fn check_useless_excludes(
-    hook: &Hook,
-    filenames: &[&Path],
-) -> Result<(i32, Vec<u8>)> {
+pub(crate) async fn check_useless_excludes(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let projects = load_meta_projects(hook, filenames)?;
     if projects.is_empty() {
-        return Ok((0, Vec::new()));
+        return Ok(HookOutput::unchanged(0, Vec::new()));
     }
 
     let relative_path = hook.project().relative_path();
@@ -352,12 +350,12 @@ pub(crate) async fn check_useless_excludes(
         }
     }
 
-    Ok((code, output))
+    Ok(HookOutput::unchanged(code, output))
 }
 
 /// Prints all arguments passed to the hook. Useful for debugging.
-pub fn identity(_hook: &Hook, filenames: &[&Path]) -> (i32, Vec<u8>) {
-    (
+pub fn identity(_hook: &Hook, filenames: &[&Path]) -> HookOutput {
+    HookOutput::unchanged(
         0,
         filenames
             .iter()

--- a/crates/prek/src/hooks/mod.rs
+++ b/crates/prek/src/hooks/mod.rs
@@ -18,7 +18,58 @@ mod meta_hooks;
 mod pre_commit_hooks;
 
 // Erase hook implementation futures before awaiting them so dispatchers have one suspension point.
-type HookFuture<'a> = Pin<Box<dyn Future<Output = anyhow::Result<(i32, Vec<u8>)>> + 'a>>;
+type HookFuture<'a> = Pin<Box<dyn Future<Output = anyhow::Result<HookOutput>> + 'a>>;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub(crate) enum FileChanges {
+    Unchanged,
+    Modified,
+    Unknown,
+}
+
+#[derive(Debug)]
+pub(crate) struct HookOutput {
+    pub(crate) exit_status: i32,
+    pub(crate) output: Vec<u8>,
+    pub(crate) file_changes: FileChanges,
+}
+
+impl HookOutput {
+    pub(crate) fn known(exit_status: i32, output: Vec<u8>, modified: bool) -> Self {
+        Self {
+            exit_status,
+            output,
+            file_changes: if modified {
+                FileChanges::Modified
+            } else {
+                FileChanges::Unchanged
+            },
+        }
+    }
+
+    pub(crate) fn unchanged(exit_status: i32, output: Vec<u8>) -> Self {
+        Self::known(exit_status, output, false)
+    }
+
+    pub(crate) fn unknown(exit_status: i32, output: Vec<u8>) -> Self {
+        Self {
+            exit_status,
+            output,
+            file_changes: FileChanges::Unknown,
+        }
+    }
+
+    fn merge_known(&mut self, other: Self) {
+        debug_assert_ne!(self.file_changes, FileChanges::Unknown);
+        debug_assert_ne!(other.file_changes, FileChanges::Unknown);
+
+        self.exit_status |= other.exit_status;
+        self.output.extend(other.output);
+        if other.file_changes == FileChanges::Modified {
+            self.file_changes = FileChanges::Modified;
+        }
+    }
+}
 
 static NO_FAST_PATH: LazyLock<bool> = LazyLock::new(|| EnvVars.is_set(EnvVars::PREK_NO_FAST_PATH));
 
@@ -47,15 +98,11 @@ fn fast_path_hook(hook: &Hook) -> Option<PreCommitHooks> {
     }
 }
 
-pub(crate) fn may_modify_files(hook: &Hook) -> bool {
+pub(crate) fn requires_diff_tracking(hook: &Hook) -> bool {
     match hook.repo() {
-        Repo::Builtin { .. } => {
-            BuiltinHooks::from_str(hook.id.as_str()).map_or(true, BuiltinHooks::may_modify_files)
-        }
-        Repo::Remote { .. } => {
-            fast_path_hook(hook).is_none_or(|implemented| implemented.may_modify_files())
-        }
-        _ => true,
+        Repo::Meta { .. } | Repo::Builtin { .. } => false,
+        Repo::Remote { .. } => fast_path_hook(hook).is_none(),
+        Repo::Local { .. } => true,
     }
 }
 
@@ -64,7 +111,7 @@ pub async fn run_fast_path(
     hook: &Hook,
     filenames: &[&Path],
     reporter: &HookRunReporter,
-) -> anyhow::Result<(i32, Vec<u8>)> {
+) -> anyhow::Result<HookOutput> {
     let progress = reporter.on_run_start(hook, filenames.len());
 
     let Some(implemented) = fast_path_hook(hook) else {
@@ -81,11 +128,11 @@ pub(crate) async fn run_concurrent_file_checks<'a, I, F, Fut>(
     filenames: I,
     concurrency: usize,
     check: F,
-) -> anyhow::Result<(i32, Vec<u8>)>
+) -> anyhow::Result<HookOutput>
 where
     I: IntoIterator<Item = &'a Path>,
     F: Fn(&'a Path) -> Fut,
-    Fut: Future<Output = anyhow::Result<(i32, Vec<u8>)>>,
+    Fut: Future<Output = anyhow::Result<HookOutput>>,
 {
     use futures_util::StreamExt;
 
@@ -93,14 +140,10 @@ where
         .map(check)
         .buffered(concurrency);
 
-    let mut code = 0;
-    let mut output = Vec::new();
-
-    while let Some(result) = tasks.next().await {
-        let (c, o) = result?;
-        code |= c;
-        output.extend(o);
+    let mut result = HookOutput::unchanged(0, Vec::new());
+    while let Some(file_result) = tasks.next().await {
+        result.merge_known(file_result?);
     }
 
-    Ok((code, output))
+    Ok(result)
 }

--- a/crates/prek/src/hooks/mod.rs
+++ b/crates/prek/src/hooks/mod.rs
@@ -98,6 +98,7 @@ fn fast_path_hook(hook: &Hook) -> Option<PreCommitHooks> {
     }
 }
 
+/// Returns whether a hook requires a Git diff to determine file changes.
 pub(crate) fn requires_diff_tracking(hook: &Hook) -> bool {
     match hook.repo() {
         Repo::Meta { .. } | Repo::Builtin { .. } => false,
@@ -124,6 +125,7 @@ pub async fn run_fast_path(
     result
 }
 
+/// Runs per-file checks concurrently and merges their results in input order.
 pub(crate) async fn run_concurrent_file_checks<'a, I, F, Fut>(
     filenames: I,
     concurrency: usize,

--- a/crates/prek/src/hooks/pre_commit_hooks/check_added_large_files.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_added_large_files.rs
@@ -5,6 +5,7 @@ use rustc_hash::FxHashSet;
 
 use crate::git::{get_added_files, get_lfs_files};
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::{hook_filenames, parse_hook_args};
 use crate::hooks::run_concurrent_file_checks;
 use crate::run::INTERNAL_CONCURRENCY;
@@ -27,7 +28,7 @@ pub(crate) struct Args {
 pub(crate) async fn check_added_large_files(
     hook: &Hook,
     filenames: &[&Path],
-) -> anyhow::Result<(i32, Vec<u8>)> {
+) -> anyhow::Result<HookOutput> {
     let args: Args = parse_hook_args(hook)?;
     let all_filenames = hook_filenames(&args.filenames, filenames).collect::<Vec<_>>();
     let filenames = all_filenames.as_slice();
@@ -49,7 +50,7 @@ pub(crate) async fn check_added_large_files(
     };
 
     if filenames.is_empty() {
-        return Ok((0, Vec::new()));
+        return Ok(HookOutput::unchanged(0, Vec::new()));
     }
 
     // Builtin hooks receive project-relative filenames, so git attribute lookups need to run
@@ -65,7 +66,7 @@ pub(crate) async fn check_added_large_files(
         let file_path = hook.project().relative_path().join(filename);
         let size = fs_err::tokio::metadata(file_path).await?.len() / 1024;
         if size > args.max_kb {
-            anyhow::Ok((
+            anyhow::Ok(HookOutput::unchanged(
                 1,
                 format!(
                     "{} ({size} KB) exceeds {} KB\n",
@@ -75,7 +76,7 @@ pub(crate) async fn check_added_large_files(
                 .into_bytes(),
             ))
         } else {
-            anyhow::Ok((0, Vec::new()))
+            anyhow::Ok(HookOutput::unchanged(0, Vec::new()))
         }
     })
     .await

--- a/crates/prek/src/hooks/pre_commit_hooks/check_added_large_files.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_added_large_files.rs
@@ -25,10 +25,8 @@ pub(crate) struct Args {
     filenames: Vec<PathBuf>,
 }
 
-pub(crate) async fn check_added_large_files(
-    hook: &Hook,
-    filenames: &[&Path],
-) -> anyhow::Result<HookOutput> {
+/// Runs the `check-added-large-files` hook.
+pub(crate) async fn run(hook: &Hook, filenames: &[&Path]) -> anyhow::Result<HookOutput> {
     let args: Args = parse_hook_args(hook)?;
     let all_filenames = hook_filenames(&args.filenames, filenames).collect::<Vec<_>>();
     let filenames = all_filenames.as_slice();

--- a/crates/prek/src/hooks/pre_commit_hooks/check_case_conflict.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_case_conflict.rs
@@ -11,7 +11,8 @@ use crate::hook::Hook;
 use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::{FilenamesArgs, hook_filenames, parse_hook_args};
 
-pub(crate) async fn check_case_conflict(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
+/// Runs the `check-case-conflict` hook.
+pub(crate) async fn run(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     let filenames = hook_filenames(&args.filenames, filenames).collect::<Vec<_>>();
     let work_dir = hook.work_dir();

--- a/crates/prek/src/hooks/pre_commit_hooks/check_case_conflict.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_case_conflict.rs
@@ -8,12 +8,10 @@ use rustc_hash::FxHashSet;
 
 use crate::git;
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::{FilenamesArgs, hook_filenames, parse_hook_args};
 
-pub(crate) async fn check_case_conflict(
-    hook: &Hook,
-    filenames: &[&Path],
-) -> Result<(i32, Vec<u8>)> {
+pub(crate) async fn check_case_conflict(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     let filenames = hook_filenames(&args.filenames, filenames).collect::<Vec<_>>();
     let work_dir = hook.work_dir();
@@ -78,7 +76,7 @@ pub(crate) async fn check_case_conflict(
 
     let mut output = Vec::new();
     if conflicts.is_empty() {
-        return Ok((0, output));
+        return Ok(HookOutput::unchanged(0, output));
     }
 
     // The sets are disjoint at this point (relevant removed from repo), so we can just chain.
@@ -97,7 +95,7 @@ pub(crate) async fn check_case_conflict(
         )?;
     }
 
-    Ok((1, output))
+    Ok(HookOutput::unchanged(1, output))
 }
 
 fn insert_path_and_parents<'p>(set: &mut FxHashSet<&'p Path>, file: &'p Path) {

--- a/crates/prek/src/hooks/pre_commit_hooks/check_executables_have_shebangs.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_executables_have_shebangs.rs
@@ -5,6 +5,7 @@ use owo_colors::OwoColorize;
 
 use crate::git;
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::shebangs::{
     file_has_shebang, git_index_stage_output, matching_git_index_paths_by_executable_bit,
 };
@@ -16,11 +17,11 @@ use rustc_hash::FxHashSet;
 pub(crate) async fn check_executables_have_shebangs(
     hook: &Hook,
     filenames: &[&Path],
-) -> Result<(i32, Vec<u8>), anyhow::Error> {
+) -> Result<HookOutput, anyhow::Error> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     let filenames = hook_filenames(&args.filenames, filenames).collect::<Vec<_>>();
     if filenames.is_empty() {
-        return Ok((0, Vec::new()));
+        return Ok(HookOutput::unchanged(0, Vec::new()));
     }
 
     let stdout = git::git_cmd()?
@@ -34,22 +35,17 @@ pub(crate) async fn check_executables_have_shebangs(
     let tracks_executable_bit = std::str::from_utf8(&stdout)?.trim() != "false";
     let file_base = hook.project().relative_path();
 
-    let (code, output) = if tracks_executable_bit {
+    if tracks_executable_bit {
         // core.fileMode=true means the platform honors the executable bit, so trust the FS metadata.
         // The `executables-have-shebangs` hook already restricts inputs to executable text files (`types: [text, executable]`).
-        os_check_shebangs(file_base, &filenames).await?
+        os_check_shebangs(file_base, &filenames).await
     } else {
         // If on win32 use git to check executable bit
-        git_check_shebangs(file_base, &filenames).await?
-    };
-
-    Ok((code, output))
+        git_check_shebangs(file_base, &filenames).await
+    }
 }
 
-async fn os_check_shebangs(
-    file_base: &Path,
-    paths: &[&Path],
-) -> Result<(i32, Vec<u8>), anyhow::Error> {
+async fn os_check_shebangs(file_base: &Path, paths: &[&Path]) -> Result<HookOutput, anyhow::Error> {
     run_concurrent_file_checks(
         paths.iter().copied(),
         *INTERNAL_CONCURRENCY,
@@ -57,10 +53,10 @@ async fn os_check_shebangs(
             let file_path = file_base.join(file);
             let has_shebang = file_has_shebang(&file_path).await?;
             if has_shebang {
-                anyhow::Ok((0, Vec::new()))
+                anyhow::Ok(HookOutput::unchanged(0, Vec::new()))
             } else {
                 let msg = build_missing_shebang_warning(file)?;
-                Ok((1, msg.into_bytes()))
+                Ok(HookOutput::unchanged(1, msg.into_bytes()))
             }
         },
     )
@@ -100,7 +96,7 @@ fn build_missing_shebang_warning(path: &Path) -> Result<String, std::fmt::Error>
 async fn git_check_shebangs(
     file_base: &Path,
     filenames: &[&Path],
-) -> Result<(i32, Vec<u8>), anyhow::Error> {
+) -> Result<HookOutput, anyhow::Error> {
     let stdout = git_index_stage_output(file_base).await?;
     let filenames: FxHashSet<_> = filenames.iter().copied().collect();
     let entries = matching_git_index_paths_by_executable_bit(&stdout, file_base, &filenames, true);
@@ -108,9 +104,12 @@ async fn git_check_shebangs(
     run_concurrent_file_checks(entries, *INTERNAL_CONCURRENCY, |file| async move {
         let file_path = file_base.join(file);
         if file_has_shebang(&file_path).await? {
-            Ok((0, Vec::new()))
+            Ok(HookOutput::unchanged(0, Vec::new()))
         } else {
-            Ok((1, build_missing_shebang_warning(file)?.into_bytes()))
+            Ok(HookOutput::unchanged(
+                1,
+                build_missing_shebang_warning(file)?.into_bytes(),
+            ))
         }
     })
     .await
@@ -126,9 +125,9 @@ mod tests {
         let file = NamedTempFile::new()?;
         fs_err::tokio::write(file.path(), b"#!/bin/bash\necho ok\n").await?;
         let files = vec![file.path()];
-        let (code, output) = os_check_shebangs(Path::new(""), &files).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = os_check_shebangs(Path::new(""), &files).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
 
         Ok(())
     }
@@ -138,10 +137,10 @@ mod tests {
         let file = NamedTempFile::new()?;
         fs_err::tokio::write(file.path(), b"echo ok\n").await?;
         let files = vec![file.path()];
-        let (code, output) = os_check_shebangs(Path::new(""), &files).await?;
-        assert_eq!(code, 1);
+        let result = os_check_shebangs(Path::new(""), &files).await?;
+        assert_eq!(result.exit_status, 1);
         assert!(
-            String::from_utf8_lossy(&output)
+            String::from_utf8_lossy(&result.output)
                 .contains("marked executable but has no (or invalid) shebang!")
         );
         Ok(())
@@ -149,9 +148,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_os_check_shebangs_empty_input() -> Result<(), anyhow::Error> {
-        let (code, output) = os_check_shebangs(Path::new(""), &[]).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = os_check_shebangs(Path::new(""), &[]).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 }

--- a/crates/prek/src/hooks/pre_commit_hooks/check_executables_have_shebangs.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_executables_have_shebangs.rs
@@ -14,10 +14,8 @@ use crate::hooks::run_concurrent_file_checks;
 use crate::run::INTERNAL_CONCURRENCY;
 use rustc_hash::FxHashSet;
 
-pub(crate) async fn check_executables_have_shebangs(
-    hook: &Hook,
-    filenames: &[&Path],
-) -> Result<HookOutput, anyhow::Error> {
+/// Runs the `check-executables-have-shebangs` hook.
+pub(crate) async fn run(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput, anyhow::Error> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     let filenames = hook_filenames(&args.filenames, filenames).collect::<Vec<_>>();
     if filenames.is_empty() {

--- a/crates/prek/src/hooks/pre_commit_hooks/check_json.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_json.rs
@@ -11,7 +11,8 @@ use crate::hooks::pre_commit_hooks::{FilenamesArgs, hook_filenames, parse_hook_a
 use crate::hooks::run_concurrent_file_checks;
 use crate::run::INTERNAL_CONCURRENCY;
 
-pub(crate) async fn check_json(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
+/// Runs the `check-json` hook.
+pub(crate) async fn run(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     run_concurrent_file_checks(
         hook_filenames(&args.filenames, filenames),

--- a/crates/prek/src/hooks/pre_commit_hooks/check_json.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_json.rs
@@ -6,11 +6,12 @@ use rustc_hash::FxHashSet;
 use serde::{Deserialize, Deserializer};
 
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::{FilenamesArgs, hook_filenames, parse_hook_args};
 use crate::hooks::run_concurrent_file_checks;
 use crate::run::INTERNAL_CONCURRENCY;
 
-pub(crate) async fn check_json(hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
+pub(crate) async fn check_json(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     run_concurrent_file_checks(
         hook_filenames(&args.filenames, filenames),
@@ -20,11 +21,11 @@ pub(crate) async fn check_json(hook: &Hook, filenames: &[&Path]) -> Result<(i32,
     .await
 }
 
-async fn check_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)> {
+async fn check_file(file_base: &Path, filename: &Path) -> Result<HookOutput> {
     let file_path = file_base.join(filename);
     let content = fs_err::tokio::read(file_path).await?;
     if content.is_empty() {
-        return Ok((0, Vec::new()));
+        return Ok(HookOutput::unchanged(0, Vec::new()));
     }
 
     let mut deserializer = serde_json::Deserializer::from_slice(&content);
@@ -33,10 +34,10 @@ async fn check_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)>
 
     // Try to parse with duplicate key detection
     match JsonDuplicateKeyChecker::deserialize(deserializer) {
-        Ok(JsonDuplicateKeyChecker) => Ok((0, Vec::new())),
+        Ok(JsonDuplicateKeyChecker) => Ok(HookOutput::unchanged(0, Vec::new())),
         Err(e) => {
             let error_message = format!("{}: Failed to json decode ({e})\n", filename.display());
-            Ok((1, error_message.into_bytes()))
+            Ok(HookOutput::unchanged(1, error_message.into_bytes()))
         }
     }
 }
@@ -139,9 +140,9 @@ mod tests {
         let dir = tempdir()?;
         let content = br#"{"key1": "value1", "key2": "value2"}"#;
         let file_path = create_test_file(&dir, "valid.json", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
 
         Ok(())
     }
@@ -151,9 +152,9 @@ mod tests {
         let dir = tempdir()?;
         let content = br#"{"key1": "value1", "key2": "value2""#;
         let file_path = create_test_file(&dir, "invalid.json", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
 
         Ok(())
     }
@@ -163,9 +164,9 @@ mod tests {
         let dir = tempdir()?;
         let content = br#"{"key1": "value1", "key1": "value2"}"#;
         let file_path = create_test_file(&dir, "duplicate.json", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
 
         Ok(())
     }
@@ -175,9 +176,9 @@ mod tests {
         let dir = tempdir()?;
         let content = b"";
         let file_path = create_test_file(&dir, "empty.json", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
 
         Ok(())
     }
@@ -187,9 +188,9 @@ mod tests {
         let dir = tempdir()?;
         let content = br#"[{"key1": "value1"}, {"key2": "value2"}]"#;
         let file_path = create_test_file(&dir, "valid_array.json", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
 
         Ok(())
     }
@@ -199,9 +200,9 @@ mod tests {
         let dir = tempdir()?;
         let content = br#"{"key1": "value1", "key2": {"nested_key": 1, "nested_key": 2}}"#;
         let file_path = create_test_file(&dir, "nested_duplicate.json", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
 
         Ok(())
     }
@@ -216,9 +217,9 @@ mod tests {
         }
 
         let file_path = create_test_file(&dir, "deeply_nested.json", json.as_bytes()).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
 
         Ok(())
     }

--- a/crates/prek/src/hooks/pre_commit_hooks/check_merge_conflict.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_merge_conflict.rs
@@ -29,7 +29,8 @@ pub(crate) struct Args {
     filenames: Vec<PathBuf>,
 }
 
-pub(crate) async fn check_merge_conflict(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
+/// Runs the `check-merge-conflict` hook.
+pub(crate) async fn run(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: Args = parse_hook_args(hook)?;
 
     // Check if we're in a merge state or assuming merge

--- a/crates/prek/src/hooks/pre_commit_hooks/check_merge_conflict.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_merge_conflict.rs
@@ -7,6 +7,7 @@ use tokio::io::AsyncBufReadExt;
 
 use crate::git::get_git_dir;
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::{hook_filenames, parse_hook_args};
 use crate::hooks::run_concurrent_file_checks;
 use crate::run::INTERNAL_CONCURRENCY;
@@ -28,15 +29,12 @@ pub(crate) struct Args {
     filenames: Vec<PathBuf>,
 }
 
-pub(crate) async fn check_merge_conflict(
-    hook: &Hook,
-    filenames: &[&Path],
-) -> Result<(i32, Vec<u8>)> {
+pub(crate) async fn check_merge_conflict(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: Args = parse_hook_args(hook)?;
 
     // Check if we're in a merge state or assuming merge
     if !args.assume_in_merge && !is_in_merge().await? {
-        return Ok((0, Vec::new()));
+        return Ok(HookOutput::unchanged(0, Vec::new()));
     }
 
     run_concurrent_file_checks(
@@ -63,7 +61,7 @@ async fn is_in_merge() -> Result<bool> {
         || git_dir.join("rebase-merge").exists())
 }
 
-async fn check_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)> {
+async fn check_file(file_base: &Path, filename: &Path) -> Result<HookOutput> {
     let file_path = file_base.join(filename);
     let file = fs_err::tokio::File::open(&file_path).await?;
     let mut reader = tokio::io::BufReader::new(file);
@@ -101,7 +99,7 @@ async fn check_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)>
         line_number += 1;
     }
 
-    Ok((code, output))
+    Ok(HookOutput::unchanged(code, output))
 }
 
 fn write_conflict_message(
@@ -138,9 +136,9 @@ mod tests {
         let dir = tempdir()?;
         let content = b"This is a normal file\nWith no conflict markers\n";
         let file_path = create_test_file(&dir, "clean.txt", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -149,10 +147,10 @@ mod tests {
         let dir = tempdir()?;
         let content = b"Some content\n<<<<<<< HEAD\nConflicting line\n";
         let file_path = create_test_file(&dir, "conflict.txt", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
-        let output_str = String::from_utf8_lossy(&output);
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
+        let output_str = String::from_utf8_lossy(&result.output);
         assert!(output_str.contains("<<<<<<< "));
         assert!(output_str.contains("conflict.txt:2"));
         Ok(())
@@ -163,10 +161,10 @@ mod tests {
         let dir = tempdir()?;
         let content = b"Some content\n>>>>>>> branch\nMore content\n";
         let file_path = create_test_file(&dir, "conflict.txt", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
-        let output_str = String::from_utf8_lossy(&output);
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
+        let output_str = String::from_utf8_lossy(&result.output);
         assert!(output_str.contains(">>>>>>> "));
         Ok(())
     }
@@ -176,10 +174,10 @@ mod tests {
         let dir = tempdir()?;
         let content = b"Before conflict\n<<<<<<< HEAD\nOur changes\n=======\nTheir changes\n>>>>>>> branch\nAfter conflict\n";
         let file_path = create_test_file(&dir, "conflict.txt", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
-        let output_str = String::from_utf8_lossy(&output);
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
+        let output_str = String::from_utf8_lossy(&result.output);
         // Should find all three markers
         assert!(output_str.contains("<<<<<<< "));
         assert!(output_str.contains("======="));
@@ -192,10 +190,10 @@ mod tests {
         let dir = tempdir()?;
         let content = b"Before conflict\n<<<<<<< HEAD\nOur changes\n||||||| base\nCommon ancestor\n=======\nTheir changes\n>>>>>>> branch\nAfter conflict\n";
         let file_path = create_test_file(&dir, "conflict.txt", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
-        let output_str = String::from_utf8_lossy(&output);
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
+        let output_str = String::from_utf8_lossy(&result.output);
         assert!(output_str.contains("<<<<<<< "));
         assert!(output_str.contains("||||||| "));
         assert!(output_str.contains("======="));
@@ -208,10 +206,10 @@ mod tests {
         let dir = tempdir()?;
         let content = b"Some content <<<<<<< HEAD\n";
         let file_path = create_test_file(&dir, "no_conflict.txt", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
+        let result = check_file(Path::new(""), &file_path).await?;
         // Should not detect conflict since marker is not at line start
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -220,9 +218,9 @@ mod tests {
         let dir = tempdir()?;
         let content = b"Some content\r\n<<<<<<< HEAD\r\nConflicting line\r\n=======\r\nOther line\r\n>>>>>>> branch\r\n";
         let file_path = create_test_file(&dir, "conflict_crlf.txt", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
         Ok(())
     }
 
@@ -232,9 +230,9 @@ mod tests {
         let content =
             b"Some content\n<<<<<<< HEAD\nConflicting line\n=======\nOther line\n>>>>>>> branch\n";
         let file_path = create_test_file(&dir, "conflict_lf.txt", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
         Ok(())
     }
 
@@ -243,9 +241,9 @@ mod tests {
         let dir = tempdir()?;
         let content = b"Before conflict\n<<<<<<< HEAD\nOur changes\n=======\n";
         let file_path = create_test_file(&dir, "partial_conflict.txt", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        let output_str = String::from_utf8_lossy(&output);
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        let output_str = String::from_utf8_lossy(&result.output);
         assert!(output_str.contains("<<<<<<< "));
         assert!(output_str.contains("======="));
         Ok(())
@@ -256,9 +254,9 @@ mod tests {
         let dir = tempdir()?;
         let content = b"Before conflict\n||||||| base\n";
         let file_path = create_test_file(&dir, "partial_conflict.txt", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -267,9 +265,9 @@ mod tests {
         let dir = tempdir()?;
         let content = b"Depends\n=======\n";
         let file_path = create_test_file(&dir, "doc.rst", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -278,9 +276,9 @@ mod tests {
         let dir = tempdir()?;
         let content = b"";
         let file_path = create_test_file(&dir, "empty.txt", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -289,9 +287,9 @@ mod tests {
         let dir = tempdir()?;
         let content = b"<<<<<<< HEAD\nFirst\n=======\nSecond\n>>>>>>> branch\nMiddle\n<<<<<<< HEAD\nThird\n=======\nFourth\n>>>>>>> other\n";
         let file_path = create_test_file(&dir, "multiple.txt", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        let output_str = String::from_utf8_lossy(&output);
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        let output_str = String::from_utf8_lossy(&result.output);
         // Should find all markers from both conflicts (one per line with marker)
         let marker_count = output_str.matches("Merge conflict string").count();
         assert_eq!(marker_count, 6); // 3 markers per conflict * 2 conflicts
@@ -304,9 +302,9 @@ mod tests {
         let mut content = vec![0xFF, 0xFE, 0xFD];
         content.extend_from_slice(b"\n<<<<<<< HEAD\n");
         let file_path = create_test_file(&dir, "binary.bin", &content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
         Ok(())
     }
 }

--- a/crates/prek/src/hooks/pre_commit_hooks/check_shebang_scripts_are_executable.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_shebang_scripts_are_executable.rs
@@ -13,10 +13,8 @@ use crate::hooks::run_concurrent_file_checks;
 use crate::run::INTERNAL_CONCURRENCY;
 use rustc_hash::FxHashSet;
 
-pub(crate) async fn check_shebang_scripts_are_executable(
-    hook: &Hook,
-    filenames: &[&Path],
-) -> Result<HookOutput, anyhow::Error> {
+/// Runs the `check-shebang-scripts-are-executable` hook.
+pub(crate) async fn run(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput, anyhow::Error> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     let filenames = hook_filenames(&args.filenames, filenames).collect::<Vec<_>>();
     if filenames.is_empty() {

--- a/crates/prek/src/hooks/pre_commit_hooks/check_shebang_scripts_are_executable.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_shebang_scripts_are_executable.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use owo_colors::OwoColorize;
 
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::shebangs::{
     file_has_shebang, git_index_stage_output, matching_git_index_paths_by_executable_bit,
 };
@@ -15,11 +16,11 @@ use rustc_hash::FxHashSet;
 pub(crate) async fn check_shebang_scripts_are_executable(
     hook: &Hook,
     filenames: &[&Path],
-) -> Result<(i32, Vec<u8>), anyhow::Error> {
+) -> Result<HookOutput, anyhow::Error> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     let filenames = hook_filenames(&args.filenames, filenames).collect::<Vec<_>>();
     if filenames.is_empty() {
-        return Ok((0, Vec::new()));
+        return Ok(HookOutput::unchanged(0, Vec::new()));
     }
 
     let file_base = hook.project().relative_path();
@@ -30,9 +31,12 @@ pub(crate) async fn check_shebang_scripts_are_executable(
     run_concurrent_file_checks(entries, *INTERNAL_CONCURRENCY, |file| async move {
         let file_path = file_base.join(file);
         if file_has_shebang(&file_path).await? {
-            Ok((1, build_non_executable_shebang_warning(file)?.into_bytes()))
+            Ok(HookOutput::unchanged(
+                1,
+                build_non_executable_shebang_warning(file)?.into_bytes(),
+            ))
         } else {
-            Ok((0, Vec::new()))
+            Ok(HookOutput::unchanged(0, Vec::new()))
         }
     })
     .await

--- a/crates/prek/src/hooks/pre_commit_hooks/check_symlinks.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_symlinks.rs
@@ -3,11 +3,12 @@ use std::path::Path;
 use anyhow::Result;
 
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::{FilenamesArgs, hook_filenames, parse_hook_args};
 use crate::hooks::run_concurrent_file_checks;
 use crate::run::INTERNAL_CONCURRENCY;
 
-pub(crate) async fn check_symlinks(hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
+pub(crate) async fn check_symlinks(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     run_concurrent_file_checks(
         hook_filenames(&args.filenames, filenames),
@@ -17,20 +18,20 @@ pub(crate) async fn check_symlinks(hook: &Hook, filenames: &[&Path]) -> Result<(
     .await
 }
 
-async fn check_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)> {
+async fn check_file(file_base: &Path, filename: &Path) -> Result<HookOutput> {
     let path = file_base.join(filename);
 
     // Check if it's a symlink and if it's broken
     let Ok(metadata) = fs_err::tokio::symlink_metadata(&path).await else {
-        return Ok((0, Vec::new()));
+        return Ok(HookOutput::unchanged(0, Vec::new()));
     };
 
     if metadata.file_type().is_symlink() && fs_err::tokio::metadata(&path).await.is_err() {
         let error_message = format!("{}: Broken symlink\n", filename.display());
-        return Ok((1, error_message.into_bytes()));
+        return Ok(HookOutput::unchanged(1, error_message.into_bytes()));
     }
 
-    Ok((0, Vec::new()))
+    Ok(HookOutput::unchanged(0, Vec::new()))
 }
 
 #[cfg(test)]
@@ -54,9 +55,9 @@ mod tests {
         let dir = tempdir()?;
         let content = b"regular file content";
         let file_path = create_test_file(&dir, "regular.txt", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -68,9 +69,9 @@ mod tests {
         let link_path = dir.path().join("link.txt");
         fs_err::tokio::symlink(&target, &link_path).await?;
 
-        let (code, output) = check_file(Path::new(""), &link_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &link_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -82,10 +83,10 @@ mod tests {
         let nonexistent = dir.path().join("nonexistent.txt");
         fs_err::tokio::symlink(&nonexistent, &link_path).await?;
 
-        let (code, output) = check_file(Path::new(""), &link_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
-        let output_str = String::from_utf8_lossy(&output);
+        let result = check_file(Path::new(""), &link_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
+        let output_str = String::from_utf8_lossy(&result.output);
         assert!(output_str.contains("Broken symlink"));
         Ok(())
     }
@@ -106,9 +107,9 @@ mod tests {
             return Ok(());
         }
 
-        let (code, output) = check_file(Path::new(""), &link_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &link_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -129,10 +130,10 @@ mod tests {
             return Ok(());
         }
 
-        let (code, output) = check_file(Path::new(""), &link_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
-        let output_str = String::from_utf8_lossy(&output);
+        let result = check_file(Path::new(""), &link_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
+        let output_str = String::from_utf8_lossy(&result.output);
         assert!(output_str.contains("Broken symlink"));
         Ok(())
     }
@@ -145,9 +146,9 @@ mod tests {
         let link_path = dir.path().join("link.txt");
         fs_err::tokio::symlink(&target, &link_path).await?;
 
-        let (code, output) = check_file(Path::new(""), &link_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &link_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -159,10 +160,10 @@ mod tests {
         let nonexistent = dir.path().join("nonexistent.txt");
         fs_err::tokio::symlink(&nonexistent, &link_path).await?;
 
-        let (code, output) = check_file(Path::new(""), &link_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
-        let output_str = String::from_utf8_lossy(&output);
+        let result = check_file(Path::new(""), &link_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
+        let output_str = String::from_utf8_lossy(&result.output);
         assert!(output_str.contains("Broken symlink"));
         Ok(())
     }

--- a/crates/prek/src/hooks/pre_commit_hooks/check_symlinks.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_symlinks.rs
@@ -8,7 +8,8 @@ use crate::hooks::pre_commit_hooks::{FilenamesArgs, hook_filenames, parse_hook_a
 use crate::hooks::run_concurrent_file_checks;
 use crate::run::INTERNAL_CONCURRENCY;
 
-pub(crate) async fn check_symlinks(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
+/// Runs the `check-symlinks` hook.
+pub(crate) async fn run(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     run_concurrent_file_checks(
         hook_filenames(&args.filenames, filenames),

--- a/crates/prek/src/hooks/pre_commit_hooks/check_toml.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_toml.rs
@@ -9,7 +9,8 @@ use crate::hooks::pre_commit_hooks::{FilenamesArgs, hook_filenames, parse_hook_a
 use crate::hooks::run_concurrent_file_checks;
 use crate::run::INTERNAL_CONCURRENCY;
 
-pub(crate) async fn check_toml(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
+/// Runs the `check-toml` hook.
+pub(crate) async fn run(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     run_concurrent_file_checks(
         hook_filenames(&args.filenames, filenames),

--- a/crates/prek/src/hooks/pre_commit_hooks/check_toml.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_toml.rs
@@ -4,11 +4,12 @@ use std::path::Path;
 use anyhow::Result;
 
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::{FilenamesArgs, hook_filenames, parse_hook_args};
 use crate::hooks::run_concurrent_file_checks;
 use crate::run::INTERNAL_CONCURRENCY;
 
-pub(crate) async fn check_toml(hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
+pub(crate) async fn check_toml(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     run_concurrent_file_checks(
         hook_filenames(&args.filenames, filenames),
@@ -18,10 +19,10 @@ pub(crate) async fn check_toml(hook: &Hook, filenames: &[&Path]) -> Result<(i32,
     .await
 }
 
-async fn check_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)> {
+async fn check_file(file_base: &Path, filename: &Path) -> Result<HookOutput> {
     let content = fs_err::tokio::read(file_base.join(filename)).await?;
     if content.is_empty() {
-        return Ok((0, Vec::new()));
+        return Ok(HookOutput::unchanged(0, Vec::new()));
     }
 
     // Use string content for borrowed parsing
@@ -29,14 +30,14 @@ async fn check_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)>
         Ok(s) => s,
         Err(e) => {
             let error_message = format!("{}: Failed to decode UTF-8 ({e})\n", filename.display());
-            return Ok((1, error_message.into_bytes()));
+            return Ok(HookOutput::unchanged(1, error_message.into_bytes()));
         }
     };
 
     // Use DeTable::parse_recoverable to report all parse errors at once
     let (_parsed, errors) = toml::de::DeTable::parse_recoverable(content_str);
     if errors.is_empty() {
-        Ok((0, Vec::new()))
+        Ok(HookOutput::unchanged(0, Vec::new()))
     } else {
         let mut output = Vec::new();
         for error in errors {
@@ -46,7 +47,7 @@ async fn check_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)>
                 filename.display()
             )?;
         }
-        Ok((1, output))
+        Ok(HookOutput::unchanged(1, output))
     }
 }
 
@@ -73,9 +74,9 @@ mod tests {
 key2 = "value2"
 "#;
         let file_path = create_test_file(&dir, "valid.toml", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -86,9 +87,9 @@ key2 = "value2"
 key2 = "value2"
 "#;
         let file_path = create_test_file(&dir, "invalid.toml", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
         Ok(())
     }
 
@@ -99,9 +100,9 @@ key2 = "value2"
 key1 = "value2"
 "#;
         let file_path = create_test_file(&dir, "duplicate.toml", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
         Ok(())
     }
 
@@ -110,9 +111,9 @@ key1 = "value2"
         let dir = tempdir()?;
         let content = b"";
         let file_path = create_test_file(&dir, "empty.toml", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -127,9 +128,9 @@ key3 = invalid_value_without_quotes
 key4 = "another unclosed string
 "#;
         let file_path = create_test_file(&dir, "multiple_errors.toml", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        let output_str = String::from_utf8_lossy(&output);
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        let output_str = String::from_utf8_lossy(&result.output);
 
         // Should contain multiple error messages (one for each error found)
         let error_count = output_str.matches("Failed to toml decode").count();
@@ -144,9 +145,9 @@ key4 = "another unclosed string
         let content = b"key1 = \"\xff\xfe\xfd\"\nkey2 = \"valid\"";
         let file_path = create_test_file(&dir, "invalid_utf8.toml", content).await?;
 
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        let output_str = String::from_utf8_lossy(&output);
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        let output_str = String::from_utf8_lossy(&result.output);
         assert!(output_str.contains("Failed to decode UTF-8"));
         assert!(output_str.contains("invalid_utf8.toml"));
         Ok(())

--- a/crates/prek/src/hooks/pre_commit_hooks/check_vcs_permalinks.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_vcs_permalinks.rs
@@ -83,7 +83,8 @@ fn is_probable_commit_hash(reference: &[u8]) -> bool {
     (4..=64).contains(&reference.len()) && reference.iter().all(u8::is_ascii_hexdigit)
 }
 
-pub(crate) async fn check_vcs_permalinks(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
+/// Runs the `check-vcs-permalinks` hook.
+pub(crate) async fn run(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: Args = parse_hook_args(hook)?;
     let matcher = Arc::new(GithubNonPermalinkMatcher::new(
         args.additional_github_domains,

--- a/crates/prek/src/hooks/pre_commit_hooks/check_vcs_permalinks.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_vcs_permalinks.rs
@@ -9,6 +9,7 @@ use memchr::memmem;
 use regex::bytes::{Match, Regex};
 
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::{hook_filenames, parse_hook_args};
 use crate::hooks::run_concurrent_file_checks;
 use crate::run::INTERNAL_CONCURRENCY;
@@ -82,10 +83,7 @@ fn is_probable_commit_hash(reference: &[u8]) -> bool {
     (4..=64).contains(&reference.len()) && reference.iter().all(u8::is_ascii_hexdigit)
 }
 
-pub(crate) async fn check_vcs_permalinks(
-    hook: &Hook,
-    filenames: &[&Path],
-) -> Result<(i32, Vec<u8>)> {
+pub(crate) async fn check_vcs_permalinks(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: Args = parse_hook_args(hook)?;
     let matcher = Arc::new(GithubNonPermalinkMatcher::new(
         args.additional_github_domains,
@@ -104,11 +102,13 @@ async fn check_file(
     file_base: &Path,
     filename: &Path,
     matcher: &Arc<GithubNonPermalinkMatcher>,
-) -> Result<(i32, Vec<u8>)> {
+) -> Result<HookOutput> {
     let path = file_base.join(filename);
     let filename = filename.to_path_buf();
     let matcher = Arc::clone(matcher);
-    tokio::task::spawn_blocking(move || check_file_sync(&path, &filename, &matcher)).await?
+    let (exit_status, output) =
+        tokio::task::spawn_blocking(move || check_file_sync(&path, &filename, &matcher)).await??;
+    Ok(HookOutput::unchanged(exit_status, output))
 }
 
 fn check_file_sync(
@@ -244,11 +244,11 @@ mod tests {
 
         let matcher = Arc::new(matcher(&["github.example.com"]));
         let relative = PathBuf::from("links.md");
-        let (code, output) = check_file(dir.path(), &relative, &matcher).await?;
+        let result = check_file(dir.path(), &relative, &matcher).await?;
 
-        assert_eq!(code, 1);
+        assert_eq!(result.exit_status, 1);
         assert_eq!(
-            String::from_utf8(output)?,
+            String::from_utf8(result.output)?,
             "Non-permanent github link detected: links.md:1:https://github.example.com/owner/repo/blob/main/file.py#L10\nNon-permanent github link detected: links.md:1:https://github.com/owner/repo/blob/master/src/lib.rs#L5\n",
         );
 

--- a/crates/prek/src/hooks/pre_commit_hooks/check_xml.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_xml.rs
@@ -9,7 +9,8 @@ use crate::hooks::pre_commit_hooks::{FilenamesArgs, hook_filenames, parse_hook_a
 use crate::hooks::run_concurrent_file_checks;
 use crate::run::INTERNAL_CONCURRENCY;
 
-pub(crate) async fn check_xml(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
+/// Runs the `check-xml` hook.
+pub(crate) async fn run(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     run_concurrent_file_checks(
         hook_filenames(&args.filenames, filenames),

--- a/crates/prek/src/hooks/pre_commit_hooks/check_xml.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_xml.rs
@@ -4,11 +4,12 @@ use anyhow::Result;
 use xml::reader::ParserConfig;
 
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::{FilenamesArgs, hook_filenames, parse_hook_args};
 use crate::hooks::run_concurrent_file_checks;
 use crate::run::INTERNAL_CONCURRENCY;
 
-pub(crate) async fn check_xml(hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
+pub(crate) async fn check_xml(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     run_concurrent_file_checks(
         hook_filenames(&args.filenames, filenames),
@@ -18,7 +19,7 @@ pub(crate) async fn check_xml(hook: &Hook, filenames: &[&Path]) -> Result<(i32, 
     .await
 }
 
-async fn check_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)> {
+async fn check_file(file_base: &Path, filename: &Path) -> Result<HookOutput> {
     let content = fs_err::tokio::read(file_base.join(filename)).await?;
 
     // Parse the whole document once with xml-rs. This is stricter than the upstream Python
@@ -35,11 +36,11 @@ async fn check_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)>
     for event in parser {
         if let Err(error) = event {
             let error_message = format!("{}: Failed to xml parse ({error})\n", filename.display());
-            return Ok((1, error_message.into_bytes()));
+            return Ok(HookOutput::unchanged(1, error_message.into_bytes()));
         }
     }
 
-    Ok((0, Vec::new()))
+    Ok(HookOutput::unchanged(0, Vec::new()))
 }
 
 #[cfg(test)]
@@ -66,9 +67,9 @@ mod tests {
     <element>value</element>
 </root>"#;
         let file_path = create_test_file(&dir, "valid.xml", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -77,9 +78,9 @@ mod tests {
         let dir = tempdir()?;
         let content = br#"<?xml-stylesheet href="style.xsl"?><root/>"#;
         let file_path = create_test_file(&dir, "processing_instruction.xml", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -91,10 +92,10 @@ mod tests {
     <element>value
 </root>"#;
         let file_path = create_test_file(&dir, "invalid.xml", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
-        let output_str = String::from_utf8_lossy(&output);
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
+        let output_str = String::from_utf8_lossy(&result.output);
         assert!(output_str.contains("Failed to xml parse"));
         Ok(())
     }
@@ -107,9 +108,9 @@ mod tests {
     <element>value</different>
 </root>"#;
         let file_path = create_test_file(&dir, "mismatched.xml", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
         Ok(())
     }
 
@@ -121,9 +122,9 @@ mod tests {
     <element attribute="unclosed value>text</element>
 </root>"#;
         let file_path = create_test_file(&dir, "syntax_error.xml", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
         Ok(())
     }
 
@@ -131,9 +132,9 @@ mod tests {
     async fn test_invalid_xml_trailing_text() -> Result<()> {
         let dir = tempdir()?;
         let file_path = create_test_file(&dir, "trailing.xml", b"<root/>junk").await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
         Ok(())
     }
 
@@ -142,10 +143,10 @@ mod tests {
         let dir = tempdir()?;
         let content = b"";
         let file_path = create_test_file(&dir, "empty.xml", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
-        let output_str = String::from_utf8_lossy(&output);
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
+        let output_str = String::from_utf8_lossy(&result.output);
         assert!(output_str.contains("no root element found"));
         Ok(())
     }
@@ -154,9 +155,9 @@ mod tests {
     async fn test_whitespace_only_xml() -> Result<()> {
         let dir = tempdir()?;
         let file_path = create_test_file(&dir, "whitespace.xml", b" \n\t").await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
         Ok(())
     }
 
@@ -169,9 +170,9 @@ mod tests {
     <element id="2">another value</element>
 </root>"#;
         let file_path = create_test_file(&dir, "attributes.xml", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -184,9 +185,9 @@ mod tests {
             br#"<root key="1" key="2"/>"#,
         )
         .await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
         Ok(())
     }
 
@@ -194,9 +195,9 @@ mod tests {
     async fn test_invalid_xml_element_name() -> Result<()> {
         let dir = tempdir()?;
         let file_path = create_test_file(&dir, "invalid_name.xml", b"<1root/>").await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
         Ok(())
     }
 
@@ -208,9 +209,9 @@ mod tests {
     <element><![CDATA[Some <special> characters & symbols]]></element>
 </root>"#;
         let file_path = create_test_file(&dir, "cdata.xml", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -224,9 +225,9 @@ mod tests {
     <!-- Another comment -->
 </root>"#;
         let file_path = create_test_file(&dir, "comments.xml", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -239,9 +240,9 @@ mod tests {
     <element>value</element>
 </root>"#;
         let file_path = create_test_file(&dir, "doctype.xml", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -250,9 +251,9 @@ mod tests {
         let dir = tempdir()?;
         let content = br#"<!DOCTYPE html SYSTEM "xhtml.dtd"><html>&nbsp;</html>"#;
         let file_path = create_test_file(&dir, "external_entity.xml", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
         Ok(())
     }
 
@@ -261,9 +262,9 @@ mod tests {
         let dir = tempdir()?;
         let file_path =
             create_test_file(&dir, "unknown_entity.xml", b"<root>&unknown;</root>").await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
         Ok(())
     }
 
@@ -273,9 +274,9 @@ mod tests {
         let content = br#"<!DOCTYPE root [<!ENTITY value "ok">]>
 <root>&value;</root>"#;
         let file_path = create_test_file(&dir, "internal_entity.xml", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -287,9 +288,9 @@ mod tests {
             content.extend_from_slice(&code_unit.to_le_bytes());
         }
         let file_path = create_test_file(&dir, "utf16.xml", &content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -300,9 +301,9 @@ mod tests {
 <element>value</element>
 <another>value</another>"#;
         let file_path = create_test_file(&dir, "no_root.xml", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
         Ok(())
     }
 }

--- a/crates/prek/src/hooks/pre_commit_hooks/check_yaml.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_yaml.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 use serde::de::IgnoredAny;
 
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::{hook_filenames, parse_hook_args};
 use crate::hooks::run_concurrent_file_checks;
 use crate::run::INTERNAL_CONCURRENCY;
@@ -24,7 +25,7 @@ pub(crate) struct Args {
     // r#unsafe: bool,
 }
 
-pub(crate) async fn check_yaml(hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
+pub(crate) async fn check_yaml(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: Args = parse_hook_args(hook)?;
 
     run_concurrent_file_checks(
@@ -45,10 +46,10 @@ async fn check_file(
     file_base: &Path,
     filename: &Path,
     allow_multi_docs: bool,
-) -> Result<(i32, Vec<u8>)> {
+) -> Result<HookOutput> {
     let content = fs_err::tokio::read(file_base.join(filename)).await?;
     if content.is_empty() {
-        return Ok((0, Vec::new()));
+        return Ok(HookOutput::unchanged(0, Vec::new()));
     }
 
     let options = serde_saphyr::options! {
@@ -65,17 +66,17 @@ async fn check_file(
             serde_saphyr::from_slice_multiple_with_options::<IgnoredAny>(&content, options)
         {
             let error_message = format!("{}: Failed to yaml decode ({e})\n", filename.display());
-            return Ok((1, error_message.into_bytes()));
+            return Ok(HookOutput::unchanged(1, error_message.into_bytes()));
         }
-        Ok((0, Vec::new()))
+        Ok(HookOutput::unchanged(0, Vec::new()))
     } else {
         match serde_saphyr::from_slice_with_options::<IgnoredAny>(&content, options) {
-            Ok(_) => Ok((0, Vec::new())),
+            Ok(_) => Ok(HookOutput::unchanged(0, Vec::new())),
             Err(e) => {
                 let err = e.render_with_formatter(&serde_saphyr::UserMessageFormatter);
                 let error_message =
                     format!("{}: Failed to yaml decode ({err})\n", filename.display());
-                Ok((1, error_message.into_bytes()))
+                Ok(HookOutput::unchanged(1, error_message.into_bytes()))
             }
         }
     }
@@ -105,9 +106,9 @@ mod tests {
 key2: value2
 ";
         let file_path = create_test_file(&dir, "valid.yaml", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path, false).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path, false).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -118,9 +119,9 @@ key2: value2
 key2: value2: another_value
 ";
         let file_path = create_test_file(&dir, "invalid.yaml", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path, false).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
+        let result = check_file(Path::new(""), &file_path, false).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
         Ok(())
     }
 
@@ -131,9 +132,9 @@ key2: value2: another_value
 key1: value2
 ";
         let file_path = create_test_file(&dir, "duplicate.yaml", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path, false).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
+        let result = check_file(Path::new(""), &file_path, false).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
         Ok(())
     }
 
@@ -142,9 +143,9 @@ key1: value2
         let dir = tempdir()?;
         let content = b"";
         let file_path = create_test_file(&dir, "empty.yaml", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path, false).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path, false).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -159,13 +160,13 @@ key2: value2
 ";
         let file_path = create_test_file(&dir, "multi.yaml", content).await?;
 
-        let (code, output) = check_file(Path::new(""), &file_path, false).await?;
-        assert_eq!(code, 1);
-        assert!(!output.is_empty());
+        let result = check_file(Path::new(""), &file_path, false).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(!result.output.is_empty());
 
-        let (code, output) = check_file(Path::new(""), &file_path, true).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path, true).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -187,9 +188,9 @@ response:
       BKa2qJVpyDuvhldbu0LOFtnicypnC0z2yV8AAAD//wMALvIkjL4DAAA=
 ";
         let file_path = create_test_file(&dir, "binary.yaml", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path, false).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path, false).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -206,9 +207,14 @@ response:
         }
 
         let file_path = create_test_file(&dir, "many-aliases.yaml", content.as_bytes()).await?;
-        let (code, output) = check_file(Path::new(""), &file_path, false).await?;
-        assert_eq!(code, 0, "{}", String::from_utf8_lossy(&output));
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path, false).await?;
+        assert_eq!(
+            result.exit_status,
+            0,
+            "{}",
+            String::from_utf8_lossy(&result.output)
+        );
+        assert!(result.output.is_empty());
         Ok(())
     }
 }

--- a/crates/prek/src/hooks/pre_commit_hooks/check_yaml.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_yaml.rs
@@ -25,7 +25,8 @@ pub(crate) struct Args {
     // r#unsafe: bool,
 }
 
-pub(crate) async fn check_yaml(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
+/// Runs the `check-yaml` hook.
+pub(crate) async fn run(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: Args = parse_hook_args(hook)?;
 
     run_concurrent_file_checks(

--- a/crates/prek/src/hooks/pre_commit_hooks/destroyed_symlinks.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/destroyed_symlinks.rs
@@ -7,13 +7,14 @@ use rustc_hash::FxHashSet;
 
 use crate::git;
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::{FilenamesArgs, hook_filenames, parse_hook_args};
 
 const ORDINARY_CHANGED_ENTRY_MARKER: &str = "1";
 const PERMS_LINK: u32 = 0o120_000;
 const PERMS_NONEXIST: u32 = 0;
 
-pub(crate) async fn destroyed_symlinks(hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
+pub(crate) async fn destroyed_symlinks(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     let filenames = hook_filenames(&args.filenames, filenames).collect::<Vec<_>>();
     let status_output = git_status_output(hook.work_dir()).await?;
@@ -27,7 +28,7 @@ pub(crate) async fn destroyed_symlinks(hook: &Hook, filenames: &[&Path]) -> Resu
 
     let destroyed_links = find_destroyed_symlinks(hook, &filenames, entries).await?;
     if destroyed_links.is_empty() {
-        return Ok((0, Vec::new()));
+        return Ok(HookOutput::unchanged(0, Vec::new()));
     }
 
     let mut output = Vec::new();
@@ -43,7 +44,7 @@ pub(crate) async fn destroyed_symlinks(hook: &Hook, filenames: &[&Path]) -> Resu
     )?;
     writeln!(output, "\tgit config core.symlinks false")?;
 
-    Ok((1, output))
+    Ok(HookOutput::unchanged(1, output))
 }
 
 fn write_reset_command(output: &mut Vec<u8>, destroyed_links: &[&Path]) -> Result<()> {

--- a/crates/prek/src/hooks/pre_commit_hooks/destroyed_symlinks.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/destroyed_symlinks.rs
@@ -14,7 +14,8 @@ const ORDINARY_CHANGED_ENTRY_MARKER: &str = "1";
 const PERMS_LINK: u32 = 0o120_000;
 const PERMS_NONEXIST: u32 = 0;
 
-pub(crate) async fn destroyed_symlinks(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
+/// Runs the `destroyed-symlinks` hook.
+pub(crate) async fn run(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     let filenames = hook_filenames(&args.filenames, filenames).collect::<Vec<_>>();
     let status_output = git_status_output(hook.work_dir()).await?;

--- a/crates/prek/src/hooks/pre_commit_hooks/detect_private_key.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/detect_private_key.rs
@@ -43,7 +43,8 @@ static PRIVATE_KEY_MATCHER: LazyLock<AhoCorasick> = LazyLock::new(|| {
     AhoCorasick::new(BLACKLIST).expect("private key blacklist patterns should be valid")
 });
 
-pub(crate) async fn detect_private_key(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
+/// Runs the `detect-private-key` hook.
+pub(crate) async fn run(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     run_concurrent_file_checks(
         hook_filenames(&args.filenames, filenames),

--- a/crates/prek/src/hooks/pre_commit_hooks/detect_private_key.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/detect_private_key.rs
@@ -6,6 +6,7 @@ use aho_corasick::AhoCorasick;
 use anyhow::Result;
 
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::{FilenamesArgs, hook_filenames, parse_hook_args};
 use crate::hooks::run_concurrent_file_checks;
 use crate::run::INTERNAL_CONCURRENCY;
@@ -42,7 +43,7 @@ static PRIVATE_KEY_MATCHER: LazyLock<AhoCorasick> = LazyLock::new(|| {
     AhoCorasick::new(BLACKLIST).expect("private key blacklist patterns should be valid")
 });
 
-pub(crate) async fn detect_private_key(hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
+pub(crate) async fn detect_private_key(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     run_concurrent_file_checks(
         hook_filenames(&args.filenames, filenames),
@@ -57,15 +58,15 @@ pub(crate) async fn detect_private_key(hook: &Hook, filenames: &[&Path]) -> Resu
 /// For example, if one read ends with `BEGIN RSA PRIV` and the next read starts
 /// with `ATE KEY`, we keep the tail of the first read, prepend it to the second
 /// read, and search the combined window so `BEGIN RSA PRIVATE KEY` is still found.
-async fn check_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)> {
+async fn check_file(file_base: &Path, filename: &Path) -> Result<HookOutput> {
     let file_path = file_base.join(filename);
     // Keep a file's blocking I/O in one task instead of re-entering the blocking pool per read.
     let found = tokio::task::spawn_blocking(move || check_file_sync(&file_path)).await??;
     if found {
         let error_message = format!("Private key found: {}\n", filename.display());
-        Ok((1, error_message.into_bytes()))
+        Ok(HookOutput::unchanged(1, error_message.into_bytes()))
     } else {
-        Ok((0, Vec::new()))
+        Ok(HookOutput::unchanged(0, Vec::new()))
     }
 }
 
@@ -119,9 +120,9 @@ mod tests {
         let dir = tempdir()?;
         let content = b"This is just a regular file\nwith some content\n";
         let file_path = create_test_file(&dir, "clean.txt", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -130,9 +131,9 @@ mod tests {
         let dir = tempdir()?;
         let content = b"-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----\n";
         let file_path = create_test_file(&dir, "id_rsa", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
-        let output_str = String::from_utf8_lossy(&output);
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
+        let output_str = String::from_utf8_lossy(&result.output);
         assert!(output_str.contains("Private key found"));
         assert!(output_str.contains("id_rsa"));
         Ok(())
@@ -144,8 +145,8 @@ mod tests {
         let content =
             b"Some documentation\n\nHere is a key:\n-----BEGIN RSA PRIVATE KEY-----\ndata\n";
         let file_path = create_test_file(&dir, "doc.txt", content).await?;
-        let (code, _output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
         Ok(())
     }
 
@@ -154,9 +155,9 @@ mod tests {
         let dir = tempdir()?;
         let content = b"This file talks about BEGIN_RSA_PRIVATE_KEY but doesn't contain one\n";
         let file_path = create_test_file(&dir, "false_positive.txt", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -165,9 +166,9 @@ mod tests {
         let dir = tempdir()?;
         let content = b"";
         let file_path = create_test_file(&dir, "empty.txt", content).await?;
-        let (code, output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         Ok(())
     }
 
@@ -177,8 +178,8 @@ mod tests {
         let mut content = vec![0xFF, 0xFE, 0x00];
         content.extend_from_slice(b"BEGIN RSA PRIVATE KEY");
         let file_path = create_test_file(&dir, "binary.dat", &content).await?;
-        let (code, _output) = check_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1);
+        let result = check_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1);
         Ok(())
     }
 }

--- a/crates/prek/src/hooks/pre_commit_hooks/file_contents_sorter.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/file_contents_sorter.rs
@@ -5,6 +5,7 @@ use bstr::ByteSlice;
 use clap::Parser;
 
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::{parse_hook_args, run_file_checks};
 use crate::run::INTERNAL_CONCURRENCY;
 
@@ -23,10 +24,7 @@ pub(crate) struct Args {
     filenames: Vec<PathBuf>,
 }
 
-pub(crate) async fn file_contents_sorter(
-    hook: &Hook,
-    filenames: &[&Path],
-) -> Result<(i32, Vec<u8>)> {
+pub(crate) async fn file_contents_sorter(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: Args = parse_hook_args(hook)?;
     let file_base = hook.project().relative_path();
 
@@ -44,17 +42,21 @@ async fn sort_file(
     filename: &Path,
     ignore_case: bool,
     unique: bool,
-) -> Result<(i32, Vec<u8>)> {
+) -> Result<HookOutput> {
     let file_path = file_base.join(filename);
     let before = fs_err::tokio::read(&file_path).await?;
     let after = sorted_contents(&before, ignore_case, unique);
 
     if before == after {
-        return Ok((0, Vec::new()));
+        return Ok(HookOutput::unchanged(0, Vec::new()));
     }
 
     fs_err::tokio::write(&file_path, &after).await?;
-    Ok((1, format!("Sorting {}\n", filename.display()).into_bytes()))
+    Ok(HookOutput::known(
+        1,
+        format!("Sorting {}\n", filename.display()).into_bytes(),
+        true,
+    ))
 }
 
 fn sorted_contents(before: &[u8], ignore_case: bool, unique: bool) -> Vec<u8> {
@@ -147,10 +149,10 @@ mod tests {
         let relative = PathBuf::from("allowlist.txt");
         let file_path = create_test_file(&dir, "allowlist.txt", b"beta\nalpha\n").await?;
 
-        let (code, output) = sort_file(dir.path(), &relative, false, false).await?;
+        let result = sort_file(dir.path(), &relative, false, false).await?;
 
-        assert_eq!(code, 1);
-        assert_eq!(String::from_utf8(output)?, "Sorting allowlist.txt\n");
+        assert_eq!(result.exit_status, 1);
+        assert_eq!(String::from_utf8(result.output)?, "Sorting allowlist.txt\n");
         assert_eq!(fs_err::tokio::read(&file_path).await?, b"alpha\nbeta\n");
 
         Ok(())
@@ -162,10 +164,10 @@ mod tests {
         let relative = PathBuf::from("allowlist.txt");
         let file_path = create_test_file(&dir, "allowlist.txt", b"alpha\nbeta\n").await?;
 
-        let (code, output) = sort_file(dir.path(), &relative, false, false).await?;
+        let result = sort_file(dir.path(), &relative, false, false).await?;
 
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         assert_eq!(fs_err::tokio::read(&file_path).await?, b"alpha\nbeta\n");
 
         Ok(())

--- a/crates/prek/src/hooks/pre_commit_hooks/file_contents_sorter.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/file_contents_sorter.rs
@@ -24,7 +24,8 @@ pub(crate) struct Args {
     filenames: Vec<PathBuf>,
 }
 
-pub(crate) async fn file_contents_sorter(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
+/// Runs the `file-contents-sorter` hook.
+pub(crate) async fn run(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: Args = parse_hook_args(hook)?;
     let file_base = hook.project().relative_path();
 

--- a/crates/prek/src/hooks/pre_commit_hooks/fix_byte_order_marker.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/fix_byte_order_marker.rs
@@ -4,16 +4,14 @@ use anyhow::Result;
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt, SeekFrom};
 
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::{FilenamesArgs, parse_hook_args, run_file_checks};
 use crate::run::INTERNAL_CONCURRENCY;
 
 const UTF8_BOM: &[u8] = b"\xef\xbb\xbf";
 const BUFFER_SIZE: usize = 8192; // 8KB buffer for streaming
 
-pub(crate) async fn fix_byte_order_marker(
-    hook: &Hook,
-    filenames: &[&Path],
-) -> Result<(i32, Vec<u8>)> {
+pub(crate) async fn fix_byte_order_marker(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     run_file_checks(
         &args.filenames,
@@ -24,7 +22,7 @@ pub(crate) async fn fix_byte_order_marker(
     .await
 }
 
-async fn fix_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)> {
+async fn fix_file(file_base: &Path, filename: &Path) -> Result<HookOutput> {
     let file_path = file_base.join(filename);
 
     let mut file = fs_err::tokio::OpenOptions::new()
@@ -36,11 +34,13 @@ async fn fix_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)> {
     let mut bom_buffer = [0u8; 3];
     match file.read_exact(&mut bom_buffer).await {
         Ok(_) => {}
-        Err(err) if err.kind() == ErrorKind::UnexpectedEof => return Ok((0, Vec::new())),
+        Err(err) if err.kind() == ErrorKind::UnexpectedEof => {
+            return Ok(HookOutput::unchanged(0, Vec::new()));
+        }
         Err(err) => return Err(err.into()),
     }
     if bom_buffer != UTF8_BOM {
-        return Ok((0, Vec::new()));
+        return Ok(HookOutput::unchanged(0, Vec::new()));
     }
 
     let file_len = file.seek(SeekFrom::End(0)).await?;
@@ -51,9 +51,10 @@ async fn fix_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)> {
         shift_file_left(&mut file, file_len, UTF8_BOM.len() as u64).await?;
     }
 
-    Ok((
+    Ok(HookOutput::known(
         1,
         format!("{}: removed byte-order marker\n", filename.display()).into_bytes(),
+        true,
     ))
 }
 
@@ -100,10 +101,10 @@ mod tests {
         let content = b"\xef\xbb\xbfHello, World!";
         let file_path = create_test_file(&dir, "with_bom.txt", content).await?;
 
-        let (code, output) = fix_file(Path::new(""), &file_path).await?;
+        let result = fix_file(Path::new(""), &file_path).await?;
 
-        assert_eq!(code, 1);
-        let output_str = String::from_utf8_lossy(&output);
+        assert_eq!(result.exit_status, 1);
+        let output_str = String::from_utf8_lossy(&result.output);
         assert!(output_str.contains("removed byte-order marker"));
 
         let new_content = fs_err::tokio::read(&file_path).await?;
@@ -118,10 +119,10 @@ mod tests {
         let content = b"Hello, World!";
         let file_path = create_test_file(&dir, "without_bom.txt", content).await?;
 
-        let (code, output) = fix_file(Path::new(""), &file_path).await?;
+        let result = fix_file(Path::new(""), &file_path).await?;
 
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
 
         let new_content = fs_err::tokio::read(&file_path).await?;
         assert_eq!(new_content, content);
@@ -135,10 +136,10 @@ mod tests {
         let content = b"";
         let file_path = create_test_file(&dir, "empty.txt", content).await?;
 
-        let (code, output) = fix_file(Path::new(""), &file_path).await?;
+        let result = fix_file(Path::new(""), &file_path).await?;
 
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
 
         let new_content = fs_err::tokio::read(&file_path).await?;
         assert_eq!(new_content, content);
@@ -152,10 +153,10 @@ mod tests {
         let content = b"Hi";
         let file_path = create_test_file(&dir, "short.txt", content).await?;
 
-        let (code, output) = fix_file(Path::new(""), &file_path).await?;
+        let result = fix_file(Path::new(""), &file_path).await?;
 
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
 
         let new_content = fs_err::tokio::read(&file_path).await?;
         assert_eq!(new_content, content);
@@ -169,10 +170,10 @@ mod tests {
         let content = b"\xef\xbbHello"; // Only first 2 bytes of BOM
         let file_path = create_test_file(&dir, "partial_bom.txt", content).await?;
 
-        let (code, output) = fix_file(Path::new(""), &file_path).await?;
+        let result = fix_file(Path::new(""), &file_path).await?;
 
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
 
         let new_content = fs_err::tokio::read(&file_path).await?;
         assert_eq!(new_content, content);
@@ -186,10 +187,10 @@ mod tests {
         let content = b"\xef\xbb\xbf";
         let file_path = create_test_file(&dir, "bom_only.txt", content).await?;
 
-        let (code, output) = fix_file(Path::new(""), &file_path).await?;
+        let result = fix_file(Path::new(""), &file_path).await?;
 
-        assert_eq!(code, 1);
-        let output_str = String::from_utf8_lossy(&output);
+        assert_eq!(result.exit_status, 1);
+        let output_str = String::from_utf8_lossy(&result.output);
         assert!(output_str.contains("removed byte-order marker"));
 
         let new_content = fs_err::tokio::read(&file_path).await?;
@@ -204,10 +205,10 @@ mod tests {
         let content = b"\xef\xbb\xbf\xe4\xb8\xad\xe6\x96\x87"; // BOM + Chinese characters "中文"
         let file_path = create_test_file(&dir, "utf8_with_bom.txt", content).await?;
 
-        let (code, output) = fix_file(Path::new(""), &file_path).await?;
+        let result = fix_file(Path::new(""), &file_path).await?;
 
-        assert_eq!(code, 1);
-        let output_str = String::from_utf8_lossy(&output);
+        assert_eq!(result.exit_status, 1);
+        let output_str = String::from_utf8_lossy(&result.output);
         assert!(output_str.contains("removed byte-order marker"));
 
         let new_content = fs_err::tokio::read(&file_path).await?;
@@ -231,10 +232,10 @@ mod tests {
 
         let file_path = create_test_file(&dir, "large_with_bom.txt", &content).await?;
 
-        let (code, output) = fix_file(Path::new(""), &file_path).await?;
+        let result = fix_file(Path::new(""), &file_path).await?;
 
-        assert_eq!(code, 1);
-        let output_str = String::from_utf8_lossy(&output);
+        assert_eq!(result.exit_status, 1);
+        let output_str = String::from_utf8_lossy(&result.output);
         assert!(output_str.contains("removed byte-order marker"));
 
         let new_content = fs_err::tokio::read(&file_path).await?;

--- a/crates/prek/src/hooks/pre_commit_hooks/fix_byte_order_marker.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/fix_byte_order_marker.rs
@@ -11,7 +11,8 @@ use crate::run::INTERNAL_CONCURRENCY;
 const UTF8_BOM: &[u8] = b"\xef\xbb\xbf";
 const BUFFER_SIZE: usize = 8192; // 8KB buffer for streaming
 
-pub(crate) async fn fix_byte_order_marker(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
+/// Runs the `fix-byte-order-marker` hook.
+pub(crate) async fn run(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     run_file_checks(
         &args.filenames,

--- a/crates/prek/src/hooks/pre_commit_hooks/fix_end_of_file.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/fix_end_of_file.rs
@@ -8,7 +8,8 @@ use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::{FilenamesArgs, parse_hook_args, run_file_checks};
 use crate::run::INTERNAL_CONCURRENCY;
 
-pub(crate) async fn fix_end_of_file(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
+/// Runs the `end-of-file-fixer` hook.
+pub(crate) async fn run(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     run_file_checks(
         &args.filenames,

--- a/crates/prek/src/hooks/pre_commit_hooks/fix_end_of_file.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/fix_end_of_file.rs
@@ -4,10 +4,11 @@ use std::path::Path;
 use anyhow::Result;
 
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::{FilenamesArgs, parse_hook_args, run_file_checks};
 use crate::run::INTERNAL_CONCURRENCY;
 
-pub(crate) async fn fix_end_of_file(hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
+pub(crate) async fn fix_end_of_file(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     run_file_checks(
         &args.filenames,
@@ -18,14 +19,18 @@ pub(crate) async fn fix_end_of_file(hook: &Hook, filenames: &[&Path]) -> Result<
     .await
 }
 
-async fn fix_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)> {
+async fn fix_file(file_base: &Path, filename: &Path) -> Result<HookOutput> {
     let file_path = file_base.join(filename);
     // Keep a file's blocking I/O in one task instead of re-entering the blocking pool per operation.
     let modified = tokio::task::spawn_blocking(move || fix_file_sync(&file_path)).await??;
     if modified {
-        Ok((1, format!("Fixing {}\n", filename.display()).into_bytes()))
+        Ok(HookOutput::known(
+            1,
+            format!("Fixing {}\n", filename.display()).into_bytes(),
+            true,
+        ))
     } else {
-        Ok((0, Vec::new()))
+        Ok(HookOutput::unchanged(0, Vec::new()))
     }
 }
 
@@ -155,25 +160,25 @@ mod tests {
 
         let content = b"line1\nline2\nline3";
         let file_path = create_test_file(&dir, "unix_no_eof.txt", content).await?;
-        let (code, output) = fix_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1, "Should fix the file");
-        assert!(output.as_bytes().contains_str("Fixing"));
+        let result = fix_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1, "Should fix the file");
+        assert!(result.output.as_bytes().contains_str("Fixing"));
         let new_content = fs_err::tokio::read(&file_path).await?;
         assert_eq!(new_content, b"line1\nline2\nline3\n");
 
         let content = b"line1\r\nline2\nline3\r\nline4";
         let file_path = create_test_file(&dir, "mixed.txt", content).await?;
-        let (code, output) = fix_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1, "Should fix the file");
-        assert!(output.as_bytes().contains_str("Fixing"));
+        let result = fix_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1, "Should fix the file");
+        assert!(result.output.as_bytes().contains_str("Fixing"));
         let new_content = fs_err::tokio::read(&file_path).await?;
         assert_eq!(new_content, b"line1\r\nline2\nline3\r\nline4\n");
 
         let content = b"line1\r\nline2\r\nline3";
         let file_path = create_test_file(&dir, "windows_no_eof.txt", content).await?;
-        let (code, output) = fix_file(Path::new(""), &file_path).await?;
-        assert_eq!(code, 1, "Should fix the file");
-        assert!(output.as_bytes().contains_str("Fixing"));
+        let result = fix_file(Path::new(""), &file_path).await?;
+        assert_eq!(result.exit_status, 1, "Should fix the file");
+        assert!(result.output.as_bytes().contains_str("Fixing"));
         let new_content = fs_err::tokio::read(&file_path).await?;
         assert_eq!(new_content, b"line1\r\nline2\r\nline3\n");
 
@@ -187,10 +192,10 @@ mod tests {
         let content = b"line1\r\nline2\r\nline3\r\n";
         let file_path = create_test_file(&dir, "windows_with_eof.txt", content).await?;
 
-        let (code, output) = fix_file(Path::new(""), &file_path).await?;
+        let result = fix_file(Path::new(""), &file_path).await?;
 
-        assert_eq!(code, 0, "Should not change the file");
-        assert!(output.is_empty());
+        assert_eq!(result.exit_status, 0, "Should not change the file");
+        assert!(result.output.is_empty());
 
         let new_content = fs_err::tokio::read(&file_path).await?;
         assert_eq!(new_content, content);
@@ -205,10 +210,10 @@ mod tests {
         let content = b"line1\nline2\nline3\n";
         let file_path = create_test_file(&dir, "unix_with_eof.txt", content).await?;
 
-        let (code, output) = fix_file(Path::new(""), &file_path).await?;
+        let result = fix_file(Path::new(""), &file_path).await?;
 
-        assert_eq!(code, 0, "Should not change the file");
-        assert!(output.is_empty());
+        assert_eq!(result.exit_status, 0, "Should not change the file");
+        assert!(result.output.is_empty());
 
         let new_content = fs_err::tokio::read(&file_path).await?;
         assert_eq!(new_content, content);
@@ -223,10 +228,10 @@ mod tests {
         let content = b"";
         let file_path = create_test_file(&dir, "empty.txt", content).await?;
 
-        let (code, output) = fix_file(Path::new(""), &file_path).await?;
+        let result = fix_file(Path::new(""), &file_path).await?;
 
-        assert_eq!(code, 0, "Should not change empty file");
-        assert!(output.is_empty());
+        assert_eq!(result.exit_status, 0, "Should not change empty file");
+        assert!(result.output.is_empty());
 
         let new_content = fs_err::tokio::read(&file_path).await?;
         assert_eq!(new_content, b"");
@@ -241,10 +246,10 @@ mod tests {
         let content = b"line1\nline2\n\n\n\n";
         let file_path = create_test_file(&dir, "excess_newlines.txt", content).await?;
 
-        let (code, output) = fix_file(Path::new(""), &file_path).await?;
+        let result = fix_file(Path::new(""), &file_path).await?;
 
-        assert_eq!(code, 1, "Should fix the file");
-        assert!(output.as_bytes().contains_str("Fixing"));
+        assert_eq!(result.exit_status, 1, "Should fix the file");
+        assert!(result.output.as_bytes().contains_str("Fixing"));
 
         let new_content = fs_err::tokio::read(&file_path).await?;
         assert_eq!(new_content, b"line1\nline2\n");
@@ -259,10 +264,10 @@ mod tests {
         let content = b"line1\r\nline2\r\n\r\n\r\n";
         let file_path = create_test_file(&dir, "excess_crlf.txt", content).await?;
 
-        let (code, output) = fix_file(Path::new(""), &file_path).await?;
+        let result = fix_file(Path::new(""), &file_path).await?;
 
-        assert_eq!(code, 1, "Should fix the file");
-        assert!(output.as_bytes().contains_str("Fixing"));
+        assert_eq!(result.exit_status, 1, "Should fix the file");
+        assert!(result.output.as_bytes().contains_str("Fixing"));
 
         let new_content = fs_err::tokio::read(&file_path).await?;
         assert_eq!(new_content, b"line1\r\nline2\r\n");
@@ -277,10 +282,10 @@ mod tests {
         let content = b"\n\n\n\n";
         let file_path = create_test_file(&dir, "only_newlines.txt", content).await?;
 
-        let (code, output) = fix_file(Path::new(""), &file_path).await?;
+        let result = fix_file(Path::new(""), &file_path).await?;
 
-        assert_eq!(code, 1, "Should fix the file");
-        assert!(output.as_bytes().contains_str("Fixing"));
+        assert_eq!(result.exit_status, 1, "Should fix the file");
+        assert!(result.output.as_bytes().contains_str("Fixing"));
 
         let new_content = fs_err::tokio::read(&file_path).await?;
         assert_eq!(new_content, b"");

--- a/crates/prek/src/hooks/pre_commit_hooks/fix_trailing_whitespace.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/fix_trailing_whitespace.rs
@@ -63,10 +63,8 @@ impl Args {
     }
 }
 
-pub(crate) async fn fix_trailing_whitespace(
-    hook: &Hook,
-    filenames: &[&Path],
-) -> Result<HookOutput> {
+/// Runs the `trailing-whitespace` hook.
+pub(crate) async fn run(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: Args = parse_hook_args(hook)?;
 
     let force_markdown = args.force_markdown();

--- a/crates/prek/src/hooks/pre_commit_hooks/fix_trailing_whitespace.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/fix_trailing_whitespace.rs
@@ -6,6 +6,7 @@ use bstr::ByteSlice;
 use clap::Parser;
 
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::{parse_hook_args, run_file_checks};
 use crate::run::INTERNAL_CONCURRENCY;
 
@@ -65,7 +66,7 @@ impl Args {
 pub(crate) async fn fix_trailing_whitespace(
     hook: &Hook,
     filenames: &[&Path],
-) -> Result<(i32, Vec<u8>)> {
+) -> Result<HookOutput> {
     let args: Args = parse_hook_args(hook)?;
 
     let force_markdown = args.force_markdown();
@@ -98,7 +99,7 @@ async fn fix_file(
     chars: &[char],
     force_markdown: bool,
     markdown_exts: &[&str],
-) -> Result<(i32, Vec<u8>)> {
+) -> Result<HookOutput> {
     let is_markdown = force_markdown || is_markdown_file(filename, markdown_exts);
 
     let file_path = file_base.join(filename);
@@ -148,9 +149,13 @@ async fn fix_file(
 
     if let Some(output) = output {
         fs_err::tokio::write(&file_path, &output).await?;
-        Ok((1, format!("Fixing {}\n", filename.display()).into_bytes()))
+        Ok(HookOutput::known(
+            1,
+            format!("Fixing {}\n", filename.display()).into_bytes(),
+            true,
+        ))
     } else {
-        Ok((0, Vec::new()))
+        Ok(HookOutput::unchanged(0, Vec::new()))
     }
 }
 
@@ -205,11 +210,11 @@ mod tests {
         let chars = vec![' ', '\t'];
         let md_exts = vec!["md"];
 
-        let (code, msg) = fix_file(Path::new(""), &file_path, &chars, false, &md_exts).await?;
+        let result = fix_file(Path::new(""), &file_path, &chars, false, &md_exts).await?;
 
         // modified
-        assert_eq!(code, 1);
-        let msg_str = String::from_utf8_lossy(&msg);
+        assert_eq!(result.exit_status, 1);
+        let msg_str = String::from_utf8_lossy(&result.output);
         assert!(msg_str.contains("file.txt"));
 
         // file content updated: trailing spaces removed
@@ -233,10 +238,10 @@ mod tests {
         let chars = vec![' ', '\t'];
         let md_exts = vec!["md"];
 
-        let (code, _msg) = fix_file(Path::new(""), &file_path, &chars, false, &md_exts).await?;
+        let result = fix_file(Path::new(""), &file_path, &chars, false, &md_exts).await?;
 
         // second line changed 3 -> 2 spaces, so modified
-        assert_eq!(code, 1);
+        assert_eq!(result.exit_status, 1);
 
         let content = fs_err::tokio::read_to_string(&file_path).await?;
         let expected = "line_keep_two  \nline_reduce_three  \nother_line\n";
@@ -259,10 +264,10 @@ mod tests {
         let chars = vec![' ', '\t'];
         let md_exts = vec![]; // irrelevant because force_markdown = true
 
-        let (code, _msg) = fix_file(Path::new(""), &file_path, &chars, true, &md_exts).await?;
+        let result = fix_file(Path::new(""), &file_path, &chars, true, &md_exts).await?;
 
         // modified because one line had 3 spaces -> reduced to 2
-        assert_eq!(code, 1);
+        assert_eq!(result.exit_status, 1);
 
         let content = fs_err::tokio::read_to_string(&file_path).await?;
         let expected = "keep_two_spaces  \nthree_spaces_line  \n";
@@ -279,9 +284,9 @@ mod tests {
         let md_exts = vec!["md"];
 
         // file already trimmed -> no changes
-        let (code, msg) = fix_file(Path::new(""), &path, &chars, false, &md_exts).await?;
-        assert_eq!(code, 0);
-        assert!(msg.is_empty());
+        let result = fix_file(Path::new(""), &path, &chars, false, &md_exts).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
 
         let content = fs_err::tokio::read_to_string(&path).await?;
         assert_eq!(content, "already_trimmed\nline_two\n");
@@ -296,9 +301,9 @@ mod tests {
         let chars = vec![' ', '\t'];
         let md_exts = vec![];
 
-        let (code, msg) = fix_file(Path::new(""), &path, &chars, false, &md_exts).await?;
-        assert_eq!(code, 0);
-        assert!(msg.is_empty());
+        let result = fix_file(Path::new(""), &path, &chars, false, &md_exts).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
         let content = fs_err::tokio::read_to_string(&path).await?;
         assert_eq!(content, "");
 
@@ -313,9 +318,9 @@ mod tests {
         let chars = vec![' ', '\t'];
         let md_exts = vec!["md"];
 
-        let (code, _msg) = fix_file(Path::new(""), &path, &chars, false, &md_exts).await?;
+        let result = fix_file(Path::new(""), &path, &chars, false, &md_exts).await?;
         // trimming whitespace-only lines will change them to empty lines -> modified true
-        assert_eq!(code, 1);
+        assert_eq!(result.exit_status, 1);
 
         let content = fs_err::tokio::read_to_string(&path).await?;
         // Expect empty lines (newline preserved per implementation)
@@ -332,8 +337,8 @@ mod tests {
         let chars = vec![]; // will hit trim_ascii_end()
         let md_exts = vec![];
 
-        let (code, _msg) = fix_file(Path::new(""), &path, &chars, false, &md_exts).await?;
-        assert_eq!(code, 1);
+        let result = fix_file(Path::new(""), &path, &chars, false, &md_exts).await?;
+        assert_eq!(result.exit_status, 1);
 
         let content = fs_err::tokio::read_to_string(&path).await?;
         let expected = "foo\nbar\n";
@@ -350,8 +355,8 @@ mod tests {
         let chars = vec![' ', '\t'];
         let md_exts = vec!["txt"]; // treat as markdown for this test
 
-        let (code, _msg) = fix_file(Path::new(""), &path, &chars, false, &md_exts).await?;
-        assert_eq!(code, 1);
+        let result = fix_file(Path::new(""), &path, &chars, false, &md_exts).await?;
+        assert_eq!(result.exit_status, 1);
 
         // read file and check logical lines presence (line endings may be normalized by lines())
         let content = fs_err::tokio::read_to_string(&path).await?;
@@ -369,8 +374,8 @@ mod tests {
         let chars = vec![' ', '\t'];
         let md_exts = vec![];
 
-        let (code, _msg) = fix_file(Path::new(""), &path, &chars, false, &md_exts).await?;
-        assert_eq!(code, 1);
+        let result = fix_file(Path::new(""), &path, &chars, false, &md_exts).await?;
+        assert_eq!(result.exit_status, 1);
 
         let content = fs_err::tokio::read_to_string(&path).await?;
         // Expect trailing spaces removed
@@ -387,8 +392,8 @@ mod tests {
         let chars = vec!['。', '　'];
         let md_exts = vec![];
 
-        let (code, _msg) = fix_file(Path::new(""), &path, &chars, false, &md_exts).await?;
-        assert_eq!(code, 1);
+        let result = fix_file(Path::new(""), &path, &chars, false, &md_exts).await?;
+        assert_eq!(result.exit_status, 1);
 
         let content = fs_err::tokio::read_to_string(&path).await?;
         assert_eq!(content, "hello\n");
@@ -404,8 +409,8 @@ mod tests {
         let chars = vec![' ', '\t'];
         let md_exts = vec!["md"];
 
-        let (code, _msg) = fix_file(Path::new(""), &path, &chars, false, &md_exts).await?;
-        assert_eq!(code, 1);
+        let result = fix_file(Path::new(""), &path, &chars, false, &md_exts).await?;
+        assert_eq!(result.exit_status, 1);
 
         let content = fs_err::tokio::read_to_string(&path).await?;
         // markdown rules: trailing >2 -> reduce to two spaces
@@ -421,8 +426,8 @@ mod tests {
         let chars = vec![' ', '\t'];
         let md_exts = vec![];
 
-        let (code, _msg) = fix_file(Path::new(""), &path, &chars, false, &md_exts).await?;
-        assert_eq!(code, 1);
+        let result = fix_file(Path::new(""), &path, &chars, false, &md_exts).await?;
+        assert_eq!(result.exit_status, 1);
 
         let content = fs_err::tokio::read_to_string(&path).await?;
         let expected = "ok\nneedtrim\nalso_ok\n";
@@ -439,9 +444,9 @@ mod tests {
         let chars = vec![' ', '\t'];
         let md_exts = vec![];
 
-        let (code, msg) = fix_file(Path::new(""), &path, &chars, false, &md_exts).await?;
-        assert_eq!(code, 0);
-        assert!(msg.is_empty());
+        let result = fix_file(Path::new(""), &path, &chars, false, &md_exts).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
 
         let content = fs_err::tokio::read_to_string(&path).await?;
         assert_eq!(content, "foo\nbar");
@@ -457,8 +462,8 @@ mod tests {
         let chars = vec![' ', '\t'];
         let md_exts = vec!["*"];
 
-        let (code, _msg) = fix_file(Path::new(""), &path, &chars, true, &md_exts).await?;
-        assert_eq!(code, 1);
+        let result = fix_file(Path::new(""), &path, &chars, true, &md_exts).await?;
+        assert_eq!(result.exit_status, 1);
 
         let expected = "foo  \nbar\nbaz  \n\n\n";
         let new_content = fs_err::tokio::read_to_string(&path).await?;
@@ -474,8 +479,8 @@ mod tests {
         let chars = vec![' '];
         let md_exts = vec!["*"];
 
-        let (code, _msg) = fix_file(Path::new(""), &path, &chars, true, &md_exts).await?;
-        assert_eq!(code, 1);
+        let result = fix_file(Path::new(""), &path, &chars, true, &md_exts).await?;
+        assert_eq!(result.exit_status, 1);
 
         let expected = "\ta \t  \n";
         let content = fs_err::tokio::read_to_string(&path).await?;
@@ -491,8 +496,8 @@ mod tests {
         let chars = vec!['x'];
         let md_exts = vec![];
 
-        let (code, _msg) = fix_file(Path::new(""), &path, &chars, true, &md_exts).await?;
-        assert_eq!(code, 0);
+        let result = fix_file(Path::new(""), &path, &chars, true, &md_exts).await?;
+        assert_eq!(result.exit_status, 0);
 
         let expected = "a\nb\r\r\r\n";
         let content = fs_err::tokio::read_to_string(&path).await?;
@@ -508,8 +513,8 @@ mod tests {
         let chars = vec!['x'];
         let md_exts = vec!["md"];
 
-        let (code, _msg) = fix_file(Path::new(""), &path, &chars, true, &md_exts).await?;
-        assert_eq!(code, 1);
+        let result = fix_file(Path::new(""), &path, &chars, true, &md_exts).await?;
+        assert_eq!(result.exit_status, 1);
 
         let expected = "a  \n";
         let content = fs_err::tokio::read_to_string(&path).await?;
@@ -536,8 +541,8 @@ mod tests {
         let chars = vec![' ', '\t'];
         let md_exts = vec![];
 
-        let (code, _msg) = fix_file(Path::new(""), &path, &chars, false, &md_exts).await?;
-        assert_eq!(code, 0);
+        let result = fix_file(Path::new(""), &path, &chars, false, &md_exts).await?;
+        assert_eq!(result.exit_status, 0);
 
         let new_content = fs_err::tokio::read(&path).await?;
         // The invalid byte should still be present, but trailing whitespace should be trimmed

--- a/crates/prek/src/hooks/pre_commit_hooks/forbid_new_submodules.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/forbid_new_submodules.rs
@@ -6,12 +6,13 @@ use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 
 use crate::git;
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::{FilenamesArgs, hook_filenames, parse_hook_args};
 
 pub(crate) async fn forbid_new_submodules(
     hook: &Hook,
     filenames: &[&Path],
-) -> Result<(i32, Vec<u8>), anyhow::Error> {
+) -> Result<HookOutput, anyhow::Error> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     let diff_arg = if let (Ok(from_ref), Ok(to_ref)) = (
         EnvVars.var("PRE_COMMIT_FROM_REF"),
@@ -40,10 +41,10 @@ pub(crate) async fn forbid_new_submodules(
 
     let new_submodules = collect_new_submodules(&stdout);
     if new_submodules.is_empty() {
-        Ok((0, Vec::new()))
+        Ok(HookOutput::unchanged(0, Vec::new()))
     } else {
         let message = render_message(&new_submodules);
-        Ok((1, message.into_bytes()))
+        Ok(HookOutput::unchanged(1, message.into_bytes()))
     }
 }
 

--- a/crates/prek/src/hooks/pre_commit_hooks/forbid_new_submodules.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/forbid_new_submodules.rs
@@ -9,10 +9,8 @@ use crate::hook::Hook;
 use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::{FilenamesArgs, hook_filenames, parse_hook_args};
 
-pub(crate) async fn forbid_new_submodules(
-    hook: &Hook,
-    filenames: &[&Path],
-) -> Result<HookOutput, anyhow::Error> {
+/// Runs the `forbid-new-submodules` hook.
+pub(crate) async fn run(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput, anyhow::Error> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     let diff_arg = if let (Ok(from_ref), Ok(to_ref)) = (
         EnvVars.var("PRE_COMMIT_FROM_REF"),

--- a/crates/prek/src/hooks/pre_commit_hooks/mixed_line_ending.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/mixed_line_ending.rs
@@ -62,7 +62,8 @@ impl LineEndingCounts {
     }
 }
 
-pub(crate) async fn mixed_line_ending(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
+/// Runs the `mixed-line-ending` hook.
+pub(crate) async fn run(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: Args = parse_hook_args(hook)?;
 
     run_file_checks(

--- a/crates/prek/src/hooks/pre_commit_hooks/mixed_line_ending.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/mixed_line_ending.rs
@@ -6,6 +6,7 @@ use clap::{Parser, ValueEnum};
 use memchr::memchr2;
 
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::{parse_hook_args, run_file_checks};
 use crate::run::INTERNAL_CONCURRENCY;
 
@@ -61,7 +62,7 @@ impl LineEndingCounts {
     }
 }
 
-pub(crate) async fn mixed_line_ending(hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
+pub(crate) async fn mixed_line_ending(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: Args = parse_hook_args(hook)?;
 
     run_file_checks(
@@ -74,13 +75,13 @@ pub(crate) async fn mixed_line_ending(hook: &Hook, filenames: &[&Path]) -> Resul
 }
 
 // Process a single file for mixed line endings
-async fn fix_file(file_base: &Path, filename: &Path, fix_mode: FixMode) -> Result<(i32, Vec<u8>)> {
+async fn fix_file(file_base: &Path, filename: &Path, fix_mode: FixMode) -> Result<HookOutput> {
     let file_path = file_base.join(filename);
     let contents = fs_err::tokio::read(&file_path).await?;
 
     // Skip empty files or binary files
     if contents.is_empty() || contents.find_byte(0).is_some() {
-        return Ok((0, Vec::new()));
+        return Ok(HookOutput::unchanged(0, Vec::new()));
     }
 
     let counts = count_line_endings(&contents);
@@ -89,22 +90,26 @@ async fn fix_file(file_base: &Path, filename: &Path, fix_mode: FixMode) -> Resul
     match fix_mode {
         FixMode::No => {
             if has_mixed_endings {
-                Ok((
+                Ok(HookOutput::unchanged(
                     1,
                     format!("{}: mixed line endings\n", filename.display()).into_bytes(),
                 ))
             } else {
-                Ok((0, Vec::new()))
+                Ok(HookOutput::unchanged(0, Vec::new()))
             }
         }
         FixMode::Auto => {
             if !has_mixed_endings {
-                return Ok((0, Vec::new()));
+                return Ok(HookOutput::unchanged(0, Vec::new()));
             }
 
             let target_ending = find_most_common_ending(&counts);
             apply_line_ending(&file_path, &contents, target_ending).await?;
-            Ok((1, format!("Fixing {}\n", filename.display()).into_bytes()))
+            Ok(HookOutput::known(
+                1,
+                format!("Fixing {}\n", filename.display()).into_bytes(),
+                true,
+            ))
         }
         _ => {
             let target_ending = match fix_mode {
@@ -117,9 +122,13 @@ async fn fix_file(file_base: &Path, filename: &Path, fix_mode: FixMode) -> Resul
 
             if needs_fixing {
                 apply_line_ending(&file_path, &contents, target_ending).await?;
-                Ok((1, format!("Fixing {}\n", filename.display()).into_bytes()))
+                Ok(HookOutput::known(
+                    1,
+                    format!("Fixing {}\n", filename.display()).into_bytes(),
+                    true,
+                ))
             } else {
-                Ok((0, Vec::new()))
+                Ok(HookOutput::unchanged(0, Vec::new()))
             }
         }
     }
@@ -212,9 +221,9 @@ mod tests {
         let dir = tempdir()?;
         let content = b"line1\nline2\r\nline3\r\n"; // 1 LF, 2 CRLF
         let file_path = create_test_file(&dir, "mixed_crlf.txt", content).await?;
-        let (code, output) = fix_file(Path::new(""), &file_path, FixMode::Auto).await?;
-        assert_eq!(code, 1);
-        assert!(output.as_bytes().contains_str("Fixing"));
+        let result = fix_file(Path::new(""), &file_path, FixMode::Auto).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(result.output.as_bytes().contains_str("Fixing"));
         let new_content = fs_err::tokio::read(&file_path).await?;
         assert_eq!(new_content, b"line1\r\nline2\r\nline3\r\n");
 
@@ -226,9 +235,9 @@ mod tests {
         let dir = tempdir()?;
         let content = b"line1\nline2\nline3\r\n"; // 2 LF, 1 CRLF
         let file_path = create_test_file(&dir, "mixed_lf.txt", content).await?;
-        let (code, output) = fix_file(Path::new(""), &file_path, FixMode::Auto).await?;
-        assert_eq!(code, 1);
-        assert!(output.as_bytes().contains_str("Fixing"));
+        let result = fix_file(Path::new(""), &file_path, FixMode::Auto).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(result.output.as_bytes().contains_str("Fixing"));
         let new_content = fs_err::tokio::read(&file_path).await?;
         assert_eq!(new_content, b"line1\nline2\nline3\n");
 
@@ -240,9 +249,9 @@ mod tests {
         let dir = tempdir()?;
         let content = b"line1\nline2\r\n"; // 1 LF, 1 CRLF
         let file_path = create_test_file(&dir, "mixed_tie.txt", content).await?;
-        let (code, output) = fix_file(Path::new(""), &file_path, FixMode::Auto).await?;
-        assert_eq!(code, 1);
-        assert!(output.as_bytes().contains_str("Fixing"));
+        let result = fix_file(Path::new(""), &file_path, FixMode::Auto).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(result.output.as_bytes().contains_str("Fixing"));
         let new_content = fs_err::tokio::read(&file_path).await?;
         assert_eq!(new_content, b"line1\nline2\n");
 
@@ -254,9 +263,9 @@ mod tests {
         let dir = tempdir()?;
         let content = b"line1\nline2\r\n";
         let file_path = create_test_file(&dir, "mixed_no.txt", content).await?;
-        let (code, output) = fix_file(Path::new(""), &file_path, FixMode::No).await?;
-        assert_eq!(code, 1);
-        assert!(output.as_bytes().contains_str("mixed line endings"));
+        let result = fix_file(Path::new(""), &file_path, FixMode::No).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(result.output.as_bytes().contains_str("mixed line endings"));
         let new_content = fs_err::tokio::read(&file_path).await?;
         assert_eq!(new_content, content); // File should not be changed
 
@@ -268,9 +277,9 @@ mod tests {
         let dir = tempdir()?;
         let content = b"some content";
         let file_path = create_test_file(&dir, "no_endings.txt", content).await?;
-        let (code, output) = fix_file(Path::new(""), &file_path, FixMode::Auto).await?;
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        let result = fix_file(Path::new(""), &file_path, FixMode::Auto).await?;
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
 
         Ok(())
     }
@@ -283,17 +292,17 @@ mod tests {
         let file_path = create_test_file(&dir, "all_mixed.txt", content).await?;
 
         // Test auto fix (should prefer LF as it's a 3-way tie)
-        let (code, output) = fix_file(Path::new(""), &file_path, FixMode::Auto).await?;
-        assert_eq!(code, 1);
-        assert!(output.as_bytes().contains_str("Fixing"));
+        let result = fix_file(Path::new(""), &file_path, FixMode::Auto).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(result.output.as_bytes().contains_str("Fixing"));
         let new_content = fs_err::tokio::read(&file_path).await?;
         assert_eq!(new_content, b"line1\nline2\nline3\n");
 
         // Restore content and test fix to CRLF
         fs_err::tokio::write(&file_path, content).await?;
-        let (code, output) = fix_file(Path::new(""), &file_path, FixMode::CRLF).await?;
-        assert_eq!(code, 1);
-        assert!(output.as_bytes().contains_str("Fixing"));
+        let result = fix_file(Path::new(""), &file_path, FixMode::CRLF).await?;
+        assert_eq!(result.exit_status, 1);
+        assert!(result.output.as_bytes().contains_str("Fixing"));
         let new_content = fs_err::tokio::read(&file_path).await?;
         assert_eq!(new_content, b"line1\r\nline2\r\nline3\r\n");
 

--- a/crates/prek/src/hooks/pre_commit_hooks/mod.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/mod.rs
@@ -10,52 +10,29 @@ use crate::hooks::{HookOutput, run_concurrent_file_checks};
 
 use super::HookFuture;
 
-pub(super) mod check_added_large_files;
-mod check_case_conflict;
-mod check_executables_have_shebangs;
+pub(crate) mod check_added_large_files;
+pub(crate) mod check_case_conflict;
+pub(crate) mod check_executables_have_shebangs;
 pub(crate) mod check_json;
-pub(super) mod check_merge_conflict;
-mod check_shebang_scripts_are_executable;
-mod check_symlinks;
-mod check_toml;
-pub(super) mod check_vcs_permalinks;
-mod check_xml;
-pub(super) mod check_yaml;
-mod destroyed_symlinks;
-mod detect_private_key;
-pub(super) mod file_contents_sorter;
-mod fix_byte_order_marker;
-mod fix_end_of_file;
-pub(super) mod fix_trailing_whitespace;
-mod forbid_new_submodules;
-pub(super) mod mixed_line_ending;
-pub(super) mod no_commit_to_branch;
-pub(super) mod pretty_format_json;
-mod requirements_txt_fixer;
-mod shebangs;
-
-pub(crate) use check_added_large_files::check_added_large_files;
-pub(crate) use check_case_conflict::check_case_conflict;
-pub(crate) use check_executables_have_shebangs::check_executables_have_shebangs;
-pub(crate) use check_json::check_json;
-pub(crate) use check_merge_conflict::check_merge_conflict;
-pub(crate) use check_shebang_scripts_are_executable::check_shebang_scripts_are_executable;
-pub(crate) use check_symlinks::check_symlinks;
-pub(crate) use check_toml::check_toml;
-pub(crate) use check_vcs_permalinks::check_vcs_permalinks;
-pub(crate) use check_xml::check_xml;
-pub(crate) use check_yaml::check_yaml;
-pub(crate) use destroyed_symlinks::destroyed_symlinks;
-pub(crate) use detect_private_key::detect_private_key;
-pub(crate) use file_contents_sorter::file_contents_sorter;
-pub(crate) use fix_byte_order_marker::fix_byte_order_marker;
-pub(crate) use fix_end_of_file::fix_end_of_file;
-pub(crate) use fix_trailing_whitespace::fix_trailing_whitespace;
-pub(crate) use forbid_new_submodules::forbid_new_submodules;
-pub(crate) use mixed_line_ending::mixed_line_ending;
-pub(crate) use no_commit_to_branch::no_commit_to_branch;
-pub(crate) use pretty_format_json::pretty_format_json;
-pub(crate) use requirements_txt_fixer::requirements_txt_fixer;
+pub(crate) mod check_merge_conflict;
+pub(crate) mod check_shebang_scripts_are_executable;
+pub(crate) mod check_symlinks;
+pub(crate) mod check_toml;
+pub(crate) mod check_vcs_permalinks;
+pub(crate) mod check_xml;
+pub(crate) mod check_yaml;
+pub(crate) mod destroyed_symlinks;
+pub(crate) mod detect_private_key;
+pub(crate) mod file_contents_sorter;
+pub(crate) mod fix_byte_order_marker;
+pub(crate) mod fix_end_of_file;
+pub(crate) mod fix_trailing_whitespace;
+pub(crate) mod forbid_new_submodules;
+pub(crate) mod mixed_line_ending;
+pub(crate) mod no_commit_to_branch;
+pub(crate) mod pretty_format_json;
+pub(crate) mod requirements_txt_fixer;
+pub(crate) mod shebangs;
 
 #[derive(Parser)]
 #[command(disable_help_subcommand = true)]
@@ -82,6 +59,9 @@ pub(crate) fn hook_filenames<'a>(
         .chain(selected.iter().copied())
 }
 
+/// Runs explicit filenames serially, followed by selected filenames concurrently.
+///
+/// Duplicates and overlaps between the two inputs are intentionally preserved.
 pub(crate) async fn run_file_checks<'a, F, Fut>(
     explicit: &'a [PathBuf],
     selected: &'a [&Path],
@@ -157,31 +137,31 @@ impl PreCommitHooks {
     pub(crate) async fn run(self, hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
         debug!("Running hook `{}` in fast path", hook.id);
         let future: HookFuture<'_> = match self {
-            Self::CheckAddedLargeFiles => Box::pin(check_added_large_files(hook, filenames)),
-            Self::CheckCaseConflict => Box::pin(check_case_conflict(hook, filenames)),
+            Self::CheckAddedLargeFiles => Box::pin(check_added_large_files::run(hook, filenames)),
+            Self::CheckCaseConflict => Box::pin(check_case_conflict::run(hook, filenames)),
             Self::CheckExecutablesHaveShebangs => {
-                Box::pin(check_executables_have_shebangs(hook, filenames))
+                Box::pin(check_executables_have_shebangs::run(hook, filenames))
             }
             Self::CheckShebangScriptsAreExecutable => {
-                Box::pin(check_shebang_scripts_are_executable(hook, filenames))
+                Box::pin(check_shebang_scripts_are_executable::run(hook, filenames))
             }
-            Self::CheckVcsPermalinks => Box::pin(check_vcs_permalinks(hook, filenames)),
-            Self::FileContentsSorter => Box::pin(file_contents_sorter(hook, filenames)),
-            Self::EndOfFileFixer => Box::pin(fix_end_of_file(hook, filenames)),
-            Self::FixByteOrderMarker => Box::pin(fix_byte_order_marker(hook, filenames)),
-            Self::ForbidNewSubmodules => Box::pin(forbid_new_submodules(hook, filenames)),
-            Self::CheckJson => Box::pin(check_json(hook, filenames)),
-            Self::CheckSymlinks => Box::pin(check_symlinks(hook, filenames)),
-            Self::CheckMergeConflict => Box::pin(check_merge_conflict(hook, filenames)),
-            Self::CheckToml => Box::pin(check_toml(hook, filenames)),
-            Self::CheckYaml => Box::pin(check_yaml(hook, filenames)),
-            Self::CheckXml => Box::pin(check_xml(hook, filenames)),
-            Self::DestroyedSymlinks => Box::pin(destroyed_symlinks(hook, filenames)),
-            Self::MixedLineEnding => Box::pin(mixed_line_ending(hook, filenames)),
-            Self::DetectPrivateKey => Box::pin(detect_private_key(hook, filenames)),
-            Self::NoCommitToBranch => Box::pin(no_commit_to_branch(hook)),
-            Self::RequirementsTxtFixer => Box::pin(requirements_txt_fixer(hook, filenames)),
-            Self::TrailingWhitespace => Box::pin(fix_trailing_whitespace(hook, filenames)),
+            Self::CheckVcsPermalinks => Box::pin(check_vcs_permalinks::run(hook, filenames)),
+            Self::FileContentsSorter => Box::pin(file_contents_sorter::run(hook, filenames)),
+            Self::EndOfFileFixer => Box::pin(fix_end_of_file::run(hook, filenames)),
+            Self::FixByteOrderMarker => Box::pin(fix_byte_order_marker::run(hook, filenames)),
+            Self::ForbidNewSubmodules => Box::pin(forbid_new_submodules::run(hook, filenames)),
+            Self::CheckJson => Box::pin(check_json::run(hook, filenames)),
+            Self::CheckSymlinks => Box::pin(check_symlinks::run(hook, filenames)),
+            Self::CheckMergeConflict => Box::pin(check_merge_conflict::run(hook, filenames)),
+            Self::CheckToml => Box::pin(check_toml::run(hook, filenames)),
+            Self::CheckYaml => Box::pin(check_yaml::run(hook, filenames)),
+            Self::CheckXml => Box::pin(check_xml::run(hook, filenames)),
+            Self::DestroyedSymlinks => Box::pin(destroyed_symlinks::run(hook, filenames)),
+            Self::MixedLineEnding => Box::pin(mixed_line_ending::run(hook, filenames)),
+            Self::DetectPrivateKey => Box::pin(detect_private_key::run(hook, filenames)),
+            Self::NoCommitToBranch => Box::pin(no_commit_to_branch::run(hook)),
+            Self::RequirementsTxtFixer => Box::pin(requirements_txt_fixer::run(hook, filenames)),
+            Self::TrailingWhitespace => Box::pin(fix_trailing_whitespace::run(hook, filenames)),
         };
         future.await
     }

--- a/crates/prek/src/hooks/pre_commit_hooks/mod.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/mod.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 use tracing::debug;
 
 use crate::hook::Hook;
-use crate::hooks::run_concurrent_file_checks;
+use crate::hooks::{HookOutput, run_concurrent_file_checks};
 
 use super::HookFuture;
 
@@ -87,35 +87,31 @@ pub(crate) async fn run_file_checks<'a, F, Fut>(
     selected: &'a [&Path],
     concurrency: usize,
     check: F,
-) -> Result<(i32, Vec<u8>)>
+) -> Result<HookOutput>
 where
     F: Fn(&'a Path) -> Fut,
-    Fut: Future<Output = Result<(i32, Vec<u8>)>>,
+    Fut: Future<Output = Result<HookOutput>>,
 {
-    // Keep the common case on the existing concurrent path without an extra accumulator.
+    // Keep the common case on the concurrent path without an extra accumulator.
     if explicit.is_empty() {
         return run_concurrent_file_checks(selected.iter().copied(), concurrency, check).await;
     }
 
     // Filenames from `entry` or `args` may repeat or overlap with `selected`, so finish
     // them serially in CLI order before starting the selected batch.
-    let mut code = 0;
-    let mut output = Vec::new();
+    let mut result = HookOutput::unchanged(0, Vec::new());
     for filename in explicit {
-        let (file_code, file_output) = check(filename).await?;
-        code |= file_code;
-        output.extend(file_output);
+        result.merge_known(check(filename).await?);
     }
     if selected.is_empty() {
-        return Ok((code, output));
+        return Ok(result);
     }
 
     // The explicit batch is complete, so selected filenames retain their normal concurrency.
-    let (selected_code, selected_output) =
+    let selected_result =
         run_concurrent_file_checks(selected.iter().copied(), concurrency, check).await?;
-    code |= selected_code;
-    output.extend(selected_output);
-    Ok((code, output))
+    result.merge_known(selected_result);
+    Ok(result)
 }
 
 /// Hooks from `https://github.com/pre-commit/pre-commit-hooks`.
@@ -158,34 +154,7 @@ impl PreCommitHooks {
         }
     }
 
-    pub(crate) fn may_modify_files(&self) -> bool {
-        match self {
-            Self::EndOfFileFixer
-            | Self::FileContentsSorter
-            | Self::FixByteOrderMarker
-            | Self::MixedLineEnding
-            | Self::RequirementsTxtFixer
-            | Self::TrailingWhitespace => true,
-
-            Self::CheckAddedLargeFiles
-            | Self::CheckCaseConflict
-            | Self::CheckExecutablesHaveShebangs
-            | Self::CheckShebangScriptsAreExecutable
-            | Self::CheckVcsPermalinks
-            | Self::ForbidNewSubmodules
-            | Self::CheckJson
-            | Self::CheckSymlinks
-            | Self::CheckMergeConflict
-            | Self::CheckToml
-            | Self::CheckXml
-            | Self::CheckYaml
-            | Self::DestroyedSymlinks
-            | Self::DetectPrivateKey
-            | Self::NoCommitToBranch => false,
-        }
-    }
-
-    pub(crate) async fn run(self, hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
+    pub(crate) async fn run(self, hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
         debug!("Running hook `{}` in fast path", hook.id);
         let future: HookFuture<'_> = match self {
             Self::CheckAddedLargeFiles => Box::pin(check_added_large_files(hook, filenames)),
@@ -242,7 +211,7 @@ mod tests {
                 events.borrow_mut().push(format!("start {path:?}"));
                 tokio::task::yield_now().await;
                 events.borrow_mut().push(format!("end {path:?}"));
-                Ok((0, Vec::new()))
+                Ok(HookOutput::unchanged(0, Vec::new()))
             }
         })
         .await

--- a/crates/prek/src/hooks/pre_commit_hooks/no_commit_to_branch.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/no_commit_to_branch.rs
@@ -41,7 +41,8 @@ impl Args {
     }
 }
 
-pub(crate) async fn no_commit_to_branch(hook: &Hook) -> Result<HookOutput> {
+/// Runs the `no-commit-to-branch` hook.
+pub(crate) async fn run(hook: &Hook) -> Result<HookOutput> {
     let args = Args::try_parse_from(hook.entry.expect_direct().split_with_args(&hook.args)?)?;
 
     let output = git_cmd()?

--- a/crates/prek/src/hooks/pre_commit_hooks/no_commit_to_branch.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/no_commit_to_branch.rs
@@ -3,6 +3,7 @@ use fancy_regex::Regex;
 
 use crate::git::git_cmd;
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 use anyhow::{Context, Result};
 
 #[derive(Parser)]
@@ -40,7 +41,7 @@ impl Args {
     }
 }
 
-pub(crate) async fn no_commit_to_branch(hook: &Hook) -> Result<(i32, Vec<u8>)> {
+pub(crate) async fn no_commit_to_branch(hook: &Hook) -> Result<HookOutput> {
     let args = Args::try_parse_from(hook.entry.expect_direct().split_with_args(&hook.args)?)?;
 
     let output = git_cmd()?
@@ -51,7 +52,7 @@ pub(crate) async fn no_commit_to_branch(hook: &Hook) -> Result<(i32, Vec<u8>)> {
         .await?;
 
     if !output.status.success() {
-        return Ok((0, Vec::new()));
+        return Ok(HookOutput::unchanged(0, Vec::new()));
     }
 
     let ref_name = String::from_utf8_lossy(&output.stdout);
@@ -60,8 +61,8 @@ pub(crate) async fn no_commit_to_branch(hook: &Hook) -> Result<(i32, Vec<u8>)> {
 
     if args.check_protected(branch)? {
         let err_msg = format!("You are not allowed to commit to branch '{branch}'\n");
-        Ok((1, err_msg.into_bytes()))
+        Ok(HookOutput::unchanged(1, err_msg.into_bytes()))
     } else {
-        Ok((0, Vec::new()))
+        Ok(HookOutput::unchanged(0, Vec::new()))
     }
 }

--- a/crates/prek/src/hooks/pre_commit_hooks/pretty_format_json.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/pretty_format_json.rs
@@ -76,7 +76,8 @@ impl From<&Args> for PreparedArgs {
     }
 }
 
-pub(crate) async fn pretty_format_json(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
+/// Runs the `pretty-format-json` hook.
+pub(crate) async fn run(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: Args = parse_hook_args(hook)?;
     let prepared = PreparedArgs::from(&args);
 

--- a/crates/prek/src/hooks/pre_commit_hooks/pretty_format_json.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/pretty_format_json.rs
@@ -10,6 +10,7 @@ use serde_json::ser::{Formatter, PrettyFormatter};
 use similar::TextDiff;
 
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::{parse_hook_args, run_file_checks};
 use crate::run::INTERNAL_CONCURRENCY;
 
@@ -75,7 +76,7 @@ impl From<&Args> for PreparedArgs {
     }
 }
 
-pub(crate) async fn pretty_format_json(hook: &Hook, filenames: &[&Path]) -> Result<(i32, Vec<u8>)> {
+pub(crate) async fn pretty_format_json(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: Args = parse_hook_args(hook)?;
     let prepared = PreparedArgs::from(&args);
 
@@ -88,11 +89,7 @@ pub(crate) async fn pretty_format_json(hook: &Hook, filenames: &[&Path]) -> Resu
     .await
 }
 
-async fn check_file(
-    file_base: &Path,
-    filename: &Path,
-    args: &PreparedArgs,
-) -> Result<(i32, Vec<u8>)> {
+async fn check_file(file_base: &Path, filename: &Path, args: &PreparedArgs) -> Result<HookOutput> {
     let original_content = fs_err::tokio::read_to_string(file_base.join(filename)).await?;
 
     match prettify_json(&original_content, args) {
@@ -101,19 +98,19 @@ async fn check_file(
             // to LF before comparison. Match that behavior without allocating in
             // the common no-change path.
             if matches_pretty_format(&original_content, &prettified_json) {
-                Ok((0, Vec::new()))
+                Ok(HookOutput::unchanged(0, Vec::new()))
             } else if args.auto_fix {
                 // Rust writes bytes exactly as provided. Preserve the file's
                 // existing newline style instead of forcing serde_json's LF.
                 let output = with_original_line_ending(&prettified_json, &original_content);
                 fs_err::tokio::write(file_base.join(filename), output.as_bytes()).await?;
                 let message = format!("Fixing file {}\n", filename.display());
-                Ok((1, message.into_bytes()))
+                Ok(HookOutput::known(1, message.into_bytes(), true))
             } else {
                 let normalized_content = normalize_newlines(&original_content);
                 let diff = generate_diff(normalized_content.as_ref(), &prettified_json, filename);
                 let message = format!("{}: not pretty-formatted.\n{diff}", filename.display());
-                Ok((1, message.into_bytes()))
+                Ok(HookOutput::unchanged(1, message.into_bytes()))
             }
         }
         Err(err) => {
@@ -121,7 +118,7 @@ async fn check_file(
                 "{}: invalid JSON ({err}). Consider using the `check-json` hook.\n",
                 filename.display(),
             );
-            Ok((1, error_message.into_bytes()))
+            Ok(HookOutput::unchanged(1, error_message.into_bytes()))
         }
     }
 }
@@ -523,10 +520,10 @@ mod tests {
             sort_keys: true,
         };
 
-        let (code, output) = check_file(dir.path(), Path::new("empty.json"), &args).await?;
+        let result = check_file(dir.path(), Path::new("empty.json"), &args).await?;
 
-        assert_eq!(code, 1);
-        let output = String::from_utf8(output)?;
+        assert_eq!(result.exit_status, 1);
+        let output = String::from_utf8(result.output)?;
         assert_eq!(
             output,
             "empty.json: invalid JSON (EOF while parsing a value at line 1 column 0). Consider using the `check-json` hook.\n",
@@ -547,10 +544,10 @@ mod tests {
             sort_keys: true,
         };
 
-        let (code, output) = check_file(dir.path(), Path::new("invalid.json"), &args).await?;
+        let result = check_file(dir.path(), Path::new("invalid.json"), &args).await?;
 
-        assert_eq!(code, 1);
-        let output = String::from_utf8(output)?;
+        assert_eq!(result.exit_status, 1);
+        let output = String::from_utf8(result.output)?;
         assert_eq!(
             output,
             "invalid.json: invalid JSON (expected value at line 1 column 9). Consider using the `check-json` hook.\n",
@@ -571,10 +568,10 @@ mod tests {
             sort_keys: true,
         };
 
-        let (code, output) = check_file(Path::new(""), &file_path, &args).await?;
+        let result = check_file(Path::new(""), &file_path, &args).await?;
 
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
 
         Ok(())
     }
@@ -592,10 +589,10 @@ mod tests {
             sort_keys: true,
         };
 
-        let (code, output) = check_file(Path::new(""), &file_path, &args).await?;
+        let result = check_file(Path::new(""), &file_path, &args).await?;
 
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
 
         Ok(())
     }
@@ -613,10 +610,10 @@ mod tests {
             sort_keys: true,
         };
 
-        let (code, output) = check_file(Path::new(""), &file_path, &args).await?;
+        let result = check_file(Path::new(""), &file_path, &args).await?;
 
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
 
         Ok(())
     }
@@ -632,10 +629,10 @@ mod tests {
             ordered_top_keys: vec![],
             sort_keys: true,
         };
-        let (code, output) = check_file(dir.path(), Path::new("non_pretty.json"), &args).await?;
+        let result = check_file(dir.path(), Path::new("non_pretty.json"), &args).await?;
 
-        assert_eq!(code, 1);
-        let output = String::from_utf8(output)?;
+        assert_eq!(result.exit_status, 1);
+        let output = String::from_utf8(result.output)?;
         let expected = indoc::indoc! {r#"
         non_pretty.json: not pretty-formatted.
         --- non_pretty.json
@@ -674,11 +671,11 @@ mod tests {
             sort_keys: false,
         };
 
-        let (code, output) = check_file(Path::new(""), &file_path, &args).await?;
+        let result = check_file(Path::new(""), &file_path, &args).await?;
 
         // With sorting disabled, no changes needed
-        assert_eq!(code, 0);
-        assert!(output.is_empty());
+        assert_eq!(result.exit_status, 0);
+        assert!(result.output.is_empty());
 
         Ok(())
     }
@@ -695,10 +692,10 @@ mod tests {
             sort_keys: true,
         };
 
-        let (code, output) = check_file(Path::new(""), &file_path, &args).await?;
+        let result = check_file(Path::new(""), &file_path, &args).await?;
 
-        assert_eq!(code, 1);
-        let output_str = String::from_utf8_lossy(&output);
+        assert_eq!(result.exit_status, 1);
+        let output_str = String::from_utf8_lossy(&result.output);
         assert!(output_str.contains("not pretty-formatted."));
 
         Ok(())
@@ -735,10 +732,10 @@ mod tests {
             sort_keys: true,
         };
 
-        let (code, output) = check_file(Path::new(""), &file_path, &args).await?;
+        let result = check_file(Path::new(""), &file_path, &args).await?;
 
-        assert_eq!(code, 1);
-        assert!(String::from_utf8_lossy(&output).contains("Fixing file"));
+        assert_eq!(result.exit_status, 1);
+        assert!(String::from_utf8_lossy(&result.output).contains("Fixing file"));
 
         // Verify the file was actually fixed
         let result = fs_err::tokio::read_to_string(&file_path).await?;
@@ -760,10 +757,10 @@ mod tests {
             sort_keys: true,
         };
 
-        let (code, output) = check_file(Path::new(""), &file_path, &args).await?;
+        let result = check_file(Path::new(""), &file_path, &args).await?;
 
-        assert_eq!(code, 1);
-        assert!(String::from_utf8_lossy(&output).contains("Fixing file"));
+        assert_eq!(result.exit_status, 1);
+        assert!(String::from_utf8_lossy(&result.output).contains("Fixing file"));
 
         let result = fs_err::tokio::read_to_string(&file_path).await?;
         assert_eq!(result, PRETTY_JSON.replace('\n', "\r\n"));
@@ -783,10 +780,10 @@ mod tests {
             sort_keys: true,
         };
 
-        let (code, output) = check_file(Path::new(""), &file_path, &args).await?;
+        let result = check_file(Path::new(""), &file_path, &args).await?;
 
-        assert_eq!(code, 1);
-        assert!(String::from_utf8_lossy(&output).contains("Fixing file"));
+        assert_eq!(result.exit_status, 1);
+        assert!(String::from_utf8_lossy(&result.output).contains("Fixing file"));
 
         let result = fs_err::tokio::read_to_string(&file_path).await?;
         let expected = "{\n\t\"alist\": [\n\t\t2,\n\t\t34,\n\t\t234\n\t],\n\t\"blah\": null,\n\t\"foo\": \"bar\"\n}\n";
@@ -807,10 +804,10 @@ mod tests {
             sort_keys: true,
         };
 
-        let (code, output) = check_file(Path::new(""), &file_path, &args).await?;
+        let result = check_file(Path::new(""), &file_path, &args).await?;
 
-        assert_eq!(code, 1);
-        assert!(String::from_utf8_lossy(&output).contains("Fixing file"));
+        assert_eq!(result.exit_status, 1);
+        assert!(String::from_utf8_lossy(&result.output).contains("Fixing file"));
 
         let result = fs_err::tokio::read_to_string(&file_path).await?;
         let expected = indoc::indoc! {r#"
@@ -852,10 +849,10 @@ mod tests {
             sort_keys: true,
         };
 
-        let (code, output) = check_file(Path::new(""), &file_path, &args).await?;
+        let result = check_file(Path::new(""), &file_path, &args).await?;
 
-        assert_eq!(code, 1);
-        assert!(String::from_utf8_lossy(&output).contains("Fixing file"));
+        assert_eq!(result.exit_status, 1);
+        assert!(String::from_utf8_lossy(&result.output).contains("Fixing file"));
 
         let result = fs_err::tokio::read_to_string(&file_path).await?;
         assert_eq!(result, PRETTY_JSON);
@@ -875,10 +872,10 @@ mod tests {
             sort_keys: true,
         };
 
-        let (code, output) = check_file(Path::new(""), &file_path, &args).await?;
+        let result = check_file(Path::new(""), &file_path, &args).await?;
 
-        assert_eq!(code, 1);
-        assert!(String::from_utf8_lossy(&output).contains("Fixing file"));
+        assert_eq!(result.exit_status, 1);
+        assert!(String::from_utf8_lossy(&result.output).contains("Fixing file"));
 
         let result = fs_err::tokio::read_to_string(&file_path).await?;
         let expected = indoc::indoc! {r#"
@@ -911,9 +908,9 @@ mod tests {
             sort_keys: true,
         };
 
-        let (code, _output) = check_file(Path::new(""), &file_path, &args).await?;
+        let result = check_file(Path::new(""), &file_path, &args).await?;
 
-        assert_eq!(code, 0);
+        assert_eq!(result.exit_status, 0);
         let result = fs_err::tokio::read_to_string(&file_path).await?;
         let expected = indoc::indoc! {r#"
         {
@@ -944,10 +941,10 @@ mod tests {
             sort_keys: true,
         };
 
-        let (code, output) = check_file(Path::new(""), &file_path, &args).await?;
+        let result = check_file(Path::new(""), &file_path, &args).await?;
 
-        assert_eq!(code, 1);
-        assert!(String::from_utf8_lossy(&output).contains("Fixing file"));
+        assert_eq!(result.exit_status, 1);
+        assert!(String::from_utf8_lossy(&result.output).contains("Fixing file"));
 
         let result = fs_err::tokio::read_to_string(&file_path).await?;
         let expected = indoc::indoc! {r#"
@@ -1002,9 +999,9 @@ mod tests {
             sort_keys: true,
         };
 
-        let (code, _output) = check_file(Path::new(""), &file_path, &args).await?;
+        let result = check_file(Path::new(""), &file_path, &args).await?;
 
-        assert_eq!(code, 1);
+        assert_eq!(result.exit_status, 1);
         let result = fs_err::tokio::read_to_string(&file_path).await?;
         let expected = indoc::indoc! {r#"
         {
@@ -1033,9 +1030,9 @@ mod tests {
             sort_keys: true,
         };
 
-        let (code, _) = check_file(Path::new(""), &file_path, &args).await?;
+        let result = check_file(Path::new(""), &file_path, &args).await?;
 
-        assert_eq!(code, 1);
+        assert_eq!(result.exit_status, 1);
         let result = fs_err::tokio::read_to_string(&file_path).await?;
         let expected = indoc::indoc! {r#"
         {

--- a/crates/prek/src/hooks/pre_commit_hooks/requirements_txt_fixer.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/requirements_txt_fixer.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use anyhow::Result;
 
 use crate::hook::Hook;
+use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::{FilenamesArgs, parse_hook_args, run_file_checks};
 use crate::run::INTERNAL_CONCURRENCY;
 
@@ -181,10 +182,7 @@ impl<'a> ParsedRequirements<'a> {
     }
 }
 
-pub(crate) async fn requirements_txt_fixer(
-    hook: &Hook,
-    filenames: &[&Path],
-) -> Result<(i32, Vec<u8>)> {
+pub(crate) async fn requirements_txt_fixer(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     let file_base = hook.project().relative_path();
 
@@ -197,21 +195,25 @@ pub(crate) async fn requirements_txt_fixer(
     .await
 }
 
-async fn fix_file(file_base: &Path, filename: &Path) -> Result<(i32, Vec<u8>)> {
+async fn fix_file(file_base: &Path, filename: &Path) -> Result<HookOutput> {
     let file_path = file_base.join(filename);
     let before = fs_err::tokio::read(&file_path).await?;
 
     let after = match fixed_contents(before) {
         Ok(Some(after)) => after,
-        Ok(None) => return Ok((0, Vec::new())),
+        Ok(None) => return Ok(HookOutput::unchanged(0, Vec::new())),
         Err(error) => {
             let output = format!("{}:{}: {error}\n", filename.display(), error.line_number());
-            return Ok((1, output.into_bytes()));
+            return Ok(HookOutput::unchanged(1, output.into_bytes()));
         }
     };
 
     fs_err::tokio::write(file_path, after).await?;
-    Ok((1, format!("Sorting {}\n", filename.display()).into_bytes()))
+    Ok(HookOutput::known(
+        1,
+        format!("Sorting {}\n", filename.display()).into_bytes(),
+        true,
+    ))
 }
 
 fn fixed_contents(mut before: Vec<u8>) -> FixResult<Option<Vec<u8>>> {

--- a/crates/prek/src/hooks/pre_commit_hooks/requirements_txt_fixer.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/requirements_txt_fixer.rs
@@ -182,7 +182,8 @@ impl<'a> ParsedRequirements<'a> {
     }
 }
 
-pub(crate) async fn requirements_txt_fixer(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
+/// Runs the `requirements-txt-fixer` hook.
+pub(crate) async fn run(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
     let args: FilenamesArgs = parse_hook_args(hook)?;
     let file_base = hook.project().relative_path();
 

--- a/crates/prek/src/languages/mod.rs
+++ b/crates/prek/src/languages/mod.rs
@@ -15,7 +15,7 @@ use crate::cli::run::HookRunReporter;
 use crate::config::Language;
 use crate::fs::CWD;
 use crate::hook::{Hook, InstallInfo, InstalledHook, Repo};
-use crate::hooks;
+use crate::hooks::{self, HookOutput};
 use crate::store::{CacheBucket, Store, ToolBucket};
 
 mod bun;
@@ -329,11 +329,11 @@ impl Language {
         hook: &'a InstalledHook,
         filenames: &'a [&'p Path],
         reporter: &'a HookRunReporter,
-    ) -> impl Future<Output = Result<(i32, Vec<u8>)>> + 'a
+    ) -> impl Future<Output = Result<HookOutput>> + 'a
     where
         'p: 'a,
     {
-        let future: LanguageFuture<'a, (i32, Vec<u8>)> = match hook.repo() {
+        let future: LanguageFuture<'a, HookOutput> = match hook.repo() {
             Repo::Meta { .. } => Box::pin(
                 hooks::MetaHooks::from_str(&hook.id)
                     .unwrap()
@@ -348,9 +348,11 @@ impl Language {
             Repo::Remote { .. } if hooks::check_fast_path(hook) => {
                 Box::pin(hooks::run_fast_path(store, hook, filenames, reporter))
             }
-            Repo::Remote { .. } | Repo::Local { .. } => {
-                self.backend().run(store, hook, filenames, reporter)
-            }
+            Repo::Remote { .. } | Repo::Local { .. } => Box::pin(async move {
+                let (exit_status, output) =
+                    self.backend().run(store, hook, filenames, reporter).await?;
+                Ok(HookOutput::unknown(exit_status, output))
+            }),
         };
 
         future.instrument(trace_span!(

--- a/crates/prek/tests/skipped_hooks.rs
+++ b/crates/prek/tests/skipped_hooks.rs
@@ -411,7 +411,7 @@ fn orphan_project_early_match_still_hides_child_files_from_parent_install() -> R
 /// 2. `git diff` is not called when every hook is skipped
 ///
 /// Note: This test uses manual output capture instead of `cmd_snapshot!` because
-/// we need to count `get_diff` occurrences in trace-level stderr. Trace output
+/// we need to count `diff_worktree` occurrences in trace-level stderr. Trace output
 /// contains non-deterministic timestamps and timing data unsuitable for snapshots.
 #[test]
 fn all_hooks_skipped_multiple_priority_groups() -> Result<()> {
@@ -460,10 +460,10 @@ fn all_hooks_skipped_multiple_priority_groups() -> Result<()> {
 
     // Regression test for #1335: skipped hooks do not need modification checks.
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let get_diff_calls = stderr.matches("get_diff").count();
+    let diff_worktree_calls = stderr.matches("diff_worktree").count();
     assert_eq!(
-        get_diff_calls, 0,
-        "Expected no get_diff calls when all hooks skip, found {get_diff_calls}.\n\
+        diff_worktree_calls, 0,
+        "Expected no diff_worktree calls when all hooks skip, found {diff_worktree_calls}.\n\
          Trace output:\n{stderr}"
     );
 
@@ -471,7 +471,7 @@ fn all_hooks_skipped_multiple_priority_groups() -> Result<()> {
 }
 
 #[test]
-fn may_modify_hook_without_changes_uses_quiet_diff_check() -> Result<()> {
+fn external_hook_without_changes_uses_quiet_diff_check() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -501,11 +501,10 @@ fn may_modify_hook_without_changes_uses_quiet_diff_check() -> Result<()> {
         "Expected one cheap worktree diff check, found {has_worktree_diff_calls}.\n\
          Trace output:\n{stderr}"
     );
-
-    let get_diff_calls = stderr.matches("get_diff").count();
+    let diff_worktree_calls = stderr.matches("diff_worktree").count();
     assert_eq!(
-        get_diff_calls, 0,
-        "Expected no full get_diff calls when the hook leaves files unchanged, found {get_diff_calls}.\n\
+        diff_worktree_calls, 0,
+        "Expected no full diff_worktree calls when the hook leaves files unchanged, found {diff_worktree_calls}.\n\
          Trace output:\n{stderr}"
     );
 
@@ -564,10 +563,10 @@ fn identical_rewrite_with_stat_change_is_not_modified() -> Result<()> {
          Trace output:\n{stderr}"
     );
 
-    let get_diff_calls = stderr.matches("get_diff").count();
+    let diff_worktree_calls = stderr.matches("diff_worktree").count();
     assert_eq!(
-        get_diff_calls, 1,
-        "Expected one content diff to filter out stat-only changes, found {get_diff_calls}.\n\
+        diff_worktree_calls, 1,
+        "Expected one content diff to filter out stat-only changes, found {diff_worktree_calls}.\n\
          Trace output:\n{stderr}"
     );
 
@@ -612,10 +611,10 @@ fn modifying_hook_uses_clean_baseline_diff_detection() -> Result<()> {
          Trace output:\n{stderr}"
     );
 
-    let get_diff_calls = stderr.matches("get_diff").count();
+    let diff_worktree_calls = stderr.matches("diff_worktree").count();
     assert_eq!(
-        get_diff_calls, 1,
-        "Expected one full get_diff call after detecting modifications, found {get_diff_calls}.\n\
+        diff_worktree_calls, 1,
+        "Expected one full diff_worktree call after detecting modifications, found {diff_worktree_calls}.\n\
          Trace output:\n{stderr}"
     );
 
@@ -666,10 +665,10 @@ fn all_files_with_existing_unstaged_changes_uses_snapshot_baseline() -> Result<(
          Trace output:\n{stderr}"
     );
 
-    let get_diff_calls = stderr.matches("get_diff").count();
+    let diff_worktree_calls = stderr.matches("diff_worktree").count();
     assert_eq!(
-        get_diff_calls, 2,
-        "Expected a full before/after diff comparison for dirty `--all-files`, found {get_diff_calls}.\n\
+        diff_worktree_calls, 2,
+        "Expected a full before/after diff comparison for dirty `--all-files`, found {diff_worktree_calls}.\n\
          Trace output:\n{stderr}"
     );
 
@@ -829,12 +828,102 @@ fn read_only_builtin_hook_does_not_run_diff_detection() -> Result<()> {
     assert!(output.status.success(), "prek should succeed");
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let get_diff_calls = stderr.matches("get_diff").count();
+    let diff_worktree_calls = stderr.matches("diff_worktree").count();
     assert_eq!(
-        get_diff_calls, 0,
-        "Expected no get_diff calls for read-only builtin hooks, found {get_diff_calls}.\n\
+        diff_worktree_calls, 0,
+        "Expected no diff_worktree calls for read-only builtin hooks, found {diff_worktree_calls}.\n\
          Trace output:\n{stderr}"
     );
+
+    Ok(())
+}
+
+#[test]
+fn modifying_builtin_invalidates_baseline_for_later_external_hook() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    let cwd = context.work_dir();
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: builtin
+            hooks:
+              - id: end-of-file-fixer
+                priority: 0
+          - repo: local
+            hooks:
+              - id: noop
+                name: noop
+                language: system
+                entry: python3 -c "pass"
+                pass_filenames: false
+                priority: 1
+    "#});
+
+    cwd.child("file.txt").write_str("missing newline")?;
+    context.git_add(".");
+
+    let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
+
+    assert!(
+        !output.status.success(),
+        "the builtin should report its modification"
+    );
+    assert_eq!(context.read("file.txt"), "missing newline\n");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("end-of-file-fixer") && stdout.contains("files were modified by this hook")
+    );
+    assert!(stdout.contains("noop") && stdout.contains("Passed"));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        stderr.matches("has_worktree_diff").count(),
+        0,
+        "The builtin result and dirty baseline should avoid the clean-worktree check.\n\
+         Trace output:\n{stderr}"
+    );
+    assert_eq!(
+        stderr.matches("diff_worktree").count(),
+        2,
+        "The later external hook should snapshot the builtin's change, then compare against it.\n\
+         Trace output:\n{stderr}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn failed_non_modifying_builtin_skips_diff_detection() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    let cwd = context.work_dir();
+    context.write_pre_commit_config(indoc::indoc! {r"
+        repos:
+          - repo: builtin
+            hooks:
+              - id: mixed-line-ending
+                args: ['--fix=no']
+    "});
+
+    cwd.child("mixed.txt").write_str("first\r\nsecond\n")?;
+    context.git_add(".");
+
+    let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
+
+    assert!(
+        !output.status.success(),
+        "mixed-line-ending should report the validation failure"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("mixed.txt: mixed line endings"));
+    assert!(!stdout.contains("files were modified by this hook"));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(stderr.matches("has_worktree_diff").count(), 0);
+    assert_eq!(stderr.matches("diff_worktree").count(), 0);
 
     Ok(())
 }


### PR DESCRIPTION
Builtin, meta, and fast-path hooks now report file changes directly, avoiding Git diff checks when their result is known.

External hooks continue to use DiffTracker, with native modifications invalidating its baseline before a later external hook.