### PR TITLE
Do not shuffle file list for verbose output

### DIFF
--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -1389,7 +1389,9 @@ fn dry_run_hook(hook: &InstalledHook, input: &HookRunInput<'_>) -> Result<Vec<u8
 
     match input {
         HookRunInput::Filenames(filenames) => {
-            for filename in filenames {
+            let mut filenames = filenames.clone();
+            filenames.sort();
+            for filename in &filenames {
                 writeln!(output, "- {}", filename.display())?;
             }
         }

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -1335,11 +1335,11 @@ async fn run_hook(
         return Ok(RunResult::from_status(hook, RunStatus::NoFiles));
     }
     let start = std::time::Instant::now();
-    input.shuffle();
 
     let hook_output = if dry_run {
         hooks::HookOutput::unchanged(0, dry_run_hook(&hook, &input)?)
     } else {
+        input.shuffle();
         match &input {
             HookRunInput::Filenames(filenames) => {
                 hook.language.run(store, &hook, filenames, reporter).await
@@ -1389,9 +1389,7 @@ fn dry_run_hook(hook: &InstalledHook, input: &HookRunInput<'_>) -> Result<Vec<u8
 
     match input {
         HookRunInput::Filenames(filenames) => {
-            let mut filenames = filenames.clone();
-            filenames.sort();
-            for filename in &filenames {
+            for filename in filenames {
                 writeln!(output, "- {}", filename.display())?;
             }
         }

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -3502,6 +3502,44 @@ fn dry_run() {
     ");
 }
 
+/// The file list printed with `--dry-run --verbose` is sorted.
+#[test]
+fn dry_run_sorted() {
+    let context = TestContext::new();
+    context.init_project();
+    context.write_pre_commit_config(indoc::indoc! {r"
+        repos:
+          - repo: local
+            hooks:
+              - id: fail
+                name: fail
+                entry: fail
+                language: fail
+    "});
+    let cwd = context.work_dir();
+    cwd.child("zebra.txt").write_str("z").unwrap();
+    cwd.child("apple.txt").write_str("a").unwrap();
+    cwd.child("mango.txt").write_str("m").unwrap();
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run().arg("--dry-run").arg("-v"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    fail....................................................................Dry Run
+    - hook id: fail
+    - duration: [TIME]
+
+      `fail` would be run on 4 files:
+      - .pre-commit-config.yaml
+      - apple.txt
+      - mango.txt
+      - zebra.txt
+
+    ----- stderr -----
+    ");
+}
+
 /// Supports reading `pre-commit-config.yml` as well.
 #[test]
 fn alternate_config_file() -> Result<()> {

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -3502,44 +3502,6 @@ fn dry_run() {
     ");
 }
 
-/// The file list printed with `--dry-run --verbose` is sorted.
-#[test]
-fn dry_run_sorted() {
-    let context = TestContext::new();
-    context.init_project();
-    context.write_pre_commit_config(indoc::indoc! {r"
-        repos:
-          - repo: local
-            hooks:
-              - id: fail
-                name: fail
-                entry: fail
-                language: fail
-    "});
-    let cwd = context.work_dir();
-    cwd.child("zebra.txt").write_str("z").unwrap();
-    cwd.child("apple.txt").write_str("a").unwrap();
-    cwd.child("mango.txt").write_str("m").unwrap();
-    context.git_add(".");
-
-    cmd_snapshot!(context.filters(), context.run().arg("--dry-run").arg("-v"), @r"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    fail....................................................................Dry Run
-    - hook id: fail
-    - duration: [TIME]
-
-      `fail` would be run on 4 files:
-      - .pre-commit-config.yaml
-      - apple.txt
-      - mango.txt
-      - zebra.txt
-
-    ----- stderr -----
-    ");
-}
-
 /// Supports reading `pre-commit-config.yml` as well.
 #[test]
 fn alternate_config_file() -> Result<()> {


### PR DESCRIPTION
Fixes #2430.

The file list usually comes from `git ls-files`, which is already ordered. Preserve that order for `--dry-run --verbose` output instead of shuffling it.