### PR TITLE
Precompute file tags in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2031,6 +2031,7 @@ dependencies = [
  "prek-identify",
  "prek-pty",
  "pretty_assertions",
+ "rayon",
  "regex",
  "regex-automata",
  "reqwest",
@@ -2243,6 +2244,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ aws-lc-rs = { version = "1.17.0", default-features = false, features = [
 ] }
 rustc-hash = { version = "2.1.1" }
 rustix = { version = "1.0.8", features = ["pty", "process", "fs", "termios"] }
+rayon = { version = "1.11.0" }
 same-file = { version = "1.0.6" }
 seahash = { version = "4.1.0" }
 semver = { version = "1.0.24", features = ["serde"] }

--- a/crates/prek/Cargo.toml
+++ b/crates/prek/Cargo.toml
@@ -64,6 +64,7 @@ owo-colors = { workspace = true }
 regex = { workspace = true }
 regex-automata = { workspace = true }
 reqwest = { workspace = true }
+rayon = { workspace = true }
 aws-lc-rs = { workspace = true }
 rustc-hash = { workspace = true }
 same-file = { workspace = true }

--- a/crates/prek/src/cli/run/filter.rs
+++ b/crates/prek/src/cli/run/filter.rs
@@ -1,4 +1,3 @@
-use std::cell::OnceCell;
 use std::ffi::OsStr;
 use std::ops::ControlFlow;
 use std::path::{Path, PathBuf};
@@ -8,6 +7,7 @@ use anyhow::{Context, Result};
 use globset::Glob;
 use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use prek_identify::{TagSet, tags_from_path};
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::{debug, error, instrument};
 
@@ -108,10 +108,10 @@ impl<'a> HookFileFilter<'a> {
     }
 
     /// Return whether a project-owned file passes this hook's file and tag filters.
-    pub(crate) fn matches_project_file<'p>(
+    pub(crate) fn matches_project_file(
         &self,
-        file: &ProjectFile<'p>,
-        tag_cache: &FileTagCache<'p>,
+        file: &ProjectFile<'_>,
+        tag_cache: &FileTagCache,
     ) -> bool {
         self.matches_filename(file.hook_path) && self.matches_tags(file.tags(tag_cache))
     }
@@ -137,42 +137,33 @@ impl<'a> ProjectFile<'a> {
     }
 
     /// Return cached tags for the workspace-relative path.
-    pub(crate) fn tags<'cache>(
-        &self,
-        tag_cache: &'cache FileTagCache<'a>,
-    ) -> Option<&'cache TagSet> {
+    pub(crate) fn tags<'cache>(&self, tag_cache: &'cache FileTagCache) -> Option<&'cache TagSet> {
         tag_cache.tags(self.file_idx)
     }
 }
 
 #[derive(Default)]
-pub(crate) struct FileTagCache<'a> {
-    paths: &'a [PathBuf],
-    tags_by_file: Vec<OnceCell<Option<TagSet>>>,
+pub(crate) struct FileTagCache {
+    tags_by_file: Vec<Option<TagSet>>,
 }
 
-impl<'a> FileTagCache<'a> {
-    pub(crate) fn from_paths(paths: &'a [PathBuf]) -> Self {
-        let tags_by_file = (0..paths.len()).map(|_| OnceCell::new()).collect();
-        Self {
-            paths,
-            tags_by_file,
-        }
+impl FileTagCache {
+    pub(crate) fn from_paths(paths: &[PathBuf]) -> Self {
+        let tags_by_file = paths
+            .par_iter()
+            .map(|path| match tags_from_path(path) {
+                Ok(tags) => Some(tags),
+                Err(err) => {
+                    error!(filename = ?path.display(), error = %err, "Failed to get tags");
+                    None
+                }
+            })
+            .collect();
+        Self { tags_by_file }
     }
 
     pub(crate) fn tags(&self, file_idx: usize) -> Option<&TagSet> {
-        self.tags_by_file[file_idx]
-            .get_or_init(|| {
-                let path = &self.paths[file_idx];
-                match tags_from_path(path) {
-                    Ok(tags) => Some(tags),
-                    Err(err) => {
-                        error!(filename = ?path.display(), error = %err, "Failed to get tags");
-                        None
-                    }
-                }
-            })
-            .as_ref()
+        self.tags_by_file[file_idx].as_ref()
     }
 }
 
@@ -275,7 +266,7 @@ impl<'a> ProjectFiles<'a> {
     pub(crate) fn matching_filenames(
         &self,
         hook: &Hook,
-        tag_cache: &FileTagCache<'a>,
+        tag_cache: &FileTagCache,
     ) -> Vec<&'a Path> {
         let hook_filter = HookFileFilter::new(hook);
         let mut filenames = Vec::new();
@@ -288,7 +279,7 @@ impl<'a> ProjectFiles<'a> {
     }
 
     /// Return whether at least one file matches a hook without collecting every filename.
-    pub(crate) fn has_matching_file(&self, hook: &Hook, tag_cache: &FileTagCache<'a>) -> bool {
+    pub(crate) fn has_matching_file(&self, hook: &Hook, tag_cache: &FileTagCache) -> bool {
         let hook_filter = HookFileFilter::new(hook);
         for file in &self.files {
             if hook_filter.matches_project_file(file, tag_cache) {
@@ -343,7 +334,7 @@ impl<'a> ProjectPathNode<'a> {
 /// Project-relative views of the run input, built once and shared by hook setup and execution.
 pub(crate) struct RunFileIndex<'a> {
     projects: Vec<ProjectFiles<'a>>,
-    tag_cache: FileTagCache<'a>,
+    tag_cache: FileTagCache,
 }
 
 impl<'a> RunFileIndex<'a> {
@@ -415,7 +406,7 @@ impl<'a> RunFileIndex<'a> {
         &self.projects[project.idx()]
     }
 
-    pub(crate) fn tag_cache(&self) -> &FileTagCache<'a> {
+    pub(crate) fn tag_cache(&self) -> &FileTagCache {
         &self.tag_cache
     }
 }

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -756,7 +756,7 @@ impl<'a> HookRunSession<'a> {
         &self,
         group_hooks: Vec<InstalledHook>,
         project_input: &ProjectHookInput<'_, '_>,
-        tag_cache: &FileTagCache<'_>,
+        tag_cache: &FileTagCache,
         semaphore: Rc<Semaphore>,
     ) -> Result<Vec<RunResult>> {
         debug!(
@@ -1093,11 +1093,7 @@ impl<'index, 'paths> ProjectHookInput<'index, 'paths> {
         }
     }
 
-    fn run_input_for_hook(
-        &self,
-        hook: &Hook,
-        tag_cache: &FileTagCache<'paths>,
-    ) -> HookRunInput<'paths> {
+    fn run_input_for_hook(&self, hook: &Hook, tag_cache: &FileTagCache) -> HookRunInput<'paths> {
         match self {
             Self::Files(project_files) => match hook.pass_filenames {
                 // Always-run hooks without filename arguments run regardless of file matches.
@@ -1124,7 +1120,7 @@ impl<'index, 'paths> ProjectHookInput<'index, 'paths> {
         }
     }
 
-    fn matches_hook(&self, hook: &Hook, tag_cache: &FileTagCache<'paths>) -> bool {
+    fn matches_hook(&self, hook: &Hook, tag_cache: &FileTagCache) -> bool {
         match self {
             Self::Files(project_files) => project_files.has_matching_file(hook, tag_cache),
             Self::MessageFile { hook_arg, tags } => {
@@ -1309,7 +1305,7 @@ impl RunResult {
 async fn run_hook(
     hook: InstalledHook,
     project_input: &ProjectHookInput<'_, '_>,
-    tag_cache: &FileTagCache<'_>,
+    tag_cache: &FileTagCache,
     store: &Store,
     dry_run: bool,
     reporter: &HookRunReporter,


### PR DESCRIPTION
Precompute all file tags in parallel with Rayon and replace the lazy per-file `OnceCell` cache with an eagerly populated ordered vector.

On a 59,330-file fixture with the default `[file]` filter, runtime fell from 575.6 ms to 162.5-166.4 ms (about 3.5x), with no measurable regression on a 310-file repository.

This intentionally computes all input file tags up front, including files that narrow filename filters might previously skip.