### PR TITLE
fix(run): roll back to the pre-hook tree, not the live index

### DIFF
--- a/crates/prek/src/cli/run/keeper.rs
+++ b/crates/prek/src/cli/run/keeper.rs
@@ -16,6 +16,15 @@ use crate::store::Store;
 struct IntentToAddRestorer(Vec<PathBuf>);
 struct UnstagedChangesRestorer {
     root: PathBuf,
+    /// Tree object written from the index BEFORE any hook ran.
+    ///
+    /// The rollback path must reset to this snapshot rather than to the live index:
+    /// hooks routinely mutate the index (any auto-fixer that re-stages what it
+    /// rewrote, e.g. a `prettier --write` + `git add` wrapper), so by the time we
+    /// roll back, `git checkout -- <root>` would restore the hook's own content as
+    /// the baseline and then apply a patch computed against the ORIGINAL content on
+    /// top of it — silently losing or duplicating unstaged work.
+    tree: String,
     patch: Option<PathBuf>,
 }
 
@@ -95,7 +104,7 @@ impl UnstagedChangesRestorer {
             .arg("--binary")
             .arg("--exit-code")
             .hidden_args(["--ignore-submodules", "--no-color", "--no-ext-diff"])
-            .arg(tree)
+            .arg(&tree)
             .arg("--")
             .arg(root)
             .check(false)
@@ -107,6 +116,7 @@ impl UnstagedChangesRestorer {
             // No non-staged changes
             Ok(Self {
                 root: root.to_path_buf(),
+                tree,
                 patch: None,
             })
         } else if output.status.code() == Some(1) {
@@ -115,6 +125,7 @@ impl UnstagedChangesRestorer {
                 // probably git auto crlf behavior quirks
                 Ok(Self {
                     root: root.to_path_buf(),
+                    tree,
                     patch: None,
                 })
             } else {
@@ -140,12 +151,14 @@ impl UnstagedChangesRestorer {
                 );
                 fs_err::write(&patch_path, output.stdout)?;
 
-                // Clean the working tree
+                // Clean the working tree. The index was just used to write `tree`,
+                // so index and tree are identical here — no tree-ish needed.
                 debug!("Cleaning working tree");
-                Self::checkout_working_tree(root)?;
+                Self::checkout_working_tree(root, None)?;
 
                 Ok(Self {
                     root: root.to_path_buf(),
+                    tree,
                     patch: Some(patch_path),
                 })
             }
@@ -154,12 +167,23 @@ impl UnstagedChangesRestorer {
         }
     }
 
-    fn checkout_working_tree(root: &Path) -> Result<()> {
+    /// Reset the working tree under `root`.
+    ///
+    /// With `tree: None`, `git checkout -- <root>` restores from the CURRENT index.
+    /// With `tree: Some(t)`, `git checkout <t> -- <root>` restores both the index
+    /// entries and the working-tree files for paths under `root` to that tree —
+    /// which is what the rollback path needs, because a hook may have mutated the
+    /// index in between (see the `tree` field docs).
+    fn checkout_working_tree(root: &Path, tree: Option<&str>) -> Result<()> {
         let mut cmd = Command::new(GIT.as_ref()?);
-        let output = git::apply_git_work_tree(&mut cmd)
+        let cmd = git::apply_git_work_tree(&mut cmd)
             .arg("-c")
             .arg("submodule.recurse=0")
-            .arg("checkout")
+            .arg("checkout");
+        if let Some(tree) = tree {
+            cmd.arg(tree);
+        }
+        let output = cmd
             .arg("--")
             .arg(root)
             // prevent recursive post-checkout hooks
@@ -202,7 +226,10 @@ impl UnstagedChangesRestorer {
             );
 
             // Discard any changes made by hooks, and try applying the patch again.
-            Self::checkout_working_tree(&self.root)?;
+            // Reset to the PRE-HOOK tree, not the live index: a hook that re-staged
+            // what it rewrote has already moved the index, and restoring from it
+            // would make the hook's content the baseline the patch applies onto.
+            Self::checkout_working_tree(&self.root, Some(&self.tree))?;
             Self::git_apply(patch)?;
         }
 

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -2032,6 +2032,69 @@ fn intent_to_add_file_survives_conflicted_stash_restore() -> Result<()> {
     Ok(())
 }
 
+/// A hook that re-stages what it rewrote must not cost the user their unstaged work.
+///
+/// Auto-fixing hooks commonly run a formatter and then `git add` the result, so the
+/// commit completes in one step instead of aborting for a manual re-stage. That moves
+/// the index while the keeper is active. If the stash restore then conflicts, rolling
+/// back with a bare `git checkout -- <root>` restores from the *hook's* index rather
+/// than the pre-hook state, so the saved patch gets applied on top of the hook's
+/// content — and the unstaged changes are silently lost.
+///
+/// Regression test for the rollback baseline: the working tree must come back exactly
+/// as the user left it, and `git status` must still report the file as dirty.
+#[test]
+fn restaging_hook_does_not_discard_unstaged_changes() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: rewrite-and-restage
+                name: rewrite-and-restage
+                language: system
+                entry: bash -c 'printf "NORMALISED\nbody\nstaged edit\n" > doc.md && git add -- doc.md'
+                files: ^doc\.md$
+                pass_filenames: false
+   "#});
+
+    let cwd = context.work_dir();
+    cwd.child("doc.md").write_str("ORIGINAL\nbody\n")?;
+    context.git_add(".");
+    context.git_commit("Initial commit");
+
+    // Stage an edit, then leave a further unstaged edit on the same file.
+    cwd.child("doc.md")
+        .write_str("ORIGINAL\nbody\nstaged edit\n")?;
+    context.git_add("doc.md");
+    cwd.child("doc.md")
+        .write_str("ORIGINAL\nbody\nstaged edit\nUNSTAGED TAIL\n")?;
+
+    let _ = context.run().assert();
+
+    // The unstaged edit must survive the conflicted restore untouched.
+    assert_eq!(
+        context.read("doc.md"),
+        "ORIGINAL\nbody\nstaged edit\nUNSTAGED TAIL\n"
+    );
+
+    // ...and it must still be unstaged, not silently absorbed into the index.
+    let output = git_cmd(cwd)
+        .arg("status")
+        .arg("--porcelain")
+        .arg("--")
+        .arg("doc.md")
+        .output()?;
+    assert!(output.status.success(), "{output:?}");
+    assert!(
+        String::from_utf8(output.stdout)?.contains("doc.md"),
+        "doc.md should still have unstaged changes"
+    );
+
+    Ok(())
+}
+
 #[cfg(unix)]
 #[test]
 fn restore_on_interrupt() -> Result<()> {


### PR DESCRIPTION
## Summary

When the stash restore conflicts, the rollback restores from the **current index** rather than the pre-hook state. If a hook has re-staged its own output, the index has already moved, so the saved patch gets applied on top of the hook's content and the user's unstaged changes are silently lost.

This is the general case behind #1889. That issue was closed because the reported scenario couldn't be reproduced from the description — this PR includes a minimal deterministic reproduction as a test.

## The mechanism

`UnstagedChangesRestorer::restore` falls back to `checkout_working_tree` when `git apply` fails, intending to discard the hook's changes and retry:

```rust
// Discard any changes made by hooks, and try applying the patch again.
Self::checkout_working_tree(&self.root)?;
Self::git_apply(patch)?;
```

`checkout_working_tree` runs `git checkout -- <root>` with no tree-ish, so it restores from the index. That's correct only while the index still holds the pre-hook state.

Auto-fixing hooks commonly break that assumption: they run a formatter and then `git add` the result, so the commit completes in one step instead of aborting for a manual re-stage. Once such a hook runs, the index holds the hook's content. The rollback then reinstates *that* as the baseline, and the patch — computed against the original content — is applied on top of it. It either fails outright or lands on the wrong lines. Either way the unstaged work is gone, and `git status` is clean afterwards, so nothing signals it.

## The fix

`clean` already computes the pre-hook tree with `git write-tree` and then discards it. This keeps it and passes it to the rollback checkout, so `git checkout <tree> -- <root>` restores both the index entries and the working tree to their true pre-hook state before the patch is re-applied.

The happy path is unchanged — the initial `clean` checkout still passes `None`, since the tree was just written from the index and the two are identical at that point. Only the conflict path differs, and it gains one argv element on a command that runs only after a conflict has already occurred.

## Reproduction

`restaging_hook_does_not_discard_unstaged_changes` in `crates/prek/tests/run.rs`. A hook rewrites a file and `git add`s it; the same file has both a staged edit and a further unstaged edit.

On master:

```
  left: "NORMALISED\nbody\nstaged edit\n"
 right: "ORIGINAL\nbody\nstaged edit\nUNSTAGED TAIL\n"
```

The unstaged tail is gone and the hook's content has replaced the user's. With the fix, the working tree comes back exactly as the user left it and the file is still reported dirty.

## Checks

- New test fails on master, passes with the change.
- `staged_files_only`, `intent_to_add_file_survives_conflicted_stash_restore`, `restore_on_interrupt`, and `all_files_with_existing_unstaged_changes_uses_snapshot_baseline` all still pass.
- Remaining failures in a full local `cargo test` run are language-toolchain tests (conda, dart, haskell, julia, lua, perl, php, r, ruby) that need toolchains not installed on this machine; they fail identically on an unmodified checkout.

Happy to adjust the approach if you'd prefer the index restored a different way.