### PR TITLE
Reuse initial Git state for default runs

### DIFF
--- a/crates/prek/src/cli/run/filter.rs
+++ b/crates/prek/src/cli/run/filter.rs
@@ -431,6 +431,10 @@ pub(crate) enum FileSelection {
 }
 
 impl FileSelection {
+    pub(crate) const fn uses_staged_files(&self) -> bool {
+        matches!(self, Self::Default)
+    }
+
     pub(crate) const fn requires_clean_worktree(&self) -> bool {
         matches!(self, Self::Default | Self::Diff { .. })
     }
@@ -449,6 +453,7 @@ pub(crate) struct CollectOptions {
     pub(crate) input_mode: RunInputMode,
     pub(crate) selection: FileSelection,
     pub(crate) commit_msg_filename: Option<String>,
+    pub(crate) known_staged_files: Option<Vec<PathBuf>>,
 }
 
 impl CollectOptions {
@@ -513,6 +518,7 @@ pub(crate) async fn collect_run_input(root: &Path, opts: CollectOptions) -> Resu
         input_mode,
         selection,
         commit_msg_filename,
+        known_staged_files,
     } = opts;
 
     let git_root = GIT_ROOT.as_ref()?;
@@ -535,7 +541,8 @@ pub(crate) async fn collect_run_input(root: &Path, opts: CollectOptions) -> Resu
         )
     })?;
 
-    let filenames = collect_files_for_selection(git_root, root, selection).await?;
+    let filenames =
+        collect_files_for_selection(git_root, root, selection, known_staged_files).await?;
 
     // Convert filenames to be relative to the workspace root.
     let mut filenames = filenames
@@ -655,6 +662,7 @@ async fn collect_files_for_selection(
     git_root: &Path,
     workspace_root: &Path,
     selection: FileSelection,
+    known_staged_files: Option<Vec<PathBuf>>,
 ) -> Result<Vec<PathBuf>> {
     match selection {
         FileSelection::Diff { from_ref, to_ref } => {
@@ -684,7 +692,11 @@ async fn collect_files_for_selection(
                 return Ok(files);
             }
 
-            let files = git::staged_files(workspace_root).await?;
+            let files = if let Some(files) = known_staged_files {
+                files
+            } else {
+                git::staged_files(workspace_root).await?
+            };
             debug!("Staged files: {}", files.len());
             Ok(files)
         }

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -166,9 +166,22 @@ pub(crate) async fn run(
         filtered_hooks.iter().map(|h| &h.id).collect::<Vec<_>>()
     );
 
+    // This query is worthwhile only when its staged paths replace a later Git query. Capture it
+    // after hook initialization so the evidence used to skip worktree cleanup stays fresh.
+    let initial_git_state = if input_mode == RunInputMode::Files && selection.uses_staged_files() {
+        git::initial_git_state(workspace.root()).await?
+    } else {
+        git::InitialGitState::Unknown
+    };
+    if initial_git_state.has_unmerged_paths() {
+        anyhow::bail!(
+            "Found unresolved merge conflicts. Resolve the conflicts, stage the files with `git add`, and try again"
+        );
+    }
+
     // Clear any unstaged changes from the git working directory.
     let mut _guard = None;
-    if should_stash {
+    if should_stash && !initial_git_state.is_worktree_known_clean() {
         _guard = Some(
             WorkTreeKeeper::clean(store, workspace.root())
                 .await
@@ -185,6 +198,7 @@ pub(crate) async fn run(
             input_mode,
             selection,
             commit_msg_filename: extra_args.commit_msg_filename,
+            known_staged_files: initial_git_state.into_staged_files(),
         },
     )
     .await

--- a/crates/prek/src/git.rs
+++ b/crates/prek/src/git.rs
@@ -136,6 +136,120 @@ pub(crate) fn git_cmd() -> Result<Cmd, Error> {
     Ok(cmd)
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum InitialGitState {
+    Known {
+        staged_files: Vec<PathBuf>,
+        worktree_clean: bool,
+    },
+    Unmerged,
+    Unknown,
+}
+
+impl InitialGitState {
+    pub(crate) const fn has_unmerged_paths(&self) -> bool {
+        matches!(self, Self::Unmerged)
+    }
+
+    pub(crate) const fn is_worktree_known_clean(&self) -> bool {
+        matches!(
+            self,
+            Self::Known {
+                worktree_clean: true,
+                ..
+            }
+        )
+    }
+
+    pub(crate) fn into_staged_files(self) -> Option<Vec<PathBuf>> {
+        match self {
+            Self::Known { staged_files, .. } => Some(staged_files),
+            Self::Unmerged | Self::Unknown => None,
+        }
+    }
+}
+
+fn parse_initial_git_state(output: &[u8]) -> InitialGitState {
+    try_parse_initial_git_state(output).unwrap_or(InitialGitState::Unknown)
+}
+
+fn try_parse_initial_git_state(output: &[u8]) -> Option<InitialGitState> {
+    let mut staged_files = Vec::new();
+    let mut worktree_clean = true;
+
+    for record in output.split(|&byte| byte == b'\0') {
+        if record.is_empty() {
+            continue;
+        }
+
+        let &[index_status, worktree_status, b' '] = record.get(..3)? else {
+            return None;
+        };
+        let unmerged = index_status == b'U'
+            || worktree_status == b'U'
+            || (index_status == worktree_status && matches!(index_status, b'A' | b'D'));
+        if unmerged {
+            return Some(InitialGitState::Unmerged);
+        }
+        if (index_status == b' ' && worktree_status == b' ')
+            || !matches!(index_status, b' ' | b'A' | b'M' | b'T' | b'D')
+            || !matches!(worktree_status, b' ' | b'A' | b'M' | b'T' | b'D')
+        {
+            return None;
+        }
+
+        let path = &record[3..];
+        if path.is_empty() {
+            return None;
+        }
+
+        worktree_clean &= worktree_status == b' ';
+        if matches!(index_status, b'A' | b'M' | b'T') {
+            staged_files.push(path_from_git_bytes(path).ok()?);
+        }
+    }
+
+    Some(InitialGitState::Known {
+        staged_files,
+        worktree_clean,
+    })
+}
+
+/// Capture the index and worktree facts needed by the run hot path in one Git query.
+///
+/// A non-zero status or an unfamiliar porcelain record is deliberately treated as unknown so
+/// callers can fall back to the existing, narrower Git queries.
+#[instrument(level = "trace")]
+pub(crate) async fn initial_git_state(root: &Path) -> Result<InitialGitState, Error> {
+    let mut cmd = git_cmd()?;
+    let output = cmd
+        .arg("--no-optional-locks")
+        .arg("status")
+        .arg("--porcelain=v1")
+        .arg("-z")
+        .arg("--untracked-files=no")
+        // Preserve staged gitlink changes while ignoring dirt inside submodules.
+        .arg("--ignore-submodules=dirty")
+        // Reporting a rename as an add plus a delete makes every record self-contained.
+        .arg("--no-renames")
+        .arg("--")
+        .arg(root)
+        .check(false)
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        debug!(
+            status = %output.status,
+            stderr = %String::from_utf8_lossy(&output.stderr),
+            "Falling back after initial Git status failed"
+        );
+        return Ok(InitialGitState::Unknown);
+    }
+
+    Ok(parse_initial_git_state(&output.stdout))
+}
+
 fn zsplit(s: &[u8]) -> Result<Vec<PathBuf>, Utf8Error> {
     s.split(|&b| b == b'\0')
         .filter(|slice| !slice.is_empty())
@@ -997,11 +1111,11 @@ mod tests {
     #[cfg(unix)]
     use super::zsplit;
     use super::{
-        Error, GIT, TerminalPrompt, apply_shared_repository_file_mode, full_clone, init_repo,
-        should_update_submodules, update_submodules,
+        Error, GIT, InitialGitState, TerminalPrompt, apply_shared_repository_file_mode, full_clone,
+        init_repo, parse_initial_git_state, should_update_submodules, update_submodules,
     };
     use assert_cmd::assert::OutputAssertExt;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     use std::process::Command;
 
     fn run_git(path: &Path, args: &[&str]) {
@@ -1102,6 +1216,91 @@ mod tests {
         assert_eq!(paths.len(), 2);
         assert_eq!(paths[0].as_os_str().as_bytes(), b"normal.py");
         assert_eq!(paths[1].as_os_str().as_bytes(), b"bad-\xff.py");
+    }
+
+    #[test]
+    fn initial_git_state_recognizes_clean_repository() {
+        assert_eq!(
+            parse_initial_git_state(b""),
+            InitialGitState::Known {
+                staged_files: vec![],
+                worktree_clean: true,
+            }
+        );
+    }
+
+    #[test]
+    fn initial_git_state_collects_staged_files_with_spaces() {
+        let state = parse_initial_git_state(
+            b"A  path with spaces.txt\0M  modified.txt\0T  type-changed.txt\0D  deleted.txt\0",
+        );
+
+        assert_eq!(
+            state,
+            InitialGitState::Known {
+                staged_files: vec![
+                    PathBuf::from("path with spaces.txt"),
+                    PathBuf::from("modified.txt"),
+                    PathBuf::from("type-changed.txt"),
+                ],
+                worktree_clean: true,
+            }
+        );
+    }
+
+    #[test]
+    fn initial_git_state_detects_unstaged_changes() {
+        let state = parse_initial_git_state(b" M file.txt\0");
+
+        assert_eq!(
+            state,
+            InitialGitState::Known {
+                staged_files: vec![],
+                worktree_clean: false,
+            }
+        );
+    }
+
+    #[test]
+    fn initial_git_state_keeps_intent_to_add_on_the_fallback_path() {
+        let state = parse_initial_git_state(b" A intent.txt\0");
+
+        assert_eq!(
+            state,
+            InitialGitState::Known {
+                staged_files: vec![],
+                worktree_clean: false,
+            }
+        );
+    }
+
+    #[test]
+    fn initial_git_state_detects_unmerged_record() {
+        for status in [b"DD", b"AU", b"UD", b"UA", b"DU", b"AA", b"UU"] {
+            let mut record = status.to_vec();
+            record.extend_from_slice(b" file.txt\0");
+            assert_eq!(parse_initial_git_state(&record), InitialGitState::Unmerged);
+        }
+    }
+
+    #[test]
+    fn initial_git_state_falls_back_for_unexpected_record() {
+        let state = parse_initial_git_state(b"R  new.txt\0old.txt\0");
+
+        assert_eq!(state, InitialGitState::Unknown);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn initial_git_state_preserves_non_utf8_paths() {
+        use std::os::unix::ffi::OsStrExt as _;
+
+        let state = parse_initial_git_state(b"A  bad-\xff.py\0");
+        let InitialGitState::Known { staged_files, .. } = state else {
+            panic!("expected known Git state");
+        };
+
+        assert_eq!(staged_files[0].as_os_str().as_bytes(), b"bad-\xff.py");
     }
 
     #[test]

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -1967,6 +1967,111 @@ fn staged_files_only() -> Result<()> {
 }
 
 #[test]
+fn clean_default_run_skips_redundant_git_queries() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: noop
+                name: noop
+                language: system
+                entry: "true"
+    "#});
+    context.git_add(PRE_COMMIT_CONFIG_YAML);
+    context.git_commit("initial commit");
+
+    let output = context
+        .run()
+        .env("RUST_LOG", "prek::process=trace")
+        .output()?;
+
+    assert!(output.status.success(), "clean default run should succeed");
+    assert!(String::from_utf8_lossy(&output.stdout).contains("(no files to check)"));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--no-optional-locks status --porcelain=v1"),
+        "expected the combined Git status query:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("--diff-filter=A")
+            && !stderr.contains("diff-index")
+            && !stderr.contains("write-tree")
+            && !stderr.contains("--cached"),
+        "clean state should skip keeper and staged-file queries:\n{stderr}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn nested_workspace_ignores_dirty_files_outside_workspace() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+    let cwd = context.work_dir();
+    let workspace = cwd.child("workspace");
+    workspace.create_dir_all()?;
+    workspace
+        .child(PRE_COMMIT_CONFIG_YAML)
+        .write_str(indoc::indoc! {r"
+        repos:
+          - repo: local
+            hooks:
+              - id: echo
+                name: echo
+                language: system
+                entry: echo
+                verbose: true
+    "})?;
+    workspace.child("inside.txt").write_str("base\n")?;
+    cwd.child("outside.txt").write_str("base\n")?;
+    context.git_add(".");
+    context.git_commit("initial commit");
+
+    workspace.child("inside.txt").write_str("staged\n")?;
+    context.git_add("workspace/inside.txt");
+    cwd.child("outside.txt").write_str("staged\n")?;
+    context.git_add("outside.txt");
+    cwd.child("outside.txt").write_str("unstaged\n")?;
+
+    let output = context
+        .run()
+        .current_dir(&workspace)
+        .env("RUST_LOG", "prek::process=trace")
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "nested workspace run should succeed"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("inside.txt"),
+        "workspace file should run:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("outside.txt"),
+        "outside staged file must not become workspace input:\n{stdout}"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--no-optional-locks status --porcelain=v1"),
+        "expected the workspace status query:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("diff-index")
+            && !stderr.contains("write-tree")
+            && !stderr.contains("--cached"),
+        "outside dirt should not force the workspace onto the fallback path:\n{stderr}"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn intent_to_add_file_survives_conflicted_stash_restore() -> Result<()> {
     let context = TestContext::new();
     context.init_project();


### PR DESCRIPTION
## Summary

- Capture staged paths and worktree cleanliness with one workspace-scoped `git status --porcelain=v1 -z` query.
- Reuse the staged paths and skip worktree cleanup only when the state is known clean.
- Conservatively fall back to the existing queries for failed or unfamiliar states.

## Performance

For a clean default run, Git queries decreased from 7 to 4 and median runtime decreased from 119.24 ms to 73.16 ms (~39%).