### PR TITLE
Move test repositories to prek-ci

### DIFF
--- a/crates/prek/tests/languages/dart.rs
+++ b/crates/prek/tests/languages/dart.rs
@@ -550,7 +550,7 @@ fn remote_hook() {
 
     context.write_pre_commit_config(indoc::indoc! {r"
         repos:
-          - repo: https://github.com/prek-test-repos/dart-hooks
+          - repo: https://github.com/prek-ci/dart-hooks
             rev: v1.1.0
             hooks:
               - id: dart-hooks

--- a/crates/prek/tests/languages/deno.rs
+++ b/crates/prek/tests/languages/deno.rs
@@ -135,7 +135,7 @@ fn remote_hook() {
 
     context.write_pre_commit_config(indoc::indoc! {r"
         repos:
-          - repo: https://github.com/prek-test-repos/deno-hooks
+          - repo: https://github.com/prek-ci/deno-hooks
             rev: v3.1.0
             hooks:
               - id: deno-eval
@@ -167,7 +167,7 @@ fn remote_hook_with_additional_dependencies() {
 
     context.write_pre_commit_config(indoc::indoc! {r#"
         repos:
-          - repo: https://github.com/prek-test-repos/deno-hooks
+          - repo: https://github.com/prek-ci/deno-hooks
             rev: v3.1.0
             hooks:
               - id: deno-semver
@@ -200,7 +200,7 @@ fn remote_hook_with_local_file_additional_dependency() {
 
     context.write_pre_commit_config(indoc::indoc! {r"
         repos:
-          - repo: https://github.com/prek-test-repos/deno-hooks
+          - repo: https://github.com/prek-ci/deno-hooks
             rev: v3.1.0
             hooks:
               - id: deno-local-dep

--- a/crates/prek/tests/languages/docker.rs
+++ b/crates/prek/tests/languages/docker.rs
@@ -10,7 +10,7 @@ fn docker() {
 
     context.write_pre_commit_config(indoc::indoc! {r#"
         repos:
-          - repo: https://github.com/prek-test-repos/docker-hooks
+          - repo: https://github.com/prek-ci/docker-hooks
             rev: v1.0
             hooks:
               - id: hello-world
@@ -45,7 +45,7 @@ fn workspace_docker() -> anyhow::Result<()> {
 
     let config = indoc::indoc! {r"
         repos:
-          - repo: https://github.com/prek-test-repos/docker-hooks
+          - repo: https://github.com/prek-ci/docker-hooks
             rev: v1.0
             hooks:
               - id: hello-world

--- a/crates/prek/tests/languages/golang.rs
+++ b/crates/prek/tests/languages/golang.rs
@@ -150,7 +150,7 @@ fn remote_hook() {
     // Run hooks with system found go.
     context.write_pre_commit_config(indoc::indoc! {r"
         repos:
-          - repo: https://github.com/prek-test-repos/golang-hooks
+          - repo: https://github.com/prek-ci/golang-hooks
             rev: v1.0
             hooks:
               - id: echo
@@ -214,7 +214,7 @@ fn remote_hook() {
     // Run hooks with newly downloaded go.
     context.write_pre_commit_config(indoc::indoc! {r"
         repos:
-          - repo: https://github.com/prek-test-repos/golang-hooks
+          - repo: https://github.com/prek-ci/golang-hooks
             rev: v1.0
             hooks:
               - id: echo

--- a/crates/prek/tests/languages/haskell.rs
+++ b/crates/prek/tests/languages/haskell.rs
@@ -124,7 +124,7 @@ fn remote_hook() {
 
     context.write_pre_commit_config(indoc::indoc! {r"
         repos:
-          - repo: https://github.com/prek-test-repos/haskell-hooks
+          - repo: https://github.com/prek-ci/haskell-hooks
             rev: v1.0.0
             hooks:
               - id: hello

--- a/crates/prek/tests/languages/julia.rs
+++ b/crates/prek/tests/languages/julia.rs
@@ -180,7 +180,7 @@ fn remote_hook() {
 
     context.write_pre_commit_config(indoc::indoc! {r"
         repos:
-          - repo: https://github.com/prek-test-repos/julia-hooks
+          - repo: https://github.com/prek-ci/julia-hooks
             rev: v1.0.0
             hooks:
               - id: hello

--- a/crates/prek/tests/languages/lua.rs
+++ b/crates/prek/tests/languages/lua.rs
@@ -281,7 +281,7 @@ fn remote_hook() {
 
     context.write_pre_commit_config(indoc::indoc! {r"
         repos:
-          - repo: https://github.com/prek-test-repos/lua-hooks
+          - repo: https://github.com/prek-ci/lua-hooks
             rev: v1.0.0
             hooks:
               - id: lua-hooks

--- a/crates/prek/tests/languages/rust.rs
+++ b/crates/prek/tests/languages/rust.rs
@@ -182,7 +182,7 @@ fn remote_hooks() {
 
     context.write_pre_commit_config(indoc::indoc! {r#"
         repos:
-          - repo: https://github.com/prek-test-repos/rust-hooks
+          - repo: https://github.com/prek-ci/rust-hooks
             rev: v1.0.0
             hooks:
               - id: hello-world
@@ -215,7 +215,7 @@ fn remote_hook_non_workspace() {
 
     context.write_pre_commit_config(indoc::indoc! {r"
         repos:
-          - repo: https://github.com/prek-test-repos/rust-hooks-non-workspace
+          - repo: https://github.com/prek-ci/rust-hooks-non-workspace
             rev: v1.0.0
             hooks:
               - id: hello-world
@@ -248,7 +248,7 @@ fn remote_hooks_with_lib_deps() {
 
     context.write_pre_commit_config(indoc::indoc! {r#"
         repos:
-          - repo: https://github.com/prek-test-repos/rust-hooks
+          - repo: https://github.com/prek-ci/rust-hooks
             rev: v1.0.0
             hooks:
               - id: hello-world-lib-deps

--- a/crates/prek/tests/languages/script.rs
+++ b/crates/prek/tests/languages/script.rs
@@ -17,7 +17,7 @@ mod unix {
         context.init_project();
         context.write_pre_commit_config(indoc::indoc! {r"
         repos:
-          - repo: https://github.com/prek-test-repos/script-hooks
+          - repo: https://github.com/prek-ci/script-hooks
             rev: v1.0.0
             hooks:
               - id: echo-env


### PR DESCRIPTION
Move the integration test fixtures to the `prek-ci` organization and update their repository URLs.