### PR TITLE
Install `uv` from Astral CDN and drop source racing

### DIFF
--- a/crates/prek/src/http.rs
+++ b/crates/prek/src/http.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::LazyLock;
+use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use futures_util::TryStreamExt;
@@ -239,9 +240,17 @@ fn load_certs_from_paths(file: Option<&Path>, dirs: &[impl AsRef<Path>]) -> Vec<
     certs
 }
 
+// Bound the connect phase, and fail a download that stalls (no bytes received for this long)
+// rather than blocking forever. This is an inactivity timeout, so it doesn't penalize slow but
+// progressing downloads, and it lets callers fall back to another source.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+const READ_TIMEOUT: Duration = Duration::from_secs(30);
+
 fn create_reqwest_client(native_tls: bool, custom_certs: Vec<Certificate>) -> reqwest::Client {
-    let builder =
-        reqwest::ClientBuilder::new().user_agent(format!("prek/{}", crate::version::version()));
+    let builder = reqwest::ClientBuilder::new()
+        .user_agent(format!("prek/{}", crate::version::version()))
+        .connect_timeout(CONNECT_TIMEOUT)
+        .read_timeout(READ_TIMEOUT);
 
     let builder = if native_tls {
         debug!("Using native TLS for reqwest client");

--- a/crates/prek/src/languages/pygrep/pygrep.rs
+++ b/crates/prek/src/languages/pygrep/pygrep.rs
@@ -99,7 +99,7 @@ impl LanguageBackend for Pygrep {
         let progress = reporter.on_install_start(&hook);
 
         let uv_dir = store.tools_path(ToolBucket::Uv);
-        let uv = Uv::install(store, &uv_dir).await?;
+        let uv = Uv::find_or_install(store, &uv_dir).await?;
         let python_dir = store.tools_path(ToolBucket::Python);
 
         // Find or download a Python interpreter.

--- a/crates/prek/src/languages/python/python.rs
+++ b/crates/prek/src/languages/python/python.rs
@@ -105,7 +105,7 @@ impl LanguageBackend for Python {
         let progress = reporter.on_install_start(&hook);
 
         let uv_dir = store.tools_path(ToolBucket::Uv);
-        let uv = Uv::install(store, &uv_dir)
+        let uv = Uv::find_or_install(store, &uv_dir)
             .await
             .context("Failed to install uv")?;
 

--- a/crates/prek/src/languages/python/uv.rs
+++ b/crates/prek/src/languages/python/uv.rs
@@ -2,13 +2,11 @@ use std::env::consts::EXE_EXTENSION;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::LazyLock;
-use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use http::header::ACCEPT;
 use semver::{Version, VersionReq};
 use target_lexicon::{Architecture, ArmArchitecture, Environment, HOST, OperatingSystem};
-use tokio::task::JoinSet;
 use tracing::{debug, trace, warn};
 
 use prek_consts::env_vars::{EnvVars, EnvVarsRead};
@@ -18,7 +16,6 @@ use crate::fs::LockedFile;
 use crate::http::{DownloadChecksumPolicy, REQWEST_CLIENT, download_artifact_with};
 use crate::process::Cmd;
 use crate::store::{CacheBucket, Store};
-use crate::version;
 use crate::warn_user;
 
 // The version range of `uv` we will install. Should update periodically.
@@ -178,10 +175,6 @@ impl PyPiMirror {
             Self::Custom(url) => url,
         }
     }
-
-    fn iter() -> impl Iterator<Item = Self> {
-        vec![Self::Pypi, Self::Tuna, Self::Aliyun, Self::Tencent].into_iter()
-    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -197,19 +190,34 @@ enum InstallSource {
 }
 
 impl InstallSource {
-    async fn install(&self, store: &Store, target: &Path) -> Result<()> {
+    async fn install(&self, store: &Store, target: &Path) -> Result<Uv> {
         match self {
             Self::Astral => {
                 self.install_from_release_archive(store, target, ASTRAL_UV_RELEASE_BASE)
-                    .await
+                    .await?;
             }
             Self::GitHub => {
                 self.install_from_release_archive(store, target, GITHUB_UV_RELEASE_BASE)
-                    .await
+                    .await?;
             }
-            Self::PyPi(source) => self.install_from_pypi(store, target, source).await,
-            Self::Pip => self.install_from_pip(target).await,
+            Self::PyPi(source) => self.install_from_pypi(store, target, source).await?,
+            Self::Pip => self.install_from_pip(target).await?,
         }
+
+        let uv_path = target.join("uv").with_extension(EXE_EXTENSION);
+        match validate_uv_binary(&uv_path) {
+            Ok(version) => trace!(version = %version, "Successfully installed uv"),
+            Err(err) => bail!(
+                "Installed uv at `{}` failed validation: {err}. \
+                This usually means the downloaded uv binary is incompatible with the \
+                current runtime environment, for example due to a libc mismatch or a \
+                missing dynamic loader path. If this keeps happening, please report it \
+                with details about your environment and the full error output.",
+                uv_path.display()
+            ),
+        }
+
+        Ok(Uv::new(uv_path))
     }
 
     async fn install_from_release_archive(
@@ -419,11 +427,9 @@ impl InstallSource {
         let bin_dir = uv_src.join(if cfg!(windows) { "Scripts" } else { "bin" });
         let lib_dir = uv_src.join(if cfg!(windows) { "Lib" } else { "lib" });
 
-        let uv = uv_src
-            .join(&bin_dir)
-            .join("uv")
-            .with_extension(EXE_EXTENSION);
-        fs_err::tokio::rename(&uv, target.join("uv").with_extension(EXE_EXTENSION)).await?;
+        let uv = bin_dir.join("uv").with_extension(EXE_EXTENSION);
+        let target_path = target.join("uv").with_extension(EXE_EXTENSION);
+        replace_uv_binary(&uv, &target_path).await?;
         fs_err::tokio::remove_dir_all(bin_dir).await?;
         fs_err::tokio::remove_dir_all(lib_dir).await?;
 
@@ -446,17 +452,23 @@ impl Uv {
         cmd
     }
 
-    /// Install managed uv, trying the default source first and falling back on failure.
+    /// Install managed uv, trying each default source in order until one succeeds.
     ///
-    /// The order is Astral CDN, then `PyPI` (probing mirrors), then `pip` as a last resort.
-    async fn install_auto(store: &Store, uv_dir: &Path) -> Result<()> {
-        if try_install(&InstallSource::Astral, store, uv_dir).await {
-            return Ok(());
-        }
-
-        let mirror = select_best_pypi().await;
-        if try_install(&InstallSource::PyPi(mirror), store, uv_dir).await {
-            return Ok(());
+    /// The order is Astral CDN, `PyPI` and its mirrors, then `pip` as a last resort.
+    async fn install_with_fallbacks(store: &Store, uv_dir: &Path) -> Result<Self> {
+        for source in [
+            InstallSource::Astral,
+            InstallSource::PyPi(PyPiMirror::Pypi),
+            InstallSource::PyPi(PyPiMirror::Tuna),
+            InstallSource::PyPi(PyPiMirror::Aliyun),
+            InstallSource::PyPi(PyPiMirror::Tencent),
+        ] {
+            match source.install(store, uv_dir).await {
+                Ok(uv) => return Ok(uv),
+                Err(err) => {
+                    warn!(?source, %err, "Failed to install uv, trying next source");
+                }
+            }
         }
 
         InstallSource::Pip
@@ -465,7 +477,7 @@ impl Uv {
             .context("Failed to install uv from every source")
     }
 
-    pub(crate) async fn install(store: &Store, uv_dir: &Path) -> Result<Self> {
+    pub(crate) async fn find_or_install(store: &Store, uv_dir: &Path) -> Result<Self> {
         // 1) Check `uv` alongside `prek` binary (e.g. `uv tool install prek --with uv`)
         let prek_exe = std::env::current_exe()?.canonicalize()?;
         if let Some(prek_dir) = prek_exe.parent() {
@@ -524,74 +536,12 @@ impl Uv {
             }
         }
 
-        if let Some(uv_source) = uv_source_from_env(&EnvVars) {
-            uv_source.install(store, uv_dir).await?;
+        if let Some(source) = uv_source_from_env(&EnvVars) {
+            source.install(store, uv_dir).await
         } else {
-            Self::install_auto(store, uv_dir).await?;
-        }
-
-        // Downloaded `uv` binaries can be present on disk but still fail to execute in the
-        // current runtime environment, such as when the libc variant or dynamic loader path
-        // does not match the host. Validate immediately so we can surface a clear error here.
-        match validate_uv_binary(&uv_path) {
-            Ok(version) => trace!(version = %version, "Successfully installed uv"),
-            Err(err) => bail!(
-                "Installed uv at `{}` failed validation: {err}. \
-                This usually means the downloaded uv binary is incompatible with the \
-                current runtime environment, for example due to a libc mismatch or a \
-                missing dynamic loader path. If this keeps happening, please report it \
-                with details about your environment and the full error output.",
-                uv_path.display()
-            ),
-        }
-
-        Ok(Self::new(uv_path))
-    }
-}
-
-/// Install uv from `source`, returning `true` on success. A failure is logged and reported as
-/// `false` so the caller can fall back to the next source.
-async fn try_install(source: &InstallSource, store: &Store, uv_dir: &Path) -> bool {
-    match source.install(store, uv_dir).await {
-        Ok(()) => true,
-        Err(err) => {
-            warn!(?source, %err, "Failed to install uv, trying next source");
-            false
+            Self::install_with_fallbacks(store, uv_dir).await
         }
     }
-}
-
-/// Pick the first responsive `PyPI` mirror, defaulting to `pypi.org`.
-async fn select_best_pypi() -> PyPiMirror {
-    let mut best = PyPiMirror::Pypi;
-    let mut tasks = PyPiMirror::iter()
-        .map(|source| {
-            let client = REQWEST_CLIENT.clone();
-            async move {
-                let url = format!("{}uv/", source.url());
-                let response = client
-                    .head(&url)
-                    .header("User-Agent", format!("prek/{}", version::version().version))
-                    .header("Accept", "*/*")
-                    .timeout(Duration::from_secs(2))
-                    .send()
-                    .await;
-                (source, response)
-            }
-        })
-        .collect::<JoinSet<_>>();
-
-    while let Some(result) = tasks.join_next().await {
-        if let Ok((source, response)) = result
-            && let Ok(resp) = response
-            && resp.status().is_success()
-        {
-            best = source;
-            break;
-        }
-    }
-
-    best
 }
 
 fn uv_source_from_env(env_vars: &impl EnvVarsRead) -> Option<InstallSource> {

--- a/crates/prek/src/languages/python/uv.rs
+++ b/crates/prek/src/languages/python/uv.rs
@@ -26,6 +26,18 @@ const CUR_UV_VERSION: &str = "0.11.29";
 static UV_VERSION_RANGE: LazyLock<VersionReq> =
     LazyLock::new(|| VersionReq::parse(">=0.7.0").unwrap());
 
+// Base URLs for the uv release archive. Astral's CDN mirrors GitHub release assets under
+// `/github/<repo>/releases/download/...` and is the default; GitHub stays reachable via
+// `PREK_UV_SOURCE=github`.
+// TODO: verify the archive against the SHA256 published in Astral's versions manifest
+// (`https://releases.astral.sh/github/versions/main/v1/uv.ndjson`).
+const ASTRAL_UV_RELEASE_BASE: &str = "https://releases.astral.sh/github/uv/releases/download";
+const GITHUB_UV_RELEASE_BASE: &str = "https://github.com/astral-sh/uv/releases/download";
+
+fn release_archive_url(base: &str, version: &str, archive_name: &str) -> String {
+    format!("{base}/{version}/{archive_name}")
+}
+
 fn wheel_platform_tag_for_host(
     operating_system: OperatingSystem,
     architecture: Architecture,
@@ -174,6 +186,8 @@ impl PyPiMirror {
 
 #[derive(Debug, PartialEq, Eq)]
 enum InstallSource {
+    /// Download uv from Astral's CDN (the default).
+    Astral,
     /// Download uv from GitHub releases.
     GitHub,
     /// Download uv from `PyPi`.
@@ -185,18 +199,28 @@ enum InstallSource {
 impl InstallSource {
     async fn install(&self, store: &Store, target: &Path) -> Result<()> {
         match self {
-            Self::GitHub => self.install_from_github(store, target).await,
+            Self::Astral => {
+                self.install_from_release_archive(store, target, ASTRAL_UV_RELEASE_BASE)
+                    .await
+            }
+            Self::GitHub => {
+                self.install_from_release_archive(store, target, GITHUB_UV_RELEASE_BASE)
+                    .await
+            }
             Self::PyPi(source) => self.install_from_pypi(store, target, source).await,
             Self::Pip => self.install_from_pip(target).await,
         }
     }
 
-    async fn install_from_github(&self, store: &Store, target: &Path) -> Result<()> {
+    async fn install_from_release_archive(
+        &self,
+        store: &Store,
+        target: &Path,
+        base_url: &str,
+    ) -> Result<()> {
         let ext = if cfg!(windows) { "zip" } else { "tar.gz" };
         let archive_name = format!("uv-{HOST}.{ext}");
-        let download_url = format!(
-            "https://github.com/astral-sh/uv/releases/download/{CUR_UV_VERSION}/{archive_name}"
-        );
+        let download_url = release_archive_url(base_url, CUR_UV_VERSION, &archive_name);
 
         let download = download_artifact_with(
             &download_url,
@@ -422,65 +446,23 @@ impl Uv {
         cmd
     }
 
-    async fn select_source() -> Result<InstallSource> {
-        async fn check_github() -> Result<bool> {
-            let url = format!(
-                "https://github.com/astral-sh/uv/releases/download/{CUR_UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz"
-            );
-            let response = REQWEST_CLIENT
-                .head(url)
-                .timeout(Duration::from_secs(3))
-                .send()
-                .await?;
-            trace!(?response, "Checked GitHub");
-            Ok(response.status().is_success())
+    /// Install managed uv, trying the default source first and falling back on failure.
+    ///
+    /// The order is Astral CDN, then `PyPI` (probing mirrors), then `pip` as a last resort.
+    async fn install_auto(store: &Store, uv_dir: &Path) -> Result<()> {
+        if try_install(&InstallSource::Astral, store, uv_dir).await {
+            return Ok(());
         }
 
-        async fn select_best_pypi() -> Result<PyPiMirror> {
-            let mut best = PyPiMirror::Pypi;
-            let mut tasks = PyPiMirror::iter()
-                .map(|source| {
-                    let client = REQWEST_CLIENT.clone();
-                    async move {
-                        let url = format!("{}uv/", source.url());
-                        let response = client
-                            .head(&url)
-                            .header("User-Agent", format!("prek/{}", version::version().version))
-                            .header("Accept", "*/*")
-                            .timeout(Duration::from_secs(2))
-                            .send()
-                            .await;
-                        (source, response)
-                    }
-                })
-                .collect::<JoinSet<_>>();
-
-            while let Some(result) = tasks.join_next().await {
-                if let Ok((source, response)) = result {
-                    if let Ok(resp) = response
-                        && resp.status().is_success()
-                    {
-                        best = source;
-                        break;
-                    }
-                }
-            }
-
-            Ok(best)
+        let mirror = select_best_pypi().await;
+        if try_install(&InstallSource::PyPi(mirror), store, uv_dir).await {
+            return Ok(());
         }
 
-        let source = tokio::select! {
-                Ok(true) = check_github() => InstallSource::GitHub,
-                Ok(source) = select_best_pypi() => InstallSource::PyPi(source),
-                else => {
-                    warn!("Failed to check uv source availability, falling back to pip install");
-                    InstallSource::Pip
-                }
-
-        };
-
-        trace!(?source, "Selected uv source");
-        Ok(source)
+        InstallSource::Pip
+            .install(store, uv_dir)
+            .await
+            .context("Failed to install uv from every source")
     }
 
     pub(crate) async fn install(store: &Store, uv_dir: &Path) -> Result<Self> {
@@ -542,12 +524,11 @@ impl Uv {
             }
         }
 
-        let source = if let Some(uv_source) = uv_source_from_env(&EnvVars) {
-            uv_source
+        if let Some(uv_source) = uv_source_from_env(&EnvVars) {
+            uv_source.install(store, uv_dir).await?;
         } else {
-            Self::select_source().await?
-        };
-        source.install(store, uv_dir).await?;
+            Self::install_auto(store, uv_dir).await?;
+        }
 
         // Downloaded `uv` binaries can be present on disk but still fail to execute in the
         // current runtime environment, such as when the libc variant or dynamic loader path
@@ -568,9 +549,55 @@ impl Uv {
     }
 }
 
+/// Install uv from `source`, returning `true` on success. A failure is logged and reported as
+/// `false` so the caller can fall back to the next source.
+async fn try_install(source: &InstallSource, store: &Store, uv_dir: &Path) -> bool {
+    match source.install(store, uv_dir).await {
+        Ok(()) => true,
+        Err(err) => {
+            warn!(?source, %err, "Failed to install uv, trying next source");
+            false
+        }
+    }
+}
+
+/// Pick the first responsive `PyPI` mirror, defaulting to `pypi.org`.
+async fn select_best_pypi() -> PyPiMirror {
+    let mut best = PyPiMirror::Pypi;
+    let mut tasks = PyPiMirror::iter()
+        .map(|source| {
+            let client = REQWEST_CLIENT.clone();
+            async move {
+                let url = format!("{}uv/", source.url());
+                let response = client
+                    .head(&url)
+                    .header("User-Agent", format!("prek/{}", version::version().version))
+                    .header("Accept", "*/*")
+                    .timeout(Duration::from_secs(2))
+                    .send()
+                    .await;
+                (source, response)
+            }
+        })
+        .collect::<JoinSet<_>>();
+
+    while let Some(result) = tasks.join_next().await {
+        if let Ok((source, response)) = result
+            && let Ok(resp) = response
+            && resp.status().is_success()
+        {
+            best = source;
+            break;
+        }
+    }
+
+    best
+}
+
 fn uv_source_from_env(env_vars: &impl EnvVarsRead) -> Option<InstallSource> {
     let var = env_vars.var(EnvVars::PREK_UV_SOURCE).ok()?;
     match var.as_str() {
+        "astral" => Some(InstallSource::Astral),
         "github" => Some(InstallSource::GitHub),
         "pypi" => Some(InstallSource::PyPi(PyPiMirror::Pypi)),
         "tuna" => Some(InstallSource::PyPi(PyPiMirror::Tuna)),
@@ -580,7 +607,7 @@ fn uv_source_from_env(env_vars: &impl EnvVarsRead) -> Option<InstallSource> {
         custom if custom.starts_with("http") => Some(InstallSource::PyPi(PyPiMirror::Custom(var))),
         _ => {
             warn_user!(
-                "Invalid value for {}: {:?}. Expected github, pypi, tuna, aliyun, tencent, pip, or an http(s) URL; using default ({:?})",
+                "Invalid value for {}: {:?}. Expected astral, github, pypi, tuna, aliyun, tencent, pip, or an http(s) URL; using default ({:?})",
                 EnvVars::PREK_UV_SOURCE,
                 var,
                 "auto",
@@ -605,8 +632,32 @@ mod tests {
     }
 
     #[test]
+    fn release_archive_url_joins_base_version_and_name() {
+        assert_eq!(
+            release_archive_url(
+                ASTRAL_UV_RELEASE_BASE,
+                "0.11.29",
+                "uv-x86_64-unknown-linux-gnu.tar.gz",
+            ),
+            "https://releases.astral.sh/github/uv/releases/download/0.11.29/uv-x86_64-unknown-linux-gnu.tar.gz"
+        );
+        assert_eq!(
+            release_archive_url(
+                GITHUB_UV_RELEASE_BASE,
+                "0.11.29",
+                "uv-x86_64-pc-windows-msvc.zip"
+            ),
+            "https://github.com/astral-sh/uv/releases/download/0.11.29/uv-x86_64-pc-windows-msvc.zip"
+        );
+    }
+
+    #[test]
     fn uv_source_from_env_reads_source_override() {
         assert_eq!(uv_source_from_env(&EnvVars::from_map(&[])), None);
+        assert_eq!(
+            uv_source_from_env(&EnvVars::from_map(&[(EnvVars::PREK_UV_SOURCE, "astral")])),
+            Some(InstallSource::Astral)
+        );
         assert_eq!(
             uv_source_from_env(&EnvVars::from_map(&[(EnvVars::PREK_UV_SOURCE, "github")])),
             Some(InstallSource::GitHub)

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -415,7 +415,7 @@ For remote hook repositories, `language_version` may be inferred from
 prek uses `uv` for creating virtual environments and installing dependencies:
 
 - First tries to find `uv` in the system PATH
-- If not found, automatically installs `uv` from the best available source (GitHub releases, PyPI, or mirrors)
+- If not found, automatically installs `uv` from Astral's CDN, falling back to PyPI (and mirrors) then `pip`
 - Automatically installs the required Python version if it's not already available
 
 !!! warning "Environment variables"

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -56,6 +56,7 @@ See [Built-in Fast Hooks](../builtin.md) for details.
 Control how uv (Python package installer) is installed.
 Options:
 
+- `astral` (download from Astral's CDN, the default source)
 - `github` (download from GitHub releases)
 - `pypi` (install from PyPI)
 - `tuna` (use Tsinghua University mirror)


### PR DESCRIPTION
Closes #1745

### What

The managed uv bootstrap currently races GitHub Releases against PyPI and three third party mirrors and installs from whichever responds first. That makes the install source depend on network latency, and a stale or compromised mirror can win silently.

This makes Astral's CDN (`releases.astral.sh`) the default source and replaces the race with a fixed fallback order:

1. Astral CDN
2. PyPI (still probing mirrors)
3. `pip` as a last resort

The mirror probing and pip paths are kept as fallbacks, so networks where GitHub is unreachable are still covered. This matches what you outlined in the issue.

### Notes on the approach

- Astral's CDN proxies GitHub release assets at `https://releases.astral.sh/github/uv/releases/download/<version>/<file>`, same archive name and layout as the GitHub path, so extraction is unchanged. I verified 200s for the darwin, linux gnu, linux musl and windows msvc assets at the pinned version.
- GitHub and Astral are the same download plus extract mechanism differing only by base URL, so they now share one helper (`install_from_release_archive`) and two named base constants. URL building is a small pure function with a unit test.
- Source ordering (policy) is separated from installing a single source (mechanism): a tiny `try_install` combinator logs a failure and reports it so the caller falls back, and `install_auto` walks the order.
- `PREK_UV_SOURCE` gains `astral` (the new default) and keeps `github`, so anyone who wants the old behavior can set `PREK_UV_SOURCE=github`.
- SHA256 verification is intentionally left for a follow-up, as discussed. The Astral versions manifest already publishes per artifact checksums; I left a TODO pointing at it.

### Verification

- `cargo test -p prek --bin prek -- languages::python::uv` passes, including new tests for the URL builder and the `astral` env override.
- End to end on macOS with a fresh cache: a `language: python` hook triggers a managed install that downloads from `https://releases.astral.sh/github/uv/releases/download/0.11.29/uv-aarch64-apple-darwin.tar.gz` and runs. `PREK_UV_SOURCE=github` still downloads from `github.com`.
- `cargo clippy -p prek --all-targets` and `cargo fmt` are clean.

### Open question

The CDN download path (`releases.astral.sh/github/.../releases/download/...`) is the working proxy path, but the versions manifest advertises `github.com` URLs for the artifacts themselves. If you would rather resolve the artifact URL from the manifest instead of hitting the proxy path, that is an easy swap. Happy to adjust.