### PR TITLE
Rewrite benchmark documentation

### DIFF
--- a/docs/assets/benchmark-fast-path.svg
+++ b/docs/assets/benchmark-fast-path.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 270" role="img" aria-labelledby="title desc">
+  <title id="title">Runtime improvement from the fast path</title>
+  <desc id="desc">Horizontal bars compare prek without the fast path at 1438 milliseconds with prek using built-in Rust hook implementations at 213 milliseconds. The fast path takes 85 percent less time and is 6.75 times faster. Lower is better.</desc>
+  <style>
+    text {
+      fill: #0f172a;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    .title { font-size: 20px; font-weight: 600; }
+    .subtitle, .tick, .note { fill: #475569; }
+    .subtitle { font-size: 13px; }
+    .label { font-size: 14px; font-weight: 600; }
+    .value { font-size: 13px; }
+    .tick, .note { font-size: 12px; }
+    .grid { stroke: #cbd5e1; stroke-width: 1; }
+    .axis { stroke: #94a3b8; stroke-width: 1; }
+    .previous { fill: #64748b; }
+    .current { fill: #6366f1; }
+    @media (prefers-color-scheme: dark) {
+      text { fill: #e2e8f0; }
+      .subtitle, .tick, .note { fill: #a8b3cf; }
+      .grid { stroke: #334155; }
+      .axis { stroke: #64748b; }
+      .previous { fill: #64748b; }
+      .current { fill: #818cf8; }
+    }
+  </style>
+
+  <text class="title" x="20" y="28">Turn on the fast path</text>
+  <text class="subtitle" x="20" y="51">Median wall time in milliseconds; lower is better</text>
+
+  <line class="grid" x1="250" y1="70" x2="250" y2="200" />
+  <line class="grid" x1="390" y1="70" x2="390" y2="200" />
+  <line class="grid" x1="530" y1="70" x2="530" y2="200" />
+  <line class="grid" x1="670" y1="70" x2="670" y2="200" />
+  <line class="grid" x1="810" y1="70" x2="810" y2="200" />
+  <line class="axis" x1="250" y1="200" x2="810" y2="200" />
+
+  <text class="label" x="20" y="105">No fast path</text>
+  <rect class="previous" x="250" y="82" width="503" height="32" rx="4" />
+  <text class="value" x="765" y="104">1,438 ms · baseline</text>
+
+  <text class="label" x="20" y="165">Fast path</text>
+  <rect class="current" x="250" y="142" width="75" height="32" rx="4" />
+  <text class="value" x="337" y="164">213 ms · 85% lower</text>
+
+  <text class="tick" x="250" y="221" text-anchor="middle">0</text>
+  <text class="tick" x="390" y="221" text-anchor="middle">400</text>
+  <text class="tick" x="530" y="221" text-anchor="middle">800</text>
+  <text class="tick" x="670" y="221" text-anchor="middle">1,200</text>
+  <text class="tick" x="810" y="221" text-anchor="middle">1,600 ms</text>
+  <text class="note" x="20" y="253">85% lower than the previous stage · 6.75x faster</text>
+</svg>

--- a/docs/assets/benchmark-framework.svg
+++ b/docs/assets/benchmark-framework.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 400" role="img" aria-labelledby="title desc">
+  <title id="title">Framework-dominated runtime with no-op hooks</title>
+  <desc id="desc">Horizontal bars compare one no-op hook at 224 milliseconds for pre-commit and 68 milliseconds for prek, and ten sequential no-op hooks at 458 milliseconds for pre-commit and 255 milliseconds for prek. Lower is better.</desc>
+  <style>
+    text {
+      fill: #0f172a;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    .title { font-size: 20px; font-weight: 600; }
+    .subtitle, .tick, .note { fill: #475569; }
+    .subtitle { font-size: 13px; }
+    .label { font-size: 14px; font-weight: 600; }
+    .value { font-size: 13px; }
+    .tick, .note { font-size: 12px; }
+    .grid { stroke: #cbd5e1; stroke-width: 1; }
+    .axis, .divider { stroke: #94a3b8; stroke-width: 1; }
+    .divider { opacity: 0.55; }
+    .reference { fill: #94a3b8; }
+    .prek { fill: #6366f1; }
+    @media (prefers-color-scheme: dark) {
+      text { fill: #e2e8f0; }
+      .subtitle, .tick, .note { fill: #a8b3cf; }
+      .grid { stroke: #334155; }
+      .axis, .divider { stroke: #64748b; }
+      .reference { fill: #94a3b8; }
+      .prek { fill: #818cf8; }
+    }
+  </style>
+
+  <text class="title" x="20" y="28">Framework overhead with no-op hooks</text>
+  <text class="subtitle" x="20" y="51">Median wall time in milliseconds; same repository with 960 workload files; lower is better</text>
+
+  <line class="grid" x1="250" y1="70" x2="250" y2="322" />
+  <line class="grid" x1="350" y1="70" x2="350" y2="322" />
+  <line class="grid" x1="450" y1="70" x2="450" y2="322" />
+  <line class="grid" x1="550" y1="70" x2="550" y2="322" />
+  <line class="grid" x1="650" y1="70" x2="650" y2="322" />
+  <line class="grid" x1="750" y1="70" x2="750" y2="322" />
+  <line class="divider" x1="20" y1="190" x2="880" y2="190" />
+  <line class="axis" x1="250" y1="322" x2="750" y2="322" />
+
+  <text class="label" x="20" y="104">1 hook · pre-commit</text>
+  <rect class="reference" x="250" y="82" width="224" height="30" rx="4" />
+  <text class="value" x="486" y="103">224 ms</text>
+
+  <text class="label" x="20" y="154">1 hook · prek</text>
+  <rect class="prek" x="250" y="132" width="68" height="30" rx="4" />
+  <text class="value" x="330" y="153">68 ms · 3.30x faster</text>
+
+  <text class="label" x="20" y="234">10 hooks · pre-commit</text>
+  <rect class="reference" x="250" y="212" width="458" height="30" rx="4" />
+  <text class="value" x="720" y="233">458 ms</text>
+
+  <text class="label" x="20" y="284">10 hooks · prek</text>
+  <rect class="prek" x="250" y="262" width="255" height="30" rx="4" />
+  <text class="value" x="517" y="283">255 ms · 1.80x faster</text>
+
+  <text class="tick" x="250" y="343" text-anchor="middle">0</text>
+  <text class="tick" x="350" y="343" text-anchor="middle">100</text>
+  <text class="tick" x="450" y="343" text-anchor="middle">200</text>
+  <text class="tick" x="550" y="343" text-anchor="middle">300</text>
+  <text class="tick" x="650" y="343" text-anchor="middle">400</text>
+  <text class="tick" x="750" y="343" text-anchor="middle">500 ms</text>
+  <text class="note" x="20" y="380">Pooled median of 30 runs (forward and reverse command order)</text>
+</svg>

--- a/docs/assets/benchmark-no-fast-path.svg
+++ b/docs/assets/benchmark-no-fast-path.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 270" role="img" aria-labelledby="title desc">
+  <title id="title">Baseline runtime without the fast path</title>
+  <desc id="desc">Horizontal bars compare pre-commit at 1737 milliseconds with prek running the original hook implementations at 1438 milliseconds. prek takes 17 percent less time. Lower is better.</desc>
+  <style>
+    text {
+      fill: #0f172a;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    .title { font-size: 20px; font-weight: 600; }
+    .subtitle, .tick, .note { fill: #475569; }
+    .subtitle { font-size: 13px; }
+    .label { font-size: 14px; font-weight: 600; }
+    .value { font-size: 13px; }
+    .tick, .note { font-size: 12px; }
+    .grid { stroke: #cbd5e1; stroke-width: 1; }
+    .axis { stroke: #94a3b8; stroke-width: 1; }
+    .reference { fill: #94a3b8; }
+    .baseline { fill: #64748b; }
+    @media (prefers-color-scheme: dark) {
+      text { fill: #e2e8f0; }
+      .subtitle, .tick, .note { fill: #a8b3cf; }
+      .grid { stroke: #334155; }
+      .axis { stroke: #64748b; }
+      .reference { fill: #94a3b8; }
+      .baseline { fill: #64748b; }
+    }
+  </style>
+
+  <text class="title" x="20" y="28">Start without the fast path</text>
+  <text class="subtitle" x="20" y="51">Median wall time in milliseconds; lower is better</text>
+
+  <line class="grid" x1="250" y1="70" x2="250" y2="200" />
+  <line class="grid" x1="390" y1="70" x2="390" y2="200" />
+  <line class="grid" x1="530" y1="70" x2="530" y2="200" />
+  <line class="grid" x1="670" y1="70" x2="670" y2="200" />
+  <line class="grid" x1="810" y1="70" x2="810" y2="200" />
+  <line class="axis" x1="250" y1="200" x2="810" y2="200" />
+
+  <text class="label" x="20" y="105">pre-commit</text>
+  <rect class="reference" x="250" y="82" width="486" height="32" rx="4" />
+  <text class="value" x="748" y="104">1,737 ms · reference</text>
+
+  <text class="label" x="20" y="165">prek: no fast path</text>
+  <rect class="baseline" x="250" y="142" width="403" height="32" rx="4" />
+  <text class="value" x="665" y="164">1,438 ms · 17% lower</text>
+
+  <text class="tick" x="250" y="221" text-anchor="middle">0</text>
+  <text class="tick" x="390" y="221" text-anchor="middle">500</text>
+  <text class="tick" x="530" y="221" text-anchor="middle">1,000</text>
+  <text class="tick" x="670" y="221" text-anchor="middle">1,500</text>
+  <text class="tick" x="810" y="221" text-anchor="middle">2,000 ms</text>
+  <text class="note" x="20" y="253">Same hooks and Python implementations; prek becomes the baseline for the next step</text>
+</svg>

--- a/docs/assets/benchmark-priority.svg
+++ b/docs/assets/benchmark-priority.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 270" role="img" aria-labelledby="title desc">
+  <title id="title">Runtime improvement from priority scheduling</title>
+  <desc id="desc">Horizontal bars compare prek using the fast path at 213 milliseconds with prek also running independent hooks at the same priority concurrently at 172 milliseconds. Priority scheduling takes 19 percent less time. Lower is better.</desc>
+  <style>
+    text {
+      fill: #0f172a;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    .title { font-size: 20px; font-weight: 600; }
+    .subtitle, .tick, .note { fill: #475569; }
+    .subtitle { font-size: 13px; }
+    .label { font-size: 14px; font-weight: 600; }
+    .value { font-size: 13px; }
+    .tick, .note { font-size: 12px; }
+    .grid { stroke: #cbd5e1; stroke-width: 1; }
+    .axis { stroke: #94a3b8; stroke-width: 1; }
+    .previous { fill: #94a3b8; }
+    .current { fill: #6366f1; }
+    @media (prefers-color-scheme: dark) {
+      text { fill: #e2e8f0; }
+      .subtitle, .tick, .note { fill: #a8b3cf; }
+      .grid { stroke: #334155; }
+      .axis { stroke: #64748b; }
+      .previous { fill: #94a3b8; }
+      .current { fill: #818cf8; }
+    }
+  </style>
+
+  <text class="title" x="20" y="28">Group independent hooks with priority</text>
+  <text class="subtitle" x="20" y="51">Median wall time in milliseconds; lower is better</text>
+
+  <line class="grid" x1="250" y1="70" x2="250" y2="200" />
+  <line class="grid" x1="362" y1="70" x2="362" y2="200" />
+  <line class="grid" x1="474" y1="70" x2="474" y2="200" />
+  <line class="grid" x1="586" y1="70" x2="586" y2="200" />
+  <line class="grid" x1="698" y1="70" x2="698" y2="200" />
+  <line class="grid" x1="810" y1="70" x2="810" y2="200" />
+  <line class="axis" x1="250" y1="200" x2="810" y2="200" />
+
+  <text class="label" x="20" y="105">Fast path</text>
+  <rect class="previous" x="250" y="82" width="477" height="32" rx="4" />
+  <text class="value" x="739" y="104">213 ms</text>
+
+  <text class="label" x="20" y="165">Fast path + priority</text>
+  <rect class="current" x="250" y="142" width="385" height="32" rx="4" />
+  <text class="value" x="647" y="164">172 ms · 19% lower</text>
+
+  <text class="tick" x="250" y="221" text-anchor="middle">0</text>
+  <text class="tick" x="362" y="221" text-anchor="middle">50</text>
+  <text class="tick" x="474" y="221" text-anchor="middle">100</text>
+  <text class="tick" x="586" y="221" text-anchor="middle">150</text>
+  <text class="tick" x="698" y="221" text-anchor="middle">200</text>
+  <text class="tick" x="810" y="221" text-anchor="middle">250 ms</text>
+  <text class="note" x="20" y="253">19% lower than the previous stage · 8.36x faster than the no-fast-path baseline</text>
+</svg>

--- a/docs/assets/benchmark-projects.svg
+++ b/docs/assets/benchmark-projects.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 270" role="img" aria-labelledby="title desc">
+  <title id="title">Runtime improvement from two concurrent projects</title>
+  <desc id="desc">Horizontal bars compare prek using the fast path and priority scheduling at 172 milliseconds with prek also splitting the workload into two concurrent projects at 135 milliseconds. Project concurrency takes 21 percent less time. Lower is better.</desc>
+  <style>
+    text {
+      fill: #0f172a;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    .title { font-size: 20px; font-weight: 600; }
+    .subtitle, .tick, .note { fill: #475569; }
+    .subtitle { font-size: 13px; }
+    .label { font-size: 14px; font-weight: 600; }
+    .value { font-size: 13px; }
+    .tick, .note { font-size: 12px; }
+    .grid { stroke: #cbd5e1; stroke-width: 1; }
+    .axis { stroke: #94a3b8; stroke-width: 1; }
+    .previous { fill: #818cf8; }
+    .current { fill: #4338ca; }
+    @media (prefers-color-scheme: dark) {
+      text { fill: #e2e8f0; }
+      .subtitle, .tick, .note { fill: #a8b3cf; }
+      .grid { stroke: #334155; }
+      .axis { stroke: #64748b; }
+      .previous { fill: #818cf8; }
+      .current { fill: #a5b4fc; }
+    }
+  </style>
+
+  <text class="title" x="20" y="28">Split the workload into two projects</text>
+  <text class="subtitle" x="20" y="51">Median wall time in milliseconds; lower is better</text>
+
+  <line class="grid" x1="250" y1="70" x2="250" y2="200" />
+  <line class="grid" x1="390" y1="70" x2="390" y2="200" />
+  <line class="grid" x1="530" y1="70" x2="530" y2="200" />
+  <line class="grid" x1="670" y1="70" x2="670" y2="200" />
+  <line class="grid" x1="810" y1="70" x2="810" y2="200" />
+  <line class="axis" x1="250" y1="200" x2="810" y2="200" />
+
+  <text class="label" x="20" y="105">Fast path + priority</text>
+  <rect class="previous" x="250" y="82" width="482" height="32" rx="4" />
+  <text class="value" x="744" y="104">172 ms</text>
+
+  <text class="label" x="20" y="165">+ 2 projects</text>
+  <rect class="current" x="250" y="142" width="378" height="32" rx="4" />
+  <text class="value" x="640" y="164">135 ms · 21% lower</text>
+
+  <text class="tick" x="250" y="221" text-anchor="middle">0</text>
+  <text class="tick" x="390" y="221" text-anchor="middle">50</text>
+  <text class="tick" x="530" y="221" text-anchor="middle">100</text>
+  <text class="tick" x="670" y="221" text-anchor="middle">150</text>
+  <text class="tick" x="810" y="221" text-anchor="middle">200 ms</text>
+  <text class="note" x="20" y="253">21% lower than the previous stage · 10.64x faster than the no-fast-path baseline</text>
+</svg>

--- a/docs/assets/benchmark-runtime.svg
+++ b/docs/assets/benchmark-runtime.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 470" role="img" aria-labelledby="title desc">
+  <title id="title">Median end-to-end runtime for each benchmark stage</title>
+  <desc id="desc">Horizontal bars compare pre-commit at 1737 milliseconds, prek without the fast path at 1438 milliseconds, prek with the fast path at 213 milliseconds, prek with priority scheduling at 172 milliseconds, and prek with two projects at 135 milliseconds. Lower is better.</desc>
+  <style>
+    text {
+      fill: #0f172a;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    .title { font-size: 20px; font-weight: 600; }
+    .subtitle, .tick, .note { fill: #475569; }
+    .subtitle { font-size: 13px; }
+    .label { font-size: 14px; font-weight: 600; }
+    .value { font-size: 13px; }
+    .tick, .note { font-size: 12px; }
+    .grid { stroke: #cbd5e1; stroke-width: 1; }
+    .axis { stroke: #94a3b8; stroke-width: 1; }
+    .reference { fill: #94a3b8; }
+    .baseline { fill: #64748b; }
+    .optimized { fill: #6366f1; }
+    .final { fill: #4338ca; }
+    @media (prefers-color-scheme: dark) {
+      text { fill: #e2e8f0; }
+      .subtitle, .tick, .note { fill: #a8b3cf; }
+      .grid { stroke: #334155; }
+      .axis { stroke: #64748b; }
+      .reference { fill: #94a3b8; }
+      .baseline { fill: #64748b; }
+      .optimized { fill: #818cf8; }
+      .final { fill: #a5b4fc; }
+    }
+  </style>
+
+  <text class="title" x="20" y="28">Runtime optimization ladder</text>
+  <text class="subtitle" x="20" y="51">Median wall time in milliseconds; lower is better</text>
+
+  <line class="grid" x1="250" y1="72" x2="250" y2="402" />
+  <line class="grid" x1="390" y1="72" x2="390" y2="402" />
+  <line class="grid" x1="530" y1="72" x2="530" y2="402" />
+  <line class="grid" x1="670" y1="72" x2="670" y2="402" />
+  <line class="grid" x1="810" y1="72" x2="810" y2="402" />
+  <line class="axis" x1="250" y1="402" x2="810" y2="402" />
+
+  <text class="label" x="20" y="106">pre-commit</text>
+  <rect class="reference" x="250" y="83" width="486" height="32" rx="4" />
+  <text class="value" x="748" y="105">1,737 ms · reference</text>
+
+  <text class="label" x="20" y="171">prek: no fast path</text>
+  <rect class="baseline" x="250" y="148" width="403" height="32" rx="4" />
+  <text class="value" x="665" y="170">1,438 ms · baseline</text>
+
+  <text class="label" x="20" y="236">prek: fast path</text>
+  <rect class="optimized" x="250" y="213" width="60" height="32" rx="4" />
+  <text class="value" x="322" y="235">213 ms · 85% lower than previous</text>
+
+  <text class="label" x="20" y="301">prek: + priority</text>
+  <rect class="optimized" x="250" y="278" width="48" height="32" rx="4" />
+  <text class="value" x="310" y="300">172 ms · 19% lower</text>
+
+  <text class="label" x="20" y="366">prek: + 2 projects</text>
+  <rect class="final" x="250" y="343" width="38" height="32" rx="4" />
+  <text class="value" x="300" y="365">135 ms · 21% lower</text>
+
+  <text class="tick" x="250" y="423" text-anchor="middle">0</text>
+  <text class="tick" x="390" y="423" text-anchor="middle">500</text>
+  <text class="tick" x="530" y="423" text-anchor="middle">1,000</text>
+  <text class="tick" x="670" y="423" text-anchor="middle">1,500</text>
+  <text class="tick" x="810" y="423" text-anchor="middle">2,000 ms</text>
+  <text class="note" x="20" y="454">Pooled median of 30 runs (forward and reverse command order)</text>
+</svg>

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,132 +1,288 @@
 # Benchmarks
 
-This page presents benchmarks comparing prek vs pre-commit.
+"How much faster is prek?" sounds like a question that should have one simple
+answer. In practice, it depends on where the time goes.
 
-Caveats:
+Some of that time belongs to the hook itself: a formatter reads files, a linter
+builds an analysis, or `cargo clippy` compiles a crate. The rest belongs to the
+runner around it. prek and pre-commit still need to load configuration, ask Git
+which files matter, match those files to hooks, start processes, present the
+results, and determine whether anything changed.
 
-- Benchmark performance may vary based on hardware, OS, network conditions, and other factors.
-- Benchmarks are not exhaustive; results may vary with different repositories and configurations.
-- prek is under active development; performance may improve over time.
+That distinction is the key to reading these numbers. If `cargo clippy` takes
+30 seconds, even cutting everything around it from roughly 1.4 seconds to 0.1
+seconds only changes the total from 31.4 seconds to 30.1 seconds: about a 1.04x
+speedup. At the other extreme, a repository with many quick hooks can spend most
+of its time inside the runner, especially when checking the worktree with
+`git diff` is expensive.
 
-Environment:
+Rather than jumping straight to one headline number, we will build the picture
+from the smallest workload upward. First we will make the hook almost free and
+compare the frameworks themselves. Then we will bring back real hooks and add
+prek's fast path, priority scheduling, and project-level concurrency one step at
+a time.
 
-pre-commit version: 4.3.0
-prek version: 0.2.0
+## Start with the framework
 
-OS: macOS 15.5
-CPU: Apple M3 Pro
-RAM: 18GB
+The simplest way to expose framework cost is to make the hook do almost
+nothing. Here every hook is a local `language: system` hook whose entry is
+`true`. `always_run: true` and `pass_filenames: false` ensure that every hook
+runs exactly once with the same tiny payload:
 
-## Cold installation
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: noop-01
+        name: no-op 01
+        entry: "true"
+        language: system
+        always_run: true
+        pass_filenames: false
+```
 
-Here is a benchmark of installing hooks from [Apache Airflow](https://github.com/apache/airflow), which has a large and complex pre-commit configuration.
+The full configuration repeats this definition with unique IDs through
+`noop-10`. Both measurements load that same configuration; the one-hook case
+selects only `noop-01`, while the ten-hook case runs all hooks sequentially.
+These are generic hooks, so prek's built-in fast path is not involved.
 
-Steps:
+![Horizontal bars comparing framework-dominated runtimes](assets/benchmark-framework.svg)
+
+This is still not a measurement of literally zero hook cost: the runner must
+launch a child process for every `true`. The one-hook case mostly exposes fixed
+startup and repository-processing costs. With ten hooks, both runners repeat
+dispatch and modification checks; prek saves 203 ms in absolute time, while the
+relative gap narrows from 3.30x to 1.80x.
+
+That gives us a useful lower bound, but not yet a representative hook workload.
+The next question is what happens when the hooks perform real, predictable work
+and prek can apply its own runtime optimizations.
+
+## Add optimizations one at a time
+
+Now we replace `true` with 13 unique hooks from
+[`pre-commit-hooks`](https://github.com/pre-commit/pre-commit-hooks). The
+medium-scale corpus remains the same: 960 workload files, a clean worktree, and
+warm hook environments and filesystem caches. Installation and network time
+are not included.
+
+To make each change visible, we begin with prek's fast path disabled and add one
+optimization at a time. Each stage keeps the improvements introduced before it,
+and we will look at its result before moving on to the next one.
+
+### 1. No fast path
+
+We first set `PREK_NO_FAST_PATH=1`, so prek runs the original Python hook
+implementations. The hooks keep their implicit priorities and run sequentially.
+This gives us a baseline before enabling any prek-specific runtime
+optimizations.
+
+The `pre-commit` reference takes 1,737 ms. prek completes the same workload in
+1,438 ms, 17% less time. We use that 1,438 ms result as the baseline for the
+remaining stages.
+
+![Horizontal bars comparing pre-commit with prek without the fast path](assets/benchmark-no-fast-path.svg)
+
+### 2. Fast path
+
+Next, we remove `PREK_NO_FAST_PATH` without changing the hook configuration.
+prek's [automatic fast path](builtin.md#1-automatic-fast-path) recognizes the
+13 hooks and runs their built-in Rust implementations. The median falls from
+1,438 ms to 213 ms: 85% less time, or a 6.75x speedup.
+
+![Horizontal bars showing the effect of the fast path](assets/benchmark-fast-path.svg)
+
+This benchmark deliberately uses hooks for which prek has built-in
+implementations. That keeps the execution path predictable, but it also makes
+the fast path unusually visible. Treat this result as an explanation of where
+time can be removed, not as a promise for every workload.
+
+### 3. Priority
+
+The fast path is automatic when a supported hook matches. Priority requires a
+little more information: you need to tell prek which hooks are independent and
+can safely run together.
+
+Hooks with the same [`priority`](reference/configuration.md#priority) may run at
+the same time. Only group hooks that are independent. In the benchmark, hooks
+which can modify overlapping text files remain ordered, and read-only checks
+share a named priority. This excerpt shows the grouping:
+
+```yaml
+priorities:
+  trim: 0
+  eof: 10
+  line-endings: 20
+  bom: 30
+  checks: 40
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+        priority: trim
+      - id: end-of-file-fixer
+        priority: eof
+      - id: mixed-line-ending
+        priority: line-endings
+      - id: fix-byte-order-marker
+        priority: bom
+      - id: check-json
+        priority: checks
+      - id: check-yaml
+        priority: checks
+      - id: check-toml
+        priority: checks
+      - id: check-xml
+        priority: checks
+```
+
+With the fast path retained, priority scheduling lowers the median from 213 ms
+to 172 ms, another 19% reduction. That is 8.36x faster than the no-fast-path
+baseline.
+
+![Horizontal bars showing the effect of priority scheduling](assets/benchmark-priority.svg)
+
+### 4. Two projects
+
+Priority scheduling shortens the critical path inside one project. The final
+stage applies the same idea one level higher by splitting structured data and
+text files into two sibling projects:
+
+```text
+benchmark-repo/
+├── .pre-commit-config.yaml
+├── structured/
+│   └── .pre-commit-config.yaml
+└── text/
+    └── .pre-commit-config.yaml
+```
+
+Each project declares only the hooks it owns. Common checks appear in both
+project configurations, but they see disjoint sets of files. This models a
+configured monorepo rather than duplicating every hook in every project just to
+exercise the scheduler.
+
+[Projects at the same depth](workspace.md#execution-order) can run concurrently.
+Nested parent and child projects still run from deepest to shallowest, so a
+workspace should reflect real ownership boundaries rather than being split only
+to chase a benchmark number.
+
+Adding the second project lowers the median from 172 ms to 135 ms, another 21%
+reduction.
+
+![Horizontal bars showing the effect of two concurrent projects](assets/benchmark-projects.svg)
+
+### Summary
+
+Put together, the four measurements form the complete optimization ladder:
+
+![Horizontal bar chart of the runtime optimization ladder](assets/benchmark-runtime.svg)
+
+Across the complete ladder, prek falls from 1,438 ms to 135 ms: 90.6% less
+time, or a 10.64x speedup. The final configuration is 12.85x faster than the
+`pre-commit` reference.
+
+## The hidden cost of `git diff`
+
+The large fast-path jump is not only about replacing Python hook
+implementations with Rust. It also removes work around the hooks.
+
+An arbitrary hook can modify files without reporting that fact, so a hook
+manager needs another way to decide whether the worktree changed. That check is
+often `git diff`, and it can be a substantial part of framework time when a
+repository contains many files.
+
+In the versions measured here, `pre-commit` captures one diff before running the
+hooks and another after every hook that executes. Thirteen executed hooks can
+therefore require 14 diffs. prek also uses diffs when a general hook's mutation
+status is unknown, but its built-in and automatic fast-path hooks report whether
+they changed files. When every result is known, prek can skip those diffs
+entirely.
+
+This fixture is deliberately moderate: a separate 30-run check of a clean
+`git diff` had a median of about 18 ms. The difference becomes much larger in an
+extreme repository where one diff takes hundreds of milliseconds. For example,
+at 300 ms per diff:
+
+| Execution path | Diff calls for 13 hooks | Diff time alone |
+| -- | -: | -: |
+| `pre-commit` | 14 | about 4.2 s |
+| prek, all results known | 0 | 0 s |
+
+This is an illustration of diff overhead, not a claim that the hooks themselves
+take zero time. If even one hook has an unknown mutation outcome, prek still
+performs the required check rather than assuming the worktree is unchanged.
+
+## What this means for a real repository
+
+At this point, two different kinds of speedup should be visible. Framework
+savings remove time around each hook, while concurrency shortens the critical
+path through the hooks themselves:
+
+- A single slow hook hides framework improvements. The total cannot become much
+  faster than that hook.
+- Correct priority groups shorten the critical path. Three independent 20-second
+  hooks can approach 20 seconds instead of 60 seconds when resources allow.
+- Independent same-depth projects can make the same improvement across a
+  monorepo. Each project advances through its own priority groups without
+  waiting for an unrelated sibling project.
+
+Well-configured priority and project concurrency can therefore produce
+multi-fold improvements even when fast-path savings are small. Actual scaling
+is bounded by CPU, memory, disk and cache contention, and by
+[`PREK_CONCURRENT_HOOKS`](reference/environment-variables.md#prek_concurrent_hooks).
+Do not run hooks concurrently when they modify the same files or share mutable
+global state.
+
+## Reproduce the benchmark
+
+The complete fixture generator, pinned hook configurations, hyperfine commands,
+and raw samples are published in
+[`prek-ci/benchmarks`](https://github.com/prek-ci/benchmarks).
+The generator recreates all three fixture layouts and verifies their Git tree
+hashes, so a change to any workload file is detected before measurements begin.
+
+With Git, uv, hyperfine, and Python 3 installed, run:
 
 ```console
-uv tool install prek@0.2.0
-uv tool install pre-commit@4.3.0
-
-git clone https://github.com/apache/airflow
-cd airflow
-git checkout 3.0.6
-
-hyperfine \
-    --prepare 'prek clean && pre-commit clean && uv cache clean' \
-    --setup 'prek --version && pre-commit --version' \
-    --runs 1 \
-    'prek prepare-hooks' \
-    'pre-commit install-hooks'
+git clone https://github.com/prek-ci/benchmarks.git
+cd benchmarks
+./scripts/setup-tools.sh
+./benchmark.sh
 ```
 
-Results:
+`setup-tools.sh` installs the prek 0.4.12 binary wheel and pre-commit 4.6.1 in
+isolated tool environments using Python 3.14.6. `benchmark.sh` creates a fresh
+960-file fixture, warms both runner caches, executes the framework,
+runtime-ladder, and clean-`git diff` benchmarks in both command orders, and
+writes the raw JSON plus a pooled-median summary to
+`results/local-<timestamp>/`.
 
-```
-Benchmark 1: prek prepare-hooks
-  Time (abs ≡):        18.395 s               [User: 11.234 s, System: 9.979 s]
+The [original 2026-07-31 samples](https://github.com/prek-ci/benchmarks/tree/main/results/2026-07-31)
+are preserved alongside the scripts. Expect absolute times to vary across
+machines; compare the ordering and relative changes on your own hardware.
 
-Benchmark 2: pre-commit install-hooks
-  Time (abs ≡):        186.990 s               [User: 68.774 s, System: 39.379 s]
+## Methodology
 
-Summary
-  prek prepare-hooks ran
-   10.17 times faster than pre-commit install-hooks
-```
+- Date: 2026-07-31
+- OS: macOS 15.7.7
+- CPU: Apple M3 Pro, 12 cores
+- RAM: 18 GiB
+- prek: `0.4.12`
+- pre-commit: `4.6.1`
+- pre-commit-hooks: `v6.0.0`
+- hyperfine: `1.20.0`
+- Framework workload: 960 workload files; 10 local `language: system` hooks
+  invoking `true`; `always_run: true`; `pass_filenames: false`; one or ten hooks
+  selected; clean worktree and warm filesystem caches
+- Optimization workload: the same 960 files; configuration files excluded from
+  hook matching; 13 unique built-in-capable hook IDs; clean worktree; warm hook
+  environments and filesystem caches
+- Sampling: 5 warmups followed by 15 measured runs in forward order and 15 in
+  reverse order; the charts report the pooled median of 30 runs
 
-Disk usage after installation:
-
-```console
-$ du -sh ~/.cache/prek ~/.cache/pre-commit
-810M	/Users/Jo/.cache/prek
-1.6G	/Users/Jo/.cache/pre-commit
-```
-
-## Runtime benchmarks
-
-Since some hooks might be slow to run (e.g., `cargo clippy`), which can take minutes, making any other overhead negligible, we choose to only run `check-toml` hook in `cpython` codebase.
-
-### With prek fast path
-
-Steps:
-
-```console
-git clone https://github.com/python/cpython
-cd cpython
-git checkout v3.14.0rc2
-
-hyperfine \
-    --warmup 3 \
-    --setup 'prek --version && pre-commit --version' \
-    --runs 5 \
-    'prek run -a check-toml' \
-    'pre-commit run -a check-toml'
-```
-
-Results:
-
-```console
-Benchmark 1: prek run -a check-toml
-  Time (mean ± σ):      77.1 ms ±   2.5 ms    [User: 44.1 ms, System: 128.5 ms]
-  Range (min … max):    75.1 ms …  81.3 ms    5 runs
-
-Benchmark 2: pre-commit run -a check-toml
-  Time (mean ± σ):     351.6 ms ±  25.0 ms    [User: 214.5 ms, System: 195.5 ms]
-  Range (min … max):   332.8 ms … 393.2 ms    5 runs
-
-Summary
-  prek run -a check-toml ran
-    4.56 ± 0.36 times faster than pre-commit run -a check-toml
-```
-
-### Without prek fast path
-
-Steps:
-
-```console
-hyperfine \
-    --warmup 3 \
-    --setup 'prek --version && pre-commit --version' \
-    --runs 5 \
-    'PREK_NO_FAST_PATH=1 prek run -a check-toml' \
-    'pre-commit run -a check-toml'
-```
-
-Results:
-
-```
-Benchmark 1: PREK_NO_FAST_PATH=1 prek run -a check-toml
-  Time (mean ± σ):     137.3 ms ±   5.1 ms    [User: 111.0 ms, System: 147.5 ms]
-  Range (min … max):   131.9 ms … 144.0 ms    5 runs
-
-Benchmark 2: pre-commit run -a check-toml
-  Time (mean ± σ):     397.6 ms ±  49.2 ms    [User: 217.6 ms, System: 197.7 ms]
-  Range (min … max):   332.6 ms … 440.7 ms    5 runs
-
-Summary
-  PREK_NO_FAST_PATH=1 prek run -a check-toml ran
-    2.90 ± 0.37 times faster than pre-commit run -a check-toml
-```
-
-## Benchmark from the community
-
-- [Ready Prek Go!](https://hugovk.dev/blog/2025/ready-prek-go/) from Hugo van Kemenade.
+Benchmark performance varies with hardware, operating system, repository shape,
+hook configuration, cache state, and background load. Compare representative
+end-to-end workloads on your own machine before making configuration decisions.


### PR DESCRIPTION
Rewrite the benchmark page with staged framework, fast-path, priority, and
multi-project comparisons backed by the reproducible `prek-ci/benchmarks`
fixture.
