### PR TITLE
Support .prek.toml as a config filename

### DIFF
--- a/crates/prek-consts/src/lib.rs
+++ b/crates/prek-consts/src/lib.rs
@@ -8,9 +8,15 @@ use env_vars::{EnvVars, EnvVarsRead};
 pub const PRE_COMMIT_CONFIG_YAML: &str = ".pre-commit-config.yaml";
 pub const PRE_COMMIT_CONFIG_YML: &str = ".pre-commit-config.yml";
 pub const PREK_TOML: &str = "prek.toml";
+pub const PREK_DOT_TOML: &str = ".prek.toml";
 pub const PRE_COMMIT_HOOKS_YAML: &str = ".pre-commit-hooks.yaml";
 
-pub const CONFIG_FILENAMES: &[&str] = &[PREK_TOML, PRE_COMMIT_CONFIG_YAML, PRE_COMMIT_CONFIG_YML];
+pub const CONFIG_FILENAMES: &[&str] = &[
+    PREK_TOML,
+    PREK_DOT_TOML,
+    PRE_COMMIT_CONFIG_YAML,
+    PRE_COMMIT_CONFIG_YML,
+];
 
 /// Prepend paths to the current $PATH, returning the joined result.
 ///

--- a/crates/prek/src/hooks/meta_hooks.rs
+++ b/crates/prek/src/hooks/meta_hooks.rs
@@ -368,7 +368,7 @@ pub fn identity(_hook: &Hook, filenames: &[&Path]) -> HookOutput {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use prek_consts::{PRE_COMMIT_CONFIG_YAML, PRE_COMMIT_CONFIG_YML, PREK_TOML};
+    use prek_consts::{PRE_COMMIT_CONFIG_YAML, PRE_COMMIT_CONFIG_YML, PREK_DOT_TOML, PREK_TOML};
 
     fn regex_pattern(pattern: &str) -> FilePattern {
         FilePattern::regex(pattern).unwrap()
@@ -402,12 +402,14 @@ mod tests {
         assert!(apply_files.is_match(Path::new(PRE_COMMIT_CONFIG_YAML)));
         assert!(apply_files.is_match(Path::new(PRE_COMMIT_CONFIG_YML)));
         assert!(apply_files.is_match(Path::new(PREK_TOML)));
+        assert!(apply_files.is_match(Path::new(PREK_DOT_TOML)));
 
         let useless = MetaHook::from_id("check-useless-excludes").expect("known meta hook");
         let useless_files = useless.options.files.as_ref().expect("files should be set");
         assert!(useless_files.is_match(Path::new(PRE_COMMIT_CONFIG_YAML)));
         assert!(useless_files.is_match(Path::new(PRE_COMMIT_CONFIG_YML)));
         assert!(useless_files.is_match(Path::new(PREK_TOML)));
+        assert!(useless_files.is_match(Path::new(PREK_DOT_TOML)));
 
         let identity = MetaHook::from_id("identity").expect("known meta hook");
         assert!(identity.options.files.is_none());

--- a/crates/prek/src/snapshots/prek__config__tests__meta_hooks-5.snap
+++ b/crates/prek/src/snapshots/prek__config__tests__meta_hooks-5.snap
@@ -22,6 +22,7 @@ Config {
                                     GlobPatterns {
                                         patterns: [
                                             "prek.toml",
+                                            ".prek.toml",
                                             ".pre-commit-config.yaml",
                                             ".pre-commit-config.yml",
                                         ],
@@ -62,6 +63,7 @@ Config {
                                     GlobPatterns {
                                         patterns: [
                                             "prek.toml",
+                                            ".prek.toml",
                                             ".pre-commit-config.yaml",
                                             ".pre-commit-config.yml",
                                         ],

--- a/crates/prek/src/workspace.rs
+++ b/crates/prek/src/workspace.rs
@@ -36,7 +36,7 @@ pub(crate) enum Error {
     Git(#[from] anyhow::Error),
 
     #[error(
-        "No `prek.toml` or `.pre-commit-config.yaml` found in the current directory or parent directories.\n\n{} If you just added one, rerun your command with the `--refresh` flag to rescan the workspace.",
+        "No `prek.toml`, `.prek.toml`, or `.pre-commit-config.yaml` found in the current directory or parent directories.\n\n{} If you just added one, rerun your command with the `--refresh` flag to rescan the workspace.",
         "hint:".yellow().bold(),
     )]
     MissingConfigFile,

--- a/crates/prek/tests/hook_impl.rs
+++ b/crates/prek/tests/hook_impl.rs
@@ -1028,7 +1028,7 @@ fn workspace_hook_impl_no_project_found() -> anyhow::Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: No `prek.toml` or `.pre-commit-config.yaml` found in the current directory or parent directories.
+    error: No `prek.toml`, `.prek.toml`, or `.pre-commit-config.yaml` found in the current directory or parent directories.
 
     hint: If you just added one, rerun your command with the `--refresh` flag to rescan the workspace.
     - To temporarily silence this, run `PREK_ALLOW_NO_CONFIG=1 git ...`

--- a/crates/prek/tests/list.rs
+++ b/crates/prek/tests/list.rs
@@ -478,7 +478,7 @@ fn list_no_config_file() {
     ----- stdout -----
 
     ----- stderr -----
-    error: No `prek.toml` or `.pre-commit-config.yaml` found in the current directory or parent directories.
+    error: No `prek.toml`, `.prek.toml`, or `.pre-commit-config.yaml` found in the current directory or parent directories.
 
     hint: If you just added one, rerun your command with the `--refresh` flag to rescan the workspace.
     ");

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -8,7 +8,7 @@ use insta::assert_snapshot;
 use predicates::prelude::predicate;
 use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use prek_consts::{
-    PRE_COMMIT_CONFIG_YAML, PRE_COMMIT_CONFIG_YML, PRE_COMMIT_HOOKS_YAML, PREK_TOML,
+    PRE_COMMIT_CONFIG_YAML, PRE_COMMIT_CONFIG_YML, PRE_COMMIT_HOOKS_YAML, PREK_DOT_TOML, PREK_TOML,
 };
 
 use crate::common::{TestContext, cmd_snapshot, git_cmd};
@@ -3703,6 +3703,38 @@ fn alternate_config_file() -> Result<()> {
     warning: Multiple configuration files found (`prek.toml`, `.pre-commit-config.yaml`, `.pre-commit-config.yml`); using `[TEMP_DIR]/prek.toml`
     ");
 
+    context
+        .work_dir()
+        .child(PREK_DOT_TOML)
+        .write_str(indoc::indoc! {r#"
+        [[repos]]
+        repo = "local"
+        hooks = [
+          {
+            id = "local-python-hook",
+            name = "local-python-hook",
+            language = "python",
+            entry = "python3 -c 'import sys; print(\"Hello, world!\")'"
+          }
+        ]
+    "#})?;
+    context.git_add(".");
+
+    // `prek.toml` still takes precedence over `.prek.toml`.
+    cmd_snapshot!(context.filters(), context.run().arg("--refresh").arg("-v"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    local-python-hook........................................................Passed
+    - hook id: local-python-hook
+    - duration: [TIME]
+
+      Hello, world!
+
+    ----- stderr -----
+    warning: Multiple configuration files found (`prek.toml`, `.prek.toml`, `.pre-commit-config.yaml`, `.pre-commit-config.yml`); using `[TEMP_DIR]/prek.toml`
+    ");
+
     Ok(())
 }
 
@@ -3715,6 +3747,45 @@ fn prek_toml() -> Result<()> {
     context
         .work_dir()
         .child(PREK_TOML)
+        .write_str(indoc::indoc! {r#"
+        [[repos]]
+        repo = "local"
+        hooks = [
+          {
+            id = "local-python-hook",
+            name = "local-python-hook",
+            language = "python",
+            entry = "python3 -c 'import sys; print(\"Hello, world!\")'"
+          }
+        ]
+    "#})?;
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run().arg("-v"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    local-python-hook........................................................Passed
+    - hook id: local-python-hook
+    - duration: [TIME]
+
+      Hello, world!
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+/// Supports `.prek.toml` as configuration file.
+#[test]
+fn prek_dot_toml() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    context
+        .work_dir()
+        .child(PREK_DOT_TOML)
         .write_str(indoc::indoc! {r#"
         [[repos]]
         repo = "local"

--- a/crates/prek/tests/workspace.rs
+++ b/crates/prek/tests/workspace.rs
@@ -1058,7 +1058,7 @@ fn workspace_no_projects() {
     ----- stdout -----
 
     ----- stderr -----
-    error: No `prek.toml` or `.pre-commit-config.yaml` found in the current directory or parent directories.
+    error: No `prek.toml`, `.prek.toml`, or `.pre-commit-config.yaml` found in the current directory or parent directories.
 
     hint: If you just added one, rerun your command with the `--refresh` flag to rescan the workspace.
     ");
@@ -1320,7 +1320,7 @@ fn submodule_discovery() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: No `prek.toml` or `.pre-commit-config.yaml` found in the current directory or parent directories.
+    error: No `prek.toml`, `.prek.toml`, or `.pre-commit-config.yaml` found in the current directory or parent directories.
 
     hint: If you just added one, rerun your command with the `--refresh` flag to rescan the workspace.
     ");

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -117,6 +117,7 @@ If you pass `--config` / `-c`, workspace discovery is disabled and only that sin
 `prek` recognizes the following configuration filenames:
 
 - `prek.toml` (TOML)
+- `.prek.toml` (TOML, dotfile alternate)
 - `.pre-commit-config.yaml` (YAML, preferred for pre-commit compatibility)
 - `.pre-commit-config.yml` (YAML, alternate)
 
@@ -130,8 +131,9 @@ In workspace mode, each project uses one of these filenames in its own directory
     The precedence order is:
 
     1. `prek.toml`
-    2. `.pre-commit-config.yaml`
-    3. `.pre-commit-config.yml`
+    2. `.prek.toml`
+    3. `.pre-commit-config.yaml`
+    4. `.pre-commit-config.yml`
 
 ### File format
 


### PR DESCRIPTION
## Summary

Adds alternate, 'hidden' `.prek.toml` config filename - in addition to existing `prek.toml`, `.pre-commit-config.yaml` and `.pre-commit-config.yml`; and taking second priority after `prek.toml`.

Change request for consideration as a seemingly small piece of work to evaluate. So open if this is not the right fit or direction with `prek`.

### Rationale

- Flexibility in cases where it is helpful to 'hide' dotfiles from display, search, etc.

  Such as at the terminal...

    <img width="660" height="128" alt="Screenshot 2026-08-03 at 22 53 24" src="https://github.com/user-attachments/assets/af34b1c2-de86-4bbd-9b5b-ec6c9c533c8e" />

  <img width="578" height="100" alt="Screenshot 2026-08-03 at 22 52 59" src="https://github.com/user-attachments/assets/b6541df0-350a-49cf-a1fd-ab2631c92376" />

  ...or within the IDE... in this case, configuring `files.exclude` within VSCode settings with `"**/.*": true`.

  <img width="392" height="408" alt="Screenshot 2026-08-03 at 22 57 09" src="https://github.com/user-attachments/assets/bcafdba5-8059-4e52-9bc5-877f9b3e1466" /><img width="355" height="293" alt="Screenshot 2026-08-03 at 22 57 39" src="https://github.com/user-attachments/assets/a39683df-41db-49e0-aa96-abb24afbd63a" />

- Enables colocation of `prek` configuration files alongside [`.prekignore`](https://prek.j178.dev/workspace/?h=%22.prekignore%22#skipping-projects-or-hooks)

  <img width="132" height="89" alt="Screenshot 2026-08-03 at 23 05 02" src="https://github.com/user-attachments/assets/52654754-9f47-417e-982e-cfa350dfec1e" />

- Matches other tools used within the Python ecosystem e.g. [`.pytest.toml`](https://docs.pytest.org/en/latest/reference/customize.html#pytest-toml) (introduced through https://github.com/pytest-dev/pytest/issues/13743), [`.ruff.toml`](https://docs.astral.sh/ruff/configuration/); and beyond e.g. [`.clippy.toml`](https://doc.rust-lang.org/stable/clippy/configuration.html#configuring-clippy), [`.rustfmt.toml`](https://rust-lang.github.io/rustfmt/?version=v1.10.0&search=), [`.cspell.config.toml`](https://cspell.org/docs/Configuration), etc.
- Parity for anyone migrating from `pre-commit` - which only offered dotfile variants

Have yet to modify the [top-level docs](https://prek.j178.dev/configuration/) listing support for either TOML or YAML - which only references `prek.toml` and `.pre-commit-config.yaml` but not `.pre-commit-config.yml` - though perhaps should be along similar lines to [pytest](https://docs.pytest.org/en/latest/reference/customize.html#pytest-toml)?