### PR TITLE
Silently ignore `x-` extension keys in configuration

### DIFF
--- a/crates/prek/src/config.rs
+++ b/crates/prek/src/config.rs
@@ -1501,6 +1501,7 @@ where
     I: Iterator<Item = &'a str>,
 {
     for key in keys {
+        // Silently ignore extension keys starting with 'x-' (used for YAML anchors and custom metadata).
         if key.starts_with("x-") {
             continue;
         }

--- a/crates/prek/src/config.rs
+++ b/crates/prek/src/config.rs
@@ -1501,6 +1501,9 @@ where
     I: Iterator<Item = &'a str>,
 {
     for key in keys {
+        if key.starts_with("x-") {
+            continue;
+        }
         let path = if prefix.is_empty() {
             key.to_string()
         } else {

--- a/crates/prek/tests/validate.rs
+++ b/crates/prek/tests/validate.rs
@@ -300,14 +300,18 @@ fn unexpected_keys_warning() {
     let context = TestContext::new();
 
     context.write_pre_commit_config(indoc::indoc! {r"
+        x-anchor: &anchor
+          language: system
         repos:
           - repo: local
             unexpected_repo_key: some_value
+            x-repo-key: some_value
             hooks:
               - id: test-hook
                 name: Test Hook
                 entry: echo test
-                language: system
+                <<: *anchor
+                x-hook-key: some_value
         unexpected_top_level_key: some_value
         another_unknown: test
         minimum_pre_commit_version: 1.0.0
@@ -355,6 +359,29 @@ fn unexpected_keys_warning() {
       - `repos[0].hooks[0].unexpected_hook_key_2`
       - `repos[0].hooks[0].unexpected_hook_key_3`
       - `repos[0].hooks[0].unexpected_hook_key_4`
+    success: All configs are valid
+    ");
+
+    context.write_pre_commit_config(indoc::indoc! {r"
+        x-anchor: &anchor
+          language: system
+        repos:
+          - repo: local
+            x-repo-key: test
+            hooks:
+              - id: test-hook
+                name: Test Hook
+                entry: echo test
+                <<: *anchor
+                x-hook-key: test
+    "});
+
+    cmd_snapshot!(context.filters(), context.validate_config().arg(PRE_COMMIT_CONFIG_YAML), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
     success: All configs are valid
     ");
 }

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -47,6 +47,10 @@ The cooldown age is computed from the tag creation timestamp for annotated tags,
 
     The legacy `auto_update` key is still accepted as an alias for `update`.
 
+## Extension keys (`x-`)
+
+Any key starting with `x-` (a lowercase `x` followed by a hyphen) is silently ignored by `prek` at any level of the configuration (top-level, repository entries, and hook entries). This supports custom metadata and YAML anchors without triggering unexpected key warnings.
+
 ## Top-level keys
 
 ### `repos` (required)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -49,7 +49,7 @@ The cooldown age is computed from the tag creation timestamp for annotated tags,
 
 ## Extension keys (`x-`)
 
-Any key starting with `x-` (a lowercase `x` followed by a hyphen) is silently ignored by `prek` at any level of the configuration (top-level, repository entries, and hook entries). This supports custom metadata and YAML anchors without triggering unexpected key warnings.
+Any key starting with `x-` (a lowercase `x` followed by a hyphen) is silently ignored by `prek` at any level of the configuration. This supports custom metadata without triggering unexpected key warnings.
 
 ## Top-level keys
 


### PR DESCRIPTION
Following the convention used by tools like Docker Compose, OpenAPI, and GitLab CI, ignore any configuration keys starting with `x-` at any level (top-level config, repository entries, and hook entries). This allows users to define custom metadata and YAML anchors without triggering unexpected key warnings.

Fixes #2481