### PR TITLE
Add `yaml-language-server:` comment to YAML sample config

### DIFF
--- a/crates/prek/src/cli/sample_config.rs
+++ b/crates/prek/src/cli/sample_config.rs
@@ -12,6 +12,7 @@ use crate::printer::Printer;
 
 static SAMPLE_CONFIG_YAML: &str = indoc::indoc! {"
 # See https://prek.j178.dev for more information.
+# yaml-language-server: $schema=https://www.schemastore.org/prek.json
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/crates/prek/tests/sample_config.rs
+++ b/crates/prek/tests/sample_config.rs
@@ -13,6 +13,7 @@ fn sample_config() -> anyhow::Result<()> {
     exit_code: 0
     ----- stdout -----
     # See https://prek.j178.dev for more information.
+    # yaml-language-server: $schema=https://www.schemastore.org/prek.json
     repos:
       - repo: https://github.com/pre-commit/pre-commit-hooks
         rev: v6.0.0
@@ -36,6 +37,7 @@ fn sample_config() -> anyhow::Result<()> {
 
     insta::assert_snapshot!(context.read(PRE_COMMIT_CONFIG_YAML), @"
     # See https://prek.j178.dev for more information.
+    # yaml-language-server: $schema=https://www.schemastore.org/prek.json
     repos:
       - repo: https://github.com/pre-commit/pre-commit-hooks
         rev: v6.0.0
@@ -57,6 +59,7 @@ fn sample_config() -> anyhow::Result<()> {
 
     insta::assert_snapshot!(context.read("sample.yaml"), @"
     # See https://prek.j178.dev for more information.
+    # yaml-language-server: $schema=https://www.schemastore.org/prek.json
     repos:
       - repo: https://github.com/pre-commit/pre-commit-hooks
         rev: v6.0.0
@@ -80,6 +83,7 @@ fn sample_config() -> anyhow::Result<()> {
     "#);
     insta::assert_snapshot!(context.read("child/sample.yaml"), @"
     # See https://prek.j178.dev for more information.
+    # yaml-language-server: $schema=https://www.schemastore.org/prek.json
     repos:
       - repo: https://github.com/pre-commit/pre-commit-hooks
         rev: v6.0.0
@@ -149,6 +153,7 @@ fn sample_config_format() {
     exit_code: 0
     ----- stdout -----
     # See https://prek.j178.dev for more information.
+    # yaml-language-server: $schema=https://www.schemastore.org/prek.json
     repos:
       - repo: https://github.com/pre-commit/pre-commit-hooks
         rev: v6.0.0
@@ -190,6 +195,7 @@ fn respect_format() {
 
     insta::assert_snapshot!(context.read("prek.toml"), @"
     # See https://prek.j178.dev for more information.
+    # yaml-language-server: $schema=https://www.schemastore.org/prek.json
     repos:
       - repo: https://github.com/pre-commit/pre-commit-hooks
         rev: v6.0.0


### PR DESCRIPTION
<!--
Thank you for contributing to prek. Please keep the following in mind:

- Opening a pull request does not guarantee that it will be accepted or merged.
- If you are proposing a new feature, changing an interface, or making another
  substantial change, please open an issue and discuss it with the maintainers
  before investing time in an implementation.
- Maintainer time is very limited. The maintainers may not have the capacity or
  interest to review, guide, or invest in your pull request, especially right away.
- You are responsible for every line you submit, including code produced with
  the assistance of AI tools.
- AI-generated communication is not acceptable. Write the pull request description
  and participate in review discussions in your own words.
-->

## Summary

Many IDEs feature automatic schema recognition of common YAML files, including `.pre-commit-config.yaml`. However, the schema loaded by default for these files is for base pre-commit, which this project has already diverged from. We already manually assign the schema used for TOML, but no equivalent exists for YAML. While no official schema specification syntax exists, the most commonly recognized one *by far* is `# yaml-language-server: $schema=...`.

This PR adds the above comment to the sample config for YAML files, making prek's schema IDE-aware regardless of which format is selected.