### PR TITLE
Show hook aliases in run output

### DIFF
--- a/crates/prek/src/cli/run/reporter.rs
+++ b/crates/prek/src/cli/run/reporter.rs
@@ -555,9 +555,9 @@ impl HookRunReporter {
         };
 
         let label = if self.show_project_headers {
-            format!("  {}", hook.name)
+            Cow::Owned(format!("  {}", hook.name))
         } else {
-            hook.name.clone()
+            Cow::Borrowed(hook.name.as_str())
         };
         let dots = self.dots.saturating_sub(label.width());
         progress.set_style(
@@ -565,7 +565,7 @@ impl HookRunReporter {
                 .unwrap()
                 .progress_chars(".."),
         );
-        progress.set_message(label);
+        progress.set_message(label.into_owned());
         progress
     }
 

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -913,6 +913,13 @@ impl<'a> HookRunSession<'a> {
                     "{detail_prefix}{}",
                     format!("- hook id: {}", result.hook.id).dimmed()
                 )?;
+                if !result.hook.alias.is_empty() && result.hook.alias != result.hook.id {
+                    writeln!(
+                        stdout,
+                        "{detail_prefix}{}",
+                        format!("- hook alias: {}", result.hook.alias).dimmed()
+                    )?;
+                }
                 if let Some(description) = result.hook.description.as_deref()
                     && let Some(description) = description.trim().lines().next()
                 {

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -664,6 +664,52 @@ fn multiple_hook_ids() {
 }
 
 #[test]
+fn run_displays_aliases_for_repeated_hook_ids() {
+    let context = TestContext::new();
+    context.init_project();
+
+    context.write_pre_commit_config(indoc::indoc! {r"
+        repos:
+          - repo: local
+            hooks:
+              - id: repeated
+                alias: repeated-format
+                name: Repeated hook
+                language: system
+                entry: git diff --quiet
+                always_run: true
+                pass_filenames: false
+                verbose: true
+              - id: repeated
+                alias: repeated-lint
+                name: Repeated hook
+                language: system
+                entry: git diff --quiet
+                always_run: true
+                pass_filenames: false
+                verbose: true
+    "});
+
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run().arg("repeated"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Repeated hook............................................................Passed
+    - hook id: repeated
+    - hook alias: repeated-format
+    - duration: [TIME]
+    Repeated hook............................................................Passed
+    - hook id: repeated
+    - hook alias: repeated-lint
+    - duration: [TIME]
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn priorities_respected() {
     let context = TestContext::new();
     context.init_project();


### PR DESCRIPTION
## Summary

- show configured hook aliases after hook IDs in verbose and failure details

Closes #2496