### PR TITLE
Isolate try-repo from inherited Git repository state

### DIFF
--- a/crates/prek/src/cli/run/filter.rs
+++ b/crates/prek/src/cli/run/filter.rs
@@ -684,7 +684,7 @@ async fn collect_files_for_selection(
                 return Ok(files);
             }
 
-            let files = git::staged_files(workspace_root).await?;
+            let files = git::staged_files(git::git_cmd()?, workspace_root).await?;
             debug!("Staged files: {}", files.len());
             Ok(files)
         }

--- a/crates/prek/src/cli/try_repo.rs
+++ b/crates/prek/src/cli/try_repo.rs
@@ -13,7 +13,7 @@ use crate::cli::run::Selectors;
 use crate::cli::{ExitStatus, RunOptions, flag};
 use crate::config::{self, Stage};
 use crate::git;
-use crate::git::GIT_ROOT;
+use crate::git::{GIT_ROOT, GitCommandExt};
 use crate::hooks::{BuiltinHooks, MetaHooks};
 use crate::printer::Printer;
 use crate::store::Store;
@@ -24,6 +24,7 @@ async fn get_head_rev(repo: &Path) -> Result<String> {
         .arg("rev-parse")
         .arg("HEAD")
         .current_dir(repo)
+        .isolate_from_git_env()
         .output()
         .await?
         .stdout;
@@ -37,6 +38,7 @@ async fn clone_and_commit(repo_path: &Path, head_rev: &str, tmp_dir: &Path) -> R
         .arg("clone")
         .arg(repo_path)
         .arg(&shadow)
+        .isolate_from_git_env()
         .output()
         .await?;
     git::git_cmd()?
@@ -45,19 +47,23 @@ async fn clone_and_commit(repo_path: &Path, head_rev: &str, tmp_dir: &Path) -> R
         .arg("-b")
         .arg("_prek_tmp")
         .current_dir(&shadow)
+        .isolate_from_git_env()
         .output()
         .await?;
 
     let index_path = shadow.join(".git/index");
     let objects_path = shadow.join(".git/objects");
 
-    let staged_files = git::staged_files(repo_path).await?;
+    let mut cmd = git::git_cmd()?;
+    cmd.isolate_from_git_env();
+    let staged_files = git::staged_files(cmd, repo_path).await?;
     if !staged_files.is_empty() {
         git::git_cmd()?
             .arg("add")
             .arg("--")
             .file_args(&staged_files)
             .current_dir(repo_path)
+            .isolate_from_git_env()
             .env("GIT_INDEX_FILE", &index_path)
             .env("GIT_OBJECT_DIRECTORY", &objects_path)
             .output()
@@ -69,6 +75,7 @@ async fn clone_and_commit(repo_path: &Path, head_rev: &str, tmp_dir: &Path) -> R
         .arg("add")
         .arg("--update") // Update tracked files
         .current_dir(repo_path)
+        .isolate_from_git_env()
         .env("GIT_INDEX_FILE", &index_path)
         .env("GIT_OBJECT_DIRECTORY", &objects_path)
         .output()
@@ -82,6 +89,7 @@ async fn clone_and_commit(repo_path: &Path, head_rev: &str, tmp_dir: &Path) -> R
         .arg("--no-edit")
         .arg("--no-verify")
         .current_dir(&shadow)
+        .isolate_from_git_env()
         .env("GIT_AUTHOR_NAME", "prek test")
         .env("GIT_AUTHOR_EMAIL", "test@example.com")
         .env("GIT_COMMITTER_NAME", "prek test")
@@ -135,6 +143,7 @@ async fn prepare_repo<'a>(
             .arg("--exit-code")
             .arg(runtime_source.as_ref())
             .arg("HEAD")
+            .isolate_from_git_env()
             .output()
             .await?
             .stdout;

--- a/crates/prek/src/git.rs
+++ b/crates/prek/src/git.rs
@@ -319,8 +319,8 @@ pub(crate) async fn hooks_dir() -> Result<PathBuf, Error> {
     }
 }
 
-pub(crate) async fn staged_files(root: &Path) -> Result<Vec<PathBuf>, Error> {
-    let output = git_cmd()?
+pub(crate) async fn staged_files(mut cmd: Cmd, root: &Path) -> Result<Vec<PathBuf>, Error> {
+    let output = cmd
         .current_dir(root)
         .arg("diff")
         .arg("--cached")
@@ -369,6 +369,7 @@ pub(crate) async fn has_diff(rev: &str, path: &Path) -> Result<bool> {
         .arg("--quiet")
         .arg(rev)
         .current_dir(path)
+        .isolate_from_git_env()
         .check(false)
         .status()
         .await?;

--- a/crates/prek/tests/try_repo.rs
+++ b/crates/prek/tests/try_repo.rs
@@ -2,6 +2,7 @@ mod common;
 use anyhow::Result;
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
+use prek_consts::env_vars::EnvVars;
 use std::path::PathBuf;
 
 use crate::common::{TestContext, cmd_snapshot, git_cmd};
@@ -280,7 +281,7 @@ fn try_repo_specific_rev() -> Result<()> {
 }
 
 #[test]
-fn try_repo_uncommitted_changes() -> Result<()> {
+fn try_repo_uncommitted_changes_ignore_inherited_git_env() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
@@ -314,7 +315,11 @@ fn try_repo_uncommitted_changes() -> Result<()> {
         ("'", "\""),
     ]);
 
-    cmd_snapshot!(filters, context.try_repo().arg(&repo_path), @r#"
+    let git_dir = context.work_dir().child(".git");
+    cmd_snapshot!(filters, context.try_repo()
+        .env(EnvVars::GIT_DIR, git_dir.path())
+        .env("GIT_INDEX_FILE", git_dir.child("index").path())
+        .arg(&repo_path), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -331,6 +336,14 @@ fn try_repo_uncommitted_changes() -> Result<()> {
     ----- stderr -----
     warning: Local repository has uncommitted changes. Creating a temporary copy...
     "#);
+
+    git_cmd(context.work_dir())
+        .arg("diff")
+        .arg("--cached")
+        .arg("--name-only")
+        .assert()
+        .success()
+        .stdout("test.txt\n");
 
     Ok(())
 }


### PR DESCRIPTION
`try-repo` operates on an explicitly selected hook repository, but its Git commands can inherit repository-local variables from the invoking repository. This can make it inspect or modify the wrong repository when invoked from a Git hook.

Isolate only Git commands that target the selected or temporary repository, while preserving the caller's Git environment for file selection and hook execution.