### PR TITLE
Reuse allocations in common filters

### DIFF
--- a/crates/prek/src/cli/list.rs
+++ b/crates/prek/src/cli/list.rs
@@ -47,7 +47,7 @@ pub(crate) async fn list(
 
     let reporter = HookInitReporter::new(printer);
     let lock = store.lock_async().await?;
-    let hooks = workspace
+    let mut hooks = workspace
         .init_hooks(
             store,
             HookInitFilters::new(Some(&selectors), Some(&group_filters)),
@@ -58,13 +58,12 @@ pub(crate) async fn list(
 
     drop(lock);
 
-    let filtered_hooks: Vec<_> = hooks
-        .into_iter()
-        .filter(|h| selectors.matches_hook(h))
-        .filter(|h| group_filters.matches_hook(h))
-        .filter(|h| hook_stage.is_none_or(|hook_stage| h.stages.contains(hook_stage)))
-        .filter(|h| language.is_none_or(|lang| h.language == lang))
-        .collect();
+    hooks.retain(|h| {
+        selectors.matches_hook(h)
+            && group_filters.matches_hook(h)
+            && hook_stage.is_none_or(|hook_stage| h.stages.contains(hook_stage))
+            && language.is_none_or(|lang| h.language == lang)
+    });
 
     selectors.report_unused();
     group_filters.report_unused();
@@ -73,7 +72,7 @@ pub(crate) async fn list(
         ListOutputFormat::Text => {
             if verbose {
                 // TODO: show repo path and environment path (if installed)
-                for hook in &filtered_hooks {
+                for hook in &hooks {
                     writeln!(printer.stdout(), "{}", hook.full_id().bold())?;
 
                     writeln!(printer.stdout(), "  {} {}", "ID:".bold().cyan(), hook.id)?;
@@ -114,13 +113,13 @@ pub(crate) async fn list(
                     writeln!(printer.stdout())?;
                 }
             } else {
-                for hook in &filtered_hooks {
+                for hook in &hooks {
                     writeln!(printer.stdout(), "{}", hook.full_id())?;
                 }
             }
         }
         ListOutputFormat::Json => {
-            let serializable_hooks: Vec<_> = filtered_hooks
+            let serializable_hooks: Vec<_> = hooks
                 .into_iter()
                 .map(|h| {
                     let id = h.id.clone();

--- a/crates/prek/src/cli/run/filter.rs
+++ b/crates/prek/src/cli/run/filter.rs
@@ -1,4 +1,4 @@
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::ops::ControlFlow;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -535,19 +535,10 @@ pub(crate) async fn collect_run_input(root: &Path, opts: CollectOptions) -> Resu
         )
     })?;
 
-    let filenames = collect_files_for_selection(git_root, root, selection).await?;
-
-    // Convert filenames to be relative to the workspace root.
-    let mut filenames = filenames
-        .into_iter()
-        .filter_map(|filename| {
-            // Only keep files under the workspace root.
-            filename
-                .strip_prefix(relative_root)
-                .map(|p| fs::normalize_path(p.to_path_buf()))
-                .ok()
-        })
-        .collect::<Vec<_>>();
+    let mut filenames = collect_files_for_selection(git_root, root, selection).await?;
+    if !relative_root.as_os_str().is_empty() {
+        filenames.retain_mut(|filename| strip_prefix_in_place(filename, relative_root));
+    }
 
     // Sort filenames if in tests to make the order consistent.
     if EnvVars.is_set(EnvVars::PREK_INTERNAL__SORT_FILENAMES) {
@@ -555,6 +546,34 @@ pub(crate) async fn collect_run_input(root: &Path, opts: CollectOptions) -> Resu
     }
 
     Ok(RunInput::Files(filenames))
+}
+
+fn strip_prefix_in_place(path: &mut PathBuf, prefix: &Path) -> bool {
+    // Examples with prefix `"workspace"`:
+    // - `"other/file.rs"` does not match, so the path is unchanged.
+    // - `"workspace/file.rs"` becomes `"file.rs"` by draining `"workspace/"`.
+    // - `"workspace/file.rs/"` also becomes `"file.rs"`, because `strip_prefix`
+    //   works on components and discards the trailing separator. Since that result
+    //   is not a byte suffix of the original path, this case uses the copy below.
+    let start = {
+        let Ok(stripped) = path.strip_prefix(prefix) else {
+            return false;
+        };
+        let path_bytes = path.as_os_str().as_encoded_bytes();
+        let stripped_bytes = stripped.as_os_str().as_encoded_bytes();
+        let Some(before) = path_bytes.strip_suffix(stripped_bytes) else {
+            *path = stripped.to_path_buf();
+            return true;
+        };
+        before.len()
+    };
+    let mut bytes = std::mem::take(path).into_os_string().into_encoded_bytes();
+    drop(bytes.drain(..start));
+
+    // SAFETY: the retained suffix is the valid `Path` returned by `strip_prefix`,
+    // moved without modification and rebuilt on the same target.
+    *path = PathBuf::from(unsafe { OsString::from_encoded_bytes_unchecked(bytes) });
+    true
 }
 
 fn adjust_relative_path(path: &str, new_cwd: &Path) -> Result<PathBuf, std::io::Error> {
@@ -711,6 +730,38 @@ mod tests {
         .into();
 
         assert_eq!(selection.refs(), (None, Some("local-sha")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn strip_prefix_in_place_preserves_non_utf8_names() {
+        use std::os::unix::ffi::OsStrExt as _;
+
+        let mut filename = PathBuf::from(OsStr::from_bytes(b"workspace/bad-\xff.py"));
+
+        let stripped = strip_prefix_in_place(&mut filename, Path::new("workspace"));
+
+        assert_eq!(
+            (stripped, filename),
+            (true, PathBuf::from(OsStr::from_bytes(b"bad-\xff.py")))
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn strip_prefix_in_place_preserves_non_utf8_names() {
+        use std::os::windows::ffi::OsStringExt as _;
+
+        let mut filename = OsString::from(r"workspace\");
+        filename.push(OsString::from_wide(&[0xD800]));
+        let mut filename = PathBuf::from(filename);
+
+        let stripped = strip_prefix_in_place(&mut filename, Path::new("workspace"));
+
+        assert_eq!(
+            (stripped, filename),
+            (true, PathBuf::from(OsString::from_wide(&[0xD800])))
+        );
     }
 
     fn glob_pattern(pattern: &str) -> FilePattern {

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -99,7 +99,7 @@ pub(crate) async fn run(
             .await
             .context("Failed to init hooks")?
     };
-    let selected_hooks: Vec<_> = hooks
+    let mut selected_hooks: Vec<_> = hooks
         .into_iter()
         .filter(|h| selectors.matches_hook(h))
         .filter(|h| group_filters.matches_hook(h))
@@ -130,22 +130,15 @@ pub(crate) async fn run(
 
     let (stage_filter, input_mode) =
         infer_stage_and_input_mode(hook_stage, has_group_filters, &selected_hooks, &selectors);
-    let filtered_hooks: Vec<Arc<Hook>> = if let Some(stage_filter) = stage_filter {
-        selected_hooks
-            .iter()
-            .filter(|h| h.stages.contains(stage_filter))
-            .cloned()
-            .collect()
+    if let Some(stage_filter) = stage_filter {
+        selected_hooks.retain(|h| h.stages.contains(stage_filter));
     } else {
         // Group selection without an explicit stage uses normal file input, so
         // hooks that can only consume Git message files cannot run correctly.
-        selected_hooks
-            .into_iter()
-            .filter(|hook| !uses_only_message_file_input(hook))
-            .collect()
-    };
+        selected_hooks.retain(|hook| !uses_only_message_file_input(hook));
+    }
 
-    if filtered_hooks.is_empty() {
+    if selected_hooks.is_empty() {
         if let Some(stage) = stage_filter {
             debug!("No hooks found for stage {stage} after filtering, exit early");
         } else {
@@ -159,7 +152,7 @@ pub(crate) async fn run(
 
     debug!(
         "Hooks going to run: {:?}",
-        filtered_hooks.iter().map(|h| &h.id).collect::<Vec<_>>()
+        selected_hooks.iter().map(|h| &h.id).collect::<Vec<_>>()
     );
 
     // Clear any unstaged changes from the git working directory.
@@ -201,7 +194,7 @@ pub(crate) async fn run(
         &workspace,
         &input,
         &file_index,
-        &filtered_hooks,
+        &selected_hooks,
     )
     .await?;
 

--- a/crates/prek/src/languages/node/node.rs
+++ b/crates/prek/src/languages/node/node.rs
@@ -306,13 +306,11 @@ impl Npm<'_> {
             .await
             .context("Failed to pack Node hook repository")?;
 
-        let archives = fs_err::read_dir(temp_dir.path())
+        let mut archives = fs_err::read_dir(temp_dir.path())
             .context("Failed to read npm pack directory")?
             .map(|entry| entry.map(|entry| entry.path()))
-            .collect::<std::io::Result<Vec<_>>>()?
-            .into_iter()
-            .filter(|path| path.extension().is_some_and(|extension| extension == "tgz"))
-            .collect::<Vec<_>>();
+            .collect::<std::io::Result<Vec<_>>>()?;
+        archives.retain(|path| path.extension().is_some_and(|extension| extension == "tgz"));
         let archive = match archives.as_slice() {
             [archive] => archive.clone(),
             _ => {


### PR DESCRIPTION
Reuse existing vectors when filtering hooks and npm pack results, and strip workspace prefixes from run filenames in place to avoid copying the whole batch.