### PR TITLE
Simplify repository initialization planning

### DIFF
--- a/crates/prek/src/workspace.rs
+++ b/crates/prek/src/workspace.rs
@@ -7,7 +7,6 @@ use std::time::SystemTime;
 
 use anyhow::Result;
 use ignore::WalkState;
-use itertools::zip_eq;
 use owo_colors::OwoColorize;
 use prek_consts::CONFIG_FILENAMES;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -106,68 +105,48 @@ impl<'a> HookInitFilters<'a> {
     }
 }
 
-/// Plan per-config-entry initialization while collecting each kept remote key once for cloning.
-fn plan_project_repo_init<'a>(
-    project: &'a Project,
-    filters: HookInitFilters<'_>,
-    remote_keys_to_clone: &mut FxHashSet<config::RemoteRepoKey<'a>>,
-    remote_configs: &mut Vec<&'a config::RemoteRepo>,
-) -> Vec<bool> {
-    let mut repo_entries_to_init = Vec::with_capacity(project.config.repos.len());
-
-    for repo in &project.config.repos {
-        match repo {
-            config::Repo::Remote(repo) => {
-                let keep = filters.keeps_remote_repo(project, repo);
-                repo_entries_to_init.push(keep);
-
-                if keep && remote_keys_to_clone.insert(repo.key()) {
-                    remote_configs.push(repo);
-                }
-            }
-            config::Repo::Local(_) | config::Repo::Meta(_) | config::Repo::Builtin(_) => {
-                repo_entries_to_init.push(true);
-            }
-        }
-    }
-
-    repo_entries_to_init
+/// Repository entries to initialize for one project, in configuration order.
+struct ProjectInitPlan<'a> {
+    project: &'a Arc<Project>,
+    repo_configs: Vec<&'a config::Repo>,
 }
 
-fn build_project_repo_slots(
-    project: &Project,
-    repo_entries_to_init: Vec<bool>,
-    remote_repos: &FxHashMap<config::RemoteRepoKey<'_>, Arc<Repo>>,
-) -> ProjectRepoSlots {
-    let mut repos = Vec::with_capacity(project.config.repos.len());
+impl<'a> ProjectInitPlan<'a> {
+    fn new(project: &'a Arc<Project>, filters: HookInitFilters<'_>) -> Self {
+        let mut repo_configs = Vec::with_capacity(project.config.repos.len());
 
-    for (repo, keep) in zip_eq(&project.config.repos, repo_entries_to_init) {
-        match repo {
-            config::Repo::Remote(repo) => {
-                if !keep {
-                    repos.push(None);
+        for repo_config in &project.config.repos {
+            if let config::Repo::Remote(repo) = repo_config {
+                if !filters.keeps_remote_repo(project, repo) {
                     continue;
                 }
-                let key = repo.key();
-                let repo = remote_repos.get(&key).expect("repo not found");
-                repos.push(Some(repo.clone()));
             }
-            config::Repo::Local(repo) => {
-                let repo = Repo::local(repo.hooks.clone());
-                repos.push(Some(Arc::new(repo)));
-            }
-            config::Repo::Meta(repo) => {
-                let repo = Repo::meta(repo.hooks.clone());
-                repos.push(Some(Arc::new(repo)));
-            }
-            config::Repo::Builtin(repo) => {
-                let repo = Repo::builtin(repo.hooks.clone());
-                repos.push(Some(Arc::new(repo)));
+            repo_configs.push(repo_config);
+        }
+
+        Self {
+            project,
+            repo_configs,
+        }
+    }
+}
+
+fn remote_configs_to_clone<'a>(projects: &[ProjectInitPlan<'a>]) -> Vec<&'a config::RemoteRepo> {
+    let mut seen = FxHashSet::default();
+    let mut remote_configs = Vec::new();
+
+    for project in projects {
+        for &repo_config in &project.repo_configs {
+            let config::Repo::Remote(repo) = repo_config else {
+                continue;
+            };
+            if seen.insert(repo.key()) {
+                remote_configs.push(repo);
             }
         }
     }
 
-    ProjectRepoSlots { repos }
+    remote_configs
 }
 
 async fn init_remote_repos<'a>(
@@ -188,23 +167,6 @@ async fn init_remote_repos<'a>(
             Ok((key, repo))
         })
         .collect()
-}
-
-/// Initialized repo slots aligned with the configured repo entries in a project.
-///
-/// A `None` slot means the corresponding remote repo entry was fully excluded by
-/// filters known before cloning, so hook construction should skip that entry.
-struct ProjectRepoSlots {
-    repos: Vec<Option<Arc<Repo>>>,
-}
-
-impl IntoIterator for ProjectRepoSlots {
-    type Item = Option<Arc<Repo>>;
-    type IntoIter = std::vec::IntoIter<Self::Item>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.repos.into_iter()
-    }
 }
 
 pub(crate) struct Project {
@@ -399,44 +361,20 @@ impl Project {
         filters: HookInitFilters<'_>,
         reporter: Option<&dyn HookInitReporter>,
     ) -> Result<Vec<Hook>, Error> {
-        let repos = self.init_repos(store, filters, reporter).await?;
-
         let project = Arc::new(self);
-        let hooks = Project::build_hooks(project, repos).await?;
-
-        Ok(hooks)
-    }
-
-    /// Initialize remote repositories for the project.
-    async fn init_repos(
-        &self,
-        store: &Store,
-        filters: HookInitFilters<'_>,
-        reporter: Option<&dyn HookInitReporter>,
-    ) -> Result<ProjectRepoSlots, Error> {
-        let mut remote_keys_to_clone = FxHashSet::default();
-        let mut remote_configs = Vec::new();
-        let repo_entries_to_init = plan_project_repo_init(
-            self,
-            filters,
-            &mut remote_keys_to_clone,
-            &mut remote_configs,
-        );
-
+        let plan = ProjectInitPlan::new(&project, filters);
+        let remote_configs = remote_configs_to_clone(std::slice::from_ref(&plan));
         let remote_repos = init_remote_repos(store, remote_configs, reporter).await?;
 
-        Ok(build_project_repo_slots(
-            self,
-            repo_entries_to_init,
-            &remote_repos,
-        ))
+        Project::build_hooks(plan, &remote_repos).await
     }
 
     /// Load and prepare hooks for the project.
     async fn build_hooks(
-        project: Arc<Project>,
-        repos: ProjectRepoSlots,
+        plan: ProjectInitPlan<'_>,
+        remote_repos: &FxHashMap<config::RemoteRepoKey<'_>, Arc<Repo>>,
     ) -> Result<Vec<Hook>, Error> {
+        let project = Arc::clone(plan.project);
         let mut hooks = Vec::new();
         let mut push_hook = async |repo: &Arc<Repo>, hook_spec: HookSpec| {
             let builder = HookBuilder::new(
@@ -450,10 +388,23 @@ impl Project {
             Ok::<_, Error>(())
         };
 
-        for (repo_config, repo) in zip_eq(project.config.repos.iter(), repos) {
-            let Some(repo) = repo else {
-                continue;
+        for repo_config in plan.repo_configs {
+            let repo = match repo_config {
+                config::Repo::Remote(repo_config) => {
+                    let repo = remote_repos
+                        .get(&repo_config.key())
+                        .expect("remote repo should have been initialized");
+                    Arc::clone(repo)
+                }
+                config::Repo::Local(repo_config) => {
+                    Arc::new(Repo::local(repo_config.hooks.clone()))
+                }
+                config::Repo::Meta(repo_config) => Arc::new(Repo::meta(repo_config.hooks.clone())),
+                config::Repo::Builtin(repo_config) => {
+                    Arc::new(Repo::builtin(repo_config.hooks.clone()))
+                }
             };
+
             match repo_config {
                 config::Repo::Remote(repo_config) => {
                     for hook_config in &repo_config.hooks {
@@ -979,40 +930,6 @@ impl Workspace {
         &self.all_projects
     }
 
-    /// Initialize remote repositories for all projects.
-    async fn init_repos(
-        &self,
-        store: &Store,
-        filters: HookInitFilters<'_>,
-        reporter: Option<&dyn HookInitReporter>,
-    ) -> Result<Vec<ProjectRepoSlots>, Error> {
-        let mut remote_keys_to_clone = FxHashSet::default();
-        let mut remote_configs = Vec::new();
-        let project_repo_entries_to_init = self
-            .projects
-            .iter()
-            .map(|project| {
-                plan_project_repo_init(
-                    project,
-                    filters,
-                    &mut remote_keys_to_clone,
-                    &mut remote_configs,
-                )
-            })
-            .collect::<Vec<_>>();
-
-        let remote_repos = init_remote_repos(store, remote_configs, reporter).await?;
-
-        Ok(self
-            .projects
-            .iter()
-            .zip(project_repo_entries_to_init)
-            .map(|(project, repo_entries_to_init)| {
-                build_project_repo_slots(project, repo_entries_to_init, &remote_repos)
-            })
-            .collect())
-    }
-
     /// Load and prepare hooks for all projects.
     pub(crate) async fn init_hooks(
         &self,
@@ -1020,11 +937,17 @@ impl Workspace {
         filters: HookInitFilters<'_>,
         reporter: Option<&dyn HookInitReporter>,
     ) -> Result<Vec<Hook>, Error> {
-        let project_repos = self.init_repos(store, filters, reporter).await?;
+        let plans = self
+            .projects
+            .iter()
+            .map(|project| ProjectInitPlan::new(project, filters))
+            .collect::<Vec<_>>();
+        let remote_configs = remote_configs_to_clone(&plans);
+        let remote_repos = init_remote_repos(store, remote_configs, reporter).await?;
 
         let mut hooks = Vec::new();
-        for (project, repos) in zip_eq(&self.projects, project_repos) {
-            let project_hooks = Project::build_hooks(Arc::clone(project), repos).await?;
+        for plan in plans {
+            let project_hooks = Project::build_hooks(plan, &remote_repos).await?;
             hooks.extend(project_hooks);
         }
 


### PR DESCRIPTION
Reuse a filtered per-project initialization plan for both remote repository cloning and hook construction. This removes the parallel slot bookkeeping and duplicate filtering.