### PR TITLE
Track explicit config paths as absolute paths

### DIFF
--- a/crates/prek/src/workspace.rs
+++ b/crates/prek/src/workspace.rs
@@ -227,6 +227,7 @@ impl Project {
             "Loading project configuration"
         );
 
+        let config_path = std::path::absolute(config_path).map_err(config::Error::from)?;
         let config = read_config(&config_path)?;
 
         let config_dir = config_path
@@ -238,7 +239,7 @@ impl Project {
         Ok(Self {
             root,
             config,
-            config_path: config_path.into_owned(),
+            config_path,
             idx: 0,
             relative_path: PathBuf::new(),
         })

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 use anyhow::Result;
@@ -260,6 +260,48 @@ fn run_does_not_rewrite_unchanged_config_tracking_file() -> Result<()> {
     assert_eq!(
         fs_err::metadata(tracking_file.path())?.modified()?,
         original_modified
+    );
+
+    Ok(())
+}
+
+#[test]
+fn run_tracks_relative_config_as_absolute_path() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: noop
+                name: Noop
+                language: system
+                entry: "true"
+                always_run: true
+    "#});
+    context.git_add(".");
+
+    context
+        .run()
+        .arg("--config")
+        .arg(PRE_COMMIT_CONFIG_YAML)
+        .assert()
+        .success();
+
+    let tracking_file = context.home_dir().child("config-tracking.json");
+    let tracked: Vec<PathBuf> =
+        serde_json::from_str(&fs_err::read_to_string(tracking_file.path())?)?;
+
+    assert_eq!(
+        tracked,
+        vec![
+            context
+                .work_dir()
+                .child(PRE_COMMIT_CONFIG_YAML)
+                .path()
+                .to_path_buf()
+        ]
     );
 
     Ok(())


### PR DESCRIPTION
Make relative `--config` paths absolute during project loading so `config-tracking.json` remains valid when later commands run from another directory.