### PR TITLE
Expose the git work tree to hooks running outside the git root

### DIFF
--- a/crates/prek/src/git.rs
+++ b/crates/prek/src/git.rs
@@ -37,9 +37,10 @@ pub(crate) enum Error {
 pub(crate) static GIT: LazyLock<Result<PathBuf, which::Error>> =
     LazyLock::new(|| which::which("git"));
 
-// Git hooks can expose `GIT_DIR` without `GIT_WORK_TREE`. Keep the derived
-// work tree scoped to prek's own git commands so user hooks do not inherit it,
-// except for hooks that run outside the git root, see [`hook_work_tree`].
+// Git can expose `GIT_DIR` without `GIT_WORK_TREE` to hooks. Keep the derived
+// work tree in process-local state so it is added only to prek's own Git commands
+// and hook commands whose working directory would otherwise break the inherited
+// current-repository context.
 static GIT_WORK_TREE: OnceLock<Option<PathBuf>> = OnceLock::new();
 
 pub(crate) fn init_git_work_tree() -> Result<()> {
@@ -71,14 +72,19 @@ fn hook_work_tree(cwd: &Path) -> Option<&'static Path> {
     Some(work_tree)
 }
 
-/// Give a hook subprocess started in `cwd` the work tree Git did not expose.
+/// Preserve Git's current-repository context for a hook started in `cwd`.
 ///
-/// Committing from a linked worktree makes Git export an absolute `GIT_DIR` without a
-/// `GIT_WORK_TREE`, which tells Git to treat the current directory as the work tree root.
-/// A workspace hook runs in its own project directory, so any Git command it runs would
-/// resolve the repository root to that subdirectory and rewrite the index as if the
-/// sub-project were the whole repository. Hooks running at the git root already resolve
-/// the root correctly, so they keep inheriting the environment Git gave us.
+/// Git exports repository-local environment variables so Git commands started by a hook
+/// operate on the repository that invoked it. In a linked worktree, Git can export an
+/// absolute `GIT_DIR` without `GIT_WORK_TREE`. If prek then starts a workspace hook below
+/// the repository root, Git treats that subdirectory as the work tree and can rewrite the
+/// current repository's index as if the sub-project were the whole repository.
+///
+/// Supplying the missing work tree preserves the inherited context. Hooks at the repository
+/// root need no completion and inherit Git's environment unchanged. prek cannot infer
+/// foreign-repository intent from `cwd`, so a hook that intentionally operates on another
+/// repository is responsible for clearing repository-local Git variables before starting
+/// that Git command.
 pub(crate) fn apply_hook_work_tree<'a>(cmd: &'a mut Cmd, cwd: &Path) -> &'a mut Cmd {
     if let Some(work_tree) = hook_work_tree(cwd) {
         cmd.env(EnvVars::GIT_WORK_TREE, work_tree);

--- a/crates/prek/src/git.rs
+++ b/crates/prek/src/git.rs
@@ -38,7 +38,8 @@ pub(crate) static GIT: LazyLock<Result<PathBuf, which::Error>> =
     LazyLock::new(|| which::which("git"));
 
 // Git hooks can expose `GIT_DIR` without `GIT_WORK_TREE`. Keep the derived
-// work tree scoped to prek's own git commands so user hooks do not inherit it.
+// work tree scoped to prek's own git commands so user hooks do not inherit it,
+// except for hooks that run outside the git root, see [`hook_work_tree`].
 static GIT_WORK_TREE: OnceLock<Option<PathBuf>> = OnceLock::new();
 
 pub(crate) fn init_git_work_tree() -> Result<()> {
@@ -59,6 +60,23 @@ pub(crate) fn init_git_work_tree() -> Result<()> {
 
 fn git_work_tree() -> Option<&'static Path> {
     GIT_WORK_TREE.get().and_then(Option::as_deref)
+}
+
+/// The work tree to expose to a hook subprocess started in `cwd`.
+///
+/// Committing from a linked worktree makes Git export an absolute `GIT_DIR` without a
+/// `GIT_WORK_TREE`, which tells Git to treat the current directory as the work tree root.
+/// A workspace hook runs in its own project directory, so any Git command it runs would
+/// resolve the repository root to that subdirectory and rewrite the index as if the
+/// sub-project were the whole repository. Hooks running at the git root already resolve
+/// the root correctly, so they keep inheriting the environment Git gave us.
+pub(crate) fn hook_work_tree(cwd: &Path) -> Option<&'static Path> {
+    let work_tree = git_work_tree()?;
+    let root = GIT_ROOT.as_ref().ok()?;
+    if cwd == root {
+        return None;
+    }
+    Some(work_tree)
 }
 
 pub(crate) static GIT_ROOT: LazyLock<Result<PathBuf, Error>> = LazyLock::new(|| {

--- a/crates/prek/src/git.rs
+++ b/crates/prek/src/git.rs
@@ -62,7 +62,16 @@ fn git_work_tree() -> Option<&'static Path> {
     GIT_WORK_TREE.get().and_then(Option::as_deref)
 }
 
-/// The work tree to expose to a hook subprocess started in `cwd`.
+fn hook_work_tree(cwd: &Path) -> Option<&'static Path> {
+    let work_tree = git_work_tree()?;
+    let root = GIT_ROOT.as_ref().ok()?;
+    if cwd == root {
+        return None;
+    }
+    Some(work_tree)
+}
+
+/// Give a hook subprocess started in `cwd` the work tree Git did not expose.
 ///
 /// Committing from a linked worktree makes Git export an absolute `GIT_DIR` without a
 /// `GIT_WORK_TREE`, which tells Git to treat the current directory as the work tree root.
@@ -70,13 +79,11 @@ fn git_work_tree() -> Option<&'static Path> {
 /// resolve the repository root to that subdirectory and rewrite the index as if the
 /// sub-project were the whole repository. Hooks running at the git root already resolve
 /// the root correctly, so they keep inheriting the environment Git gave us.
-pub(crate) fn hook_work_tree(cwd: &Path) -> Option<&'static Path> {
-    let work_tree = git_work_tree()?;
-    let root = GIT_ROOT.as_ref().ok()?;
-    if cwd == root {
-        return None;
+pub(crate) fn apply_hook_work_tree<'a>(cmd: &'a mut Cmd, cwd: &Path) -> &'a mut Cmd {
+    if let Some(work_tree) = hook_work_tree(cwd) {
+        cmd.env(EnvVars::GIT_WORK_TREE, work_tree);
     }
-    Some(work_tree)
+    cmd
 }
 
 pub(crate) static GIT_ROOT: LazyLock<Result<PathBuf, Error>> = LazyLock::new(|| {

--- a/crates/prek/src/git.rs
+++ b/crates/prek/src/git.rs
@@ -7,6 +7,7 @@ use std::sync::{LazyLock, OnceLock};
 use anyhow::Result;
 use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use rustc_hash::FxHashSet;
+use same_file::is_same_file;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing::{debug, instrument, warn};
 
@@ -38,9 +39,8 @@ pub(crate) static GIT: LazyLock<Result<PathBuf, which::Error>> =
     LazyLock::new(|| which::which("git"));
 
 // Git can expose `GIT_DIR` without `GIT_WORK_TREE` to hooks. Keep the derived
-// work tree in process-local state so it is added only to prek's own Git commands
-// and hook commands whose working directory would otherwise break the inherited
-// current-repository context.
+// work tree in process-local state and add it only when preserving the current
+// repository requires it.
 static GIT_WORK_TREE: OnceLock<Option<PathBuf>> = OnceLock::new();
 
 pub(crate) fn init_git_work_tree() -> Result<()> {
@@ -61,35 +61,6 @@ pub(crate) fn init_git_work_tree() -> Result<()> {
 
 fn git_work_tree() -> Option<&'static Path> {
     GIT_WORK_TREE.get().and_then(Option::as_deref)
-}
-
-fn hook_work_tree(cwd: &Path) -> Option<&'static Path> {
-    let work_tree = git_work_tree()?;
-    let root = GIT_ROOT.as_ref().ok()?;
-    if cwd == root {
-        return None;
-    }
-    Some(work_tree)
-}
-
-/// Preserve Git's current-repository context for a hook started in `cwd`.
-///
-/// Git exports repository-local environment variables so Git commands started by a hook
-/// operate on the repository that invoked it. In a linked worktree, Git can export an
-/// absolute `GIT_DIR` without `GIT_WORK_TREE`. If prek then starts a workspace hook below
-/// the repository root, Git treats that subdirectory as the work tree and can rewrite the
-/// current repository's index as if the sub-project were the whole repository.
-///
-/// Supplying the missing work tree preserves the inherited context. Hooks at the repository
-/// root need no completion and inherit Git's environment unchanged. prek cannot infer
-/// foreign-repository intent from `cwd`, so a hook that intentionally operates on another
-/// repository is responsible for clearing repository-local Git variables before starting
-/// that Git command.
-pub(crate) fn apply_hook_work_tree<'a>(cmd: &'a mut Cmd, cwd: &Path) -> &'a mut Cmd {
-    if let Some(work_tree) = hook_work_tree(cwd) {
-        cmd.env(EnvVars::GIT_WORK_TREE, work_tree);
-    }
-    cmd
 }
 
 pub(crate) static GIT_ROOT: LazyLock<Result<PathBuf, Error>> = LazyLock::new(|| {
@@ -122,6 +93,17 @@ static GIT_REPO_LOCAL_ENVS: &[&str] = &[
 ];
 
 pub(crate) trait GitCommandExt {
+    /// Keep nested Git commands operating on the repository that invoked the hook.
+    ///
+    /// Git treats the current directory as the work tree when `GIT_DIR` is set but
+    /// `GIT_WORK_TREE` is not. If prek starts the hook in a subdirectory, this method passes
+    /// the original work tree explicitly so Git commands in the hook still use the repository
+    /// that invoked prek.
+    ///
+    /// A hook that intentionally operates on another repository must clear Git's
+    /// repository-local environment before starting Git.
+    fn preserve_current_worktree(&mut self, hook_cwd: &Path) -> &mut Self;
+
     fn sanitize_git_repo_env(&mut self) -> &mut Self;
 }
 
@@ -133,6 +115,18 @@ pub(crate) fn apply_git_work_tree(cmd: &mut Command) -> &mut Command {
 }
 
 impl GitCommandExt for Cmd {
+    fn preserve_current_worktree(&mut self, hook_cwd: &Path) -> &mut Self {
+        let Some(work_tree) = git_work_tree() else {
+            return self;
+        };
+        let is_work_tree_root =
+            hook_cwd == work_tree || is_same_file(hook_cwd, work_tree).unwrap_or(false);
+        if !is_work_tree_root {
+            self.env(EnvVars::GIT_WORK_TREE, work_tree);
+        }
+        self
+    }
+
     fn sanitize_git_repo_env(&mut self) -> &mut Self {
         for key in GIT_REPO_LOCAL_ENVS {
             self.env_remove(key);

--- a/crates/prek/src/languages/julia.rs
+++ b/crates/prek/src/languages/julia.rs
@@ -7,7 +7,7 @@ use tracing::debug;
 
 use crate::cli::reporter::HookInstallReporter;
 use crate::cli::run::HookRunReporter;
-use crate::git::GitCommandExt;
+use crate::git::{self, GitCommandExt};
 use crate::hook::{Hook, InstallInfo, InstalledHook};
 use crate::languages::LanguageBackend;
 use crate::process::Cmd;
@@ -117,8 +117,11 @@ impl LanguageBackend for Julia {
         }
 
         let run = async |batch: &[&Path]| {
-            let output = Cmd::new("julia")
-                .current_dir(hook.work_dir())
+            let mut cmd = Cmd::new("julia");
+            cmd.current_dir(hook.work_dir());
+            git::apply_hook_work_tree(&mut cmd, hook.work_dir());
+
+            let output = cmd
                 .arg("--startup-file=no")
                 .arg(format!("--project={}", env_dir.display()))
                 .args(&entry)

--- a/crates/prek/src/languages/julia.rs
+++ b/crates/prek/src/languages/julia.rs
@@ -7,7 +7,7 @@ use tracing::debug;
 
 use crate::cli::reporter::HookInstallReporter;
 use crate::cli::run::HookRunReporter;
-use crate::git::{self, GitCommandExt};
+use crate::git::GitCommandExt;
 use crate::hook::{Hook, InstallInfo, InstalledHook};
 use crate::languages::LanguageBackend;
 use crate::process::Cmd;
@@ -117,11 +117,9 @@ impl LanguageBackend for Julia {
         }
 
         let run = async |batch: &[&Path]| {
-            let mut cmd = Cmd::new("julia");
-            cmd.current_dir(hook.work_dir());
-            git::apply_hook_work_tree(&mut cmd, hook.work_dir());
-
-            let output = cmd
+            let output = Cmd::new("julia")
+                .current_dir(hook.work_dir())
+                .preserve_current_worktree(hook.work_dir())
                 .arg("--startup-file=no")
                 .arg(format!("--project={}", env_dir.display()))
                 .args(&entry)

--- a/crates/prek/src/languages/mod.rs
+++ b/crates/prek/src/languages/mod.rs
@@ -15,6 +15,7 @@ use crate::cli::reporter::HookInstallReporter;
 use crate::cli::run::HookRunReporter;
 use crate::config::Language;
 use crate::fs::PathClean;
+use crate::git;
 use crate::hook::{Hook, InstallInfo, InstalledHook, Repo};
 use crate::hook_entry::PreparedHookEntry;
 use crate::hooks::{self, HookOutput};
@@ -219,6 +220,9 @@ impl ExecutionEnvironment {
         let (program, args) = command.split_first().context("Command cannot be empty")?;
         let mut cmd = Cmd::new(program);
         cmd.current_dir(cwd).args(args).check(false);
+        if let Some(work_tree) = git::hook_work_tree(cwd) {
+            cmd.env(EnvVars::GIT_WORK_TREE, work_tree);
+        }
         self.patch.apply(&mut cmd);
         cmd.envs(&hook.env);
         Ok(cmd)

--- a/crates/prek/src/languages/mod.rs
+++ b/crates/prek/src/languages/mod.rs
@@ -15,7 +15,7 @@ use crate::cli::reporter::HookInstallReporter;
 use crate::cli::run::HookRunReporter;
 use crate::config::Language;
 use crate::fs::PathClean;
-use crate::git;
+use crate::git::GitCommandExt;
 use crate::hook::{Hook, InstallInfo, InstalledHook, Repo};
 use crate::hook_entry::PreparedHookEntry;
 use crate::hooks::{self, HookOutput};
@@ -219,7 +219,8 @@ impl ExecutionEnvironment {
         let command = resolve_command(command.to_vec(), self.path(hook), cwd);
         let (program, args) = command.split_first().context("Command cannot be empty")?;
         let mut cmd = Cmd::new(program);
-        git::apply_hook_work_tree(cmd.current_dir(cwd), cwd)
+        cmd.current_dir(cwd)
+            .preserve_current_worktree(cwd)
             .args(args)
             .check(false);
         self.patch.apply(&mut cmd);

--- a/crates/prek/src/languages/mod.rs
+++ b/crates/prek/src/languages/mod.rs
@@ -219,10 +219,9 @@ impl ExecutionEnvironment {
         let command = resolve_command(command.to_vec(), self.path(hook), cwd);
         let (program, args) = command.split_first().context("Command cannot be empty")?;
         let mut cmd = Cmd::new(program);
-        cmd.current_dir(cwd).args(args).check(false);
-        if let Some(work_tree) = git::hook_work_tree(cwd) {
-            cmd.env(EnvVars::GIT_WORK_TREE, work_tree);
-        }
+        git::apply_hook_work_tree(cmd.current_dir(cwd), cwd)
+            .args(args)
+            .check(false);
         self.patch.apply(&mut cmd);
         cmd.envs(&hook.env);
         Ok(cmd)

--- a/crates/prek/tests/hook_impl.rs
+++ b/crates/prek/tests/hook_impl.rs
@@ -647,6 +647,129 @@ fn git_dir_synthesized_git_work_tree_not_leaked_to_hook() {
     ");
 }
 
+/// Committing from a linked worktree makes Git export an absolute `GIT_DIR` without a
+/// `GIT_WORK_TREE`, so Git falls back to treating the hook's working directory as the
+/// work tree root. A workspace hook runs in its own project directory, so a Git command
+/// it runs must still resolve the repository root, not the project directory.
+#[test]
+fn workspace_hook_in_linked_worktree_keeps_git_index() -> anyhow::Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    context.write_pre_commit_config(indoc! { r"
+        repos:
+        - repo: local
+          hooks:
+           - id: root-noop
+             name: root-noop
+             language: system
+             entry: true
+             always_run: true
+             pass_filenames: false
+    "});
+
+    let project = context.work_dir().child("sub");
+    project.create_dir_all()?;
+    project.child(PRE_COMMIT_CONFIG_YAML).write_str(indoc! { r"
+        repos:
+        - repo: local
+          hooks:
+           - id: sub-git-add
+             name: sub-git-add
+             language: system
+             entry: git add -u
+             always_run: true
+             pass_filenames: false
+    "})?;
+
+    context.work_dir().child("README.md").write_str("root\n")?;
+    context.work_dir().child("tracked.txt").write_str("b\n")?;
+    project.child("README.md").write_str("sub\n")?;
+    let nested = context.work_dir().child("deep").child("nested");
+    nested.create_dir_all()?;
+    nested.child("a.txt").write_str("a\n")?;
+
+    context.git_add(".");
+    context.git_commit("Initial commit");
+
+    cmd_snapshot!(context.filters(), context.install(), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    prek installed at `.git/hooks/pre-commit`
+
+    ----- stderr -----
+    "#);
+
+    git_cmd(context.work_dir())
+        .args(["worktree", "add", "worktree", "HEAD"])
+        .assert()
+        .success();
+
+    let worktree = context.work_dir().child("worktree");
+    worktree.child("tracked.txt").write_str("b2\n")?;
+    git_cmd(&worktree)
+        .args(["add", "tracked.txt"])
+        .assert()
+        .success();
+
+    let mut commit = git_cmd(&worktree);
+    commit
+        .env(EnvVars::PREK_HOME, &**context.home_dir())
+        .arg("commit")
+        .arg("-m")
+        .arg("Commit from the linked worktree");
+
+    let filters = context
+        .filters()
+        .into_iter()
+        .chain([("[a-f0-9]{7}", "abc1234")])
+        .collect::<Vec<_>>();
+
+    cmd_snapshot!(filters, commit, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [detached HEAD abc1234] Commit from the linked worktree
+     1 file changed, 1 insertion(+), 1 deletion(-)
+
+    ----- stderr -----
+    ✓ sub
+      sub-git-add............................................................Passed
+    ✓ <workspace>
+      root-noop..............................................................Passed
+    ");
+
+    // The hook's `git add -u` must not rewrite the index as if `sub` were the repository.
+    let mut ls_files = git_cmd(&worktree);
+    ls_files.arg("ls-files");
+    cmd_snapshot!(context.filters(), ls_files, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    .pre-commit-config.yaml
+    README.md
+    deep/nested/a.txt
+    sub/.pre-commit-config.yaml
+    sub/README.md
+    tracked.txt
+
+    ----- stderr -----
+    ");
+
+    let mut status = git_cmd(&worktree);
+    status.args(["status", "--porcelain"]);
+    cmd_snapshot!(context.filters(), status, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
 #[test]
 fn workspace_hook_impl_root() -> anyhow::Result<()> {
     let context = TestContext::new();


### PR DESCRIPTION
Committing from a linked worktree (`git worktree add`) makes Git export an
absolute `GIT_DIR` to hooks without a `GIT_WORK_TREE`. Git then treats the
current directory as the work tree root. Committing from a main worktree
exports neither, so only linked worktrees are affected.

prek runs each workspace project's hooks with the cwd set to that project's
directory. In a linked worktree that made a hook's own Git command resolve the
repository root to the sub-project directory: `git add -u` inside a
sub-project hook rewrote the whole index as if the sub-project were the
repository, staging every path outside it as deleted and giving the surviving
paths the sub-project's blobs.

prek already derives the correct work tree in `init_git_work_tree`, but #2356
scoped it to prek's own Git commands so hooks do not inherit an environment Git
did not expose. Keep that scoping, with one exception: hook subprocesses that
start outside the git root, which is exactly the sub-project case. Hooks
running at the git root are unaffected, so #2293 stays fixed.

Related: #2505 isolated the same environment leak for dependency installs, but
hook execution still inherits it.
