### PR TITLE
Resolve hook log files from their config directory

### DIFF
--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -940,6 +940,16 @@ impl<'a> HookRunSession<'a> {
                 let output = result.output.trim_ascii();
                 if !output.is_empty() {
                     if let Some(file) = result.hook.log_file.as_deref() {
+                        let file = Path::new(file);
+                        let config_file = result.hook.project().config_file();
+                        let file = if file.is_relative() {
+                            let config_dir = config_file
+                                .parent()
+                                .context("Configuration file must have a parent directory")?;
+                            config_dir.join(file)
+                        } else {
+                            file.to_path_buf()
+                        };
                         let mut file = fs_err::OpenOptions::new()
                             .create(true)
                             .append(true)

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -2116,11 +2116,14 @@ fn global_path_options_expand_tilde() -> Result<()> {
 
 /// Test hook `log_file` option.
 #[test]
-fn log_file() {
+fn log_file() -> Result<()> {
     let context = TestContext::new();
     context.init_project();
 
-    context.write_pre_commit_config(indoc::indoc! {r#"
+    let config_dir = context.work_dir().child("config");
+    config_dir.create_dir_all()?;
+    let config_file = config_dir.child(PRE_COMMIT_CONFIG_YAML);
+    config_file.write_str(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -2130,10 +2133,10 @@ fn log_file() {
                 entry: python3 -c 'import sys; sys.stdout.buffer.write(b"\x1b[2Kraw\xff"); exit(1)'
                 always_run: true
                 log_file: log.txt
-    "#});
+    "#})?;
     context.git_add(".");
 
-    cmd_snapshot!(context.filters(), context.run(), @r#"
+    cmd_snapshot!(context.filters(), context.run().arg("-c").arg(config_file.path()), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -2144,8 +2147,10 @@ fn log_file() {
     ----- stderr -----
     "#);
 
-    let log = fs_err::read(context.work_dir().join("log.txt")).expect("log file should exist");
+    let log = fs_err::read(config_dir.join("log.txt"))?;
     assert_eq!(log, b"\x1b[2Kraw\xff");
+
+    Ok(())
 }
 
 /// Pass pre-commit environment variables to the hook.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1390,6 +1390,7 @@ Print hook output even when the hook succeeds.
 ### `log_file`
 
 Write hook output to a file when the hook fails (and also when `verbose: true`).
+Relative paths are resolved from the directory containing the configuration file.
 
 - Type: string path
 


### PR DESCRIPTION
Resolve relative hook `log_file` paths from the directory containing each project configuration.