### PR TITLE
Reduce binary size by trimming dependency features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,7 @@ jobs:
           echo "::group::Test install uv with auto select"
           cargo llvm-cov nextest \
             --profile ci-core \
-            --cargo-profile fast-build \
+            --cargo-profile no-debug \
             --no-report \
             -E 'binary_id(prek::run) and test(run_basic)'
           echo "::endgroup::"
@@ -334,13 +334,13 @@ jobs:
             export PREK_UV_SOURCE=$source
             cargo llvm-cov nextest \
               --profile ci-core \
-              --cargo-profile fast-build \
+              --cargo-profile no-debug \
               --no-report \
               -E 'binary_id(prek::run) and test(run_basic)'
             echo "::endgroup::"
           done
 
-          cargo llvm-cov report --profile fast-build --lcov --output-path lcov.info
+          cargo llvm-cov report --profile no-debug --lcov --output-path lcov.info
 
       - name: "Upload coverage reports to Codecov"
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -403,7 +403,7 @@ jobs:
             --lcov \
             --output-path lcov.info \
             --workspace \
-            --cargo-profile fast-build \
+            --cargo-profile no-debug \
             --profile ci-core \
             --features schemars \
             -E "${CI_CORE_FILTER}"
@@ -475,7 +475,7 @@ jobs:
             --lcov `
             --output-path lcov.info `
             --workspace `
-            --cargo-profile fast-build `
+            --cargo-profile no-debug `
             --features schemars `
             --profile ci-core `
             -E $env:CI_CORE_FILTER
@@ -672,7 +672,7 @@ jobs:
             --lcov \
             --output-path lcov.info \
             --workspace \
-            --cargo-profile fast-build \
+            --cargo-profile no-debug \
             --features schemars \
             --profile ci-language \
             -E "$NEXTEST_FILTER"
@@ -692,7 +692,7 @@ jobs:
             --lcov `
             --output-path lcov.info `
             --workspace `
-            --cargo-profile fast-build `
+            --cargo-profile no-debug `
             --features schemars `
             --profile ci-language `
             -E $env:NEXTEST_FILTER

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -43,7 +43,7 @@ jobs:
         id: bloat_head
         run: |
           # Build head branch
-          cargo bloat | tee bloat_head.txt >&1
+          cargo bloat --profile profiling | tee bloat_head.txt >&1
 
       - name: Checkout base
         run: |
@@ -53,7 +53,7 @@ jobs:
         id: bloat_base
         run: |
           # Build base branch
-          cargo bloat | tee bloat_base.txt >&1
+          cargo bloat --profile profiling | tee bloat_base.txt >&1
 
       - name: Compare bloat results
         shell: python
@@ -62,7 +62,7 @@ jobs:
           from pathlib import Path
 
           def parse_size(text):
-              match = re.search(r'\.text section size.*?([\d.]+)\s*([KMGT]i?B)', text)
+              match = re.search(r'([\d.]+)\s*([KMGT]i?B)\s+\.text section size', text)
               if not match:
                   raise ValueError("Could not find .text section size")
               value, unit = float(match.group(1)), match.group(2)
@@ -80,7 +80,7 @@ jobs:
           pct_display = f"{pct_change:+.2f}%"
           comparison = f"""\
           ### 📦 Cargo Bloat Comparison
-          **Binary size change:** {pct_display} ({base_size} → {head_size})
+          **`.text` size change:** {pct_display} ({base_size} → {head_size})
 
           <details>
             <summary>Expand for cargo-bloat output</summary>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,12 +869,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1058,25 +1052,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,7 +1136,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -2327,7 +2301,6 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -3112,7 +3085,6 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
- "libc",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ async-trait = { version = "0.1.89" }
 async-compression = { version = "0.4.18", features = ["gzip", "xz", "tokio"] }
 async_zip = { version = "0.0.20", package = "astral_async_zip", features = ["deflate", "tokio"] }
 axoupdater = { version = "0.10.0", default-features = false, features = ["github_releases"] }
-bstr = { version = "1.11.0" }
+bstr = { version = "1.11.0", default-features = false, features = ["std"] }
 cargo_metadata = { version = "0.23.1" }
 clap = { version = "4.6.0", features = ["derive", "env", "string", "wrap_help"] }
 clap_complete = { version = "4.6.0", features = ["unstable-dynamic"] }
@@ -54,7 +54,6 @@ owo-colors = { version = "4.1.0" }
 phf = { version = "0.14.0", default-features = false, features = ["macros"] }
 pprof = { version = "0.15.0" }
 reqwest = { version = "0.13.2", default-features = false, features = [
-  "http2",
   "stream",
   "json",
   "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,26 +178,13 @@ ignored = ["liblzma"]
 insta.opt-level = 3
 similar.opt-level = 3
 
-# Profile for fast test execution: Skip debug info generation, and
-# apply basic optimization, which speed up build and running tests.
-[profile.fast-build]
-inherits = "dev"
-debug = 0
-strip = "debuginfo"
-
 # Profile for faster builds: Skip debug info generation, for faster
 # builds of smaller binaries.
 [profile.no-debug]
 inherits = "dev"
+opt-level = 1
 debug = 0
 strip = "debuginfo"
-
-[profile.profiling]
-inherits = "release"
-strip = false
-debug = "full"
-lto = false
-codegen-units = 16
 
 [profile.release]
 # Enable Full LTO for the best optimizations
@@ -207,6 +194,9 @@ codegen-units = 1
 strip = true
 panic = "abort"
 
-[profile.minimal-size]
+[profile.profiling]
 inherits = "release"
-opt-level = "z"
+strip = false
+debug = "full"
+lto = false
+codegen-units = 16

--- a/crates/prek/src/cli/install.rs
+++ b/crates/prek/src/cli/install.rs
@@ -4,7 +4,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use bstr::ByteSlice;
 use clap::ValueEnum;
 use owo_colors::OwoColorize;
 use prek_consts::CONFIG_FILENAMES;
@@ -525,7 +524,7 @@ pub(crate) async fn init_template_dir(
         .check(false)
         .output()
         .await?;
-    let template_dir = String::from_utf8_lossy(output.stdout.trim()).to_string();
+    let template_dir = String::from_utf8_lossy(output.stdout.trim_ascii()).to_string();
 
     if template_dir.is_empty() || !is_same_file(&directory, &template_dir)? {
         warn_user!(


### PR DESCRIPTION
Remove unused HTTP/2 and bstr Unicode features from the release dependency graph. This reduces `cargo bsize` code by 356.6 KiB and the stripped binary by 4.4%.