### PR TITLE
Use stabilized assertion macros

### DIFF
--- a/crates/prek-consts/src/env_vars.rs
+++ b/crates/prek-consts/src/env_vars.rs
@@ -257,6 +257,8 @@ fn parse_boolish(val: &str) -> Option<bool> {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::{EnvVars, EnvVarsRead, parse_boolish};
 
     #[test]
@@ -283,10 +285,10 @@ mod tests {
         assert!(env_vars.is_set(EnvVars::PREK_COLOR));
 
         let env_vars = EnvVars::from_map(&[]);
-        assert!(matches!(
+        assert_matches!(
             env_vars.var(EnvVars::PREK_COLOR),
             Err(std::env::VarError::NotPresent)
-        ));
+        );
         assert!(!env_vars.is_set(EnvVars::PREK_COLOR));
 
         let env_vars = EnvVars::from_map(&[(EnvVars::PRE_COMMIT_NO_CONCURRENCY, "1")]);

--- a/crates/prek/src/cli/run/filter.rs
+++ b/crates/prek/src/cli/run/filter.rs
@@ -1,3 +1,4 @@
+use std::debug_assert_matches;
 use std::ffi::{OsStr, OsString};
 use std::ops::ControlFlow;
 use std::path::{Path, PathBuf};
@@ -303,7 +304,7 @@ impl<'a> ProjectPathNode<'a> {
             node = node.children.entry(component.as_os_str()).or_default();
         }
         let previous = node.project_idx.replace(project_idx);
-        debug_assert!(previous.is_none());
+        debug_assert_matches!(previous, None);
     }
 
     fn matching_projects(&self, path: &Path, matches: &mut Vec<usize>) {

--- a/crates/prek/src/cli/run/reporter.rs
+++ b/crates/prek/src/cli/run/reporter.rs
@@ -55,6 +55,7 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::collections::hash_map::Entry;
+use std::debug_assert_matches;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -198,7 +199,7 @@ impl CompletedBars {
         // Hooks can finish in a different order than their progress rows were inserted;
         // collapse completed rows by their original visual order.
         let replaced = self.visible.insert(completed.line_order, completed);
-        debug_assert!(replaced.is_none());
+        debug_assert_matches!(replaced, None);
     }
 
     fn collapse_one_line(&mut self) -> Option<CollapsedCompletedBars> {

--- a/crates/prek/src/cli/run/selector.rs
+++ b/crates/prek/src/cli/run/selector.rs
@@ -804,6 +804,8 @@ fn parse_comma_separated(input: &str) -> impl Iterator<Item = &str> {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
     use tempfile::TempDir;
 
@@ -845,14 +847,14 @@ mod tests {
 
         // Test explicit hook ID with colon prefix
         let selector = parse_single_selector(":black", fs.root(), SelectorSource::CliArg, &fs)?;
-        assert!(matches!(selector.expr, SelectorExpr::HookId(ref id) if id == "black"));
+        assert_matches!(selector.expr, SelectorExpr::HookId(ref id) if id == "black");
 
         let selector = parse_single_selector(":lint:ruff", fs.root(), SelectorSource::CliArg, &fs)?;
-        assert!(matches!(selector.expr, SelectorExpr::HookId(ref id) if id == "lint:ruff"));
+        assert_matches!(selector.expr, SelectorExpr::HookId(ref id) if id == "lint:ruff");
 
         // Test bare hook ID (backward compatibility)
         let selector = parse_single_selector("black", fs.root(), SelectorSource::CliArg, &fs)?;
-        assert!(matches!(selector.expr, SelectorExpr::HookId(ref id) if id == "black"));
+        assert_matches!(selector.expr, SelectorExpr::HookId(ref id) if id == "black");
 
         Ok(())
     }
@@ -863,18 +865,21 @@ mod tests {
 
         // Test project path with slash
         let selector = parse_single_selector("src/", fs.root(), SelectorSource::CliArg, &fs)?;
-        assert!(
-            matches!(selector.expr, SelectorExpr::ProjectPrefix(ref path) if path == &PathBuf::from("src"))
+        assert_matches!(
+            selector.expr,
+            SelectorExpr::ProjectPrefix(ref path) if path == &PathBuf::from("src")
         );
 
         // Test current directory
         let selector = parse_single_selector(".", fs.root(), SelectorSource::CliArg, &fs)?;
-        assert!(
-            matches!(selector.expr, SelectorExpr::ProjectPrefix(ref path) if path == &PathBuf::from(""))
+        assert_matches!(
+            selector.expr,
+            SelectorExpr::ProjectPrefix(ref path) if path == &PathBuf::from("")
         );
         let selector = parse_single_selector("./", fs.root(), SelectorSource::CliArg, &fs)?;
-        assert!(
-            matches!(selector.expr, SelectorExpr::ProjectPrefix(ref path) if path == &PathBuf::from(""))
+        assert_matches!(
+            selector.expr,
+            SelectorExpr::ProjectPrefix(ref path) if path == &PathBuf::from("")
         );
 
         Ok(())

--- a/crates/prek/src/config/pattern.rs
+++ b/crates/prek/src/config/pattern.rs
@@ -235,6 +235,8 @@ impl TryFrom<FilePatternWire> for FilePattern {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
 
     #[test]
@@ -251,8 +253,9 @@ mod tests {
         "};
         let parsed: Wrapper =
             serde_saphyr::from_str(regex_yaml).expect("regex patterns should parse");
-        assert!(
-            matches!(parsed.files, FilePattern::Regex(_)),
+        assert_matches!(
+            parsed.files,
+            FilePattern::Regex(_),
             "expected regex pattern"
         );
         assert!(parsed.files.is_match(Path::new("src/main.rs")));
@@ -267,10 +270,7 @@ mod tests {
         "};
         let parsed: Wrapper =
             serde_saphyr::from_str(glob_yaml).expect("glob patterns should parse");
-        assert!(
-            matches!(parsed.files, FilePattern::Glob(_)),
-            "expected glob pattern"
-        );
+        assert_matches!(parsed.files, FilePattern::Glob(_), "expected glob pattern");
         assert!(parsed.files.is_match(Path::new("src/lib/main.rs")));
         assert!(!parsed.files.is_match(Path::new("src/lib/main.py")));
         assert!(parsed.exclude.is_match(Path::new("target/debug/app")));

--- a/crates/prek/src/git.rs
+++ b/crates/prek/src/git.rs
@@ -1024,6 +1024,10 @@ pub(crate) fn list_submodules(git_root: &Path) -> Result<Vec<PathBuf>, Error> {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
     #[cfg(unix)]
     use super::lfs_files;
     use super::zsplit;
@@ -1032,8 +1036,6 @@ mod tests {
         list_submodules, should_update_submodules, update_submodules,
     };
     use assert_cmd::assert::OutputAssertExt;
-    use std::path::{Path, PathBuf};
-    use std::process::Command;
 
     fn run_git(path: &Path, args: &[&str]) {
         let mut command = Command::new(GIT.as_ref().unwrap());
@@ -1108,7 +1110,7 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert!(matches!(err, Error::Command(_)));
+        assert_matches!(err, Error::Command(_));
         let message = err.to_string();
         assert!(message.contains("submodule update --init --recursive"));
         assert!(message.contains("--depth=1"));
@@ -1117,7 +1119,7 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert!(matches!(err, Error::Command(_)));
+        assert_matches!(err, Error::Command(_));
         let message = err.to_string();
         assert!(message.contains("submodule update --init --recursive"));
         assert!(!message.contains("--depth=1"));

--- a/crates/prek/src/languages/bun/version.rs
+++ b/crates/prek/src/languages/bun/version.rs
@@ -118,6 +118,8 @@ impl BunRequest {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
 
     #[test]
@@ -164,10 +166,10 @@ mod tests {
     #[test]
     fn test_bun_request_range() {
         let req = BunRequest::from_str(">=1.0").unwrap();
-        assert!(matches!(req, BunRequest::Range(_)));
+        assert_matches!(req, BunRequest::Range(_));
 
         let req = BunRequest::from_str(">=1.0, <2.0").unwrap();
-        assert!(matches!(req, BunRequest::Range(_)));
+        assert_matches!(req, BunRequest::Range(_));
     }
 
     #[test]

--- a/crates/prek/src/languages/deno/version.rs
+++ b/crates/prek/src/languages/deno/version.rs
@@ -122,6 +122,8 @@ impl DenoRequest {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
 
     #[test]
@@ -174,10 +176,10 @@ mod tests {
     #[test]
     fn test_deno_request_range() {
         let req = DenoRequest::from_str(">=2.0").unwrap();
-        assert!(matches!(req, DenoRequest::Range(_)));
+        assert_matches!(req, DenoRequest::Range(_));
 
         let req = DenoRequest::from_str(">=2.0, <3.0").unwrap();
-        assert!(matches!(req, DenoRequest::Range(_)));
+        assert_matches!(req, DenoRequest::Range(_));
     }
 
     #[test]

--- a/crates/prek/src/languages/ruby/version.rs
+++ b/crates/prek/src/languages/ruby/version.rs
@@ -116,9 +116,11 @@ impl RubyRequest {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+    use std::path::PathBuf;
+
     use super::*;
     use crate::config::Language;
-    use std::path::PathBuf;
 
     #[test]
     fn test_parse_ruby_request() {
@@ -153,10 +155,10 @@ mod tests {
         );
 
         // Semver range
-        assert!(matches!(
+        assert_matches!(
             RubyRequest::from_str(">=3.2, <4.0").unwrap(),
             RubyRequest::Range(_, _)
-        ));
+        );
         assert!(RubyRequest::from_str("ruby>=3.2, <4.0").is_err());
     }
 


### PR DESCRIPTION
Use Rust 1.96's pattern assertion macros for clearer failure diagnostics.