### PR TITLE
Preserve terminal theme contrast for status labels

### DIFF
--- a/crates/prek/src/cli/run/mod.rs
+++ b/crates/prek/src/cli/run/mod.rs
@@ -1,3 +1,5 @@
+use owo_colors::{Style, Styled};
+
 pub(crate) use filter::{
     CollectOptions, FileSelection, FileTagCache, FileTagFilter, HookFileFilter, ProjectFiles,
     RunFileIndex, RunInput, collect_run_input,
@@ -15,3 +17,8 @@ mod reporter;
 #[allow(clippy::module_inception)]
 mod run;
 mod selector;
+
+const PASSED: Styled<&str> = Style::new().green().reversed().style("Passed");
+const FAILED: Styled<&str> = Style::new().red().reversed().style("Failed");
+const SKIPPED: Styled<&str> = Style::new().cyan().reversed().style("Skipped");
+const DRY_RUN: Styled<&str> = Style::new().yellow().reversed().style("Dry Run");

--- a/crates/prek/src/cli/run/reporter.rs
+++ b/crates/prek/src/cli/run/reporter.rs
@@ -62,7 +62,7 @@ use std::time::{Duration, Instant};
 use anstyle_parse::{DefaultCharAccumulator, Parser, Perform};
 use console::Term;
 use indicatif::{ProgressBar, ProgressStyle};
-use owo_colors::OwoColorize;
+use owo_colors::{OwoColorize, XtermColors};
 use rustc_hash::FxHashMap;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -676,9 +676,21 @@ impl HookRunReporter {
 
         let label = progress.message();
         let (status, status_width) = if passed {
-            ("Passed".on_green().to_string(), "Passed".width())
+            (
+                "Passed"
+                    .on_color(XtermColors::Jade)
+                    .color(XtermColors::White)
+                    .to_string(),
+                "Passed".width(),
+            )
         } else {
-            ("Failed".on_red().to_string(), "Failed".width())
+            (
+                "Failed"
+                    .on_color(XtermColors::Red)
+                    .color(XtermColors::White)
+                    .to_string(),
+                "Failed".width(),
+            )
         };
         let dots = self
             .dots

--- a/crates/prek/src/cli/run/reporter.rs
+++ b/crates/prek/src/cli/run/reporter.rs
@@ -62,7 +62,7 @@ use std::time::{Duration, Instant};
 use anstyle_parse::{DefaultCharAccumulator, Parser, Perform};
 use console::Term;
 use indicatif::{ProgressBar, ProgressStyle};
-use owo_colors::{OwoColorize, XtermColors};
+use owo_colors::OwoColorize;
 use rustc_hash::FxHashMap;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -71,6 +71,8 @@ use crate::hook::Hook;
 use crate::printer::Printer;
 use crate::process::OutputSink;
 use crate::workspace;
+
+use super::{FAILED, PASSED};
 
 /// UI state for one hook run.
 ///
@@ -675,27 +677,11 @@ impl HookRunReporter {
         };
 
         let label = progress.message();
-        let (status, status_width) = if passed {
-            (
-                "Passed"
-                    .on_color(XtermColors::Jade)
-                    .color(XtermColors::White)
-                    .to_string(),
-                "Passed".width(),
-            )
-        } else {
-            (
-                "Failed"
-                    .on_color(XtermColors::Red)
-                    .color(XtermColors::White)
-                    .to_string(),
-                "Failed".width(),
-            )
-        };
+        let status = if passed { PASSED } else { FAILED };
         let dots = self
             .dots
             .saturating_add("Passed".width())
-            .saturating_sub(label.width() + status_width);
+            .saturating_sub(label.width() + status.inner().width());
         let dots = ".".repeat(dots).green().to_string();
 
         progress.set_style(ProgressStyle::with_template("{wide_msg}").unwrap());

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Result};
 use asyncband::semaphore::Semaphore;
 use futures_util::TryStreamExt;
 use futures_util::stream::FuturesUnordered;
-use owo_colors::{OwoColorize, XtermColors};
+use owo_colors::OwoColorize;
 use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use prek_consts::{PRE_COMMIT_CONFIG_YAML, PREK_TOML};
 use prek_identify::{TagSet, tags_from_path};
@@ -37,6 +37,8 @@ use crate::store::Store;
 use crate::terminal::{USE_COLOR, sanitize_output};
 use crate::workspace::{HookInitFilters, Project, Workspace};
 use crate::{fs, git, hooks, warn_user};
+
+use super::{DRY_RUN, FAILED, PASSED, SKIPPED};
 
 #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 pub(crate) async fn run(
@@ -1220,10 +1222,6 @@ struct StatusPrinter {
 }
 
 impl StatusPrinter {
-    const PASSED: &'static str = "Passed";
-    const FAILED: &'static str = "Failed";
-    const SKIPPED: &'static str = "Skipped";
-    const DRY_RUN: &'static str = "Dry Run";
     const NO_FILES: &'static str = "(no files to check)";
 
     fn for_hooks<T>(hooks: &[T], printer: Printer) -> Self
@@ -1238,7 +1236,7 @@ impl StatusPrinter {
         let columns = std::cmp::max(
             79,
             // Hook name...(no files to check)Skipped
-            name_len + 3 + Self::NO_FILES.len() + Self::SKIPPED.len(),
+            name_len + 3 + Self::NO_FILES.len() + SKIPPED.inner().width(),
         );
         Self { printer, columns }
     }
@@ -1248,7 +1246,7 @@ impl StatusPrinter {
     }
 
     fn bar_len(&self) -> usize {
-        self.columns - Self::PASSED.len()
+        self.columns - PASSED.inner().width()
     }
 
     fn write(
@@ -1257,46 +1255,19 @@ impl StatusPrinter {
         prefix: &str,
         status: RunStatus,
     ) -> Result<(), std::fmt::Error> {
-        let (suffix, status_line, status_width) = match status {
-            RunStatus::NoFiles => (
-                Self::NO_FILES,
-                Self::SKIPPED
-                    .on_color(XtermColors::FlushOrange)
-                    .color(XtermColors::White)
-                    .to_string(),
-                Self::SKIPPED.width(),
-            ),
-            RunStatus::DryRun => (
-                "",
-                Self::DRY_RUN
-                    .on_color(XtermColors::FlushOrange)
-                    .color(XtermColors::White)
-                    .to_string(),
-                Self::DRY_RUN.width(),
-            ),
-            RunStatus::Success => (
-                "",
-                Self::PASSED
-                    .on_color(XtermColors::Jade)
-                    .color(XtermColors::White)
-                    .to_string(),
-                Self::PASSED.width(),
-            ),
-            RunStatus::Failed => (
-                "",
-                Self::FAILED
-                    .on_color(XtermColors::Red)
-                    .color(XtermColors::White)
-                    .to_string(),
-                Self::FAILED.width(),
-            ),
+        let (suffix, status_line) = match status {
+            RunStatus::NoFiles => (Self::NO_FILES, SKIPPED),
+            RunStatus::DryRun => ("", DRY_RUN),
+            RunStatus::Success => ("", PASSED),
+            RunStatus::Failed => ("", FAILED),
         };
         let (prefix, prefix_width) = if prefix.is_empty() {
             (String::new(), 0)
         } else {
             (prefix.dimmed().to_string(), prefix.width())
         };
-        let used_width = prefix_width + hook_name.width() + suffix.width() + status_width;
+        let used_width =
+            prefix_width + hook_name.width() + suffix.width() + status_line.inner().width();
         let dots = self.columns.saturating_sub(used_width);
         let dots = ".".repeat(dots).green().to_string();
         let line = format!("{prefix}{hook_name}{dots}{suffix}{status_line}");

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Result};
 use asyncband::semaphore::Semaphore;
 use futures_util::TryStreamExt;
 use futures_util::stream::FuturesUnordered;
-use owo_colors::OwoColorize;
+use owo_colors::{OwoColorize, XtermColors};
 use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use prek_consts::{PRE_COMMIT_CONFIG_YAML, PREK_TOML};
 use prek_identify::{TagSet, tags_from_path};
@@ -1260,20 +1260,36 @@ impl StatusPrinter {
         let (suffix, status_line, status_width) = match status {
             RunStatus::NoFiles => (
                 Self::NO_FILES,
-                Self::SKIPPED.black().on_cyan().to_string(),
+                Self::SKIPPED
+                    .on_color(XtermColors::FlushOrange)
+                    .color(XtermColors::White)
+                    .to_string(),
                 Self::SKIPPED.width(),
             ),
             RunStatus::DryRun => (
                 "",
-                Self::DRY_RUN.on_yellow().to_string(),
+                Self::DRY_RUN
+                    .on_color(XtermColors::FlushOrange)
+                    .color(XtermColors::White)
+                    .to_string(),
                 Self::DRY_RUN.width(),
             ),
             RunStatus::Success => (
                 "",
-                Self::PASSED.on_green().to_string(),
+                Self::PASSED
+                    .on_color(XtermColors::Jade)
+                    .color(XtermColors::White)
+                    .to_string(),
                 Self::PASSED.width(),
             ),
-            RunStatus::Failed => ("", Self::FAILED.on_red().to_string(), Self::FAILED.width()),
+            RunStatus::Failed => (
+                "",
+                Self::FAILED
+                    .on_color(XtermColors::Red)
+                    .color(XtermColors::White)
+                    .to_string(),
+                Self::FAILED.width(),
+            ),
         };
         let (prefix, prefix_width) = if prefix.is_empty() {
             (String::new(), 0)

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -3297,11 +3297,11 @@ fn tty_output_preserves_color_without_replaying_terminal_controls() -> Result<()
     cmd_snapshot!(
         context.filters(),
         context.run().arg("--color=always"),
-        @r#"
+        @"
     success: true
     exit_code: 0
     ----- stdout -----
-    terminal-output[32m..........................................................[39m[42mPassed[49m
+    terminal-output[32m..........................................................[39m[38;5;231;48;5;35mPassed[0m
     [2m- hook id: terminal-output[0m
     [2m- duration: [TIME][0m
 
@@ -3309,7 +3309,7 @@ fn tty_output_preserves_color_without_replaying_terminal_controls() -> Result<()
       plain
 
     ----- stderr -----
-    "#
+    "
     );
 
     Ok(())
@@ -4482,18 +4482,18 @@ fn run_with_stdin_closed() {
     ----- stderr -----
     ");
 
-    cmd_snapshot!(context.filters(), context.run().arg("--color").arg("always"), @r#"
+    cmd_snapshot!(context.filters(), context.run().arg("--color").arg("always"), @"
     success: true
     exit_code: 0
     ----- stdout -----
-    check-stdin[32m..............................................................[39m[42mPassed[49m
+    check-stdin[32m..............................................................[39m[38;5;231;48;5;35mPassed[0m
     [2m- hook id: check-stdin[0m
     [2m- duration: [TIME][0m
 
       STDIN closed
 
     ----- stderr -----
-    "#);
+    ");
 }
 
 /// Test `prek --version` outputs version info.

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -3244,18 +3244,18 @@ fn color() -> Result<()> {
     ");
 
     // Force color output
-    cmd_snapshot!(context.filters(), context.run().arg("--color=always"), @r#"
+    cmd_snapshot!(context.filters(), context.run().arg("--color=always"), @"
     success: true
     exit_code: 0
     ----- stdout -----
-    color[32m....................................................................[39m[42mPassed[49m
+    color[32m....................................................................[39m[38;5;231;48;5;35mPassed[0m
     [2m- hook id: color[0m
     [2m- duration: [TIME][0m
 
       [1;32mHello, world![0m
 
     ----- stderr -----
-    "#);
+    ");
 
     Ok(())
 }

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -3244,18 +3244,18 @@ fn color() -> Result<()> {
     ");
 
     // Force color output
-    cmd_snapshot!(context.filters(), context.run().arg("--color=always"), @"
+    cmd_snapshot!(context.filters(), context.run().arg("--color=always"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
-    color[32m....................................................................[39m[38;5;231;48;5;35mPassed[0m
+    color[32m....................................................................[39m[32;7mPassed[0m
     [2m- hook id: color[0m
     [2m- duration: [TIME][0m
 
       [1;32mHello, world![0m
 
     ----- stderr -----
-    ");
+    "#);
 
     Ok(())
 }
@@ -3297,11 +3297,11 @@ fn tty_output_preserves_color_without_replaying_terminal_controls() -> Result<()
     cmd_snapshot!(
         context.filters(),
         context.run().arg("--color=always"),
-        @"
+        @r#"
     success: true
     exit_code: 0
     ----- stdout -----
-    terminal-output[32m..........................................................[39m[38;5;231;48;5;35mPassed[0m
+    terminal-output[32m..........................................................[39m[32;7mPassed[0m
     [2m- hook id: terminal-output[0m
     [2m- duration: [TIME][0m
 
@@ -3309,7 +3309,7 @@ fn tty_output_preserves_color_without_replaying_terminal_controls() -> Result<()
       plain
 
     ----- stderr -----
-    "
+    "#
     );
 
     Ok(())
@@ -4482,18 +4482,18 @@ fn run_with_stdin_closed() {
     ----- stderr -----
     ");
 
-    cmd_snapshot!(context.filters(), context.run().arg("--color").arg("always"), @"
+    cmd_snapshot!(context.filters(), context.run().arg("--color").arg("always"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
-    check-stdin[32m..............................................................[39m[38;5;231;48;5;35mPassed[0m
+    check-stdin[32m..............................................................[39m[32;7mPassed[0m
     [2m- hook id: check-stdin[0m
     [2m- duration: [TIME][0m
 
       STDIN closed
 
     ----- stderr -----
-    ");
+    "#);
 }
 
 /// Test `prek --version` outputs version info.


### PR DESCRIPTION
Love prek, I am using it in all my projects now. There is just one tiny thing I would like to fix... See #1310, which is still a  problem for many terminal themes (like mine).

We should probably be using fully specified ansi colors for bg/fg since you can't rely on the user's theme for bg colors. This PR switches to ANSI 256 colors (from ANSI 16). Also consider adding a space on either side of the text to make it prettier, but that's a separate thing. Thanks guys!

### NEW
<img width="725" height="348" alt="new" src="https://github.com/user-attachments/assets/e60bb92a-d4fc-4a33-976d-e06cd56c89b4" />

### OLD
<img width="732" height="373" alt="old" src="https://github.com/user-attachments/assets/f4bdd92d-18e2-48bf-b93c-847426690f7c" />

Fixes #1310