### PR TITLE
Support `{hook_repo}` placeholder in hook `entry`

### DIFF
--- a/crates/prek/src/hook_entry.rs
+++ b/crates/prek/src/hook_entry.rs
@@ -36,7 +36,7 @@ pub(crate) struct PreparedHookEntry {
 }
 
 impl PreparedHookEntry {
-    pub(crate) fn direct(argv: Vec<OsString>) -> Self {
+    pub(crate) fn argv(argv: Vec<OsString>) -> Self {
         Self {
             argv,
             _temp_dir: None,
@@ -48,10 +48,6 @@ impl PreparedHookEntry {
             argv,
             _temp_dir: Some(temp_dir),
         }
-    }
-
-    pub(crate) fn argv(&self) -> &[OsString] {
-        &self.argv
     }
 
     pub(crate) fn argv_mut(&mut self) -> &mut Vec<OsString> {
@@ -69,7 +65,7 @@ impl Deref for PreparedHookEntry {
 
 #[derive(Debug, Clone)]
 pub(crate) enum HookEntry {
-    Direct(DirectHookEntry),
+    Argv(ArgvHookEntry),
     Shell(ShellHookEntry),
 }
 
@@ -77,7 +73,7 @@ impl HookEntry {
     pub(crate) fn new(hook: String, entry: String, shell: Option<Shell>) -> Self {
         match shell {
             Some(shell) => Self::Shell(ShellHookEntry { hook, entry, shell }),
-            None => Self::Direct(DirectHookEntry { hook, entry }),
+            None => Self::Argv(ArgvHookEntry { hook, entry }),
         }
     }
 
@@ -90,7 +86,7 @@ impl HookEntry {
         store: &Store,
     ) -> Result<PreparedHookEntry, Error> {
         match self {
-            Self::Direct(entry) => entry.resolve(repo_path, env_path, cwd),
+            Self::Argv(entry) => entry.resolve(repo_path, env_path, cwd),
             Self::Shell(entry) => entry.resolve(env_path, cwd, store),
         }
     }
@@ -107,89 +103,57 @@ impl HookEntry {
         store: &Store,
     ) -> Result<PreparedHookEntry, Error> {
         match self {
-            Self::Direct(entry) => entry.resolve_script(repo_path, env_path, cwd),
+            Self::Argv(entry) => entry.resolve_script(repo_path, env_path, cwd),
             Self::Shell(entry) => entry.resolve(env_path, cwd, store),
         }
     }
 
-    /// Split a direct entry into an argument vector.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if this entry uses `shell` or cannot be parsed.
-    pub(crate) fn split(&self) -> Result<Vec<OsString>, Error> {
-        self.direct()?.split()
-    }
-
-    /// Split a direct entry and expand `{hook_repo}` using `repo_path`.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if this entry uses `shell` or cannot be parsed.
-    pub(crate) fn split_expanded(&self, repo_path: &Path) -> Result<Vec<OsString>, Error> {
-        self.direct()?.split_expanded(repo_path)
-    }
-
-    /// Split a direct entry into an argument vector and append `args`.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if this entry uses `shell` or cannot be parsed.
-    pub(crate) fn split_with_args(&self, args: &[String]) -> Result<Vec<OsString>, Error> {
-        self.direct()?.split_with_args(args)
-    }
-
-    /// Return the original string for a direct entry.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if this entry uses `shell`.
-    pub(crate) fn raw(&self) -> Result<&str, Error> {
-        Ok(self.direct()?.raw())
-    }
-
-    fn direct(&self) -> Result<&DirectHookEntry, Error> {
+    /// Return the argv-style entry, or `None` when `entry` is shell source.
+    pub(crate) fn as_argv_entry(&self) -> Option<&ArgvHookEntry> {
         match self {
-            Self::Direct(entry) => Ok(entry),
-            Self::Shell(entry) => Err(Error::Hook {
-                hook: entry.hook.clone(),
-                error: anyhow::anyhow!(
-                    "Hook specified `shell`, but this execution path requires an argv-style entry"
-                ),
-            }),
+            Self::Argv(entry) => Some(entry),
+            Self::Shell(_) => None,
         }
     }
 
-    pub(crate) fn shell(&self) -> Option<Shell> {
+    /// Return the argv-style entry after its execution path has rejected `shell`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this entry is shell source.
+    pub(crate) fn expect_argv_entry(&self) -> &ArgvHookEntry {
         match self {
-            Self::Direct(_) => None,
-            Self::Shell(entry) => Some(entry.shell),
+            Self::Argv(entry) => entry,
+            Self::Shell(entry) => panic!(
+                "hook `{}` uses `shell` in an argv-only execution path",
+                entry.hook
+            ),
         }
     }
 }
 
+/// An entry that can be interpreted as an argument vector without shell evaluation.
 #[derive(Debug, Clone)]
-pub(crate) struct DirectHookEntry {
+pub(crate) struct ArgvHookEntry {
     hook: String,
     entry: String,
 }
 
-impl DirectHookEntry {
+impl ArgvHookEntry {
     /// Split the entry and resolve the command by parsing its shebang.
-    fn resolve(
+    pub(crate) fn resolve(
         &self,
         repo_path: &Path,
         env_path: Option<&OsStr>,
         cwd: &Path,
     ) -> Result<PreparedHookEntry, Error> {
         let argv = self.split_expanded(repo_path)?;
+        let argv = resolve_command(argv, env_path, cwd);
 
-        Ok(PreparedHookEntry::direct(resolve_command(
-            argv, env_path, cwd,
-        )))
+        Ok(PreparedHookEntry::argv(argv))
     }
 
-    /// Resolve a direct `language: script` entry.
+    /// Resolve an argv-style `language: script` entry.
     fn resolve_script(
         &self,
         repo_path: &Path,
@@ -198,14 +162,13 @@ impl DirectHookEntry {
     ) -> Result<PreparedHookEntry, Error> {
         let mut argv = self.split_expanded(repo_path)?;
         argv[0] = repo_path.join(&argv[0]).into_os_string();
+        let argv = resolve_command(argv, env_path, cwd);
 
-        Ok(PreparedHookEntry::direct(resolve_command(
-            argv, env_path, cwd,
-        )))
+        Ok(PreparedHookEntry::argv(argv))
     }
 
-    /// Split the entry into a list of commands.
-    fn split(&self) -> Result<Vec<OsString>, Error> {
+    /// Split the entry into an argument vector.
+    pub(crate) fn split(&self) -> Result<Vec<OsString>, Error> {
         let splits = shlex::split(&self.entry).ok_or_else(|| Error::Hook {
             hook: self.hook.clone(),
             error: anyhow::anyhow!("Failed to parse entry `{}` as commands", self.entry),
@@ -219,20 +182,22 @@ impl DirectHookEntry {
         Ok(splits.into_iter().map(OsString::from).collect())
     }
 
-    fn split_expanded(&self, repo_path: &Path) -> Result<Vec<OsString>, Error> {
+    /// Split the entry and expand `{hook_repo}` using `repo_path`.
+    pub(crate) fn split_expanded(&self, repo_path: &Path) -> Result<Vec<OsString>, Error> {
         let mut argv = self.split()?;
         expand_placeholders(&mut argv, repo_path);
         Ok(argv)
     }
 
-    fn split_with_args(&self, args: &[String]) -> Result<Vec<OsString>, Error> {
+    /// Split the entry and append `args`.
+    pub(crate) fn split_with_args(&self, args: &[String]) -> Result<Vec<OsString>, Error> {
         let mut split = self.split()?;
         split.extend(args.iter().map(OsString::from));
         Ok(split)
     }
 
     /// Get the original entry string.
-    fn raw(&self) -> &str {
+    pub(crate) fn raw(&self) -> &str {
         &self.entry
     }
 }
@@ -333,9 +298,7 @@ mod tests {
     use std::ffi::OsString;
     use std::path::Path;
 
-    use super::{HookEntry, expand_placeholders};
-    use crate::config::Shell;
-    use crate::hook::Error;
+    use super::expand_placeholders;
 
     #[test]
     fn expand_placeholders_replaces_hook_repo() {
@@ -352,20 +315,5 @@ mod tests {
         expand_placeholders(&mut argv, repo_path);
 
         assert_eq!(argv, vec![OsString::from("tool"), config_arg]);
-    }
-
-    #[test]
-    fn shell_entry_rejects_argv_operation() {
-        let entry = HookEntry::new("test".to_string(), "echo test".to_string(), Some(Shell::Sh));
-
-        let Error::Hook { hook, error } = entry.split().unwrap_err() else {
-            panic!("argv operation should return a hook error");
-        };
-
-        assert_eq!(hook, "test");
-        assert_eq!(
-            error.to_string(),
-            "Hook specified `shell`, but this execution path requires an argv-style entry"
-        );
     }
 }

--- a/crates/prek/src/hook_entry.rs
+++ b/crates/prek/src/hook_entry.rs
@@ -2,12 +2,32 @@ use std::ffi::{OsStr, OsString};
 use std::ops::Deref;
 use std::path::Path;
 
+use itertools::intersperse;
 use tempfile::TempDir;
 
 use crate::config::Shell;
 use crate::hook::Error;
 use crate::languages::resolve_command;
 use crate::store::Store;
+
+const HOOK_REPO_PLACEHOLDER: &str = "{hook_repo}";
+
+fn expand_placeholders(argv: &mut [OsString], repo_path: &Path) {
+    for arg in argv {
+        let Some(value) = arg.to_str() else {
+            continue;
+        };
+        if !value.contains(HOOK_REPO_PLACEHOLDER) {
+            continue;
+        }
+
+        *arg = intersperse(
+            value.split(HOOK_REPO_PLACEHOLDER).map(OsStr::new),
+            repo_path.as_os_str(),
+        )
+        .collect();
+    }
+}
 
 #[derive(Debug)]
 pub(crate) struct PreparedHookEntry {
@@ -64,12 +84,13 @@ impl HookEntry {
     /// Split the entry and resolve the command by parsing its shebang.
     pub(crate) fn resolve(
         &self,
+        repo_path: &Path,
         env_path: Option<&OsStr>,
         cwd: &Path,
         store: &Store,
     ) -> Result<PreparedHookEntry, Error> {
         match self {
-            Self::Direct(entry) => entry.resolve(env_path, cwd),
+            Self::Direct(entry) => entry.resolve(repo_path, env_path, cwd),
             Self::Shell(entry) => entry.resolve(env_path, cwd, store),
         }
     }
@@ -91,18 +112,51 @@ impl HookEntry {
         }
     }
 
-    /// Return the argv-style entry for execution paths that reject `shell` during validation.
+    /// Split a direct entry into an argument vector.
     ///
-    /// Panicking here means validation and execution support have diverged.
-    pub(crate) fn expect_direct(&self) -> &DirectHookEntry {
+    /// # Errors
+    ///
+    /// Returns an error if this entry uses `shell` or cannot be parsed.
+    pub(crate) fn split(&self) -> Result<Vec<OsString>, Error> {
+        self.direct()?.split()
+    }
+
+    /// Split a direct entry and expand `{hook_repo}` using `repo_path`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if this entry uses `shell` or cannot be parsed.
+    pub(crate) fn split_expanded(&self, repo_path: &Path) -> Result<Vec<OsString>, Error> {
+        self.direct()?.split_expanded(repo_path)
+    }
+
+    /// Split a direct entry into an argument vector and append `args`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if this entry uses `shell` or cannot be parsed.
+    pub(crate) fn split_with_args(&self, args: &[String]) -> Result<Vec<OsString>, Error> {
+        self.direct()?.split_with_args(args)
+    }
+
+    /// Return the original string for a direct entry.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if this entry uses `shell`.
+    pub(crate) fn raw(&self) -> Result<&str, Error> {
+        Ok(self.direct()?.raw())
+    }
+
+    fn direct(&self) -> Result<&DirectHookEntry, Error> {
         match self {
-            Self::Direct(entry) => entry,
-            Self::Shell(entry) => {
-                panic!(
-                    "Hook `{}` specified `shell`, but this execution path requires an argv-style entry",
-                    entry.hook,
-                );
-            }
+            Self::Direct(entry) => Ok(entry),
+            Self::Shell(entry) => Err(Error::Hook {
+                hook: entry.hook.clone(),
+                error: anyhow::anyhow!(
+                    "Hook specified `shell`, but this execution path requires an argv-style entry"
+                ),
+            }),
         }
     }
 
@@ -122,11 +176,16 @@ pub(crate) struct DirectHookEntry {
 
 impl DirectHookEntry {
     /// Split the entry and resolve the command by parsing its shebang.
-    fn resolve(&self, env_path: Option<&OsStr>, cwd: &Path) -> Result<PreparedHookEntry, Error> {
-        let split = self.split()?;
+    fn resolve(
+        &self,
+        repo_path: &Path,
+        env_path: Option<&OsStr>,
+        cwd: &Path,
+    ) -> Result<PreparedHookEntry, Error> {
+        let argv = self.split_expanded(repo_path)?;
 
         Ok(PreparedHookEntry::direct(resolve_command(
-            split, env_path, cwd,
+            argv, env_path, cwd,
         )))
     }
 
@@ -137,17 +196,16 @@ impl DirectHookEntry {
         env_path: Option<&OsStr>,
         cwd: &Path,
     ) -> Result<PreparedHookEntry, Error> {
-        let mut split = self.split()?;
-        let cmd = repo_path.join(&split[0]);
-        split[0] = cmd.into_os_string();
+        let mut argv = self.split_expanded(repo_path)?;
+        argv[0] = repo_path.join(&argv[0]).into_os_string();
 
         Ok(PreparedHookEntry::direct(resolve_command(
-            split, env_path, cwd,
+            argv, env_path, cwd,
         )))
     }
 
     /// Split the entry into a list of commands.
-    pub(crate) fn split(&self) -> Result<Vec<OsString>, Error> {
+    fn split(&self) -> Result<Vec<OsString>, Error> {
         let splits = shlex::split(&self.entry).ok_or_else(|| Error::Hook {
             hook: self.hook.clone(),
             error: anyhow::anyhow!("Failed to parse entry `{}` as commands", self.entry),
@@ -161,14 +219,20 @@ impl DirectHookEntry {
         Ok(splits.into_iter().map(OsString::from).collect())
     }
 
-    pub(crate) fn split_with_args(&self, args: &[String]) -> Result<Vec<OsString>, Error> {
+    fn split_expanded(&self, repo_path: &Path) -> Result<Vec<OsString>, Error> {
+        let mut argv = self.split()?;
+        expand_placeholders(&mut argv, repo_path);
+        Ok(argv)
+    }
+
+    fn split_with_args(&self, args: &[String]) -> Result<Vec<OsString>, Error> {
         let mut split = self.split()?;
         split.extend(args.iter().map(OsString::from));
         Ok(split)
     }
 
     /// Get the original entry string.
-    pub(crate) fn raw(&self) -> &str {
+    fn raw(&self) -> &str {
         &self.entry
     }
 }
@@ -262,4 +326,46 @@ fn cmd_argv(script: OsString) -> Vec<OsString> {
         .collect::<Vec<_>>();
     argv.push(script);
     argv
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+    use std::path::Path;
+
+    use super::{HookEntry, expand_placeholders};
+    use crate::config::Shell;
+    use crate::hook::Error;
+
+    #[test]
+    fn expand_placeholders_replaces_hook_repo() {
+        let repo_path = Path::new("hook repo");
+        let mut argv = vec![
+            OsString::from("tool"),
+            OsString::from("--config={hook_repo}/path with spaces/config.toml"),
+        ];
+
+        let mut config_arg = OsString::from("--config=");
+        config_arg.push(repo_path);
+        config_arg.push("/path with spaces/config.toml");
+
+        expand_placeholders(&mut argv, repo_path);
+
+        assert_eq!(argv, vec![OsString::from("tool"), config_arg]);
+    }
+
+    #[test]
+    fn shell_entry_rejects_argv_operation() {
+        let entry = HookEntry::new("test".to_string(), "echo test".to_string(), Some(Shell::Sh));
+
+        let Error::Hook { hook, error } = entry.split().unwrap_err() else {
+            panic!("argv operation should return a hook error");
+        };
+
+        assert_eq!(hook, "test");
+        assert_eq!(
+            error.to_string(),
+            "Hook specified `shell`, but this execution path requires an argv-style entry"
+        );
+    }
 }

--- a/crates/prek/src/hooks/builtin_hooks/pattern.rs
+++ b/crates/prek/src/hooks/builtin_hooks/pattern.rs
@@ -119,8 +119,7 @@ fn run_filename_pattern(
     filenames: &[&Path],
     policy: MatchPolicy,
 ) -> Result<HookOutput> {
-    let args =
-        FilenameArgs::try_parse_from(hook.entry.expect_direct().split_with_args(&hook.args)?)?;
+    let args = FilenameArgs::try_parse_from(hook.entry.split_with_args(&hook.args)?)?;
     let regex = build_regex(&args.patterns, args.ignore_case, false)?;
     let mut failed = false;
     let mut output = Vec::new();
@@ -143,7 +142,7 @@ fn run_filename_pattern(
 }
 
 async fn run(hook: &Hook, filenames: &[&Path], policy: MatchPolicy) -> Result<HookOutput> {
-    let args = Args::try_parse_from(hook.entry.expect_direct().split_with_args(&hook.args)?)?;
+    let args = Args::try_parse_from(hook.entry.split_with_args(&hook.args)?)?;
     let matcher = Matcher::new(&args)?;
     let file_base = hook.project().relative_path();
 

--- a/crates/prek/src/hooks/builtin_hooks/pattern.rs
+++ b/crates/prek/src/hooks/builtin_hooks/pattern.rs
@@ -9,6 +9,7 @@ use regex_automata::{MatchKind, meta::Regex, util::syntax};
 
 use crate::hook::Hook;
 use crate::hooks::HookOutput;
+use crate::hooks::pre_commit_hooks::parse_hook_args;
 use crate::hooks::run_concurrent_file_checks;
 use crate::run::INTERNAL_CONCURRENCY;
 
@@ -119,7 +120,7 @@ fn run_filename_pattern(
     filenames: &[&Path],
     policy: MatchPolicy,
 ) -> Result<HookOutput> {
-    let args = FilenameArgs::try_parse_from(hook.entry.split_with_args(&hook.args)?)?;
+    let args = parse_hook_args::<FilenameArgs>(hook)?;
     let regex = build_regex(&args.patterns, args.ignore_case, false)?;
     let mut failed = false;
     let mut output = Vec::new();
@@ -142,7 +143,7 @@ fn run_filename_pattern(
 }
 
 async fn run(hook: &Hook, filenames: &[&Path], policy: MatchPolicy) -> Result<HookOutput> {
-    let args = Args::try_parse_from(hook.entry.split_with_args(&hook.args)?)?;
+    let args = parse_hook_args::<Args>(hook)?;
     let matcher = Matcher::new(&args)?;
     let file_base = hook.project().relative_path();
 

--- a/crates/prek/src/hooks/mod.rs
+++ b/crates/prek/src/hooks/mod.rs
@@ -79,6 +79,7 @@ pub fn check_fast_path(hook: &Hook) -> bool {
 }
 
 fn fast_path_hook(hook: &Hook) -> Option<PreCommitHooks> {
+    // TODO: Decide whether fast-path hooks should honor or ignore a configured `shell`.
     if *NO_FAST_PATH {
         return None;
     }

--- a/crates/prek/src/hooks/pre_commit_hooks/mod.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/mod.rs
@@ -45,7 +45,9 @@ pub(crate) struct FilenamesArgs {
 }
 
 pub(crate) fn parse_hook_args<T: Parser>(hook: &Hook) -> Result<T> {
-    Ok(T::try_parse_from(hook.entry.split_with_args(&hook.args)?)?)
+    Ok(T::try_parse_from(
+        hook.entry.expect_argv_entry().split_with_args(&hook.args)?,
+    )?)
 }
 
 pub(crate) fn hook_filenames<'a>(

--- a/crates/prek/src/hooks/pre_commit_hooks/mod.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/mod.rs
@@ -45,9 +45,7 @@ pub(crate) struct FilenamesArgs {
 }
 
 pub(crate) fn parse_hook_args<T: Parser>(hook: &Hook) -> Result<T> {
-    Ok(T::try_parse_from(
-        hook.entry.expect_direct().split_with_args(&hook.args)?,
-    )?)
+    Ok(T::try_parse_from(hook.entry.split_with_args(&hook.args)?)?)
 }
 
 pub(crate) fn hook_filenames<'a>(

--- a/crates/prek/src/hooks/pre_commit_hooks/no_commit_to_branch.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/no_commit_to_branch.rs
@@ -46,7 +46,7 @@ impl Args {
 
 /// Runs the `no-commit-to-branch` hook.
 pub(crate) async fn run(hook: &Hook) -> Result<HookOutput> {
-    let args = Args::try_parse_from(hook.entry.expect_direct().split_with_args(&hook.args)?)?;
+    let args = Args::try_parse_from(hook.entry.split_with_args(&hook.args)?)?;
 
     let output = git_cmd()?
         .arg("symbolic-ref")

--- a/crates/prek/src/hooks/pre_commit_hooks/no_commit_to_branch.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/no_commit_to_branch.rs
@@ -4,6 +4,7 @@ use fancy_regex::Regex;
 use crate::git::git_cmd;
 use crate::hook::Hook;
 use crate::hooks::HookOutput;
+use crate::hooks::pre_commit_hooks::parse_hook_args;
 use anyhow::{Context, Result};
 
 #[derive(Parser)]
@@ -46,7 +47,7 @@ impl Args {
 
 /// Runs the `no-commit-to-branch` hook.
 pub(crate) async fn run(hook: &Hook) -> Result<HookOutput> {
-    let args = Args::try_parse_from(hook.entry.split_with_args(&hook.args)?)?;
+    let args = parse_hook_args::<Args>(hook)?;
 
     let output = git_cmd()?
         .arg("symbolic-ref")

--- a/crates/prek/src/languages/dart.rs
+++ b/crates/prek/src/languages/dart.rs
@@ -167,21 +167,20 @@ impl LanguageBackend for Dart {
 
     fn prepare_hook_entry(
         &self,
-        store: &Store,
+        _store: &Store,
         hook: &InstalledHook,
         environment: &ExecutionEnvironment,
     ) -> Result<PreparedHookEntry> {
         let env_dir = hook.env_path().expect("Dart must have env path");
         let packages_path = package_config_path(env_dir);
         let repo_path = hook.repo_path().unwrap_or(hook.work_dir());
-        let mut entry =
-            hook.entry
-                .resolve(repo_path, environment.path(hook), hook.work_dir(), store)?;
+        let argv_entry = hook.entry.expect_argv_entry();
+        let mut entry = argv_entry.resolve(repo_path, environment.path(hook), hook.work_dir())?;
         // `dart pub get` writes the hook env's dependency graph here. Dart's
         // VM-level `--packages` flag makes `Platform.packageConfig` and package
         // imports resolve against this env instead of the hook work dir.
         if packages_path.exists()
-            && let Some(index) = packages_arg_insert_position(entry.argv(), &hook.args)
+            && let Some(index) = packages_arg_insert_position(&entry, &hook.args)
         {
             entry.argv_mut().insert(
                 index,

--- a/crates/prek/src/languages/dart.rs
+++ b/crates/prek/src/languages/dart.rs
@@ -173,9 +173,10 @@ impl LanguageBackend for Dart {
     ) -> Result<PreparedHookEntry> {
         let env_dir = hook.env_path().expect("Dart must have env path");
         let packages_path = package_config_path(env_dir);
-        let mut entry = hook
-            .entry
-            .resolve(environment.path(hook), hook.work_dir(), store)?;
+        let repo_path = hook.repo_path().unwrap_or(hook.work_dir());
+        let mut entry =
+            hook.entry
+                .resolve(repo_path, environment.path(hook), hook.work_dir(), store)?;
         // `dart pub get` writes the hook env's dependency graph here. Dart's
         // VM-level `--packages` flag makes `Platform.packageConfig` and package
         // imports resolve against this env instead of the hook work dir.

--- a/crates/prek/src/languages/docker.rs
+++ b/crates/prek/src/languages/docker.rs
@@ -494,7 +494,7 @@ impl LanguageBackend for Docker {
         )
         .await
         .context("Failed to build docker image")?;
-        let entry = hook.entry.expect_direct().split()?;
+        let entry = hook.entry.split()?;
 
         let run = async |batch: &[&Path]| {
             // docker run [OPTIONS] IMAGE [COMMAND] [ARG...]

--- a/crates/prek/src/languages/docker.rs
+++ b/crates/prek/src/languages/docker.rs
@@ -494,7 +494,7 @@ impl LanguageBackend for Docker {
         )
         .await
         .context("Failed to build docker image")?;
-        let entry = hook.entry.split()?;
+        let entry = hook.entry.expect_argv_entry().split()?;
 
         let run = async |batch: &[&Path]| {
             // docker run [OPTIONS] IMAGE [COMMAND] [ARG...]

--- a/crates/prek/src/languages/docker_image.rs
+++ b/crates/prek/src/languages/docker_image.rs
@@ -46,7 +46,7 @@ impl LanguageBackend for DockerImage {
             .flat_map(|(key, value)| ["-e".to_owned(), format!("{key}={value}")])
             .collect();
 
-        let entry = hook.entry.expect_direct().split()?;
+        let entry = hook.entry.split()?;
         let run = async |batch: &[&Path]| {
             let mut cmd = Docker::docker_run_cmd(hook.work_dir());
             let output = cmd

--- a/crates/prek/src/languages/docker_image.rs
+++ b/crates/prek/src/languages/docker_image.rs
@@ -46,7 +46,7 @@ impl LanguageBackend for DockerImage {
             .flat_map(|(key, value)| ["-e".to_owned(), format!("{key}={value}")])
             .collect();
 
-        let entry = hook.entry.split()?;
+        let entry = hook.entry.expect_argv_entry().split()?;
         let run = async |batch: &[&Path]| {
             let mut cmd = Docker::docker_run_cmd(hook.work_dir());
             let output = cmd

--- a/crates/prek/src/languages/fail.rs
+++ b/crates/prek/src/languages/fail.rs
@@ -35,8 +35,9 @@ impl LanguageBackend for Fail {
         filenames: &[&Path],
         _reporter: &HookRunReporter,
     ) -> Result<(i32, Vec<u8>)> {
+        let entry = hook.entry.expect_argv_entry();
         let mut out = Vec::new();
-        writeln!(out, "{}\n", hook.entry.raw()?)?;
+        writeln!(out, "{}\n", entry.raw())?;
         for f in filenames {
             out.extend(f.to_string_lossy().as_bytes());
             out.push(b'\n');

--- a/crates/prek/src/languages/fail.rs
+++ b/crates/prek/src/languages/fail.rs
@@ -36,7 +36,7 @@ impl LanguageBackend for Fail {
         _reporter: &HookRunReporter,
     ) -> Result<(i32, Vec<u8>)> {
         let mut out = Vec::new();
-        writeln!(out, "{}\n", hook.entry.expect_direct().raw())?;
+        writeln!(out, "{}\n", hook.entry.raw()?)?;
         for f in filenames {
             out.extend(f.to_string_lossy().as_bytes());
             out.push(b'\n');

--- a/crates/prek/src/languages/julia.rs
+++ b/crates/prek/src/languages/julia.rs
@@ -108,7 +108,7 @@ impl LanguageBackend for Julia {
 
         let env_dir = hook.env_path().expect("Julia must have env path");
 
-        let mut entry = hook.entry.expect_direct().split()?;
+        let mut entry = hook.entry.split()?;
         if let Some(repo_path) = hook.repo_path() {
             let jl_path = repo_path.join(&entry[0]);
             if jl_path.exists() {

--- a/crates/prek/src/languages/julia.rs
+++ b/crates/prek/src/languages/julia.rs
@@ -108,7 +108,7 @@ impl LanguageBackend for Julia {
 
         let env_dir = hook.env_path().expect("Julia must have env path");
 
-        let mut entry = hook.entry.split()?;
+        let mut entry = hook.entry.expect_argv_entry().split()?;
         if let Some(repo_path) = hook.repo_path() {
             let jl_path = repo_path.join(&entry[0]);
             if jl_path.exists() {

--- a/crates/prek/src/languages/mod.rs
+++ b/crates/prek/src/languages/mod.rs
@@ -124,7 +124,7 @@ trait LanguageBackend: Sync {
         let entry = self.prepare_hook_entry(store, hook, &environment)?;
         let run = async |batch: &[&Path]| {
             let output = environment
-                .command(hook, hook.work_dir(), entry.argv())?
+                .command(hook, hook.work_dir(), &entry)?
                 .args(&hook.args)
                 .file_args(batch)
                 .stdin(Stdio::null())
@@ -136,7 +136,7 @@ trait LanguageBackend: Sync {
             anyhow::Ok(output)
         };
 
-        let output = run_by_batch(hook, filenames, entry.argv(), run).await?;
+        let output = run_by_batch(hook, filenames, &entry, run).await?;
 
         reporter.on_run_complete(progress);
 

--- a/crates/prek/src/languages/mod.rs
+++ b/crates/prek/src/languages/mod.rs
@@ -85,9 +85,10 @@ trait LanguageBackend: Sync {
         hook: &InstalledHook,
         environment: &ExecutionEnvironment,
     ) -> Result<PreparedHookEntry> {
+        let repo_path = hook.repo_path().unwrap_or(hook.work_dir());
         Ok(hook
             .entry
-            .resolve(environment.path(hook), hook.work_dir(), store)?)
+            .resolve(repo_path, environment.path(hook), hook.work_dir(), store)?)
     }
 
     /// Applies asynchronous or working-directory-dependent changes to `environment`.

--- a/crates/prek/src/languages/pygrep/pygrep.rs
+++ b/crates/prek/src/languages/pygrep/pygrep.rs
@@ -205,7 +205,7 @@ impl LanguageBackend for Pygrep {
             .arg(py_script.path())
             .args(args.to_args())
             .arg(INTERNAL_CONCURRENCY.to_string())
-            .arg(hook.entry.expect_direct().raw())
+            .arg(hook.entry.raw()?)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())

--- a/crates/prek/src/languages/pygrep/pygrep.rs
+++ b/crates/prek/src/languages/pygrep/pygrep.rs
@@ -197,6 +197,7 @@ impl LanguageBackend for Pygrep {
             .context("Failed to write Python script")?;
 
         let args = Args::parse(&hook.args).context("Failed to parse `args`")?;
+        let entry = hook.entry.expect_argv_entry();
         let mut cmd = Cmd::new(&info.toolchain)
             .current_dir(hook.work_dir())
             .envs(&hook.env)
@@ -205,7 +206,7 @@ impl LanguageBackend for Pygrep {
             .arg(py_script.path())
             .args(args.to_args())
             .arg(INTERNAL_CONCURRENCY.to_string())
-            .arg(hook.entry.raw()?)
+            .arg(entry.raw())
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())

--- a/crates/prek/src/languages/python/pep723.rs
+++ b/crates/prek/src/languages/python/pep723.rs
@@ -272,8 +272,8 @@ pub(crate) async fn extract_pep723_metadata(hook: &mut Hook) -> Result<()> {
 
     let repo_path = hook.repo_path().unwrap_or(hook.work_dir());
 
-    let split = hook.entry.expect_direct().split()?;
-    let file = repo_path.join(&split[0]);
+    let argv = hook.entry.split_expanded(repo_path)?;
+    let file = repo_path.join(&argv[0]);
 
     let Some(script) = Pep723Script::read(&file).await? else {
         return Ok(());

--- a/crates/prek/src/languages/python/pep723.rs
+++ b/crates/prek/src/languages/python/pep723.rs
@@ -256,12 +256,12 @@ impl ScriptTag {
 /// Effectively, we are implementing a new `python-script` language which works like `script`.
 /// But we don't want to introduce a new language just for this for now.
 pub(crate) async fn extract_pep723_metadata(hook: &mut Hook) -> Result<()> {
-    if hook.entry.shell().is_some() {
+    let Some(entry) = hook.entry.as_argv_entry() else {
         trace!(
             "Skipping reading PEP 723 metadata for hook `{hook}` because `shell` treats `entry` as shell source",
         );
         return Ok(());
-    }
+    };
 
     if !hook.additional_dependencies.is_empty() {
         trace!(
@@ -272,7 +272,7 @@ pub(crate) async fn extract_pep723_metadata(hook: &mut Hook) -> Result<()> {
 
     let repo_path = hook.repo_path().unwrap_or(hook.work_dir());
 
-    let argv = hook.entry.split_expanded(repo_path)?;
+    let argv = entry.split_expanded(repo_path)?;
     let file = repo_path.join(&argv[0]);
 
     let Some(script) = Pep723Script::read(&file).await? else {

--- a/crates/prek/src/languages/r.rs
+++ b/crates/prek/src/languages/r.rs
@@ -236,7 +236,7 @@ fn additional_dependency_install_code(env_path: &Path) -> String {
 }
 
 fn r_hook_entry(hook: &InstalledHook) -> Result<Vec<OsString>> {
-    let entry = hook.entry.expect_direct().split()?;
+    let entry = hook.entry.split()?;
     validate_r_entry(&entry)?;
 
     let mut cmd = Vec::with_capacity(entry.len() + 4);

--- a/crates/prek/src/languages/r.rs
+++ b/crates/prek/src/languages/r.rs
@@ -140,7 +140,7 @@ impl LanguageBackend for R {
         hook: &InstalledHook,
         _environment: &ExecutionEnvironment,
     ) -> Result<PreparedHookEntry> {
-        Ok(PreparedHookEntry::direct(r_hook_entry(hook)?))
+        Ok(PreparedHookEntry::argv(r_hook_entry(hook)?))
     }
 }
 
@@ -236,7 +236,7 @@ fn additional_dependency_install_code(env_path: &Path) -> String {
 }
 
 fn r_hook_entry(hook: &InstalledHook) -> Result<Vec<OsString>> {
-    let entry = hook.entry.split()?;
+    let entry = hook.entry.expect_argv_entry().split()?;
     validate_r_entry(&entry)?;
 
     let mut cmd = Vec::with_capacity(entry.len() + 4);

--- a/crates/prek/src/languages/rust/rust.rs
+++ b/crates/prek/src/languages/rust/rust.rs
@@ -446,7 +446,7 @@ impl LanguageBackend for Rust {
             });
 
         // Use the hook entry as the binary name to find the package, this could be improved by allowing an explicit binary name in the hook config.
-        let hook_entry = hook.entry.split()?;
+        let hook_entry = hook.entry.expect_argv_entry().split()?;
         let hook_bin = hook_entry[0]
             .to_str()
             .context("Rust hook entry binary must be valid UTF-8")?;

--- a/crates/prek/src/languages/rust/rust.rs
+++ b/crates/prek/src/languages/rust/rust.rs
@@ -446,7 +446,7 @@ impl LanguageBackend for Rust {
             });
 
         // Use the hook entry as the binary name to find the package, this could be improved by allowing an explicit binary name in the hook config.
-        let hook_entry = hook.entry.expect_direct().split()?;
+        let hook_entry = hook.entry.split()?;
         let hook_bin = hook_entry[0]
             .to_str()
             .context("Rust hook entry binary must be valid UTF-8")?;

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -568,10 +568,7 @@ fn local() {
 
 #[test]
 fn hook_repo_placeholder_expands_to_local_project() -> Result<()> {
-    let context = TestContext::new();
-    context.init_project();
-
-    context.write_pre_commit_config(indoc::indoc! {r#"
+    let context = TestEnv::new().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -583,10 +580,10 @@ fn hook_repo_placeholder_expands_to_local_project() -> Result<()> {
                 pass_filenames: false
     "#});
     context.work_dir().child("hook-repo-marker").write_str("")?;
-    context.git_add(".");
+    context.git_add_all();
     context.git_commit("Add local hook");
 
-    cmd_snapshot!(context.filters(), context.run(), @r#"
+    cmd_snapshot!(context, context.run(), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -600,10 +597,10 @@ fn hook_repo_placeholder_expands_to_local_project() -> Result<()> {
 
 #[test]
 fn hook_repo_placeholder_expands_to_remote_checkout() -> Result<()> {
-    let hook_repo = TestContext::new();
-    hook_repo.init_project();
+    let context = TestEnv::new();
+    let hook_repo = context.create_repo("hook-repo-placeholder");
     hook_repo
-        .work_dir()
+        .path()
         .child(PRE_COMMIT_HOOKS_YAML)
         .write_str(indoc::indoc! {r#"
             - id: hook-repo-remote
@@ -612,27 +609,22 @@ fn hook_repo_placeholder_expands_to_remote_checkout() -> Result<()> {
               entry: git -C "{hook_repo}" cat-file -e HEAD:hook-repo-marker
               always_run: true
               pass_filenames: false
-        "#})?;
-    hook_repo
-        .work_dir()
-        .child("hook-repo-marker")
-        .write_str("")?;
-    hook_repo.git_add(".");
+    "#})?;
+    hook_repo.path().child("hook-repo-marker").write_str("")?;
+    hook_repo.git_add_all();
     hook_repo.git_commit("Add remote hook");
     hook_repo.git_tag("v1.0.0");
 
-    let context = TestContext::new();
-    context.init_project();
-    context.write_pre_commit_config(&indoc::formatdoc! {r"
+    let context = context.with_config(indoc::formatdoc! {r"
         repos:
           - repo: '{}'
             rev: v1.0.0
             hooks:
               - id: hook-repo-remote
-    ", hook_repo.work_dir().display()});
-    context.git_add(".");
+    ", hook_repo.path().display()});
+    context.git_add_all();
 
-    cmd_snapshot!(context.filters(), context.run(), @r#"
+    cmd_snapshot!(context, context.run(), @r#"
     success: true
     exit_code: 0
     ----- stdout -----

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -566,6 +566,84 @@ fn local() {
     "#);
 }
 
+#[test]
+fn hook_repo_placeholder_expands_to_local_project() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: hook-repo-local
+                name: local
+                language: system
+                entry: git -C "{hook_repo}" cat-file -e HEAD:hook-repo-marker
+                always_run: true
+                pass_filenames: false
+    "#});
+    context.work_dir().child("hook-repo-marker").write_str("")?;
+    context.git_add(".");
+    context.git_commit("Add local hook");
+
+    cmd_snapshot!(context.filters(), context.run(), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    local....................................................................Passed
+
+    ----- stderr -----
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn hook_repo_placeholder_expands_to_remote_checkout() -> Result<()> {
+    let hook_repo = TestContext::new();
+    hook_repo.init_project();
+    hook_repo
+        .work_dir()
+        .child(PRE_COMMIT_HOOKS_YAML)
+        .write_str(indoc::indoc! {r#"
+            - id: hook-repo-remote
+              name: remote
+              language: system
+              entry: git -C "{hook_repo}" cat-file -e HEAD:hook-repo-marker
+              always_run: true
+              pass_filenames: false
+        "#})?;
+    hook_repo
+        .work_dir()
+        .child("hook-repo-marker")
+        .write_str("")?;
+    hook_repo.git_add(".");
+    hook_repo.git_commit("Add remote hook");
+    hook_repo.git_tag("v1.0.0");
+
+    let context = TestContext::new();
+    context.init_project();
+    context.write_pre_commit_config(&indoc::formatdoc! {r"
+        repos:
+          - repo: '{}'
+            rev: v1.0.0
+            hooks:
+              - id: hook-repo-remote
+    ", hook_repo.work_dir().display()});
+    context.git_add(".");
+
+    cmd_snapshot!(context.filters(), context.run(), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    remote...................................................................Passed
+
+    ----- stderr -----
+    "#);
+
+    Ok(())
+}
+
 /// Test multiple hook IDs scenarios.
 #[test]
 fn multiple_hook_ids() {

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1,0 +1,96 @@
+# Internals
+
+This page documents some of prek's internal implementation details.
+
+## Hook entry resolution
+
+`repo` and `language` control different parts of hook execution:
+
+- `repo` determines where the hook source comes from.
+- `language` determines how the hook is installed and what `entry` means.
+
+The hook checkout does not become the working directory. Hooks run against the
+project being checked, including hooks loaded from a remote repository.
+
+| Configuration | Hook source | Working directory |
+| -- | -- | -- |
+| `repo: local` | The project itself; there is no separate hook checkout. | The project directory. |
+| `repo: <URL or path>` | A checkout cached by prek at the configured `rev`. | The project that uses the hook. |
+
+### Direct command entries
+
+For command-style languages such as `system`, `mise`, `python`, and `node`, prek
+splits `entry` into arguments and invokes it directly. A shell is not involved:
+shell operators such as `|`, `&&`, `$VAR`, and `*` are not interpreted. Use the
+prek-only [`shell`](reference/configuration.md#shell) option when shell syntax is
+required.
+
+A bare command such as `ruff` is looked up on the `PATH` prepared by the language.
+An explicit relative path such as `./scripts/check.sh` is resolved from the hook's
+working directory. For a remote command-style hook, that means the end user's
+project, not the cached hook checkout. For `repo: local`, it naturally refers to
+the project that defines the hook.
+
+Hook `args` are appended after the arguments from `entry`, followed by matching
+filenames when `pass_filenames` allows them. See
+[Passing arguments to hooks](authoring-hooks.md#passing-arguments-to-hooks) for
+an example.
+
+### Language-specific meanings
+
+Most languages use the direct command rules above, with their installed tools
+available on `PATH`. When `shell` is omitted, some backends intentionally give
+`entry` a more specific meaning:
+
+| Language | Meaning of `entry` |
+| -- | -- |
+| [`script`](languages.md#script) | The first argument is a script path. It is relative to the hook checkout for remote hooks and the project directory for local hooks. |
+| [`julia`](languages.md#julia) | A Julia source path, relative to the hook checkout for remote hooks and the project directory for local hooks. |
+| [`r`](languages.md#r) | `Rscript -e <expr>` or `Rscript <file>`; file paths use the same remote-checkout/local-project rule. |
+| [`rust`](languages.md#rust) | The executable name; for a remote hook, it identifies a binary built and installed from the hook package. |
+| [`docker`](languages.md#docker), [`docker_image`](languages.md#docker_image) | Container entrypoint, image, and argument information. The project is mounted as `/src` inside the container. |
+| [`fail`](languages.md#fail), [`pygrep`](languages.md#pygrep) | A failure message or regular expression, not a command. |
+
+The linked language sections describe the complete backend-specific behavior.
+
+### Referencing files from the hook repository
+
+`language: script` already resolves its script path from the remote hook checkout:
+
+```yaml
+- id: check
+  name: Check files
+  language: script
+  entry: scripts/check.sh
+```
+
+For a command-style language, use the prek-only `{hook_repo}` placeholder when
+the command or one of its arguments must refer to a file shipped in the hook
+repository:
+
+```yaml
+- id: helm-lint
+  name: Helm lint
+  language: mise
+  additional_dependencies: ["helm@4", "yq@4"]
+  entry: "{hook_repo}/scripts/lint-helm-charts.sh"
+```
+
+```yaml
+- id: check-config
+  name: Check config
+  language: system
+  entry: tool --config "{hook_repo}/config/default.toml"
+```
+
+The placeholder is expanded independently inside each `entry` argument, after
+command-line splitting. Quote an `entry` that begins with `{hook_repo}` so YAML
+treats it as a string. For remote hooks it expands to the cached checkout; for
+local hooks it expands to the project directory. It does not change the working
+directory. Expansion applies only to direct command entries and `language: script`, not to `args`, filenames, `shell` source, or other backend-specific
+entry forms.
+
+!!! warning "pre-commit compatibility"
+
+    Upstream `pre-commit` passes the placeholder through literally. Published hooks
+    that depend on it should declare an appropriate `minimum_prek_version`.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -758,6 +758,10 @@ The command line to execute for the hook.
 - Optional override for remote hooks.
 - Not allowed for `repo: meta` and `repo: builtin`.
 
+The repository type, language, and optional `shell` setting determine how this
+value is interpreted. See [Hook entry resolution](../internals.md#hook-entry-resolution)
+for the command, path, and working-directory rules.
+
 If [`pass_filenames`](#pass_filenames) is `true`, `prek` appends matching filenames to this command when running.
 
 ### `shell`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ plugins:
           - reference/cli.md
           - reference/configuration.md
           - reference/environment-variables.md
+          - internals.md
         Help:
           - debugging.md
           - faq.md
@@ -117,6 +118,7 @@ nav:
     - CLI Reference: reference/cli.md
     - Configuration Reference: reference/configuration.md
     - Environment Variables: reference/environment-variables.md
+    - Internals: internals.md
   - Help:
     - Debugging: debugging.md
     - FAQ: faq.md


### PR DESCRIPTION
## Summary

Add a prek-only `{hook_repo}` placeholder for argv-style hook entries that need to reference files shipped in the hook repository.

For remote hooks, `{hook_repo}` expands to prek's cached checkout of the configured revision. For local hooks, it expands to the project directory.

Closes #2601