### PR TITLE
Add `@ungrouped` and `@builtin` group selectors

### DIFF
--- a/crates/prek/src/cli/mod.rs
+++ b/crates/prek/src/cli/mod.rs
@@ -679,6 +679,8 @@ pub(crate) struct RunArgs {
     ///
     /// Can be specified multiple times; a hook may match any specified group.
     /// When combined with `--require-group`, both filters must match.
+    /// `@ungrouped` matches hooks without groups, while `@builtin` matches
+    /// hooks from the builtin repository.
     #[arg(long = "group", value_name = "GROUP")]
     pub(crate) groups: Vec<String>,
 
@@ -690,12 +692,14 @@ pub(crate) struct RunArgs {
     ///
     /// For example, `--require-group fast --group format --group lint-only`
     /// selects hooks in `fast` and either `format` or `lint-only`.
+    /// The special selectors `@ungrouped` and `@builtin` are also supported.
     #[arg(long = "require-group", value_name = "GROUP")]
     pub(crate) required_groups: Vec<String>,
 
     /// Do not run hooks belonging to the specified group.
     ///
     /// Can be specified multiple times. Exclusion wins over inclusion.
+    /// The special selectors `@ungrouped` and `@builtin` are also supported.
     #[arg(long = "no-group", value_name = "GROUP")]
     pub(crate) no_groups: Vec<String>,
 }
@@ -782,19 +786,22 @@ pub(crate) struct ListArgs {
 
     /// Show hooks belonging to the specified group.
     ///
-    /// Can be specified multiple times.
+    /// Can be specified multiple times. `@ungrouped` matches hooks without
+    /// groups, while `@builtin` matches hooks from the builtin repository.
     #[arg(long = "group", value_name = "GROUP")]
     pub(crate) groups: Vec<String>,
 
     /// Show hooks belonging to every specified group.
     ///
     /// Can be specified multiple times. Composes with `--group` and `--no-group`.
+    /// The special selectors `@ungrouped` and `@builtin` are also supported.
     #[arg(long = "require-group", value_name = "GROUP")]
     pub(crate) required_groups: Vec<String>,
 
     /// Do not show hooks belonging to the specified group.
     ///
     /// Can be specified multiple times. Exclusion wins over inclusion.
+    /// The special selectors `@ungrouped` and `@builtin` are also supported.
     #[arg(long = "no-group", value_name = "GROUP")]
     pub(crate) no_groups: Vec<String>,
 

--- a/crates/prek/src/cli/run/selector.rs
+++ b/crates/prek/src/cli/run/selector.rs
@@ -3,8 +3,8 @@ use std::fmt::Display;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-use crate::config::validate_name;
-use crate::hook::Hook;
+use crate::config::validate_group_name;
+use crate::hook::{Hook, Repo};
 use crate::warn_user;
 
 use anyhow::anyhow;
@@ -424,10 +424,43 @@ impl Selectors {
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct GroupFilters {
-    include_any: Vec<String>,
-    require_all: Vec<String>,
-    exclude_any: Vec<String>,
+    include_any: Vec<GroupSelector>,
+    require_all: Vec<GroupSelector>,
+    exclude_any: Vec<GroupSelector>,
     usage: Arc<Mutex<FilterUsage>>,
+}
+
+#[derive(Debug, Clone)]
+enum GroupSelector {
+    Named(String),
+    Ungrouped,
+    Builtin,
+}
+
+const UNGROUPED_GROUP: &str = "@ungrouped";
+const BUILTIN_GROUP: &str = "@builtin";
+
+impl GroupSelector {
+    fn parse(group: &str) -> Result<Self, &'static str> {
+        match group {
+            UNGROUPED_GROUP => Ok(Self::Ungrouped),
+            BUILTIN_GROUP => Ok(Self::Builtin),
+            _ => {
+                validate_group_name(group)?;
+                Ok(Self::Named(group.to_owned()))
+            }
+        }
+    }
+}
+
+impl Display for GroupSelector {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Named(group) => f.write_str(group),
+            Self::Ungrouped => f.write_str(UNGROUPED_GROUP),
+            Self::Builtin => f.write_str(BUILTIN_GROUP),
+        }
+    }
 }
 
 impl GroupFilters {
@@ -438,21 +471,20 @@ impl GroupFilters {
     ) -> Result<Self, Error> {
         let parse_groups = |flag: &'static str, groups: &[String]| {
             let mut seen = FxHashSet::default();
-            let mut names = Vec::new();
+            let mut selectors = Vec::new();
 
             for group in groups {
-                if let Err(reason) = validate_name(group) {
-                    return Err(Error::GroupSelector {
+                let selector =
+                    GroupSelector::parse(group).map_err(|reason| Error::GroupSelector {
                         selector: format!("{flag}={group}"),
                         source: anyhow!("group name {reason}"),
-                    });
-                }
+                    })?;
                 if seen.insert(group.as_str()) {
-                    names.push(group.clone());
+                    selectors.push(selector);
                 }
             }
 
-            Ok(names)
+            Ok(selectors)
         };
 
         Ok(Self {
@@ -467,7 +499,7 @@ impl GroupFilters {
         !self.include_any.is_empty() || !self.require_all.is_empty() || !self.exclude_any.is_empty()
     }
 
-    fn matches_groups(&self, contains_group: impl Fn(&str) -> bool) -> bool {
+    fn matches_groups(&self, contains_group: impl Fn(&GroupSelector) -> bool) -> bool {
         let mut usage = self.usage.lock().unwrap();
 
         let mut matches_any_excluded = false;
@@ -499,13 +531,20 @@ impl GroupFilters {
     }
 
     pub(crate) fn matches_hook(&self, hook: &Hook) -> bool {
-        self.matches_groups(|group| hook.groups.contains(group))
+        self.matches_groups(|group| match group {
+            GroupSelector::Named(group) => hook.groups.contains(group),
+            GroupSelector::Ungrouped => hook.groups.is_empty(),
+            GroupSelector::Builtin => matches!(hook.repo(), Repo::Builtin),
+        })
     }
 
     pub(crate) fn matches_configured_hook(&self, hook: &ConfiguredHook<'_>) -> bool {
-        self.matches_groups(|group| {
-            hook.groups
-                .is_some_and(|groups| groups.iter().any(|hook_group| hook_group == group))
+        self.matches_groups(|group| match group {
+            GroupSelector::Named(group) => hook
+                .groups
+                .is_some_and(|groups| groups.iter().any(|hook_group| hook_group == group)),
+            GroupSelector::Ungrouped => hook.groups.is_none_or(<[String]>::is_empty),
+            GroupSelector::Builtin => false,
         })
     }
 

--- a/crates/prek/src/config/hook.rs
+++ b/crates/prek/src/config/hook.rs
@@ -710,8 +710,8 @@ pub(crate) struct RemoteHook {
     /// It is not allowed in manifests (e.g. `.pre-commit-hooks.yaml`).
     pub priority: Option<Priority>,
     /// User-defined hook groups used by `prek run --group` and `--no-group`.
-    /// Group names cannot be empty or contain whitespace.
-    #[cfg_attr(feature = "schemars", schemars(inner(regex(pattern = r"^\S+$"))))]
+    /// Group names cannot be empty, contain whitespace, or start with `@`.
+    #[cfg_attr(feature = "schemars", schemars(inner(regex(pattern = r"^[^@\s]\S*$"))))]
     pub groups: Option<Vec<String>>,
     #[cfg_attr(feature = "schemars", serde(flatten))]
     pub options: HookOptions,
@@ -752,8 +752,8 @@ pub(crate) struct LocalHook {
     /// Hooks with the same priority can run in parallel.
     pub priority: Option<Priority>,
     /// User-defined hook groups used by `prek run --group` and `--no-group`.
-    /// Group names cannot be empty or contain whitespace.
-    #[cfg_attr(feature = "schemars", schemars(inner(regex(pattern = r"^\S+$"))))]
+    /// Group names cannot be empty, contain whitespace, or start with `@`.
+    #[cfg_attr(feature = "schemars", schemars(inner(regex(pattern = r"^[^@\s]\S*$"))))]
     pub groups: Option<Vec<String>>,
     #[cfg_attr(feature = "schemars", serde(flatten))]
     pub options: HookOptions,
@@ -795,7 +795,7 @@ pub(crate) struct MetaHook {
     /// Hooks with the same priority can run in parallel.
     pub priority: Option<Priority>,
     /// User-defined hook groups used by `prek run --group` and `--no-group`.
-    /// Group names cannot be empty or contain whitespace.
+    /// Group names cannot be empty, contain whitespace, or start with `@`.
     pub groups: Option<Vec<String>>,
     pub options: HookOptions,
 }
@@ -884,7 +884,7 @@ pub(crate) struct BuiltinHook {
     /// Hooks with the same priority can run in parallel.
     pub priority: Option<Priority>,
     /// User-defined hook groups used by `prek run --group` and `--no-group`.
-    /// Group names cannot be empty or contain whitespace.
+    /// Group names cannot be empty, contain whitespace, or start with `@`.
     pub groups: Option<Vec<String>>,
     /// Common hook options.
     ///

--- a/crates/prek/src/config/mod.rs
+++ b/crates/prek/src/config/mod.rs
@@ -20,7 +20,7 @@ pub(crate) use hook::{
     MetaHook, PassFilenames, RemoteHook, Shell, Stage, Stages, ToolchainPreference,
 };
 pub(crate) use pattern::{FilePattern, GlobPatterns};
-pub(crate) use priority::{Priority, PriorityAlias, validate_name};
+pub(crate) use priority::{Priority, PriorityAlias, validate_group_name};
 #[cfg(feature = "schemars")]
 pub(crate) use repo::{BuiltinRepo, LocalRepo, MetaRepo};
 pub(crate) use repo::{RemoteRepo, RemoteRepoKey, Repo};
@@ -408,6 +408,10 @@ mod tests {
             (
                 r#"["ci\tslow"]"#,
                 "group name `ci\tslow` cannot contain whitespace",
+            ),
+            (
+                r#"["@builtin"]"#,
+                "group name `@builtin` uses the reserved `@` prefix",
             ),
         ] {
             let yaml = indoc::formatdoc! {r"

--- a/crates/prek/src/config/priority.rs
+++ b/crates/prek/src/config/priority.rs
@@ -6,11 +6,20 @@ use serde::{Deserialize, Deserializer};
 
 use super::Error;
 
-pub(crate) fn validate_name(name: &str) -> Result<(), &'static str> {
+fn validate_name(name: &str) -> Result<(), &'static str> {
     if name.is_empty() {
         Err("cannot be empty")
     } else if name.chars().any(char::is_whitespace) {
         Err("cannot contain whitespace")
+    } else {
+        Ok(())
+    }
+}
+
+pub(crate) fn validate_group_name(name: &str) -> Result<(), &'static str> {
+    validate_name(name)?;
+    if name.starts_with('@') {
+        Err("uses the reserved `@` prefix")
     } else {
         Ok(())
     }
@@ -122,7 +131,7 @@ where
     let groups = Option::<Vec<String>>::deserialize(deserializer)?;
     if let Some(groups) = &groups {
         for group in groups {
-            if let Err(reason) = validate_name(group) {
+            if let Err(reason) = validate_group_name(group) {
                 return Err(D::Error::custom(format!("group name `{group}` {reason}")));
             }
         }

--- a/crates/prek/tests/list.rs
+++ b/crates/prek/tests/list.rs
@@ -304,6 +304,26 @@ fn list_with_group_filter() {
     ----- stderr -----
     ");
 
+    cmd_snapshot!(context, context.list().arg("--group").arg("@ungrouped"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    .:ungrouped
+
+    ----- stderr -----
+    ");
+
+    cmd_snapshot!(context, context.list().arg("--no-group").arg("@ungrouped"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    .:fast-lint
+    .:slow-lint
+    .:format
+
+    ----- stderr -----
+    ");
+
     cmd_snapshot!(context, context.list().arg("--group").arg("ci").arg("--no-group").arg("slow"), @r"
     success: true
     exit_code: 0

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -938,6 +938,67 @@ fn run_group_without_stage_selects_hooks_across_stages() {
 }
 
 #[test]
+fn run_reserved_groups_select_ungrouped_and_builtin_hooks() {
+    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+        repos:
+          - repo: builtin
+            hooks:
+              - id: end-of-file-fixer
+                groups: [other]
+
+          - repo: local
+            hooks:
+              - id: ungrouped
+                name: Ungrouped
+                language: system
+                entry: python3 -c "print('ungrouped')"
+                always_run: true
+              - id: ci
+                name: CI
+                language: system
+                entry: python3 -c "print('ci')"
+                always_run: true
+                groups: [ci]
+              - id: other
+                name: Other
+                language: system
+                entry: python3 -c "print('other')"
+                always_run: true
+                groups: [other]
+
+          - repo: https://notexistentatallnevergonnahappen.com/nonexistent/repo
+            rev: v1.0.0
+            hooks:
+              - id: remote-other
+                groups: [other]
+    "#});
+
+    context.git_add_all();
+
+    cmd_snapshot!(context,
+        context
+            .run()
+            .arg("--all-files")
+            .arg("--group")
+            .arg("ci")
+            .arg("--group")
+            .arg("@ungrouped")
+            .arg("--group")
+            .arg("@builtin"),
+        @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    fix end of files.........................................................Passed
+    Ungrouped................................................................Passed
+    CI.......................................................................Passed
+
+    ----- stderr -----
+    "#
+    );
+}
+
+#[test]
 fn run_required_group_without_stage_warns_when_only_message_file_hooks_match() {
     let context = TestEnv::new().with_config(indoc::indoc! {r#"
         repos:
@@ -1183,7 +1244,7 @@ fn run_unknown_group_selectors_warn_and_empty_selection_fails() {
 }
 
 #[test]
-fn run_group_selectors_reject_whitespace() {
+fn run_group_selectors_reject_invalid_names() {
     let context = TestEnv::new().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -1216,6 +1277,16 @@ fn run_group_selectors_reject_whitespace() {
     ----- stderr -----
     error: Invalid group selector: `--no-group=ci slow`
       caused by: group name cannot contain whitespace
+    "#);
+
+    cmd_snapshot!(context, context.run().arg("--all-files").arg("--group").arg("@custom"), @r#"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Invalid group selector: `--group=@custom`
+      caused by: group name uses the reserved `@` prefix
     "#);
 }
 

--- a/docs/proposals/hook-groups.md
+++ b/docs/proposals/hook-groups.md
@@ -105,6 +105,15 @@ its `groups` contains every required group.
 `--no-group <name>` is an exclude filter. A hook is removed if its `groups`
 contains any excluded group.
 
+Two names are reserved as special selectors:
+
+- `@ungrouped` matches hooks whose effective `groups` list is empty.
+- `@builtin` matches hooks from the `builtin` repository, regardless of their
+  configured groups.
+
+They compose with all three options like ordinary group memberships, but cannot
+be configured in a hook's `groups` list.
+
 The three options compose independently of argument order, and exclusion wins:
 
 1. Select hooks matching `--group`, if any `--group` values were provided.
@@ -129,6 +138,7 @@ prek run --all-files --group lint --group typecheck
 prek run --all-files --require-group lint --require-group fast
 prek run --all-files --no-group format
 prek run --all-files --group ci --require-group lint --no-group slow
+prek run --all-files --group ci --group @ungrouped --group @builtin
 prek run --all-files --group ci --stage pre-push
 ```
 
@@ -265,12 +275,21 @@ Hooks with omitted `groups` or `groups: []` are ungrouped.
 If no group options are passed, ungrouped hooks run as they do today.
 
 If `--group <name>` is passed, ungrouped hooks do not match and are not run.
-This proposal does not add a virtual `ungrouped` group.
+`--group @ungrouped` includes them explicitly.
 
 If `--require-group <name>` is passed, ungrouped hooks also do not match.
 
 If only `--no-group <name>` is passed, ungrouped hooks remain selected, because
 they do not belong to the excluded group.
+
+`@ungrouped` also works with the other filters. `--require-group @ungrouped`
+keeps only ungrouped hooks, while `--no-group @ungrouped` removes them.
+
+### Builtin Hooks
+
+Every hook from a `repo: builtin` entry matches `@builtin`, whether or not it
+has configured groups. `@builtin` does not match `local`, `meta`, or remote
+hooks.
 
 ### Multiple Groups
 
@@ -301,18 +320,20 @@ groups: ["ci", "ci"]
 
 ### Invalid Group Names
 
-Group names should be non-empty strings and must not contain whitespace. Names
-are matched exactly, so implementations should not trim or normalize group
-names before validation.
+Group names should be non-empty strings, must not contain whitespace, and must
+not start with `@`. Names are matched exactly, so implementations should not
+trim or normalize group names before validation. The `@` namespace is reserved
+for special CLI selectors.
 
 Invalid examples:
 
 ```yaml
-groups: ["", "ci slow", " ci", "ci\nslow"]
+groups: ["", "ci slow", " ci", "ci\nslow", "@builtin"]
 ```
 
-No fixed vocabulary should be enforced. In particular, `ci`, `agent`, `slow`,
-`format`, and `lint` are examples, not reserved names.
+Apart from the reserved `@` namespace, no fixed vocabulary should be enforced.
+In particular, `ci`, `agent`, `slow`, `format`, and `lint` are examples, not
+reserved names.
 
 ### Case Sensitivity
 
@@ -422,7 +443,6 @@ This proposal does not add:
 - A scheduler or dependency group. `priority` remains the scheduling mechanism.
 - DAG scheduling or `after` dependencies.
 - `--output-format=grouped`.
-- A virtual `ungrouped` selector.
 - Default-disabled hooks.
 - Environment variables for group selection.
 - `prek install --group`.
@@ -438,6 +458,9 @@ is unchanged.
 Existing `stages` behavior is unchanged for normal `prek run` and installed Git
 hook execution. The only new behavior is explicit group selection mode and the
 ability to intersect that mode with an explicitly requested stage.
+
+Group names beginning with `@` are rejected so special selectors cannot collide
+with configured memberships.
 
 Existing configs that contain an unknown `groups` key currently ignore it. Once
 this proposal is implemented, that key becomes meaningful. This is acceptable

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -233,12 +233,12 @@ prek run [OPTIONS] [HOOK|PROJECT]...
 </dd><dt id="prek-run--glob"><a href="#prek-run--glob"><code>--glob</code></a> <i>pattern</i></dt><dd><p>Run hooks on tracked files matching the specified glob pattern.</p>
 <p>Patterns are matched against paths relative to the current working directory after applying <code>--cd</code>. Quote patterns to prevent shell expansion. This option can be repeated and combined with <code>--files</code> and <code>--directory</code>.</p>
 </dd><dt id="prek-run--group"><a href="#prek-run--group"><code>--group</code></a> <i>group</i></dt><dd><p>Run hooks belonging to the specified group.</p>
-<p>Can be specified multiple times; a hook may match any specified group. When combined with <code>--require-group</code>, both filters must match.</p>
+<p>Can be specified multiple times; a hook may match any specified group. When combined with <code>--require-group</code>, both filters must match. <code>@ungrouped</code> matches hooks without groups, while <code>@builtin</code> matches hooks from the builtin repository.</p>
 </dd><dt id="prek-run--help"><a href="#prek-run--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Display the concise help for this command</p>
 </dd><dt id="prek-run--last-commit"><a href="#prek-run--last-commit"><code>--last-commit</code></a></dt><dd><p>Run hooks against the last commit. Equivalent to <code>--from-ref HEAD~1 --to-ref HEAD</code></p>
 </dd><dt id="prek-run--log-file"><a href="#prek-run--log-file"><code>--log-file</code></a> <i>log-file</i></dt><dd><p>Write trace logs to the specified file. If not specified, trace logs will be written to <code>$PREK_HOME/prek.log</code></p>
 </dd><dt id="prek-run--no-group"><a href="#prek-run--no-group"><code>--no-group</code></a> <i>group</i></dt><dd><p>Do not run hooks belonging to the specified group.</p>
-<p>Can be specified multiple times. Exclusion wins over inclusion.</p>
+<p>Can be specified multiple times. Exclusion wins over inclusion. The special selectors <code>@ungrouped</code> and <code>@builtin</code> are also supported.</p>
 </dd><dt id="prek-run--no-progress"><a href="#prek-run--no-progress"><code>--no-progress</code></a></dt><dd><p>Hide all progress outputs.</p>
 <p>For example, spinners or progress bars.</p>
 </dd><dt id="prek-run--quiet"><a href="#prek-run--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
@@ -246,7 +246,7 @@ prek run [OPTIONS] [HOOK|PROJECT]...
 <p>May also be set with the <code>PREK_QUIET</code> environment variable.</p></dd><dt id="prek-run--refresh"><a href="#prek-run--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
 </dd><dt id="prek-run--require-group"><a href="#prek-run--require-group"><code>--require-group</code></a> <i>group</i></dt><dd><p>Run hooks belonging to every specified group.</p>
 <p>Can be specified multiple times; a hook must match every specified group. When combined with <code>--group</code>, it must also match at least one <code>--group</code>. <code>--no-group</code> excludes matching hooks regardless of argument order.</p>
-<p>For example, <code>--require-group fast --group format --group lint-only</code> selects hooks in <code>fast</code> and either <code>format</code> or <code>lint-only</code>.</p>
+<p>For example, <code>--require-group fast --group format --group lint-only</code> selects hooks in <code>fast</code> and either <code>format</code> or <code>lint-only</code>. The special selectors <code>@ungrouped</code> and <code>@builtin</code> are also supported.</p>
 </dd><dt id="prek-run--show-diff-on-failure"><a href="#prek-run--show-diff-on-failure"><code>--show-diff-on-failure</code></a></dt><dd><p>When hooks fail, run <code>git diff</code> directly afterward</p>
 </dd><dt id="prek-run--skip"><a href="#prek-run--skip"><code>--skip</code></a> <i>hook|project</i></dt><dd><p>Skip the specified hooks or projects.</p>
 <p>Supports flexible selector syntax:</p>
@@ -359,7 +359,7 @@ prek list [OPTIONS] [HOOK|PROJECT]...
 <li><code>never</code>:  Disables colored output</li>
 </ul></dd><dt id="prek-list--config"><a href="#prek-list--config"><code>--config</code></a>, <code>-c</code> <i>config</i></dt><dd><p>Path to alternate config file</p>
 </dd><dt id="prek-list--group"><a href="#prek-list--group"><code>--group</code></a> <i>group</i></dt><dd><p>Show hooks belonging to the specified group.</p>
-<p>Can be specified multiple times.</p>
+<p>Can be specified multiple times. <code>@ungrouped</code> matches hooks without groups, while <code>@builtin</code> matches hooks from the builtin repository.</p>
 </dd><dt id="prek-list--help"><a href="#prek-list--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Display the concise help for this command</p>
 </dd><dt id="prek-list--hook-stage"><a href="#prek-list--hook-stage"><code>--hook-stage</code></a> <i>hook-stage</i></dt><dd><p>Show only hooks that has the specified stage</p>
 <p>Possible values:</p>
@@ -405,7 +405,7 @@ prek list [OPTIONS] [HOOK|PROJECT]...
 <li><code>system</code></li>
 </ul></dd><dt id="prek-list--log-file"><a href="#prek-list--log-file"><code>--log-file</code></a> <i>log-file</i></dt><dd><p>Write trace logs to the specified file. If not specified, trace logs will be written to <code>$PREK_HOME/prek.log</code></p>
 </dd><dt id="prek-list--no-group"><a href="#prek-list--no-group"><code>--no-group</code></a> <i>group</i></dt><dd><p>Do not show hooks belonging to the specified group.</p>
-<p>Can be specified multiple times. Exclusion wins over inclusion.</p>
+<p>Can be specified multiple times. Exclusion wins over inclusion. The special selectors <code>@ungrouped</code> and <code>@builtin</code> are also supported.</p>
 </dd><dt id="prek-list--no-progress"><a href="#prek-list--no-progress"><code>--no-progress</code></a></dt><dd><p>Hide all progress outputs.</p>
 <p>For example, spinners or progress bars.</p>
 </dd><dt id="prek-list--output-format"><a href="#prek-list--output-format"><code>--output-format</code></a> <i>output-format</i></dt><dd><p>The output format</p>
@@ -417,7 +417,7 @@ prek list [OPTIONS] [HOOK|PROJECT]...
 <p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which prek will write no output to stdout.</p>
 <p>May also be set with the <code>PREK_QUIET</code> environment variable.</p></dd><dt id="prek-list--refresh"><a href="#prek-list--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
 </dd><dt id="prek-list--require-group"><a href="#prek-list--require-group"><code>--require-group</code></a> <i>group</i></dt><dd><p>Show hooks belonging to every specified group.</p>
-<p>Can be specified multiple times. Composes with <code>--group</code> and <code>--no-group</code>.</p>
+<p>Can be specified multiple times. Composes with <code>--group</code> and <code>--no-group</code>. The special selectors <code>@ungrouped</code> and <code>@builtin</code> are also supported.</p>
 </dd><dt id="prek-list--skip"><a href="#prek-list--skip"><code>--skip</code></a> <i>hook|project</i></dt><dd><p>Skip the specified hooks or projects.</p>
 <p>Supports flexible selector syntax:</p>
 <ul>

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1159,7 +1159,15 @@ Tag a hook with user-defined run groups.
 Groups are arbitrary labels used by [`prek run --group <group>`](cli.md#prek-run--group),
 [`prek run --require-group <group>`](cli.md#prek-run--require-group), and
 [`prek run --no-group <group>`](cli.md#prek-run--no-group).
-Group names cannot be empty or contain whitespace.
+Group names cannot be empty, contain whitespace, or start with `@`. Names that
+start with `@` are reserved for special selectors:
+
+- `@ungrouped` matches hooks whose effective `groups` list is empty.
+- `@builtin` matches hooks from the `builtin` repository, regardless of their
+  configured groups.
+
+These selectors work with `--group`, `--require-group`, and `--no-group`. They
+are virtual memberships and cannot be added to a hook's `groups` list.
 
 `groups` is a project configuration field. If it appears in a remote
 `.pre-commit-hooks.yaml` manifest, `prek` ignores it.
@@ -1212,6 +1220,12 @@ Run only the `ci` group:
 
 ```bash
 prek run --all-files --group ci
+```
+
+Run the `ci` group together with ungrouped and builtin hooks:
+
+```bash
+prek run --all-files --group ci --group @ungrouped --group @builtin
 ```
 
 Run only hooks belonging to both `lint` and `ci`:

--- a/prek.schema.json
+++ b/prek.schema.json
@@ -289,11 +289,11 @@
           "$ref": "#/definitions/Priority"
         },
         "groups": {
-          "description": "User-defined hook groups used by `prek run --group` and `--no-group`.\nGroup names cannot be empty or contain whitespace.",
+          "description": "User-defined hook groups used by `prek run --group` and `--no-group`.\nGroup names cannot be empty, contain whitespace, or start with `@`.",
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^\\S+$"
+            "pattern": "^[^@\\s]\\S*$"
           }
         },
         "alias": {
@@ -599,11 +599,11 @@
           "$ref": "#/definitions/Priority"
         },
         "groups": {
-          "description": "User-defined hook groups used by `prek run --group` and `--no-group`.\nGroup names cannot be empty or contain whitespace.",
+          "description": "User-defined hook groups used by `prek run --group` and `--no-group`.\nGroup names cannot be empty, contain whitespace, or start with `@`.",
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^\\S+$"
+            "pattern": "^[^@\\s]\\S*$"
           }
         },
         "alias": {
@@ -768,11 +768,11 @@
           "$ref": "#/definitions/Priority"
         },
         "groups": {
-          "description": "User-defined hook groups used by `prek run --group` and `--no-group`.\nGroup names cannot be empty or contain whitespace.",
+          "description": "User-defined hook groups used by `prek run --group` and `--no-group`.\nGroup names cannot be empty, contain whitespace, or start with `@`.",
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^\\S+$"
+            "pattern": "^[^@\\s]\\S*$"
           }
         },
         "alias": {
@@ -942,11 +942,11 @@
           "$ref": "#/definitions/Priority"
         },
         "groups": {
-          "description": "User-defined hook groups used by `prek run --group` and `--no-group`.\nGroup names cannot be empty or contain whitespace.",
+          "description": "User-defined hook groups used by `prek run --group` and `--no-group`.\nGroup names cannot be empty, contain whitespace, or start with `@`.",
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^\\S+$"
+            "pattern": "^[^@\\s]\\S*$"
           }
         },
         "alias": {


### PR DESCRIPTION
Adds `@ungrouped` and `@builtin` special selectors to `--group`, `--require-group`, and `--no-group`.

Addresses https://github.com/j178/prek/discussions/2616
Closes #2618
