### PR TITLE
Remove legacy update aliases

### DIFF
--- a/crates/prek/src/cli/mod.rs
+++ b/crates/prek/src/cli/mod.rs
@@ -268,7 +268,7 @@ pub(crate) enum Command {
     /// Generate a sample prek configuration file.
     SampleConfig(SampleConfigArgs),
     /// Update configured repositories.
-    #[command(aliases = ["auto-update", "autoupdate"])]
+    #[command(alias = "autoupdate")]
     Update(UpdateArgs),
     /// Manage the prek cache.
     Cache(CacheNamespace),

--- a/crates/prek/src/config/mod.rs
+++ b/crates/prek/src/config/mod.rs
@@ -45,7 +45,6 @@ use crate::warn_user_once;
 )]
 pub(crate) struct Config {
     /// Default settings for `prek update` in this project.
-    #[serde(alias = "auto_update")]
     pub update: Option<UpdateOptions>,
     /// Configuration-local aliases for numeric hook priorities.
     #[serde(default)]
@@ -871,21 +870,6 @@ mod tests {
         3 | repos: []
           |
         "#);
-    }
-
-    #[test]
-    fn parse_legacy_update_key_alias() {
-        let yaml = indoc::indoc! {r"
-            auto_update:
-              cooldown_days: 7
-            repos: []
-        "};
-        let result = serde_saphyr::from_str::<Config>(yaml).unwrap();
-
-        assert_eq!(
-            result.update.and_then(|options| options.cooldown_days),
-            Some(7)
-        );
     }
 
     #[test]

--- a/crates/prek/src/schema.rs
+++ b/crates/prek/src/schema.rs
@@ -120,32 +120,6 @@ fn strip_null_acceptance(schema: &mut schemars::Schema) {
     }
 }
 
-fn add_compatibility_aliases(schema: &mut schemars::Schema) {
-    use serde_json::Value;
-
-    let Some(properties) = schema
-        .as_object_mut()
-        .and_then(|schema| schema.get_mut("properties"))
-        .and_then(Value::as_object_mut)
-    else {
-        return;
-    };
-
-    let Some(update_schema) = properties.get("update").cloned() else {
-        return;
-    };
-    let mut auto_update_schema = update_schema;
-    if let Some(obj) = auto_update_schema.as_object_mut() {
-        obj.insert(
-            "description".to_string(),
-            Value::String(
-                "Compatibility alias for `update`. Prefer `update` in new configs.".to_string(),
-            ),
-        );
-    }
-    properties.insert("auto_update".to_string(), auto_update_schema);
-}
-
 impl schemars::JsonSchema for Stages {
     fn inline_schema() -> bool {
         true
@@ -471,8 +445,7 @@ mod _gen {
             .with_transform(schemars::transform::RestrictFormats::default())
             .with_transform(super::RemoveNullTypes);
         let generator = schemars::SchemaGenerator::new(settings);
-        let mut schema = generator.into_root_schema_for::<Config>();
-        super::add_compatibility_aliases(&mut schema);
+        let schema = generator.into_root_schema_for::<Config>();
         serde_json::to_string_pretty(&schema).unwrap() + "\n"
     }
 

--- a/crates/prek/src/settings.rs
+++ b/crates/prek/src/settings.rs
@@ -82,7 +82,6 @@ impl Deref for FilesystemOptions {
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default, rename_all = "snake_case")]
 pub(crate) struct Options {
-    #[serde(alias = "auto_update")]
     update: Option<GlobalUpdateOptions>,
 }
 
@@ -258,22 +257,6 @@ mod tests {
           |                            ^^^^^^^^^^^
         error parsing glob '[': unclosed character class; missing ']'
         "#);
-    }
-
-    #[test]
-    fn options_deserializes_legacy_update_key_alias() {
-        let options: Options = toml::from_str(
-            r"
-            [auto_update]
-            cooldown_days = 7
-            ",
-        )
-        .unwrap();
-
-        assert_eq!(
-            options.update.and_then(|options| options.cooldown_days),
-            Some(7)
-        );
     }
 
     #[test]

--- a/crates/prek/tests/global_config.rs
+++ b/crates/prek/tests/global_config.rs
@@ -36,10 +36,10 @@ fn global_config_ignores_unknown_options() {
 }
 
 #[test]
-fn update_command_accepts_legacy_command_alias() {
+fn update_command_accepts_upstream_alias() {
     let context = TestEnv::new().with_config("repos: []");
 
-    cmd_snapshot!(context, context.command().arg("auto-update"), @"
+    cmd_snapshot!(context, context.command().arg("autoupdate"), @"
     success: true
     exit_code: 0
     ----- stdout -----

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -16,21 +16,12 @@
 | -- | -- |
 | `prek install-hooks` | `prek prepare-hooks` |
 | `prek install --install-hooks` | `prek install --prepare-hooks` |
-| `prek auto-update` | `prek update` |
 | `prek autoupdate` | `prek update` |
 | `prek gc` | `prek cache gc` |
 | `prek clean` | `prek cache clean` |
 | `prek init-templatedir` | `prek util init-template-dir` |
 | `prek init-template-dir` | `prek util init-template-dir` |
 | `pre-commit migrate-config` | Not provided directly; use `prek util yaml-to-toml` to migrate YAML to `prek.toml` |
-
-## Preferred config key spellings
-
-`prek` still accepts legacy config keys below as aliases.
-
-| Compatibility spelling | Preferred `prek` spelling |
-| -- | -- |
-| `auto_update` | `update` |
 
 ## Why the CLI is reorganized
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -43,10 +43,6 @@ The cooldown age is computed from the tag creation timestamp for annotated tags,
 
     If the current `rev` is newer than the latest cooldown-eligible tag, [`prek update`](cli.md#prek-update) keeps the current `rev` instead of downgrading it.
 
-!!! note "Compatibility alias"
-
-    The legacy `auto_update` key is still accepted as an alias for `update`.
-
 ## Extension keys (`x-`)
 
 Any key starting with `x-` (a lowercase `x` followed by a hyphen) is silently ignored by `prek` at any level of the configuration. This supports custom metadata without triggering unexpected key warnings.
@@ -410,10 +406,6 @@ Each project-level field overrides the corresponding [global `update`](#global-u
 CLI filters have the highest precedence. `--include-tag` and `--exclude-tag` replace the configured effective defaults; `--repo-include-tag` then replaces the include filters for its named repository, while `--repo-exclude-tag` adds excludes for its named repository.
 
 In workspace mode, `update` is scoped to the project config file that defines it and is not inherited by nested projects. Sub-projects use their own `update`, then the user-level global config, then built-in defaults. Repositories shared by multiple projects are fetched once but evaluated with each project's cooldown, freeze, and tag-filter settings.
-
-!!! note "Compatibility alias"
-
-    The legacy `auto_update` key is still accepted as an alias for `update`.
 
 ### `minimum_prek_version`
 

--- a/prek.schema.json
+++ b/prek.schema.json
@@ -149,10 +149,6 @@
     "orphan": {
       "description": "Set to true to isolate this project from parent configurations in workspace mode.\nWhen true, files in this project are \"consumed\" by this project and will not be processed\nby parent projects.\nWhen false (default), files in subprojects are processed by both the subproject and\nany parent projects that contain them.",
       "type": "boolean"
-    },
-    "auto_update": {
-      "description": "Compatibility alias for `update`. Prefer `update` in new configs.",
-      "$ref": "#/definitions/UpdateOptions"
     }
   },
   "required": [

--- a/skills/prek/SKILL.md
+++ b/skills/prek/SKILL.md
@@ -154,7 +154,7 @@ Common install methods:
 - `prek run <hook-id>`: run only one hook
 - `prek list`: list discovered hooks and projects
 - `prek validate-config`: validate `prek.toml` or `.pre-commit-config.yaml`
-- `prek auto-update`: update pinned hook revisions
+- `prek update`: update pinned hook revisions
 - `prek util yaml-to-toml`: convert an existing YAML config to `prek.toml`
 - `prek util identify <path>`: inspect file tags when `types`, `types_or`, or `exclude_types` do not match as expected
 


### PR DESCRIPTION
Removes the deprecated `auto_update` config key and `auto-update` command spelling.
