### PR TITLE
Remove the `@builtin` group selector

### DIFF
--- a/crates/prek/src/cli/mod.rs
+++ b/crates/prek/src/cli/mod.rs
@@ -679,8 +679,7 @@ pub(crate) struct RunArgs {
     ///
     /// Can be specified multiple times; a hook may match any specified group.
     /// When combined with `--require-group`, both filters must match.
-    /// `@ungrouped` matches hooks without groups, while `@builtin` matches
-    /// hooks from the builtin repository.
+    /// `@ungrouped` matches hooks without groups.
     #[arg(long = "group", value_name = "GROUP")]
     pub(crate) groups: Vec<String>,
 
@@ -692,14 +691,14 @@ pub(crate) struct RunArgs {
     ///
     /// For example, `--require-group fast --group format --group lint-only`
     /// selects hooks in `fast` and either `format` or `lint-only`.
-    /// The special selectors `@ungrouped` and `@builtin` are also supported.
+    /// The special selector `@ungrouped` is also supported.
     #[arg(long = "require-group", value_name = "GROUP")]
     pub(crate) required_groups: Vec<String>,
 
     /// Do not run hooks belonging to the specified group.
     ///
     /// Can be specified multiple times. Exclusion wins over inclusion.
-    /// The special selectors `@ungrouped` and `@builtin` are also supported.
+    /// The special selector `@ungrouped` is also supported.
     #[arg(long = "no-group", value_name = "GROUP")]
     pub(crate) no_groups: Vec<String>,
 }
@@ -786,22 +785,21 @@ pub(crate) struct ListArgs {
 
     /// Show hooks belonging to the specified group.
     ///
-    /// Can be specified multiple times. `@ungrouped` matches hooks without
-    /// groups, while `@builtin` matches hooks from the builtin repository.
+    /// Can be specified multiple times. `@ungrouped` matches hooks without groups.
     #[arg(long = "group", value_name = "GROUP")]
     pub(crate) groups: Vec<String>,
 
     /// Show hooks belonging to every specified group.
     ///
     /// Can be specified multiple times. Composes with `--group` and `--no-group`.
-    /// The special selectors `@ungrouped` and `@builtin` are also supported.
+    /// The special selector `@ungrouped` is also supported.
     #[arg(long = "require-group", value_name = "GROUP")]
     pub(crate) required_groups: Vec<String>,
 
     /// Do not show hooks belonging to the specified group.
     ///
     /// Can be specified multiple times. Exclusion wins over inclusion.
-    /// The special selectors `@ungrouped` and `@builtin` are also supported.
+    /// The special selector `@ungrouped` is also supported.
     #[arg(long = "no-group", value_name = "GROUP")]
     pub(crate) no_groups: Vec<String>,
 

--- a/crates/prek/src/cli/run/selector.rs
+++ b/crates/prek/src/cli/run/selector.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use crate::config::validate_group_name;
-use crate::hook::{Hook, Repo};
+use crate::hook::Hook;
 use crate::warn_user;
 
 use anyhow::anyhow;
@@ -434,21 +434,17 @@ pub(crate) struct GroupFilters {
 enum GroupSelector {
     Named(String),
     Ungrouped,
-    Builtin,
 }
 
 const UNGROUPED_GROUP: &str = "@ungrouped";
-const BUILTIN_GROUP: &str = "@builtin";
 
 impl GroupSelector {
     fn parse(group: &str) -> Result<Self, &'static str> {
-        match group {
-            UNGROUPED_GROUP => Ok(Self::Ungrouped),
-            BUILTIN_GROUP => Ok(Self::Builtin),
-            _ => {
-                validate_group_name(group)?;
-                Ok(Self::Named(group.to_owned()))
-            }
+        if group == UNGROUPED_GROUP {
+            Ok(Self::Ungrouped)
+        } else {
+            validate_group_name(group)?;
+            Ok(Self::Named(group.to_owned()))
         }
     }
 }
@@ -458,7 +454,6 @@ impl Display for GroupSelector {
         match self {
             Self::Named(group) => f.write_str(group),
             Self::Ungrouped => f.write_str(UNGROUPED_GROUP),
-            Self::Builtin => f.write_str(BUILTIN_GROUP),
         }
     }
 }
@@ -534,7 +529,6 @@ impl GroupFilters {
         self.matches_groups(|group| match group {
             GroupSelector::Named(group) => hook.groups.contains(group),
             GroupSelector::Ungrouped => hook.groups.is_empty(),
-            GroupSelector::Builtin => matches!(hook.repo(), Repo::Builtin),
         })
     }
 
@@ -544,7 +538,6 @@ impl GroupFilters {
                 .groups
                 .is_some_and(|groups| groups.iter().any(|hook_group| hook_group == group)),
             GroupSelector::Ungrouped => hook.groups.is_none_or(<[String]>::is_empty),
-            GroupSelector::Builtin => false,
         })
     }
 

--- a/crates/prek/src/config/mod.rs
+++ b/crates/prek/src/config/mod.rs
@@ -410,8 +410,8 @@ mod tests {
                 "group name `ci\tslow` cannot contain whitespace",
             ),
             (
-                r#"["@builtin"]"#,
-                "group name `@builtin` uses the reserved `@` prefix",
+                r#"["@custom"]"#,
+                "group name `@custom` uses the reserved `@` prefix",
             ),
         ] {
             let yaml = indoc::formatdoc! {r"

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -938,14 +938,9 @@ fn run_group_without_stage_selects_hooks_across_stages() {
 }
 
 #[test]
-fn run_reserved_groups_select_ungrouped_and_builtin_hooks() {
+fn run_ungrouped_group_selects_hooks_without_groups() {
     let context = TestEnv::new().with_config(indoc::indoc! {r#"
         repos:
-          - repo: builtin
-            hooks:
-              - id: end-of-file-fixer
-                groups: [other]
-
           - repo: local
             hooks:
               - id: ungrouped
@@ -982,14 +977,11 @@ fn run_reserved_groups_select_ungrouped_and_builtin_hooks() {
             .arg("--group")
             .arg("ci")
             .arg("--group")
-            .arg("@ungrouped")
-            .arg("--group")
-            .arg("@builtin"),
+            .arg("@ungrouped"),
         @r#"
     success: true
     exit_code: 0
     ----- stdout -----
-    fix end of files.........................................................Passed
     Ungrouped................................................................Passed
     CI.......................................................................Passed
 

--- a/docs/proposals/hook-groups.md
+++ b/docs/proposals/hook-groups.md
@@ -105,13 +105,10 @@ its `groups` contains every required group.
 `--no-group <name>` is an exclude filter. A hook is removed if its `groups`
 contains any excluded group.
 
-Two names are reserved as special selectors:
+`@ungrouped` is reserved as a special selector. It matches hooks whose
+effective `groups` list is empty.
 
-- `@ungrouped` matches hooks whose effective `groups` list is empty.
-- `@builtin` matches hooks from the `builtin` repository, regardless of their
-  configured groups.
-
-They compose with all three options like ordinary group memberships, but cannot
+It composes with all three options like an ordinary group membership, but cannot
 be configured in a hook's `groups` list.
 
 The three options compose independently of argument order, and exclusion wins:
@@ -138,7 +135,7 @@ prek run --all-files --group lint --group typecheck
 prek run --all-files --require-group lint --require-group fast
 prek run --all-files --no-group format
 prek run --all-files --group ci --require-group lint --no-group slow
-prek run --all-files --group ci --group @ungrouped --group @builtin
+prek run --all-files --group ci --group @ungrouped
 prek run --all-files --group ci --stage pre-push
 ```
 
@@ -285,12 +282,6 @@ they do not belong to the excluded group.
 `@ungrouped` also works with the other filters. `--require-group @ungrouped`
 keeps only ungrouped hooks, while `--no-group @ungrouped` removes them.
 
-### Builtin Hooks
-
-Every hook from a `repo: builtin` entry matches `@builtin`, whether or not it
-has configured groups. `@builtin` does not match `local`, `meta`, or remote
-hooks.
-
 ### Multiple Groups
 
 A hook may belong to multiple groups:
@@ -328,7 +319,7 @@ for special CLI selectors.
 Invalid examples:
 
 ```yaml
-groups: ["", "ci slow", " ci", "ci\nslow", "@builtin"]
+groups: ["", "ci slow", " ci", "ci\nslow", "@custom"]
 ```
 
 Apart from the reserved `@` namespace, no fixed vocabulary should be enforced.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -233,12 +233,12 @@ prek run [OPTIONS] [HOOK|PROJECT]...
 </dd><dt id="prek-run--glob"><a href="#prek-run--glob"><code>--glob</code></a> <i>pattern</i></dt><dd><p>Run hooks on tracked files matching the specified glob pattern.</p>
 <p>Patterns are matched against paths relative to the current working directory after applying <code>--cd</code>. Quote patterns to prevent shell expansion. This option can be repeated and combined with <code>--files</code> and <code>--directory</code>.</p>
 </dd><dt id="prek-run--group"><a href="#prek-run--group"><code>--group</code></a> <i>group</i></dt><dd><p>Run hooks belonging to the specified group.</p>
-<p>Can be specified multiple times; a hook may match any specified group. When combined with <code>--require-group</code>, both filters must match. <code>@ungrouped</code> matches hooks without groups, while <code>@builtin</code> matches hooks from the builtin repository.</p>
+<p>Can be specified multiple times; a hook may match any specified group. When combined with <code>--require-group</code>, both filters must match. <code>@ungrouped</code> matches hooks without groups.</p>
 </dd><dt id="prek-run--help"><a href="#prek-run--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Display the concise help for this command</p>
 </dd><dt id="prek-run--last-commit"><a href="#prek-run--last-commit"><code>--last-commit</code></a></dt><dd><p>Run hooks against the last commit. Equivalent to <code>--from-ref HEAD~1 --to-ref HEAD</code></p>
 </dd><dt id="prek-run--log-file"><a href="#prek-run--log-file"><code>--log-file</code></a> <i>log-file</i></dt><dd><p>Write trace logs to the specified file. If not specified, trace logs will be written to <code>$PREK_HOME/prek.log</code></p>
 </dd><dt id="prek-run--no-group"><a href="#prek-run--no-group"><code>--no-group</code></a> <i>group</i></dt><dd><p>Do not run hooks belonging to the specified group.</p>
-<p>Can be specified multiple times. Exclusion wins over inclusion. The special selectors <code>@ungrouped</code> and <code>@builtin</code> are also supported.</p>
+<p>Can be specified multiple times. Exclusion wins over inclusion. The special selector <code>@ungrouped</code> is also supported.</p>
 </dd><dt id="prek-run--no-progress"><a href="#prek-run--no-progress"><code>--no-progress</code></a></dt><dd><p>Hide all progress outputs.</p>
 <p>For example, spinners or progress bars.</p>
 </dd><dt id="prek-run--quiet"><a href="#prek-run--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
@@ -246,7 +246,7 @@ prek run [OPTIONS] [HOOK|PROJECT]...
 <p>May also be set with the <code>PREK_QUIET</code> environment variable.</p></dd><dt id="prek-run--refresh"><a href="#prek-run--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
 </dd><dt id="prek-run--require-group"><a href="#prek-run--require-group"><code>--require-group</code></a> <i>group</i></dt><dd><p>Run hooks belonging to every specified group.</p>
 <p>Can be specified multiple times; a hook must match every specified group. When combined with <code>--group</code>, it must also match at least one <code>--group</code>. <code>--no-group</code> excludes matching hooks regardless of argument order.</p>
-<p>For example, <code>--require-group fast --group format --group lint-only</code> selects hooks in <code>fast</code> and either <code>format</code> or <code>lint-only</code>. The special selectors <code>@ungrouped</code> and <code>@builtin</code> are also supported.</p>
+<p>For example, <code>--require-group fast --group format --group lint-only</code> selects hooks in <code>fast</code> and either <code>format</code> or <code>lint-only</code>. The special selector <code>@ungrouped</code> is also supported.</p>
 </dd><dt id="prek-run--show-diff-on-failure"><a href="#prek-run--show-diff-on-failure"><code>--show-diff-on-failure</code></a></dt><dd><p>When hooks fail, run <code>git diff</code> directly afterward</p>
 </dd><dt id="prek-run--skip"><a href="#prek-run--skip"><code>--skip</code></a> <i>hook|project</i></dt><dd><p>Skip the specified hooks or projects.</p>
 <p>Supports flexible selector syntax:</p>
@@ -359,7 +359,7 @@ prek list [OPTIONS] [HOOK|PROJECT]...
 <li><code>never</code>:  Disables colored output</li>
 </ul></dd><dt id="prek-list--config"><a href="#prek-list--config"><code>--config</code></a>, <code>-c</code> <i>config</i></dt><dd><p>Path to alternate config file</p>
 </dd><dt id="prek-list--group"><a href="#prek-list--group"><code>--group</code></a> <i>group</i></dt><dd><p>Show hooks belonging to the specified group.</p>
-<p>Can be specified multiple times. <code>@ungrouped</code> matches hooks without groups, while <code>@builtin</code> matches hooks from the builtin repository.</p>
+<p>Can be specified multiple times. <code>@ungrouped</code> matches hooks without groups.</p>
 </dd><dt id="prek-list--help"><a href="#prek-list--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Display the concise help for this command</p>
 </dd><dt id="prek-list--hook-stage"><a href="#prek-list--hook-stage"><code>--hook-stage</code></a> <i>hook-stage</i></dt><dd><p>Show only hooks that has the specified stage</p>
 <p>Possible values:</p>
@@ -405,7 +405,7 @@ prek list [OPTIONS] [HOOK|PROJECT]...
 <li><code>system</code></li>
 </ul></dd><dt id="prek-list--log-file"><a href="#prek-list--log-file"><code>--log-file</code></a> <i>log-file</i></dt><dd><p>Write trace logs to the specified file. If not specified, trace logs will be written to <code>$PREK_HOME/prek.log</code></p>
 </dd><dt id="prek-list--no-group"><a href="#prek-list--no-group"><code>--no-group</code></a> <i>group</i></dt><dd><p>Do not show hooks belonging to the specified group.</p>
-<p>Can be specified multiple times. Exclusion wins over inclusion. The special selectors <code>@ungrouped</code> and <code>@builtin</code> are also supported.</p>
+<p>Can be specified multiple times. Exclusion wins over inclusion. The special selector <code>@ungrouped</code> is also supported.</p>
 </dd><dt id="prek-list--no-progress"><a href="#prek-list--no-progress"><code>--no-progress</code></a></dt><dd><p>Hide all progress outputs.</p>
 <p>For example, spinners or progress bars.</p>
 </dd><dt id="prek-list--output-format"><a href="#prek-list--output-format"><code>--output-format</code></a> <i>output-format</i></dt><dd><p>The output format</p>
@@ -417,7 +417,7 @@ prek list [OPTIONS] [HOOK|PROJECT]...
 <p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which prek will write no output to stdout.</p>
 <p>May also be set with the <code>PREK_QUIET</code> environment variable.</p></dd><dt id="prek-list--refresh"><a href="#prek-list--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
 </dd><dt id="prek-list--require-group"><a href="#prek-list--require-group"><code>--require-group</code></a> <i>group</i></dt><dd><p>Show hooks belonging to every specified group.</p>
-<p>Can be specified multiple times. Composes with <code>--group</code> and <code>--no-group</code>. The special selectors <code>@ungrouped</code> and <code>@builtin</code> are also supported.</p>
+<p>Can be specified multiple times. Composes with <code>--group</code> and <code>--no-group</code>. The special selector <code>@ungrouped</code> is also supported.</p>
 </dd><dt id="prek-list--skip"><a href="#prek-list--skip"><code>--skip</code></a> <i>hook|project</i></dt><dd><p>Skip the specified hooks or projects.</p>
 <p>Supports flexible selector syntax:</p>
 <ul>

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1163,11 +1163,9 @@ Group names cannot be empty, contain whitespace, or start with `@`. Names that
 start with `@` are reserved for special selectors:
 
 - `@ungrouped` matches hooks whose effective `groups` list is empty.
-- `@builtin` matches hooks from the `builtin` repository, regardless of their
-  configured groups.
 
-These selectors work with `--group`, `--require-group`, and `--no-group`. They
-are virtual memberships and cannot be added to a hook's `groups` list.
+This selector works with `--group`, `--require-group`, and `--no-group`. It is a
+virtual membership and cannot be added to a hook's `groups` list.
 
 `groups` is a project configuration field. If it appears in a remote
 `.pre-commit-hooks.yaml` manifest, `prek` ignores it.
@@ -1222,10 +1220,10 @@ Run only the `ci` group:
 prek run --all-files --group ci
 ```
 
-Run the `ci` group together with ungrouped and builtin hooks:
+Run the `ci` group together with ungrouped hooks:
 
 ```bash
-prek run --all-files --group ci --group @ungrouped --group @builtin
+prek run --all-files --group ci --group @ungrouped
 ```
 
 Run only hooks belonging to both `lint` and `ci`:


### PR DESCRIPTION
Keeps `@ungrouped` as the only special group selector.

Follow-up to #2617.
