### PR TITLE
Simplify TestEnv file and Git setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ In integration tests, you can use `cmd_snapshot!` macro to simplify creating sna
 ```rust
 #[test]
 fn test_run() {
-    let env = TestEnv::new();
+    let env = TestEnv::new_git();
 
     cmd_snapshot!(env, env.run(), @"");
 }

--- a/crates/prek/tests/builtin_hooks.rs
+++ b/crates/prek/tests/builtin_hooks.rs
@@ -16,7 +16,7 @@ mod common;
 /// Tests that `repo: builtin` hooks doesn't create hook env.
 #[test]
 fn builtin_hooks_not_create_env() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -46,7 +46,7 @@ fn builtin_hooks_not_create_env() {
 
 #[test]
 fn builtin_hooks_unknown_hook() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -73,7 +73,7 @@ fn builtin_hooks_unknown_hook() {
 
 #[test]
 fn deny_filename_pattern_hook_matches_only_basename() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -109,7 +109,7 @@ fn deny_filename_pattern_hook_matches_only_basename() -> Result<()> {
 
 #[test]
 fn deny_pattern_hook_reports_matching_lines() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -152,7 +152,7 @@ fn deny_pattern_hook_reports_matching_lines() -> Result<()> {
 
 #[test]
 fn deny_pattern_hook_rejects_invalid_regex() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -186,7 +186,7 @@ fn deny_pattern_hook_rejects_invalid_regex() -> Result<()> {
 
 #[test]
 fn deny_pattern_hook_reports_earliest_multiline_match() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // `END` is listed first, but `BEGIN.*END` starts earlier in the file.
     // Multiline matching should report the earliest match, not the first pattern.
@@ -232,7 +232,7 @@ fn deny_pattern_hook_reports_earliest_multiline_match() -> Result<()> {
 
 #[test]
 fn require_filename_pattern_hook_accepts_any_pattern_for_basename() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -274,7 +274,7 @@ fn require_filename_pattern_hook_accepts_any_pattern_for_basename() -> Result<()
 
 #[test]
 fn require_pattern_hook_reports_files_without_any_match() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -308,7 +308,7 @@ fn require_pattern_hook_reports_files_without_any_match() -> Result<()> {
 
 #[test]
 fn end_of_file_fixer_hook() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -379,7 +379,7 @@ fn end_of_file_fixer_hook() -> Result<()> {
 
 #[test]
 fn file_contents_sorter_hook() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -436,7 +436,7 @@ fn file_contents_sorter_hook() -> Result<()> {
 
 #[test]
 fn builtin_hook_checks_filename_from_args_after_options() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -474,7 +474,7 @@ fn builtin_hook_checks_filename_from_args_after_options() -> Result<()> {
 
 #[test]
 fn requirements_txt_fixer_hook() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -563,7 +563,7 @@ fn requirements_txt_fixer_hook() -> Result<()> {
 
 #[test]
 fn forbid_new_submodules_hook_in_workspace_project() -> Result<()> {
-    let context = TestEnv::new().with_config("repos: []\n");
+    let context = TestEnv::new_git().with_config("repos: []\n");
 
     let cwd = context.work_dir();
     cwd.child("project2").create_dir_all()?;
@@ -637,7 +637,7 @@ fn forbid_new_submodules_hook_in_workspace_project() -> Result<()> {
 
 #[test]
 fn check_yaml_hook() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -700,7 +700,7 @@ fn check_yaml_hook() -> Result<()> {
 
 #[test]
 fn check_yaml_multiple_document() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -750,7 +750,7 @@ fn check_yaml_multiple_document() -> Result<()> {
 
 #[test]
 fn check_vcs_permalinks_builtin() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -788,7 +788,7 @@ fn check_vcs_permalinks_builtin() -> Result<()> {
 
 #[test]
 fn check_json_hook() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -844,7 +844,7 @@ fn check_json_hook() -> Result<()> {
 
 #[test]
 fn mixed_line_ending_hook() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -999,29 +999,21 @@ fn mixed_line_ending_hook() -> Result<()> {
 }
 
 #[test]
-fn check_added_large_files_hook() -> Result<()> {
-    let context = TestEnv::new();
-
+fn check_added_large_files_hook() {
     // Create an initial commit
-    let cwd = context.work_dir();
-    cwd.child("README.md").write_str("Initial commit")?;
-    context.git_add_all();
-    context.git_commit("Initial commit");
+    let context = TestEnv::new_git().with_file("README.md", "Initial commit");
+    context.git_add_all().git_commit("Initial commit");
 
-    let context = context.with_config(indoc::indoc! {r"
-        repos:
-          - repo: builtin
-            hooks:
-              - id: check-added-large-files
-                args: ['--maxkb', '1']
-    "});
-
-    let cwd = context.work_dir();
-
-    // Create test files
-    cwd.child("small_file.txt").write_str("Hello World\n")?;
-    let large_file = cwd.child("large_file.txt");
-    large_file.write_binary(&[0; 2048])?; // 2KB file
+    let context = context
+        .with_config(indoc::indoc! {r"
+            repos:
+              - repo: builtin
+                hooks:
+                  - id: check-added-large-files
+                    args: ['--maxkb', '1']
+        "})
+        .with_file("small_file.txt", "Hello World\n")
+        .with_file("large_file.txt", [0_u8; 2048]);
 
     context.git_add_all();
 
@@ -1041,12 +1033,10 @@ fn check_added_large_files_hook() -> Result<()> {
     ");
 
     // Commit the files
-    context.git_add_all();
-    context.git_commit("Add large file");
+    context.git_add_all().git_commit("Add large file");
 
     // Create a new unstaged large file
-    let unstaged_large_file = cwd.child("unstaged_large_file.txt");
-    unstaged_large_file.write_binary(&[0; 2048])?; // 2KB file
+    context.write_file("unstaged_large_file.txt", [0_u8; 2048]);
     context.git_add("unstaged_large_file.txt");
 
     context.write_config(indoc::indoc! {r"
@@ -1073,8 +1063,7 @@ fn check_added_large_files_hook() -> Result<()> {
     ----- stderr -----
     "#);
 
-    context.git_rm("unstaged_large_file.txt");
-    context.git_clean();
+    context.git_rm("unstaged_large_file.txt").git_clean();
 
     // Test git-lfs integration
     context.write_config(indoc::indoc! {r"
@@ -1085,11 +1074,12 @@ fn check_added_large_files_hook() -> Result<()> {
                 args: ['--maxkb=1']
         "});
 
-    cwd.child(".gitattributes")
-        .write_str("*.dat filter=lfs diff=lfs merge=lfs -text")?;
+    context.write_file(
+        ".gitattributes",
+        "*.dat filter=lfs diff=lfs merge=lfs -text",
+    );
     context.git_add(".gitattributes");
-    let lfs_file = cwd.child("lfs_file.dat");
-    lfs_file.write_binary(&[0; 2048])?; // 2KB file
+    context.write_file("lfs_file.dat", [0_u8; 2048]);
     context.git_add_all();
 
     // Third run: hook should pass because the large file is tracked by git-lfs
@@ -1101,13 +1091,11 @@ fn check_added_large_files_hook() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
 fn check_added_large_files_workspace_mode_respects_project_relative_lfs_paths() -> Result<()> {
-    let context = TestEnv::new().with_config("repos: []\n");
+    let context = TestEnv::new_git().with_config("repos: []\n");
 
     // Regression: builtin hooks receive project-relative filenames even in workspace mode.
     // `check-added-large-files` must therefore resolve git-lfs attributes relative to the
@@ -1145,7 +1133,7 @@ fn check_added_large_files_workspace_mode_respects_project_relative_lfs_paths() 
 
 #[test]
 fn check_added_large_files_workspace_mode_respects_project_relative_added_files() -> Result<()> {
-    let context = TestEnv::new().with_config("repos: []\n");
+    let context = TestEnv::new_git().with_config("repos: []\n");
 
     let app = context.work_dir().child("app");
     app.create_dir_all()?;
@@ -1181,7 +1169,7 @@ fn check_added_large_files_workspace_mode_respects_project_relative_added_files(
 
 #[test]
 fn tracked_file_exceeds_large_file_limit() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -1215,7 +1203,7 @@ fn tracked_file_exceeds_large_file_limit() -> Result<()> {
 
 #[test]
 fn builtin_hooks_workspace_mode() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: meta
             hooks:
@@ -1432,7 +1420,7 @@ fn builtin_hooks_workspace_mode() -> Result<()> {
 
 #[test]
 fn fix_byte_order_marker_hook() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -1493,7 +1481,7 @@ fn fix_byte_order_marker_hook() -> Result<()> {
 
 #[test]
 fn pretty_format_json_hook() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -1628,7 +1616,7 @@ fn pretty_format_json_hook() -> Result<()> {
 
 #[test]
 fn pretty_format_json_with_options() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -1682,7 +1670,7 @@ fn pretty_format_json_with_options() -> Result<()> {
 
 #[test]
 fn pretty_format_json_with_top_keys() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -1738,7 +1726,7 @@ fn pretty_format_json_with_top_keys() -> Result<()> {
 
 #[test]
 fn pretty_format_json_no_ensure_ascii() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -1791,7 +1779,7 @@ fn pretty_format_json_no_ensure_ascii() -> Result<()> {
 
 #[test]
 fn pretty_format_json_custom_space_indent() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -1844,7 +1832,7 @@ fn pretty_format_json_custom_space_indent() -> Result<()> {
 #[test]
 #[cfg(unix)]
 fn check_symlinks_hook_unix() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -1906,7 +1894,7 @@ fn check_symlinks_hook_unix() -> Result<()> {
 #[test]
 #[cfg(windows)]
 fn check_symlinks_hook_windows() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -1979,7 +1967,7 @@ fn destroyed_symlinks_hook() -> Result<()> {
     const TEST_FILE: &str = "test_file";
     const TEST_FILE_RENAMED: &str = "test_file_renamed";
 
-    let source = TestEnv::new();
+    let source = TestEnv::new_git();
 
     fs_err::os::unix::fs::symlink(
         TEST_SYMLINK_TARGET,
@@ -2001,7 +1989,7 @@ fn destroyed_symlinks_hook() -> Result<()> {
     assert!(tree.status.success());
     assert!(String::from_utf8(tree.stdout)?.contains("120000 "));
 
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
     context
         .git()
         .arg("-c")
@@ -2113,7 +2101,7 @@ fn destroyed_symlinks_hook() -> Result<()> {
 
 #[test]
 fn detect_private_key_hook() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -2201,7 +2189,7 @@ fn detect_private_key_hook() -> Result<()> {
 
 #[test]
 fn check_merge_conflict_hook() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -2291,7 +2279,7 @@ fn check_merge_conflict_hook() -> Result<()> {
 
 #[test]
 fn check_merge_conflict_ignores_rst_headings() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -2321,7 +2309,7 @@ fn check_merge_conflict_ignores_rst_headings() -> Result<()> {
 
 #[test]
 fn check_merge_conflict_diff3_hook() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -2366,7 +2354,7 @@ fn check_merge_conflict_diff3_hook() -> Result<()> {
 
 #[test]
 fn check_merge_conflict_without_assume_flag() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Without --assume-in-merge, hook should pass even with conflict markers
     // if we're not actually in a merge state
@@ -2404,7 +2392,7 @@ fn check_merge_conflict_without_assume_flag() -> Result<()> {
 
 #[test]
 fn check_xml_hook() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -2502,7 +2490,7 @@ fn check_xml_hook() -> Result<()> {
 
 #[test]
 fn check_xml_with_features() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -2556,7 +2544,7 @@ fn check_xml_with_features() -> Result<()> {
 
 #[test]
 fn no_commit_to_branch_hook() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -2586,8 +2574,9 @@ fn no_commit_to_branch_hook() -> Result<()> {
     ");
 
     // Test 2: Create and switch to a feature branch (should pass)
-    context.git_branch("feature/new-feature");
-    context.git_checkout("feature/new-feature");
+    context
+        .git_branch("feature/new-feature")
+        .git_checkout("feature/new-feature");
 
     cwd.child("feature.txt").write_str("Feature content")?;
     context.git_add_all();
@@ -2603,8 +2592,7 @@ fn no_commit_to_branch_hook() -> Result<()> {
     ");
 
     // Test 3: Try to commit to main branch (should fail)
-    context.git_branch("main");
-    context.git_checkout("main");
+    context.git_branch("main").git_checkout("main");
 
     cwd.child("main.txt").write_str("Main content")?;
     context.git_add_all();
@@ -2628,7 +2616,7 @@ fn no_commit_to_branch_hook() -> Result<()> {
 
 #[test]
 fn no_commit_to_branch_hook_with_custom_branches() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -2701,7 +2689,7 @@ fn no_commit_to_branch_hook_with_custom_branches() -> Result<()> {
 
 #[test]
 fn no_commit_to_branch_hook_with_patterns() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -2833,7 +2821,7 @@ fn no_commit_to_branch_hook_with_patterns() -> Result<()> {
 #[cfg(unix)]
 #[test]
 fn check_executables_have_shebangs_hook() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -2915,7 +2903,7 @@ fn check_executables_have_shebangs_hook() -> Result<()> {
 #[cfg(windows)]
 #[test]
 fn check_executables_have_shebangs_win() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -2968,7 +2956,7 @@ fn check_executables_have_shebangs_win() -> Result<()> {
 #[cfg(unix)]
 #[test]
 fn check_executables_have_shebangs_various_cases() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -3060,7 +3048,7 @@ fn check_executables_have_shebangs_various_cases() -> Result<()> {
 #[cfg(windows)]
 #[test]
 fn check_executables_have_shebangs_various_cases_win() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -3126,7 +3114,7 @@ fn check_executables_have_shebangs_various_cases_win() -> Result<()> {
 
 #[test]
 fn check_shebang_scripts_are_executable() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -3205,7 +3193,7 @@ fn is_case_sensitive_filesystem(context: &TestEnv) -> Result<bool> {
 
 #[test]
 fn check_case_conflict_hook() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     if !is_case_sensitive_filesystem(&context)? {
         // Skipping test on case-insensitive filesystem
@@ -3213,11 +3201,9 @@ fn check_case_conflict_hook() -> Result<()> {
     }
 
     // Create initial files and commit
-    let cwd = context.work_dir();
-    cwd.child("README.md").write_str("Initial commit")?;
-    cwd.child("src/foo.txt").write_str("existing file")?;
-    context.git_add_all();
-    context.git_commit("Initial commit");
+    context.write_file("README.md", "Initial commit");
+    context.write_file("src/foo.txt", "existing file");
+    context.git_add_all().git_commit("Initial commit");
 
     let context = context.with_config(indoc::indoc! {r"
         repos:
@@ -3270,7 +3256,7 @@ fn check_case_conflict_hook() -> Result<()> {
 
 #[test]
 fn check_case_conflict_directory() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     if !is_case_sensitive_filesystem(&context)? {
         // Skipping test on case-insensitive filesystem
@@ -3278,10 +3264,8 @@ fn check_case_conflict_directory() -> Result<()> {
     }
 
     // Create directory with file
-    let cwd = context.work_dir();
-    cwd.child("src/utils/helper.py").write_str("helper")?;
-    context.git_add_all();
-    context.git_commit("Initial commit");
+    context.write_file("src/utils/helper.py", "helper");
+    context.git_add_all().git_commit("Initial commit");
 
     let context = context.with_config(indoc::indoc! {r"
         repos:
@@ -3316,7 +3300,7 @@ fn check_case_conflict_directory() -> Result<()> {
 
 #[test]
 fn check_case_conflict_among_new_files() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     if !is_case_sensitive_filesystem(&context)? {
         // Skipping test on case-insensitive filesystem
@@ -3364,7 +3348,7 @@ fn check_case_conflict_among_new_files() -> Result<()> {
 
 #[test]
 fn check_case_conflict_workspace_mode_includes_added_files() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     if !is_case_sensitive_filesystem(&context)? {
         return Ok(());
@@ -3421,7 +3405,7 @@ fn check_case_conflict_workspace_mode_includes_added_files() -> Result<()> {
 
 #[test]
 fn check_json5() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -3489,7 +3473,7 @@ fn check_json5() -> Result<()> {
 #[cfg(unix)]
 #[test]
 fn check_illegal_windows_names() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -3528,7 +3512,7 @@ fn check_illegal_windows_names() -> Result<()> {
 #[test]
 #[cfg(unix)]
 fn builtin_hooks_ignore_system_path_binaries() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Create a fake "trailing-whitespace-fixer" binary with a shebang in a temp dir.
     // This simulates `pip install pre-commit-hooks` which places such binaries in PATH.

--- a/crates/prek/tests/builtin_hooks.rs
+++ b/crates/prek/tests/builtin_hooks.rs
@@ -22,7 +22,7 @@ fn builtin_hooks_not_create_env() {
             hooks:
               - id: end-of-file-fixer
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -52,7 +52,7 @@ fn builtin_hooks_unknown_hook() {
             hooks:
               - id: this-hook-does-not-exist
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @"
     success: false
@@ -88,7 +88,7 @@ fn deny_filename_pattern_hook_matches_only_basename() -> Result<()> {
     cwd.child("docs/README.md").touch()?;
     cwd.child("README/guide.md").touch()?;
     cwd.child("docs/guide.md").touch()?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -130,7 +130,7 @@ fn deny_pattern_hook_reports_matching_lines() -> Result<()> {
     "})?;
     cwd.child("ignored.txt")
         .write_str("TODO: ignored by files filter\n")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -164,7 +164,7 @@ fn deny_pattern_hook_rejects_invalid_regex() -> Result<()> {
         .work_dir()
         .child("file.txt")
         .write_str("content\n")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -209,7 +209,7 @@ fn deny_pattern_hook_reports_earliest_multiline_match() -> Result<()> {
         END
         after
     "})?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -252,7 +252,7 @@ fn require_filename_pattern_hook_accepts_any_pattern_for_basename() -> Result<()
     cwd.child("tests/unit/__init__.py").touch()?;
     cwd.child("tests/unit/conftest.py").touch()?;
     cwd.child("tests/test_unit/parser.py").touch()?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -287,7 +287,7 @@ fn require_pattern_hook_reports_files_without_any_match() -> Result<()> {
     cwd.child("block.txt").write_str("BEGIN\nmiddle\nEND\n")?;
     cwd.child("copyright.txt").write_str("Copyright 2026\n")?;
     cwd.child("missing.txt").write_str("No required marker\n")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -330,7 +330,7 @@ fn end_of_file_fixer_hook() -> Result<()> {
     cwd.child("only_newlines.txt").write_str("\n\n")?;
     cwd.child("only_win_newlines.txt").write_str("\r\n\r\n")?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     // First run: hooks should fail and fix the files
     cmd_snapshot!(context, context.run(), @r#"
@@ -362,7 +362,7 @@ fn end_of_file_fixer_hook() -> Result<()> {
     assert_snapshot!(context.read("only_newlines.txt"), @"");
     assert_snapshot!(context.read("only_win_newlines.txt"), @"");
 
-    context.git_add_all();
+    context.git().add_all();
 
     // Second run: hooks should now pass. The output will be stable.
     cmd_snapshot!(context, context.run(), @r"
@@ -393,7 +393,7 @@ fn file_contents_sorter_hook() -> Result<()> {
         .write_str("Banana\n\napple\nApricot\n")?;
     cwd.child("ignored.txt").write_str("zebra\nant\n")?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -420,7 +420,7 @@ fn file_contents_sorter_hook() -> Result<()> {
     ant
     ");
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -448,7 +448,7 @@ fn builtin_hook_checks_filename_from_args_after_options() -> Result<()> {
     let cwd = context.work_dir();
     cwd.child("configured.txt").write_str("beta\nAlpha\n")?;
     cwd.child("selected.txt").write_str("Beta\nalpha\n")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -491,7 +491,7 @@ fn requirements_txt_fixer_hook() -> Result<()> {
     "})?;
     cwd.child("requirements.in")
         .write_str("z-project\na-project\n")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -518,7 +518,7 @@ fn requirements_txt_fixer_hook() -> Result<()> {
     );
     assert_eq!(context.read("requirements.in"), "z-project\na-project\n");
 
-    context.git_add_all();
+    context.git().add_all();
     cmd_snapshot!(context, context.run(), @r"
     success: true
     exit_code: 0
@@ -539,7 +539,7 @@ fn requirements_txt_fixer_hook() -> Result<()> {
     cwd.child("requirements.txt")
         .write_str("flask\n  requests==2\n")?;
     cwd.child("valid.json").write_str("{}\n")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -576,33 +576,20 @@ fn forbid_new_submodules_hook_in_workspace_project() -> Result<()> {
                   - id: forbid-new-submodules
         "})?;
 
-    context.git_add_all();
-    context.git_commit("Initial commit");
+    context.git().add_all().commit("Initial commit");
 
     let submodule_path = cwd.child("project2/sub module");
     submodule_path.create_dir_all()?;
-    context
-        .git_at(&submodule_path)
-        .arg("-c")
-        .arg("init.defaultBranch=master")
-        .arg("init")
-        .assert()
-        .success();
     submodule_path.child("README.md").write_str("submodule\n")?;
     context
         .git_at(&submodule_path)
-        .arg("add")
-        .arg("README.md")
-        .assert()
-        .success();
-    context
-        .git_at(&submodule_path)
-        .args(["commit", "-m", "Initial commit"])
-        .assert()
-        .success();
+        .init()
+        .add("README.md")
+        .commit("Initial commit");
 
     context
         .git_at(cwd)
+        .command()
         .args([
             "submodule",
             "add",
@@ -652,7 +639,7 @@ fn check_yaml_hook() -> Result<()> {
     cwd.child("duplicate.yaml").write_str("a: 1\na: 2")?;
     cwd.child("empty.yaml").touch()?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     // First run: hooks should fail
     cmd_snapshot!(context, context.run(), @"
@@ -683,7 +670,7 @@ fn check_yaml_hook() -> Result<()> {
     cwd.child("invalid.yaml").write_str("a:\n  b: c")?;
     cwd.child("duplicate.yaml").write_str("a: 1\nb: 2")?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     // Second run: hooks should now pass
     cmd_snapshot!(context, context.run(), @r"
@@ -722,7 +709,7 @@ fn check_yaml_multiple_document() -> Result<()> {
         "
         })?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @"
     success: false
@@ -766,7 +753,7 @@ fn check_vcs_permalinks_builtin() -> Result<()> {
         https://github.com/owner/repo/blob/abcdef1234567890abcdef1234567890abcdef12/file.py#L10
     "})?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -804,7 +791,7 @@ fn check_json_hook() -> Result<()> {
         .write_str(r#"{"a": 1, "a": 2}"#)?;
     cwd.child("empty.json").touch()?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     // First run: hooks should fail
     cmd_snapshot!(context, context.run(), @r"
@@ -827,7 +814,7 @@ fn check_json_hook() -> Result<()> {
     cwd.child("duplicate.json")
         .write_str(r#"{"a": 1, "b": 2}"#)?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     // Second run: hooks should now pass
     cmd_snapshot!(context, context.run(), @r"
@@ -861,7 +848,7 @@ fn mixed_line_ending_hook() -> Result<()> {
     cwd.child("no_endings.txt").write_str("hello world")?;
     cwd.child("empty.txt").touch()?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     // First run: hooks should fail and fix the files
     cmd_snapshot!(context, context.run(), @r"
@@ -894,7 +881,7 @@ fn mixed_line_ending_hook() -> Result<()> {
     line2
     ");
 
-    context.git_add_all();
+    context.git().add_all();
 
     // Second run: hooks should now pass.
     cmd_snapshot!(context, context.run(), @r"
@@ -918,7 +905,7 @@ fn mixed_line_ending_hook() -> Result<()> {
         .work_dir()
         .child("mixed.txt")
         .write_str("line1\nline2\r\n")?;
-    context.git_add_all();
+    context.git().add_all();
     cmd_snapshot!(context, context.run(), @r"
     success: false
     exit_code: 1
@@ -949,7 +936,7 @@ fn mixed_line_ending_hook() -> Result<()> {
         .work_dir()
         .child("mixed.txt")
         .write_str("line1\nline2\r\n")?;
-    context.git_add_all();
+    context.git().add_all();
     cmd_snapshot!(context, context.run(), @r#"
     success: false
     exit_code: 1
@@ -983,7 +970,7 @@ fn mixed_line_ending_hook() -> Result<()> {
         .work_dir()
         .child("mixed.txt")
         .write_str("line1\nline2\r\nline3\n")?;
-    context.git_add_all();
+    context.git().add_all();
     cmd_snapshot!(context, context.run(), @r"
     success: false
     exit_code: 2
@@ -1002,7 +989,7 @@ fn mixed_line_ending_hook() -> Result<()> {
 fn check_added_large_files_hook() {
     // Create an initial commit
     let context = TestEnv::new_git().with_file("README.md", "Initial commit");
-    context.git_add_all().git_commit("Initial commit");
+    context.git().add_all().commit("Initial commit");
 
     let context = context
         .with_config(indoc::indoc! {r"
@@ -1015,7 +1002,7 @@ fn check_added_large_files_hook() {
         .with_file("small_file.txt", "Hello World\n")
         .with_file("large_file.txt", [0_u8; 2048]);
 
-    context.git_add_all();
+    context.git().add_all();
 
     // First run: hook should fail because of the large file
     cmd_snapshot!(context, context.run(), @r"
@@ -1033,11 +1020,11 @@ fn check_added_large_files_hook() {
     ");
 
     // Commit the files
-    context.git_add_all().git_commit("Add large file");
+    context.git().add_all().commit("Add large file");
 
     // Create a new unstaged large file
     context.write_file("unstaged_large_file.txt", [0_u8; 2048]);
-    context.git_add("unstaged_large_file.txt");
+    context.git().add("unstaged_large_file.txt");
 
     context.write_config(indoc::indoc! {r"
         repos:
@@ -1063,7 +1050,7 @@ fn check_added_large_files_hook() {
     ----- stderr -----
     "#);
 
-    context.git_rm("unstaged_large_file.txt").git_clean();
+    context.git().rm("unstaged_large_file.txt").clean();
 
     // Test git-lfs integration
     context.write_config(indoc::indoc! {r"
@@ -1078,9 +1065,9 @@ fn check_added_large_files_hook() {
         ".gitattributes",
         "*.dat filter=lfs diff=lfs merge=lfs -text",
     );
-    context.git_add(".gitattributes");
+    context.git().add(".gitattributes");
     context.write_file("lfs_file.dat", [0_u8; 2048]);
-    context.git_add_all();
+    context.git().add_all();
 
     // Third run: hook should pass because the large file is tracked by git-lfs
     cmd_snapshot!(context, context.run(), @r"
@@ -1116,7 +1103,7 @@ fn check_added_large_files_workspace_mode_respects_project_relative_lfs_paths() 
         .write_str("*.dat filter=lfs diff=lfs merge=lfs -text")?;
     app.child("large.dat").write_binary(&[0; 2048])?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -1147,7 +1134,7 @@ fn check_added_large_files_workspace_mode_respects_project_relative_added_files(
     "})?;
     app.child("large.bin").write_binary(&[0; 2048])?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -1182,11 +1169,10 @@ fn tracked_file_exceeds_large_file_limit() -> Result<()> {
     // Create and commit a large file
     let large_file = cwd.child("large_file.txt");
     large_file.write_binary(&[0; 2048])?; // 2KB file
-    context.git_add_all();
-    context.git_commit("Add large file");
+    context.git().add_all().commit("Add large file");
     // Modify the large file
     large_file.write_binary(&[0; 4096])?; // 4KB file
-    context.git_add_all();
+    context.git().add_all();
 
     // Run the hook: it should pass because the file is already tracked
     cmd_snapshot!(context, context.run(), @r"
@@ -1250,7 +1236,7 @@ fn builtin_hooks_workspace_mode() -> Result<()> {
     // 2KB file to trigger check-added-large-files (1 KB threshold).
     app.child("large.bin").write_binary(&[0u8; 2048])?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     // First run: expect failures and auto-fixes where applicable.
     cmd_snapshot!(context, context.run(), @r#"
@@ -1361,7 +1347,7 @@ fn builtin_hooks_workspace_mode() -> Result<()> {
     app.child("duplicate.json")
         .write_str(concat!(r#"{"a": 1, "b": 2}"#, "\n"))?;
     app.child("large.bin").write_binary(&[0u8; 100])?;
-    context.git_add_all();
+    context.git().add_all();
 
     // Second run: all hooks should now pass.
     cmd_snapshot!(context, context.run(), @r#"
@@ -1439,7 +1425,7 @@ fn fix_byte_order_marker_hook() -> Result<()> {
         .write_binary(&[0xef, 0xbb, 0xbf])?;
     cwd.child("empty.txt").touch()?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     // First run: hooks should fix files with BOM
     cmd_snapshot!(context, context.run(), @r"
@@ -1464,7 +1450,7 @@ fn fix_byte_order_marker_hook() -> Result<()> {
     assert_eq!(context.read("without_bom.txt"), "Hello, World!");
     assert_eq!(context.read("empty.txt"), "");
 
-    context.git_add_all();
+    context.git().add_all();
 
     // Second run: all should pass now
     cmd_snapshot!(context, context.run(), @r"
@@ -1523,7 +1509,7 @@ fn pretty_format_json_hook() -> Result<()> {
     cwd.child("invalid.json").write_str(r#"{"a": 1,}"#)?;
     cwd.child("empty.json").touch()?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     // First run: hooks should fail and fix the files
     cmd_snapshot!(context, context.run(), @r#"
@@ -1599,7 +1585,7 @@ fn pretty_format_json_hook() -> Result<()> {
 "#,
     )?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     // Second run: hooks should now pass
     cmd_snapshot!(context, context.run(), @r#"
@@ -1628,7 +1614,7 @@ fn pretty_format_json_with_options() -> Result<()> {
 
     cwd.child("test.json").write_str(r#"{"z":1,"a":2,"m":3}"#)?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -1654,7 +1640,7 @@ fn pretty_format_json_with_options() -> Result<()> {
     }
     "#);
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -1684,7 +1670,7 @@ fn pretty_format_json_with_top_keys() -> Result<()> {
         r#"{"description":"test","name":"my-package","author":"me","version":"1.0.0"}"#,
     )?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -1710,7 +1696,7 @@ fn pretty_format_json_with_top_keys() -> Result<()> {
     }
     "#);
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -1739,7 +1725,7 @@ fn pretty_format_json_no_ensure_ascii() -> Result<()> {
     cwd.child("unicode.json")
         .write_str(r#"{"text":"\u4E2D\u6587\u306B\u307B\u3093\u3054"}"#)?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -1763,7 +1749,7 @@ fn pretty_format_json_no_ensure_ascii() -> Result<()> {
     }
     "#);
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -1791,7 +1777,7 @@ fn pretty_format_json_custom_space_indent() -> Result<()> {
 
     cwd.child("test.json").write_str(r#"{"a":1,"b":2}"#)?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -1815,7 +1801,7 @@ fn pretty_format_json_custom_space_indent() -> Result<()> {
     }
     "#);
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -1857,7 +1843,7 @@ fn check_symlinks_hook_unix() -> Result<()> {
         cwd.child("broken_link.txt").path(),
     )?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     // First run: should fail due to broken symlink
     cmd_snapshot!(context, context.run(), @r"
@@ -1876,7 +1862,7 @@ fn check_symlinks_hook_unix() -> Result<()> {
 
     // Remove broken symlink
     fs_err::remove_file(cwd.child("broken_link.txt").path())?;
-    context.git_add_all();
+    context.git().add_all();
 
     // Second run: should pass
     cmd_snapshot!(context, context.run(), @r"
@@ -1925,7 +1911,7 @@ fn check_symlinks_hook_windows() -> Result<()> {
         return Ok(());
     }
 
-    context.git_add_all();
+    context.git().add_all();
 
     // First run: should fail due to broken symlink
     cmd_snapshot!(context, context.run(), @r#"
@@ -1944,7 +1930,7 @@ fn check_symlinks_hook_windows() -> Result<()> {
 
     // Remove broken symlink
     fs_err::remove_file(cwd.child("broken_link.txt").path())?;
-    context.git_add_all();
+    context.git().add_all();
 
     // Second run: should pass
     cmd_snapshot!(context, context.run(), @r#"
@@ -1977,11 +1963,11 @@ fn destroyed_symlinks_hook() -> Result<()> {
         .work_dir()
         .child(TEST_FILE)
         .write_str("some random content\n")?;
-    source.git_add_all();
-    source.git_commit("initial");
+    source.git().add_all().commit("initial");
 
     let tree = source
         .git()
+        .command()
         .arg("cat-file")
         .arg("-p")
         .arg("HEAD^{tree}")
@@ -1992,6 +1978,7 @@ fn destroyed_symlinks_hook() -> Result<()> {
     let context = TestEnv::new();
     context
         .git()
+        .command()
         .arg("-c")
         .arg("core.symlinks=false")
         .arg("clone")
@@ -2002,11 +1989,13 @@ fn destroyed_symlinks_hook() -> Result<()> {
 
     context
         .git()
+        .command()
         .args(["config", "--local", "core.symlinks", "true"])
         .assert()
         .success();
     context
         .git()
+        .command()
         .args(["mv", TEST_FILE, TEST_FILE_RENAMED])
         .assert()
         .success();
@@ -2020,7 +2009,7 @@ fn destroyed_symlinks_hook() -> Result<()> {
               - id: destroyed-symlinks
     "});
 
-    context.git_add(TEST_SYMLINK);
+    context.git().add(TEST_SYMLINK);
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -2045,7 +2034,7 @@ fn destroyed_symlinks_hook() -> Result<()> {
         .work_dir()
         .child(TEST_SYMLINK)
         .write_str(&format!("{TEST_SYMLINK_TARGET}\n"))?;
-    context.git_add(TEST_SYMLINK);
+    context.git().add(TEST_SYMLINK);
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -2070,7 +2059,7 @@ fn destroyed_symlinks_hook() -> Result<()> {
         .work_dir()
         .child(TEST_SYMLINK)
         .write_str(&format!("{}\n", "0".repeat(TEST_SYMLINK_TARGET.len())))?;
-    context.git_add(TEST_SYMLINK);
+    context.git().add(TEST_SYMLINK);
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -2085,7 +2074,7 @@ fn destroyed_symlinks_hook() -> Result<()> {
         .work_dir()
         .child(TEST_SYMLINK)
         .write_str(&format!("{}\n", "0".repeat(TEST_SYMLINK_TARGET.len() + 3)))?;
-    context.git_add(TEST_SYMLINK);
+    context.git().add(TEST_SYMLINK);
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -2137,7 +2126,7 @@ fn detect_private_key_hook() -> Result<()> {
         .write_str("This is just a regular file\nwith some content\n")?;
     cwd.child("empty.txt").touch()?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     // First run: hooks should fail due to private keys
     cmd_snapshot!(context, context.run(), @r#"
@@ -2162,17 +2151,18 @@ fn detect_private_key_hook() -> Result<()> {
     "#);
 
     // Remove all private keys
-    context.git_rm("id_rsa");
-    context.git_rm("id_dsa");
-    context.git_rm("id_ecdsa");
-    context.git_rm("id_ed25519");
-    context.git_rm("key.ppk");
-    context.git_rm("private.asc");
-    context.git_rm("ta.key");
-    context.git_rm("doc.txt");
-    context.git_clean();
-
-    context.git_add_all();
+    context
+        .git()
+        .rm("id_rsa")
+        .rm("id_dsa")
+        .rm("id_ecdsa")
+        .rm("id_ed25519")
+        .rm("key.ppk")
+        .rm("private.asc")
+        .rm("ta.key")
+        .rm("doc.txt")
+        .clean()
+        .add_all();
 
     // Second run: hooks should now pass
     cmd_snapshot!(context, context.run(), @r"
@@ -2227,7 +2217,7 @@ fn check_merge_conflict_hook() -> Result<()> {
         =======
     "})?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     // First run: hooks should fail due to conflict markers
     cmd_snapshot!(context, context.run(), @r#"
@@ -2262,7 +2252,7 @@ fn check_merge_conflict_hook() -> Result<()> {
     cwd.child("partial_separator_conflict.txt")
         .write_str("Some content\nResolved line\n")?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     // Second run: hooks should now pass
     cmd_snapshot!(context, context.run(), @r"
@@ -2293,7 +2283,7 @@ fn check_merge_conflict_ignores_rst_headings() -> Result<()> {
         =======
     "})?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -2330,7 +2320,7 @@ fn check_merge_conflict_diff3_hook() -> Result<()> {
         After conflict
     "})?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -2375,7 +2365,7 @@ fn check_merge_conflict_without_assume_flag() -> Result<()> {
         >>>>>>> branch
     "})?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     // Should pass because we're not in a merge state and no --assume-in-merge flag
     cmd_snapshot!(context, context.run(), @r"
@@ -2427,7 +2417,7 @@ fn check_xml_hook() -> Result<()> {
     )?;
     cwd.child("empty.xml").touch()?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     // First run: hooks should fail
     cmd_snapshot!(context, context.run(), @r#"
@@ -2468,7 +2458,7 @@ fn check_xml_hook() -> Result<()> {
 </root>"#,
     )?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     // Second run: hooks should now pass
     cmd_snapshot!(context, context.run(), @r"
@@ -2527,7 +2517,7 @@ fn check_xml_with_features() -> Result<()> {
 </root>"#,
     )?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     // All should pass
     cmd_snapshot!(context, context.run(), @r"
@@ -2555,8 +2545,7 @@ fn no_commit_to_branch_hook() -> Result<()> {
 
     // Create a test file
     cwd.child("test.txt").write_str("Hello World")?;
-    context.git_add_all();
-    context.git_commit("Initial commit");
+    context.git().add_all().commit("Initial commit");
 
     // Test 1: Try to commit to master branch (should fail)
     cmd_snapshot!(context, context.run(), @r"
@@ -2575,12 +2564,12 @@ fn no_commit_to_branch_hook() -> Result<()> {
 
     // Test 2: Create and switch to a feature branch (should pass)
     context
-        .git_branch("feature/new-feature")
-        .git_checkout("feature/new-feature");
+        .git()
+        .branch("feature/new-feature")
+        .checkout("feature/new-feature");
 
     cwd.child("feature.txt").write_str("Feature content")?;
-    context.git_add_all();
-    context.git_commit("Add feature");
+    context.git().add_all().commit("Add feature");
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -2592,10 +2581,10 @@ fn no_commit_to_branch_hook() -> Result<()> {
     ");
 
     // Test 3: Try to commit to main branch (should fail)
-    context.git_branch("main").git_checkout("main");
+    context.git().branch("main").checkout("main");
 
     cwd.child("main.txt").write_str("Main content")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -2628,8 +2617,7 @@ fn no_commit_to_branch_hook_with_custom_branches() -> Result<()> {
 
     // Create a test file
     cwd.child("test.txt").write_str("Hello World")?;
-    context.git_add_all();
-    context.git_commit("Initial commit");
+    context.git().add_all().commit("Initial commit");
 
     // Test 1: Try to commit to master branch (should pass - not in custom list)
     cmd_snapshot!(context, context.run(), @r"
@@ -2642,11 +2630,10 @@ fn no_commit_to_branch_hook_with_custom_branches() -> Result<()> {
     ");
 
     // Test 2: Create and switch to develop branch (should fail)
-    context.git_branch("develop");
-    context.git_checkout("develop");
+    context.git().branch("develop").checkout("develop");
 
     cwd.child("develop.txt").write_str("Develop content")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -2663,12 +2650,11 @@ fn no_commit_to_branch_hook_with_custom_branches() -> Result<()> {
     ");
 
     // Test 3: Create and switch to production branch (should fail)
-    context.git_branch("production");
-    context.git_checkout("production");
+    context.git().branch("production").checkout("production");
 
     cwd.child("production.txt")
         .write_str("Production content")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -2701,8 +2687,7 @@ fn no_commit_to_branch_hook_with_patterns() -> Result<()> {
 
     // Create a test file
     cwd.child("test.txt").write_str("Hello World")?;
-    context.git_add_all();
-    context.git_commit("Initial commit");
+    context.git().add_all().commit("Initial commit");
 
     // Test 1: Try to commit to master branch (should fail - If branch is not specified, branch defaults to master and main)
     cmd_snapshot!(context, context.run(), @r"
@@ -2720,11 +2705,13 @@ fn no_commit_to_branch_hook_with_patterns() -> Result<()> {
     ");
 
     // Test 2: Create and switch to feature branch (should fail - matches pattern)
-    context.git_branch("feature/new-feature");
-    context.git_checkout("feature/new-feature");
+    context
+        .git()
+        .branch("feature/new-feature")
+        .checkout("feature/new-feature");
 
     cwd.child("feature.txt").write_str("Feature content")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -2741,11 +2728,13 @@ fn no_commit_to_branch_hook_with_patterns() -> Result<()> {
     ");
 
     // Test 3: Create and switch to wip branch (should fail - matches pattern)
-    context.git_branch("my-branch-wip");
-    context.git_checkout("my-branch-wip");
+    context
+        .git()
+        .branch("my-branch-wip")
+        .checkout("my-branch-wip");
 
     cwd.child("wip.txt").write_str("WIP content")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -2762,12 +2751,13 @@ fn no_commit_to_branch_hook_with_patterns() -> Result<()> {
     ");
 
     // Test 4: Create and switch to normal branch (should pass - doesn't match patterns)
-    context.git_branch("normal-branch");
-    context.git_checkout("normal-branch");
+    context
+        .git()
+        .branch("normal-branch")
+        .checkout("normal-branch");
 
     cwd.child("normal.txt").write_str("Normal content")?;
-    context.git_add_all();
-    context.git_commit("Add normal content");
+    context.git().add_all().commit("Add normal content");
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -2779,7 +2769,7 @@ fn no_commit_to_branch_hook_with_patterns() -> Result<()> {
     ");
 
     // Test 5: Try to run with detached head pointer status (should pass - ignore this status)
-    context.git_checkout("HEAD~1");
+    context.git().checkout("HEAD~1");
     cmd_snapshot!(context, context.run(), @r"
     success: true
     exit_code: 0
@@ -2798,11 +2788,13 @@ fn no_commit_to_branch_hook_with_patterns() -> Result<()> {
                 args: ['--pattern', '*invalid-pattern*']
         "});
 
-    context.git_branch("invalid-branch");
-    context.git_checkout("invalid-branch");
+    context
+        .git()
+        .branch("invalid-branch")
+        .checkout("invalid-branch");
 
     cwd.child("invalid.txt").write_str("Invalid content")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -2853,7 +2845,7 @@ fn check_executables_have_shebangs_hook() -> Result<()> {
         std::fs::Permissions::from_mode(0o755),
     )?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     // First run: should fail for script_without_shebang.sh and empty.sh
     cmd_snapshot!(context, context.run(), @r"
@@ -2885,7 +2877,7 @@ fn check_executables_have_shebangs_hook() -> Result<()> {
         std::fs::Permissions::from_mode(0o644),
     )?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     // Second run: should now pass
     cmd_snapshot!(context, context.run(), @r"
@@ -2917,15 +2909,17 @@ fn check_executables_have_shebangs_win() -> Result<()> {
     cwd.child("win_script_without_shebang.sh")
         .write_str("missing shebang\n")?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     context
         .git_at(cwd)
+        .command()
         .args(["update-index", "--chmod=+x", "win_script_with_shebang.sh"])
         .status()?;
 
     context
         .git_at(cwd)
+        .command()
         .args([
             "update-index",
             "--chmod=+x",
@@ -2995,7 +2989,7 @@ fn check_executables_have_shebangs_various_cases() -> Result<()> {
     )?;
     // non_executable.txt is not marked executable
 
-    context.git_add_all();
+    context.git().add_all();
 
     // Run: should fail for partial_shebang.sh, whitespace.sh, invalid_shebang.sh
     cmd_snapshot!(context, context.run(), @r#"
@@ -3030,7 +3024,7 @@ fn check_executables_have_shebangs_various_cases() -> Result<()> {
     cwd.child("invalid_shebang.sh")
         .write_str("#!/bin/bash\necho fixed\n")?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     // Second run: should now pass
     cmd_snapshot!(context, context.run(), @r"
@@ -3067,7 +3061,7 @@ fn check_executables_have_shebangs_various_cases_win() -> Result<()> {
     cwd.child("invalid_shebang.sh")
         .write_str("##!/bin/bash\necho bad\n")?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     let executable_files = [
         "partial_shebang.sh",
@@ -3079,6 +3073,7 @@ fn check_executables_have_shebangs_various_cases_win() -> Result<()> {
     for file in &executable_files {
         context
             .git_at(cwd.path())
+            .command()
             .args(["update-index", "--chmod=+x", file])
             .status()?;
     }
@@ -3134,9 +3129,10 @@ fn check_shebang_scripts_are_executable() -> Result<()> {
         std::fs::Permissions::from_mode(0o755),
     )?;
 
-    context.git_add_all();
+    context.git().add_all();
     context
         .git_at(cwd.path())
+        .command()
         .args(["update-index", "--chmod=+x", "script_exec.sh"])
         .assert()
         .success();
@@ -3166,6 +3162,7 @@ fn check_shebang_scripts_are_executable() -> Result<()> {
 
     context
         .git_at(cwd.path())
+        .command()
         .args(["update-index", "--chmod=+x", "script.sh"])
         .assert()
         .success();
@@ -3203,7 +3200,7 @@ fn check_case_conflict_hook() -> Result<()> {
     // Create initial files and commit
     context.write_file("README.md", "Initial commit");
     context.write_file("src/foo.txt", "existing file");
-    context.git_add_all().git_commit("Initial commit");
+    context.git().add_all().commit("Initial commit");
 
     let context = context.with_config(indoc::indoc! {r"
         repos:
@@ -3216,7 +3213,7 @@ fn check_case_conflict_hook() -> Result<()> {
 
     // Try to add a file with conflicting case
     cwd.child("src/FOO.txt").write_str("conflicting case")?;
-    context.git_add_all();
+    context.git().add_all();
 
     // First run: should fail due to case conflict
     cmd_snapshot!(context, context.run(), @r#"
@@ -3235,11 +3232,11 @@ fn check_case_conflict_hook() -> Result<()> {
     "#);
 
     // Remove the conflicting file
-    context.git_rm("src/FOO.txt");
+    context.git().rm("src/FOO.txt");
 
     // Add a non-conflicting file
     cwd.child("src/bar.txt").write_str("no conflict")?;
-    context.git_add_all();
+    context.git().add_all();
 
     // Second run: should pass
     cmd_snapshot!(context, context.run(), @r#"
@@ -3265,7 +3262,7 @@ fn check_case_conflict_directory() -> Result<()> {
 
     // Create directory with file
     context.write_file("src/utils/helper.py", "helper");
-    context.git_add_all().git_commit("Initial commit");
+    context.git().add_all().commit("Initial commit");
 
     let context = context.with_config(indoc::indoc! {r"
         repos:
@@ -3278,7 +3275,7 @@ fn check_case_conflict_directory() -> Result<()> {
 
     // Try to add a file that conflicts with directory name
     cwd.child("src/UTILS/other.py").write_str("conflict")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -3309,8 +3306,7 @@ fn check_case_conflict_among_new_files() -> Result<()> {
 
     let cwd = context.work_dir();
     cwd.child("README.md").write_str("Initial")?;
-    context.git_add_all();
-    context.git_commit("Initial commit");
+    context.git().add_all().commit("Initial commit");
 
     let context = context.with_config(indoc::indoc! {r"
         repos:
@@ -3325,7 +3321,7 @@ fn check_case_conflict_among_new_files() -> Result<()> {
     cwd.child("NewFile.txt").write_str("file 1")?;
     cwd.child("newfile.txt").write_str("file 2")?;
     cwd.child("NEWFILE.TXT").write_str("file 3")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -3360,8 +3356,7 @@ fn check_case_conflict_workspace_mode_includes_added_files() -> Result<()> {
     app.create_dir_all()?;
     app.child("foo.txt").write_str("existing file")?;
     app.child("trigger.txt").write_str("tracked trigger")?;
-    context.git_add_all();
-    context.git_commit("Initial commit");
+    context.git().add_all().commit("Initial commit");
 
     app.child(PRE_COMMIT_CONFIG_YAML)
         .write_str(indoc::indoc! {r"
@@ -3372,7 +3367,7 @@ fn check_case_conflict_workspace_mode_includes_added_files() -> Result<()> {
     "})?;
 
     app.child("FOO.txt").write_str("conflicting case")?;
-    context.git_add("app/FOO.txt");
+    context.git().add("app/FOO.txt");
 
     // Regression: in workspace mode, staged additions must be reported relative to the nested
     // project root so they still participate in conflict detection even when `--files` only
@@ -3430,7 +3425,7 @@ fn check_json5() -> Result<()> {
         }
     "})?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     // First run: hooks should fail
     cmd_snapshot!(context, context.run(), @r"
@@ -3455,7 +3450,7 @@ fn check_json5() -> Result<()> {
             key2: 'value2',
         }
     "})?;
-    context.git_add_all();
+    context.git().add_all();
 
     // Second run: hooks should now pass
     cmd_snapshot!(context, context.run(), @r"
@@ -3483,7 +3478,7 @@ fn check_illegal_windows_names() -> Result<()> {
     let cwd = context.work_dir();
     cwd.child("normal.txt").write_str("ok")?;
     cwd.child("CON.txt").write_str("bad")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @"
     success: false
@@ -3532,7 +3527,7 @@ fn builtin_hooks_ignore_system_path_binaries() -> Result<()> {
 
     let cwd = context.work_dir();
     cwd.child("test.txt").write_str("hello world   \n")?;
-    context.git_add_all();
+    context.git().add_all();
 
     // Prepend the fake bin directory to PATH so the fake binary is found first.
     let original_path = EnvVars.var_os(EnvVars::PATH).unwrap_or_default();

--- a/crates/prek/tests/cache.rs
+++ b/crates/prek/tests/cache.rs
@@ -1,4 +1,3 @@
-use assert_cmd::assert::OutputAssertExt;
 use assert_fs::assert::PathAssert;
 use assert_fs::fixture::{ChildPath, PathChild, PathCreateDir};
 use assert_fs::prelude::FileWriteStr;
@@ -195,7 +194,7 @@ fn cache_size_with_populated_cache() -> anyhow::Result<()> {
     let cwd = context.work_dir();
 
     cwd.child("file.txt").write_str("Hello, world!\n")?;
-    context.git_add_all();
+    context.git().add_all();
 
     context.run();
 
@@ -239,7 +238,7 @@ fn cache_gc_removes_unreferenced_entries() -> anyhow::Result<()> {
     let cwd = context.work_dir();
 
     cwd.child("valid.yaml").write_str("a: 1\n")?;
-    context.git_add_all();
+    context.git().add_all();
 
     let home = context.home_dir();
     // Populate store + config tracking.
@@ -293,7 +292,6 @@ fn cache_gc_keeps_relative_remote_repo() -> anyhow::Result<()> {
 
     let hook_repo = context.work_dir().child("hook-repo");
     hook_repo.create_dir_all()?;
-    context.git_at(&hook_repo).args(["init"]).assert().success();
     hook_repo
         .child(PRE_COMMIT_HOOKS_YAML)
         .write_str(indoc::indoc! {r"
@@ -303,21 +301,12 @@ fn cache_gc_keeps_relative_remote_repo() -> anyhow::Result<()> {
           language: system
           always_run: true
     "})?;
-    context
-        .git_at(&hook_repo)
-        .args(["add", "."])
-        .assert()
-        .success();
-    context
-        .git_at(&hook_repo)
-        .args(["commit", "-m", "Initial commit"])
-        .assert()
-        .success();
-    let output = context
-        .git_at(&hook_repo)
-        .args(["rev-parse", "HEAD"])
-        .output()?;
-    let revision = String::from_utf8(output.stdout)?.trim().to_string();
+    let git = context.git_at(&hook_repo);
+    let revision = git
+        .init()
+        .add(".")
+        .commit("Initial commit")
+        .rev_parse("HEAD")?;
 
     let subproject = context.work_dir().child("subproject");
     subproject.create_dir_all()?;
@@ -330,7 +319,7 @@ fn cache_gc_keeps_relative_remote_repo() -> anyhow::Result<()> {
                 hooks:
                   - id: test-hook
         "})?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run()
         .arg("--config")
@@ -619,7 +608,7 @@ fn cache_gc_keeps_local_hook_env() -> anyhow::Result<()> {
     let cwd = context.work_dir();
 
     cwd.child("file.txt").write_str("Hello\n")?;
-    context.git_add_all();
+    context.git().add_all();
 
     // Install + run the local hook so it creates a hook env under PREK_HOME/hooks.
     cmd_snapshot!(context, context.run(), @r"
@@ -761,7 +750,7 @@ fn cache_gc_drops_missing_tracked_config() -> anyhow::Result<()> {
     let context = TestEnv::new_git().with_config("repos: []\n");
 
     let cwd = context.work_dir();
-    context.git_add_all();
+    context.git().add_all();
 
     let home = context.home_dir();
     let config_path = cwd.child(PRE_COMMIT_CONFIG_YAML);
@@ -806,7 +795,7 @@ fn cache_gc_keeps_tracked_config_on_parse_error() -> anyhow::Result<()> {
     let cwd = context.work_dir();
     // Intentionally invalid YAML.
     cwd.child(PRE_COMMIT_CONFIG_YAML).write_str("repos: [\n")?;
-    context.git_add_all();
+    context.git().add_all();
 
     let home = context.home_dir();
     let config_path = cwd.child(PRE_COMMIT_CONFIG_YAML);
@@ -840,7 +829,7 @@ fn cache_gc_dry_run_does_not_remove_entries() -> anyhow::Result<()> {
     let context = TestEnv::new_git().with_config("repos: []\n");
 
     let cwd = context.work_dir();
-    context.git_add_all();
+    context.git().add_all();
 
     let home = context.home_dir();
     // Seed tracking with a missing config to force sweeping everything.

--- a/crates/prek/tests/cache.rs
+++ b/crates/prek/tests/cache.rs
@@ -12,7 +12,7 @@ mod common;
 
 #[test]
 fn cache_dir() {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
     let home = context.work_dir().child("home");
 
     cmd_snapshot!(context, context.command().arg("cache").arg("dir").env("PREK_HOME", &*home), @r"
@@ -27,7 +27,7 @@ fn cache_dir() {
 
 #[test]
 fn cache_gc_verbose_shows_removed_entries() {
-    let context = TestEnv::new_without_git().with_config("repos: []\n");
+    let context = TestEnv::new().with_config("repos: []\n");
     let home = context.home_dir();
 
     // Seed store entries that will be removed.
@@ -108,7 +108,7 @@ fn cache_gc_verbose_shows_removed_entries() {
 
 #[test]
 fn cache_clean() -> anyhow::Result<()> {
-    let context = TestEnv::new_without_git().with_filter(
+    let context = TestEnv::new().with_filter(
         r"(?m)^Removed \d+ files? \([^)]+\)\n",
         "Removed [N] file(s) ([SIZE])\n",
     );
@@ -150,7 +150,7 @@ fn cache_clean() -> anyhow::Result<()> {
 
 #[test]
 fn cache_size_output_formats() {
-    let context = TestEnv::new_without_git().with_filter(r"(?m)^\d+\n", "[BYTES]\n");
+    let context = TestEnv::new().with_filter(r"(?m)^\d+\n", "[BYTES]\n");
 
     cmd_snapshot!(context, context.command().args(["cache", "size", "--no-log-file", "--output-format", "auto"]), @r"
     success: true
@@ -182,7 +182,7 @@ fn cache_size_output_formats() {
 
 #[test]
 fn cache_size_with_populated_cache() -> anyhow::Result<()> {
-    let context = TestEnv::new()
+    let context = TestEnv::new_git()
         .with_filter(r"(?m)^\d+\n", "[BYTES]\n")
         .with_config(indoc::indoc! {r"
         repos:
@@ -222,7 +222,7 @@ fn cache_size_with_populated_cache() -> anyhow::Result<()> {
 
 #[test]
 fn cache_gc_removes_unreferenced_entries() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: https://github.com/pre-commit/pre-commit-hooks
             rev: v6.0.0
@@ -289,7 +289,7 @@ fn cache_gc_removes_unreferenced_entries() -> anyhow::Result<()> {
 
 #[test]
 fn cache_gc_keeps_relative_remote_repo() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let hook_repo = context.work_dir().child("hook-repo");
     hook_repo.create_dir_all()?;
@@ -370,7 +370,7 @@ fn cache_gc_keeps_relative_remote_repo() -> anyhow::Result<()> {
 
 #[test]
 fn cache_gc_prunes_unused_tool_versions() -> anyhow::Result<()> {
-    let context = TestEnv::new_without_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -525,7 +525,7 @@ fn cache_gc_prunes_unused_tool_versions() -> anyhow::Result<()> {
 
 #[test]
 fn cache_gc_prunes_tool_versions_without_positive_identification() -> anyhow::Result<()> {
-    let context = TestEnv::new_without_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -606,7 +606,7 @@ fn cache_gc_prunes_tool_versions_without_positive_identification() -> anyhow::Re
 
 #[test]
 fn cache_gc_keeps_local_hook_env() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -678,7 +678,7 @@ fn cache_gc_keeps_local_hook_env() -> anyhow::Result<()> {
 
 #[test]
 fn cache_gc_removes_stale_patch_files() -> anyhow::Result<()> {
-    let context = TestEnv::new_without_git().with_config("repos: []\n");
+    let context = TestEnv::new().with_config("repos: []\n");
 
     let home = context.home_dir();
     let config_path = context.work_dir().child(PRE_COMMIT_CONFIG_YAML);
@@ -758,7 +758,7 @@ fn write_patch_file(path: &ChildPath, content: &str, modified: SystemTime) -> an
 
 #[test]
 fn cache_gc_drops_missing_tracked_config() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config("repos: []\n");
+    let context = TestEnv::new_git().with_config("repos: []\n");
 
     let cwd = context.work_dir();
     context.git_add_all();
@@ -801,7 +801,7 @@ fn cache_gc_drops_missing_tracked_config() -> anyhow::Result<()> {
 
 #[test]
 fn cache_gc_keeps_tracked_config_on_parse_error() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let cwd = context.work_dir();
     // Intentionally invalid YAML.
@@ -837,7 +837,7 @@ fn cache_gc_keeps_tracked_config_on_parse_error() -> anyhow::Result<()> {
 
 #[test]
 fn cache_gc_dry_run_does_not_remove_entries() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config("repos: []\n");
+    let context = TestEnv::new_git().with_config("repos: []\n");
 
     let cwd = context.work_dir();
     context.git_add_all();

--- a/crates/prek/tests/common/mod.rs
+++ b/crates/prek/tests/common/mod.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::OnceLock;
 
 use assert_cmd::assert::OutputAssertExt;
-use assert_fs::fixture::{ChildPath, FileWriteStr, PathChild, PathCreateDir};
+use assert_fs::fixture::{ChildPath, FileWriteBin, FileWriteStr, PathChild, PathCreateDir};
 use etcetera::BaseStrategy;
 use rustc_hash::FxHashSet;
 
@@ -74,23 +74,26 @@ impl TestRepo {
         git_cmd(&self.path, &self.home_dir)
     }
 
-    pub fn git_add_all(&self) {
+    pub fn git_add_all(&self) -> &Self {
         self.git().args(["add", "."]).assert().success();
+        self
     }
 
-    pub fn git_commit(&self, message: &str) {
+    pub fn git_commit(&self, message: &str) -> &Self {
         self.git()
             .args(["commit", "-m", message])
             .assert()
             .success();
+        self
     }
 
-    pub fn git_tag(&self, tag: &str) {
+    pub fn git_tag(&self, tag: &str) -> &Self {
         self.git()
             .args(["tag", tag, "-m"])
             .arg(format!("Tag {tag}"))
             .assert()
             .success();
+        self
     }
 
     pub fn git_rev_parse(&self, rev: &str) -> anyhow::Result<String> {
@@ -114,13 +117,8 @@ pub struct TestEnv {
 }
 
 impl TestEnv {
+    /// Create an isolated test environment without a Git repository.
     pub fn new() -> Self {
-        let env = Self::new_without_git();
-        env.init_project();
-        env
-    }
-
-    pub fn new_without_git() -> Self {
         let bucket = Self::test_bucket_dir();
         fs_err::create_dir_all(&bucket).expect("Failed to create test bucket");
 
@@ -132,13 +130,21 @@ impl TestEnv {
         Self::from_root(root, work_dir)
     }
 
-    pub fn new_at(path: impl AsRef<Path>) -> Self {
-        let env = Self::new_without_git_at(path);
-        env.init_project();
+    /// Create an isolated test environment with a Git repository.
+    pub fn new_git() -> Self {
+        let env = Self::new();
+        init_repo(&env.work_dir, &env.home_dir);
         env
     }
 
-    fn new_without_git_at(path: impl AsRef<Path>) -> Self {
+    /// Create a Git test environment at the given working directory.
+    pub fn new_git_at(path: impl AsRef<Path>) -> Self {
+        let env = Self::new_at(path);
+        init_repo(&env.work_dir, &env.home_dir);
+        env
+    }
+
+    fn new_at(path: impl AsRef<Path>) -> Self {
         let bucket = Self::test_bucket_dir();
         fs_err::create_dir_all(&bucket).expect("Failed to create test bucket");
 
@@ -242,6 +248,22 @@ impl TestEnv {
     pub fn read(&self, file: impl AsRef<Path>) -> String {
         fs_err::read_to_string(self.work_dir.join(&file))
             .unwrap_or_else(|_| panic!("Missing file: `{}`", file.as_ref().display()))
+    }
+
+    /// Write or replace a file in the working directory.
+    pub fn write_file(&self, file: impl AsRef<Path>, content: impl AsRef<[u8]>) {
+        let file = file.as_ref();
+        self.work_dir
+            .child(file)
+            .write_binary(content.as_ref())
+            .unwrap_or_else(|err| panic!("Failed to write test file `{}`: {err}", file.display()));
+    }
+
+    /// Write a file in the working directory and return this environment.
+    #[must_use]
+    pub fn with_file(self, file: impl AsRef<Path>, content: impl AsRef<[u8]>) -> Self {
+        self.write_file(file, content);
+        self
     }
 
     pub fn command(&self) -> Command {
@@ -394,42 +416,29 @@ impl TestEnv {
         )
     }
 
-    fn init_project(&self) {
-        init_repo(&self.work_dir, &self.home_dir);
-    }
-
     /// Run `git add`.
-    pub fn git_add(&self, path: impl AsRef<OsStr>) {
+    pub fn git_add(&self, path: impl AsRef<OsStr>) -> &Self {
         self.git().arg("add").arg(path).assert().success();
+        self
     }
 
-    pub fn git_add_all(&self) {
-        self.git_add(".");
+    pub fn git_add_all(&self) -> &Self {
+        self.git_add(".")
     }
 
     /// Run `git commit`.
-    pub fn git_commit(&self, message: &str) {
+    pub fn git_commit(&self, message: &str) -> &Self {
         self.git()
             .arg("commit")
             .arg("-m")
             .arg(message)
             .assert()
             .success();
-    }
-
-    /// Run `git tag`.
-    pub fn git_tag(&self, tag: &str) {
-        self.git()
-            .arg("tag")
-            .arg(tag)
-            .arg("-m")
-            .arg(format!("Tag {tag}"))
-            .assert()
-            .success();
+        self
     }
 
     /// Run `git rm`.
-    pub fn git_rm(&self, path: &str) {
+    pub fn git_rm(&self, path: &str) -> &Self {
         self.git()
             .arg("rm")
             .arg("--cached")
@@ -440,25 +449,29 @@ impl TestEnv {
         if file_path.exists() {
             fs_err::remove_file(file_path).unwrap();
         }
+        self
     }
 
     /// Run `git clean`.
-    pub fn git_clean(&self) {
+    pub fn git_clean(&self) -> &Self {
         self.git().arg("clean").arg("-fdx").assert().success();
+        self
     }
 
     /// Create a new git branch.
-    pub fn git_branch(&self, branch_name: &str) {
+    pub fn git_branch(&self, branch_name: &str) -> &Self {
         self.git().arg("branch").arg(branch_name).assert().success();
+        self
     }
 
     /// Switch to a git branch.
-    pub fn git_checkout(&self, branch_name: &str) {
+    pub fn git_checkout(&self, branch_name: &str) -> &Self {
         self.git()
             .arg("checkout")
             .arg(branch_name)
             .assert()
             .success();
+        self
     }
 
     /// Write a `.pre-commit-config.yaml` file and return this environment.

--- a/crates/prek/tests/common/mod.rs
+++ b/crates/prek/tests/common/mod.rs
@@ -53,6 +53,98 @@ fn init_repo(path: impl AsRef<Path>, home_dir: impl AsRef<Path>) {
         .success();
 }
 
+/// Git operations for an integration-test repository.
+pub struct TestGit<'a> {
+    path: PathBuf,
+    home_dir: &'a Path,
+}
+
+impl<'a> TestGit<'a> {
+    fn new(path: impl AsRef<Path>, home_dir: &'a Path) -> Self {
+        Self {
+            path: path.as_ref().to_path_buf(),
+            home_dir,
+        }
+    }
+
+    /// Create a raw Git command for operations not covered by this wrapper.
+    pub fn command(&self) -> Command {
+        git_cmd(&self.path, self.home_dir)
+    }
+
+    pub fn init(&self) -> &Self {
+        init_repo(&self.path, self.home_dir);
+        self
+    }
+
+    pub fn add(&self, path: impl AsRef<OsStr>) -> &Self {
+        self.command().arg("add").arg(path).assert().success();
+        self
+    }
+
+    pub fn add_all(&self) -> &Self {
+        self.add(".")
+    }
+
+    pub fn commit(&self, message: &str) -> &Self {
+        self.command()
+            .args(["commit", "-m", message])
+            .assert()
+            .success();
+        self
+    }
+
+    pub fn tag(&self, tag: &str) -> &Self {
+        self.command()
+            .args(["tag", tag, "-m"])
+            .arg(format!("Tag {tag}"))
+            .assert()
+            .success();
+        self
+    }
+
+    pub fn rev_parse(&self, rev: &str) -> anyhow::Result<String> {
+        let output = self.command().args(["rev-parse", rev]).output()?;
+        let output = output.assert().success();
+        Ok(std::str::from_utf8(&output.get_output().stdout)?
+            .trim()
+            .to_owned())
+    }
+
+    pub fn rm(&self, path: &str) -> &Self {
+        self.command()
+            .args(["rm", "--cached", path])
+            .assert()
+            .success();
+        let file_path = self.path.join(path);
+        if file_path.exists() {
+            fs_err::remove_file(file_path).unwrap();
+        }
+        self
+    }
+
+    pub fn clean(&self) -> &Self {
+        self.command().args(["clean", "-fdx"]).assert().success();
+        self
+    }
+
+    pub fn branch(&self, branch_name: &str) -> &Self {
+        self.command()
+            .args(["branch", branch_name])
+            .assert()
+            .success();
+        self
+    }
+
+    pub fn checkout(&self, branch_name: &str) -> &Self {
+        self.command()
+            .args(["checkout", branch_name])
+            .assert()
+            .success();
+        self
+    }
+}
+
 pub struct TestRepo {
     path: ChildPath,
     home_dir: PathBuf,
@@ -70,38 +162,8 @@ impl TestRepo {
         &self.path
     }
 
-    pub fn git(&self) -> Command {
-        git_cmd(&self.path, &self.home_dir)
-    }
-
-    pub fn git_add_all(&self) -> &Self {
-        self.git().args(["add", "."]).assert().success();
-        self
-    }
-
-    pub fn git_commit(&self, message: &str) -> &Self {
-        self.git()
-            .args(["commit", "-m", message])
-            .assert()
-            .success();
-        self
-    }
-
-    pub fn git_tag(&self, tag: &str) -> &Self {
-        self.git()
-            .args(["tag", tag, "-m"])
-            .arg(format!("Tag {tag}"))
-            .assert()
-            .success();
-        self
-    }
-
-    pub fn git_rev_parse(&self, rev: &str) -> anyhow::Result<String> {
-        let output = self.git().args(["rev-parse", rev]).output()?;
-        let output = output.assert().success();
-        Ok(std::str::from_utf8(&output.get_output().stdout)?
-            .trim()
-            .to_owned())
+    pub fn git(&self) -> TestGit<'_> {
+        TestGit::new(&self.path, &self.home_dir)
     }
 }
 
@@ -286,12 +348,12 @@ impl TestEnv {
         cmd
     }
 
-    pub fn git(&self) -> Command {
+    pub fn git(&self) -> TestGit<'_> {
         self.git_at(&self.work_dir)
     }
 
-    pub fn git_at(&self, dir: impl AsRef<Path>) -> Command {
-        git_cmd(dir, &self.home_dir)
+    pub fn git_at(&self, dir: impl AsRef<Path>) -> TestGit<'_> {
+        TestGit::new(dir, self.home_dir.as_ref())
     }
 
     fn user_config_path(&self) -> ChildPath {
@@ -414,64 +476,6 @@ impl TestEnv {
             self.home_dir.child("test-repos").child(name),
             self.home_dir.to_path_buf(),
         )
-    }
-
-    /// Run `git add`.
-    pub fn git_add(&self, path: impl AsRef<OsStr>) -> &Self {
-        self.git().arg("add").arg(path).assert().success();
-        self
-    }
-
-    pub fn git_add_all(&self) -> &Self {
-        self.git_add(".")
-    }
-
-    /// Run `git commit`.
-    pub fn git_commit(&self, message: &str) -> &Self {
-        self.git()
-            .arg("commit")
-            .arg("-m")
-            .arg(message)
-            .assert()
-            .success();
-        self
-    }
-
-    /// Run `git rm`.
-    pub fn git_rm(&self, path: &str) -> &Self {
-        self.git()
-            .arg("rm")
-            .arg("--cached")
-            .arg(path)
-            .assert()
-            .success();
-        let file_path = self.work_dir.child(path);
-        if file_path.exists() {
-            fs_err::remove_file(file_path).unwrap();
-        }
-        self
-    }
-
-    /// Run `git clean`.
-    pub fn git_clean(&self) -> &Self {
-        self.git().arg("clean").arg("-fdx").assert().success();
-        self
-    }
-
-    /// Create a new git branch.
-    pub fn git_branch(&self, branch_name: &str) -> &Self {
-        self.git().arg("branch").arg(branch_name).assert().success();
-        self
-    }
-
-    /// Switch to a git branch.
-    pub fn git_checkout(&self, branch_name: &str) -> &Self {
-        self.git()
-            .arg("checkout")
-            .arg(branch_name)
-            .assert()
-            .success();
-        self
     }
 
     /// Write a `.pre-commit-config.yaml` file and return this environment.

--- a/crates/prek/tests/exec.rs
+++ b/crates/prek/tests/exec.rs
@@ -25,7 +25,7 @@ fn config() -> &'static str {
 }
 
 fn context_with_config() -> TestEnv {
-    TestEnv::new().with_config(config())
+    TestEnv::new_git().with_config(config())
 }
 
 #[test]
@@ -108,7 +108,7 @@ fn exec_propagates_child_exit_status() {
 
 #[test]
 fn exec_rejects_ambiguous_hook_selector() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     context.setup_workspace(&["frontend"], config())?;
 
     cmd_snapshot!(context, context.exec().args([
@@ -133,7 +133,7 @@ fn exec_rejects_ambiguous_hook_selector() -> Result<()> {
 
 #[test]
 fn exec_keeps_current_working_directory() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     context.setup_workspace(&["frontend"], config())?;
 
     cmd_snapshot!(context, context.exec().args([
@@ -156,7 +156,7 @@ fn exec_keeps_current_working_directory() -> Result<()> {
 #[cfg(unix)]
 #[test]
 fn exec_resolves_relative_command_from_current_working_directory() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     context.setup_workspace(&["frontend"], config())?;
 
     let command = context.work_dir().join("exec-tool");
@@ -180,7 +180,7 @@ fn exec_resolves_relative_command_from_current_working_directory() -> Result<()>
 
 #[test]
 fn exec_rejects_unsupported_language_before_install() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:

--- a/crates/prek/tests/global_config.rs
+++ b/crates/prek/tests/global_config.rs
@@ -4,7 +4,7 @@ mod common;
 
 #[test]
 fn global_config_missing_file_is_optional() {
-    let context = TestEnv::new().with_config("repos: []");
+    let context = TestEnv::new_git().with_config("repos: []");
 
     cmd_snapshot!(context, context.update(), @"
     success: true
@@ -17,7 +17,7 @@ fn global_config_missing_file_is_optional() {
 
 #[test]
 fn global_config_ignores_unknown_options() {
-    let context = TestEnv::new().with_config("repos: []");
+    let context = TestEnv::new_git().with_config("repos: []");
     context.write_user_config(indoc::indoc! {r#"
         future_option = true
 
@@ -37,7 +37,7 @@ fn global_config_ignores_unknown_options() {
 
 #[test]
 fn update_command_accepts_upstream_alias() {
-    let context = TestEnv::new().with_config("repos: []");
+    let context = TestEnv::new_git().with_config("repos: []");
 
     cmd_snapshot!(context, context.command().arg("autoupdate"), @"
     success: true
@@ -50,7 +50,7 @@ fn update_command_accepts_upstream_alias() {
 
 #[test]
 fn global_config_invalid_file_reports_parse_error() {
-    let context = TestEnv::new().with_config("repos: []");
+    let context = TestEnv::new_git().with_config("repos: []");
     context.write_user_config(indoc::indoc! {r#"
         [update]
         cooldown_days = "soon"

--- a/crates/prek/tests/hook_impl.rs
+++ b/crates/prek/tests/hook_impl.rs
@@ -22,9 +22,9 @@ fn hook_impl() {
              always_run: true
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
-    let mut commit = context.git();
+    let mut commit = context.git().command();
     commit.arg("commit").arg("-m").arg("Initial commit");
 
     cmd_snapshot!(context, context.install(), @r#"
@@ -109,9 +109,9 @@ fn hook_impl_pre_push() -> anyhow::Result<()> {
              entry: echo "hook ran successfully"
              always_run: true
     "#});
-    context.git_add_all();
+    context.git().add_all();
 
-    let mut commit = context.git();
+    let mut commit = context.git().command();
     commit.arg("commit").arg("-m").arg("Initial commit");
 
     cmd_snapshot!(context, context.install().arg("--hook-type").arg("pre-push"), @r#"
@@ -138,7 +138,7 @@ fn hook_impl_pre_push() -> anyhow::Result<()> {
     let remote_repo_path = context.home_dir().join("remote.git");
     fs_err::create_dir_all(&remote_repo_path)?;
 
-    let mut init_remote = context.git_at(&remote_repo_path);
+    let mut init_remote = context.git_at(&remote_repo_path).command();
     init_remote
         .arg("-c")
         .arg("init.defaultBranch=master")
@@ -154,7 +154,7 @@ fn hook_impl_pre_push() -> anyhow::Result<()> {
     "#);
 
     // Add remote to local repo
-    let mut add_remote = context.git();
+    let mut add_remote = context.git().command();
     add_remote
         .arg("remote")
         .arg("add")
@@ -169,7 +169,7 @@ fn hook_impl_pre_push() -> anyhow::Result<()> {
     "#);
 
     // First push - should trigger the hook
-    let mut push_cmd = context.git();
+    let mut push_cmd = context.git().command();
     push_cmd.arg("push").arg("origin").arg("master");
 
     cmd_snapshot!(context, push_cmd, @r"
@@ -184,7 +184,7 @@ fn hook_impl_pre_push() -> anyhow::Result<()> {
     ");
 
     // Second push - should not trigger the hook (nothing new to push)
-    let mut push_cmd2 = context.git();
+    let mut push_cmd2 = context.git().command();
     push_cmd2.arg("push").arg("origin").arg("master");
 
     cmd_snapshot!(context, push_cmd2, @r"
@@ -227,13 +227,12 @@ fn hook_impl_pre_push_force_push_after_rebase() -> anyhow::Result<()> {
 
             raise SystemExit(1)
         "})?;
-    context.git_add_all();
-    context.git_commit("Initial commit");
+    context.git().add_all().commit("Initial commit");
 
     let remote_repo_path = context.home_dir().join("remote.git");
     fs_err::create_dir_all(&remote_repo_path)?;
 
-    let mut init_remote = context.git_at(&remote_repo_path);
+    let mut init_remote = context.git_at(&remote_repo_path).command();
     init_remote
         .arg("-c")
         .arg("init.defaultBranch=master")
@@ -241,7 +240,7 @@ fn hook_impl_pre_push_force_push_after_rebase() -> anyhow::Result<()> {
         .arg("--bare");
     init_remote.output()?.assert().success();
 
-    let mut add_remote = context.git();
+    let mut add_remote = context.git().command();
     add_remote
         .arg("remote")
         .arg("add")
@@ -249,14 +248,14 @@ fn hook_impl_pre_push_force_push_after_rebase() -> anyhow::Result<()> {
         .arg(&remote_repo_path);
     add_remote.output()?.assert().success();
 
-    let mut push_master = context.git();
+    let mut push_master = context.git().command();
     push_master.arg("push").arg("origin").arg("master");
     push_master.output()?.assert().success();
 
     // Create and push a feature branch so the remote has an old feature tip.
     // This old tip is what Git passes to pre-push as remote_sha during the
     // later force-push.
-    let mut checkout_feature = context.git();
+    let mut checkout_feature = context.git().command();
     checkout_feature.arg("checkout").arg("-b").arg("feature");
     checkout_feature.output()?.assert().success();
 
@@ -264,36 +263,34 @@ fn hook_impl_pre_push_force_push_after_rebase() -> anyhow::Result<()> {
         .work_dir()
         .child("feature.txt")
         .write_str("feature")?;
-    context.git_add_all();
-    context.git_commit("Add feature file");
+    context.git().add_all().commit("Add feature file");
 
-    let mut push_feature = context.git();
+    let mut push_feature = context.git().command();
     push_feature.arg("push").arg("origin").arg("feature");
     push_feature.output()?.assert().success();
 
     // Move master forward with an unrelated file. After the feature branch is
     // rebased onto this commit, main.txt must not appear in the pre-push file
     // list because it is default-branch churn, not a feature-branch change.
-    context.git_checkout("master");
+    context.git().checkout("master");
     context.work_dir().child("main.txt").write_str("main")?;
-    context.git_add_all();
-    context.git_commit("Update master");
+    context.git().add_all().commit("Update master");
 
-    let mut push_master = context.git();
+    let mut push_master = context.git().command();
     push_master.arg("push").arg("origin").arg("master");
     push_master.output()?.assert().success();
 
-    let mut fetch_origin = context.git();
+    let mut fetch_origin = context.git().command();
     fetch_origin.arg("fetch").arg("origin");
     fetch_origin.output()?.assert().success();
 
-    context.git_checkout("feature");
+    context.git().checkout("feature");
 
     // Rebase rewrites the feature commit, so the old remote feature tip still
     // exists locally but is no longer an ancestor of the new local feature tip.
     // That is the #2088 shape that used to make old_remote...new_local include
     // unrelated master changes.
-    let mut rebase = context.git();
+    let mut rebase = context.git().command();
     rebase.arg("rebase").arg("origin/master");
     rebase.output()?.assert().success();
 
@@ -305,7 +302,7 @@ fn hook_impl_pre_push_force_push_after_rebase() -> anyhow::Result<()> {
         .assert()
         .success();
 
-    let mut push_cmd = context.git();
+    let mut push_cmd = context.git().command();
     push_cmd
         .arg("push")
         .arg("--force")
@@ -351,7 +348,7 @@ fn hook_impl_runs_legacy_hook() -> anyhow::Result<()> {
   "})?;
 
     context.work_dir().child("file.txt").write_str("x")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.install(), @r#"
     success: true
@@ -370,7 +367,7 @@ fn hook_impl_runs_legacy_hook() -> anyhow::Result<()> {
     "#})?;
     make_executable(legacy_hook.path())?;
 
-    let mut commit = context.git();
+    let mut commit = context.git().command();
     commit.arg("commit").arg("-m").arg("Test commit");
 
     cmd_snapshot!(context, commit, @"
@@ -397,8 +394,7 @@ fn hook_impl_pre_push_runs_legacy_and_prek() -> anyhow::Result<()> {
             entry: echo "hook ran successfully"
             always_run: true
   "#});
-    context.git_add_all();
-    context.git_commit("Initial commit");
+    context.git().add_all().commit("Initial commit");
 
     cmd_snapshot!(context, context.install().arg("--hook-type").arg("pre-push"), @r#"
     success: true
@@ -420,7 +416,7 @@ fn hook_impl_pre_push_runs_legacy_and_prek() -> anyhow::Result<()> {
     let remote_repo_path = context.home_dir().join("remote.git");
     fs_err::create_dir_all(&remote_repo_path)?;
 
-    let mut init_remote = context.git_at(&remote_repo_path);
+    let mut init_remote = context.git_at(&remote_repo_path).command();
     init_remote
         .arg("-c")
         .arg("init.defaultBranch=master")
@@ -428,7 +424,7 @@ fn hook_impl_pre_push_runs_legacy_and_prek() -> anyhow::Result<()> {
         .arg("--bare");
     init_remote.output()?.assert().success();
 
-    let mut add_remote = context.git();
+    let mut add_remote = context.git().command();
     add_remote
         .arg("remote")
         .arg("add")
@@ -437,10 +433,9 @@ fn hook_impl_pre_push_runs_legacy_and_prek() -> anyhow::Result<()> {
     add_remote.output()?.assert().success();
 
     context.work_dir().child("file.txt").write_str("x")?;
-    context.git_add_all();
-    context.git_commit("Second commit");
+    context.git().add_all().commit("Second commit");
 
-    let mut push_cmd = context.git();
+    let mut push_cmd = context.git().command();
     push_cmd.arg("push").arg("origin").arg("master");
 
     cmd_snapshot!(context, push_cmd, @"
@@ -470,8 +465,7 @@ fn run_worktree() -> anyhow::Result<()> {
              entry: always fail
              always_run: true
     "});
-    context.git_add_all();
-    context.git_commit("Initial commit");
+    context.git().add_all().commit("Initial commit");
 
     cmd_snapshot!(context, context.install(), @r#"
     success: true
@@ -485,6 +479,7 @@ fn run_worktree() -> anyhow::Result<()> {
     // Create a new worktree.
     context
         .git()
+        .command()
         .arg("worktree")
         .arg("add")
         .arg("worktree")
@@ -499,7 +494,9 @@ fn run_worktree() -> anyhow::Result<()> {
         .child(PRE_COMMIT_CONFIG_YAML)
         .write_str("")?;
 
-    let mut commit = context.git_at(context.work_dir().child("worktree"));
+    let mut commit = context
+        .git_at(context.work_dir().child("worktree"))
+        .command();
     commit
         .arg("commit")
         .arg("-m")
@@ -535,7 +532,7 @@ fn git_dir_respected() {
              entry: python -c 'import os, sys; print("GIT_DIR:", os.environ.get("GIT_DIR")); print("GIT_WORK_TREE:", os.environ.get("GIT_WORK_TREE")); sys.exit(1)'
              pass_filenames: false
     "#});
-    context.git_add_all();
+    context.git().add_all();
     let cwd = context.work_dir();
 
     cmd_snapshot!(context, context.install(), @r#"
@@ -547,7 +544,7 @@ fn git_dir_respected() {
     ----- stderr -----
     "#);
 
-    let mut commit = context.git_at(context.home_dir());
+    let mut commit = context.git_at(context.home_dir()).command();
     commit
         .arg("--git-dir")
         .arg(cwd.join(".git"))
@@ -585,7 +582,7 @@ fn git_dir_synthesized_git_work_tree_not_leaked_to_hook() {
              pass_filenames: false
              always_run: true
     "#});
-    context.git_add_all();
+    context.git().add_all();
 
     let mut run = context.run();
     run.env(EnvVars::GIT_DIR, context.work_dir().join(".git"));
@@ -646,8 +643,7 @@ fn workspace_hook_in_linked_worktree_keeps_git_index() -> anyhow::Result<()> {
     nested.create_dir_all()?;
     nested.child("a.txt").write_str("a\n")?;
 
-    context.git_add_all();
-    context.git_commit("Initial commit");
+    context.git().add_all().commit("Initial commit");
 
     cmd_snapshot!(context, context.install(), @r#"
     success: true
@@ -660,19 +656,16 @@ fn workspace_hook_in_linked_worktree_keeps_git_index() -> anyhow::Result<()> {
 
     context
         .git()
+        .command()
         .args(["worktree", "add", "worktree", "HEAD"])
         .assert()
         .success();
 
     let worktree = context.work_dir().child("worktree");
     worktree.child("tracked.txt").write_str("b2\n")?;
-    context
-        .git_at(&worktree)
-        .args(["add", "tracked.txt"])
-        .assert()
-        .success();
+    context.git_at(&worktree).add("tracked.txt");
 
-    let mut commit = context.git_at(&worktree);
+    let mut commit = context.git_at(&worktree).command();
     commit
         .arg("commit")
         .arg("-m")
@@ -693,7 +686,7 @@ fn workspace_hook_in_linked_worktree_keeps_git_index() -> anyhow::Result<()> {
     ");
 
     // The hook's `git add -u` must not rewrite the index as if `sub` were the repository.
-    let mut ls_files = context.git_at(&worktree);
+    let mut ls_files = context.git_at(&worktree).command();
     ls_files.arg("ls-files");
     cmd_snapshot!(context, ls_files, @r"
     success: true
@@ -709,7 +702,7 @@ fn workspace_hook_in_linked_worktree_keeps_git_index() -> anyhow::Result<()> {
     ----- stderr -----
     ");
 
-    let mut status = context.git_at(&worktree);
+    let mut status = context.git_at(&worktree).command();
     status.args(["status", "--porcelain"]);
     cmd_snapshot!(context, status, @r"
     success: true
@@ -738,7 +731,7 @@ fn workspace_hook_impl_root() -> anyhow::Result<()> {
     "#};
 
     context.setup_workspace(&["project2", "project3"], config)?;
-    context.git_add_all();
+    context.git().add_all();
 
     // Install from root
     cmd_snapshot!(context, context.install(), @r#"
@@ -750,7 +743,7 @@ fn workspace_hook_impl_root() -> anyhow::Result<()> {
     ----- stderr -----
     "#);
 
-    let mut commit = context.git();
+    let mut commit = context.git().command();
     commit
         .arg("commit")
         .arg("-m")
@@ -810,7 +803,7 @@ fn workspace_commit_msg_hook_receives_message_file_for_each_project() -> anyhow:
     "#};
 
     context.setup_workspace(&["template"], config)?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.install(), @r#"
     success: true
@@ -821,7 +814,7 @@ fn workspace_commit_msg_hook_receives_message_file_for_each_project() -> anyhow:
     ----- stderr -----
     "#);
 
-    let mut commit = context.git();
+    let mut commit = context.git().command();
     commit.arg("commit").arg("-m").arg("feat: initial");
 
     cmd_snapshot!(context, commit, @r#"
@@ -865,7 +858,7 @@ fn commit_msg_builtin_hook_respects_message_file_filters() {
         hooks:
         - id: check-json
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.install(), @r#"
     success: true
@@ -876,7 +869,7 @@ fn commit_msg_builtin_hook_respects_message_file_filters() {
     ----- stderr -----
     "#);
 
-    let mut commit = context.git();
+    let mut commit = context.git().command();
     commit.arg("commit").arg("-m").arg("dummy");
 
     cmd_snapshot!(context, commit, @r"
@@ -909,7 +902,7 @@ fn workspace_hook_impl_subdirectory() -> anyhow::Result<()> {
     "#};
 
     context.setup_workspace(&["project2", "project3"], config)?;
-    context.git_add_all();
+    context.git().add_all();
 
     // Install from a subdirectory
     cmd_snapshot!(context, context.install().current_dir(cwd.join("project2")), @r#"
@@ -923,7 +916,7 @@ fn workspace_hook_impl_subdirectory() -> anyhow::Result<()> {
     ----- stderr -----
     "#);
 
-    let mut commit = context.git_at(cwd);
+    let mut commit = context.git_at(cwd).command();
     commit
         .arg("commit")
         .arg("-m")
@@ -969,8 +962,7 @@ fn workspace_hook_impl_worktree_subdirectory() -> anyhow::Result<()> {
     "#};
 
     context.setup_workspace(&["project2", "project3"], config)?;
-    context.git_add_all();
-    context.git_commit("Initial commit");
+    context.git().add_all().commit("Initial commit");
 
     // Install from a subdirectory
     cmd_snapshot!(context, context.install().current_dir(cwd.join("project2")), @r#"
@@ -987,6 +979,7 @@ fn workspace_hook_impl_worktree_subdirectory() -> anyhow::Result<()> {
     // Create a new worktree.
     context
         .git_at(cwd)
+        .command()
         .arg("worktree")
         .arg("add")
         .arg("worktree")
@@ -1002,7 +995,7 @@ fn workspace_hook_impl_worktree_subdirectory() -> anyhow::Result<()> {
         .child(PRE_COMMIT_CONFIG_YAML)
         .write_str("")?;
 
-    let mut commit = context.git_at(cwd.child("worktree"));
+    let mut commit = context.git_at(cwd.child("worktree")).command();
     commit
         .arg("commit")
         .arg("-m")
@@ -1031,7 +1024,7 @@ fn workspace_hook_impl_no_project_found() -> anyhow::Result<()> {
     let empty_dir = context.work_dir().child("empty");
     empty_dir.create_dir_all()?;
     empty_dir.child("file.txt").write_str("Some content")?;
-    context.git_add_all();
+    context.git().add_all();
 
     // Install hook that allows missing config
     cmd_snapshot!(context, context.install(), @r#"
@@ -1044,7 +1037,7 @@ fn workspace_hook_impl_no_project_found() -> anyhow::Result<()> {
     "#);
 
     // Try to run hook-impl from directory without config
-    let mut commit = context.git_at(&empty_dir);
+    let mut commit = context.git_at(&empty_dir).command();
     commit.arg("commit").arg("-m").arg("Test commit");
 
     cmd_snapshot!(context, commit, @r"
@@ -1062,7 +1055,7 @@ fn workspace_hook_impl_no_project_found() -> anyhow::Result<()> {
     ");
 
     // Commit with `PREK_ALLOW_NO_CONFIG=1`
-    let mut commit = context.git_at(&empty_dir);
+    let mut commit = context.git_at(&empty_dir).command();
     commit
         .env(EnvVars::PREK_ALLOW_NO_CONFIG, "1")
         .arg("commit")
@@ -1094,10 +1087,10 @@ fn workspace_hook_impl_no_project_found() -> anyhow::Result<()> {
                 entry: fail
                 language: fail
     "})?;
-    context.git_add_all();
+    context.git().add_all();
 
     // Commit with `PREK_ALLOW_NO_CONFIG=1` again, the hooks should run (and fail)
-    let mut commit = context.git_at(&empty_dir);
+    let mut commit = context.git_at(&empty_dir).command();
     commit
         .env(EnvVars::PREK_ALLOW_NO_CONFIG, "1")
         .arg("commit")
@@ -1142,7 +1135,7 @@ fn hook_impl_does_not_fail_when_no_hooks_match_stage() -> anyhow::Result<()> {
     "})?;
 
     context.work_dir().child("file.txt").write_str("x")?;
-    context.git_add_all();
+    context.git().add_all();
 
     // Install the git hook (which invokes `prek hook-impl`).
     cmd_snapshot!(context, context.install(), @r#"
@@ -1155,7 +1148,7 @@ fn hook_impl_does_not_fail_when_no_hooks_match_stage() -> anyhow::Result<()> {
     "#);
 
     // Commit should succeed; the hook should not error just because no hooks match pre-commit.
-    let mut commit = context.git();
+    let mut commit = context.git().command();
     commit.arg("commit").arg("-m").arg("Test commit");
 
     cmd_snapshot!(context, commit, @r"
@@ -1190,7 +1183,7 @@ fn workspace_hook_impl_with_selectors() -> anyhow::Result<()> {
     "#};
 
     context.setup_workspace(&["project2", "project3"], config)?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.install().arg("project2/"), @r#"
     success: true
@@ -1201,7 +1194,7 @@ fn workspace_hook_impl_with_selectors() -> anyhow::Result<()> {
     ----- stderr -----
     "#);
 
-    let mut commit = context.git_at(cwd);
+    let mut commit = context.git_at(cwd).command();
     commit
         .arg("commit")
         .arg("-m")

--- a/crates/prek/tests/hook_impl.rs
+++ b/crates/prek/tests/hook_impl.rs
@@ -11,7 +11,7 @@ mod common;
 
 #[test]
 fn hook_impl() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
         - repo: local
           hooks:
@@ -54,7 +54,7 @@ fn hook_impl() {
 
 #[test]
 fn hook_impl_allows_missing_hook_dir() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
         - repo: local
           hooks:
@@ -97,7 +97,7 @@ fn hook_impl_allows_missing_hook_dir() -> anyhow::Result<()> {
 
 #[test]
 fn hook_impl_pre_push() -> anyhow::Result<()> {
-    let context = TestEnv::new()
+    let context = TestEnv::new_git()
         .with_filter(r"\b[0-9a-f]{7}\b", "[SHA1]")
         .with_config(indoc::indoc! {r#"
         repos:
@@ -201,7 +201,7 @@ fn hook_impl_pre_push() -> anyhow::Result<()> {
 
 #[test]
 fn hook_impl_pre_push_force_push_after_rebase() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Regression test for https://github.com/j178/prek/issues/2088.
     // The hook fails after printing its filenames so the assertion can inspect
@@ -334,7 +334,7 @@ fn hook_impl_pre_push_force_push_after_rebase() -> anyhow::Result<()> {
 
 #[test]
 fn hook_impl_runs_legacy_hook() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     context
         .work_dir()
@@ -387,7 +387,7 @@ fn hook_impl_runs_legacy_hook() -> anyhow::Result<()> {
 
 #[test]
 fn hook_impl_pre_push_runs_legacy_and_prek() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
     repos:
     - repo: local
       hooks:
@@ -460,7 +460,7 @@ fn hook_impl_pre_push_runs_legacy_and_prek() -> anyhow::Result<()> {
 /// Test prek hook runs in the correct worktree.
 #[test]
 fn run_worktree() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
         - repo: local
           hooks:
@@ -525,7 +525,7 @@ fn run_worktree() -> anyhow::Result<()> {
 /// Test prek hooks runs with `GIT_DIR` respected.
 #[test]
 fn git_dir_respected() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
         - repo: local
           hooks:
@@ -574,7 +574,7 @@ fn git_dir_respected() {
 
 #[test]
 fn git_dir_synthesized_git_work_tree_not_leaked_to_hook() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
         - repo: local
           hooks:
@@ -611,7 +611,7 @@ fn git_dir_synthesized_git_work_tree_not_leaked_to_hook() {
 /// it runs must still resolve the repository root, not the project directory.
 #[test]
 fn workspace_hook_in_linked_worktree_keeps_git_index() -> anyhow::Result<()> {
-    let context = TestEnv::new()
+    let context = TestEnv::new_git()
         .with_filter("[a-f0-9]{7}", "abc1234")
         .with_config(indoc::indoc! {r"
         repos:
@@ -724,7 +724,7 @@ fn workspace_hook_in_linked_worktree_keeps_git_index() -> anyhow::Result<()> {
 
 #[test]
 fn workspace_hook_impl_root() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_filter("[a-f0-9]{7}", "abc1234");
+    let context = TestEnv::new_git().with_filter("[a-f0-9]{7}", "abc1234");
 
     let config = indoc! {r#"
     repos:
@@ -792,7 +792,7 @@ fn workspace_hook_impl_root() -> anyhow::Result<()> {
 
 #[test]
 fn workspace_commit_msg_hook_receives_message_file_for_each_project() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_filter("[a-f0-9]{7}", "abc1234");
+    let context = TestEnv::new_git().with_filter("[a-f0-9]{7}", "abc1234");
 
     let config = indoc! {r#"
     default_install_hook_types:
@@ -855,7 +855,7 @@ fn workspace_commit_msg_hook_receives_message_file_for_each_project() -> anyhow:
 
 #[test]
 fn commit_msg_builtin_hook_respects_message_file_filters() {
-    let context = TestEnv::new()
+    let context = TestEnv::new_git()
         .with_filter("[a-f0-9]{7}", "abc1234")
         .with_config(indoc::indoc! {r"
     default_install_hook_types:
@@ -894,7 +894,7 @@ fn commit_msg_builtin_hook_respects_message_file_filters() {
 
 #[test]
 fn workspace_hook_impl_subdirectory() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_filter("[a-f0-9]{7}", "abc1234");
+    let context = TestEnv::new_git().with_filter("[a-f0-9]{7}", "abc1234");
     let cwd = context.work_dir();
 
     let config = indoc! {r#"
@@ -954,7 +954,7 @@ fn workspace_hook_impl_subdirectory() -> anyhow::Result<()> {
 /// Install from a subdirectory, and run commit in another worktree.
 #[test]
 fn workspace_hook_impl_worktree_subdirectory() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_filter("[a-f0-9]{7}", "abc1234");
+    let context = TestEnv::new_git().with_filter("[a-f0-9]{7}", "abc1234");
     let cwd = context.work_dir();
 
     let config = indoc! {r#"
@@ -1025,7 +1025,7 @@ fn workspace_hook_impl_worktree_subdirectory() -> anyhow::Result<()> {
 
 #[test]
 fn workspace_hook_impl_no_project_found() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_filter("[a-f0-9]{7}", "1d5e501");
+    let context = TestEnv::new_git().with_filter("[a-f0-9]{7}", "1d5e501");
 
     // Create a directory without .pre-commit-config.yaml
     let empty_dir = context.work_dir().child("empty");
@@ -1124,7 +1124,7 @@ fn workspace_hook_impl_no_project_found() -> anyhow::Result<()> {
 
 #[test]
 fn hook_impl_does_not_fail_when_no_hooks_match_stage() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_filter("[a-f0-9]{7}", "abc1234");
+    let context = TestEnv::new_git().with_filter("[a-f0-9]{7}", "abc1234");
 
     // Only a manual-stage hook; a pre-commit hook run should find nothing for the stage.
     context
@@ -1175,7 +1175,7 @@ fn hook_impl_does_not_fail_when_no_hooks_match_stage() -> anyhow::Result<()> {
 
 #[test]
 fn workspace_hook_impl_with_selectors() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_filter("[a-f0-9]{7}", "abc1234");
+    let context = TestEnv::new_git().with_filter("[a-f0-9]{7}", "abc1234");
     let cwd = context.work_dir();
 
     let config = indoc! {r#"

--- a/crates/prek/tests/identify.rs
+++ b/crates/prek/tests/identify.rs
@@ -8,7 +8,7 @@ mod common;
 #[cfg(unix)] // "executable" tag is different on Windows
 #[test]
 fn identify_text_with_missing_paths() -> anyhow::Result<()> {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
     context
         .work_dir()
         .child("hello.py")
@@ -40,7 +40,7 @@ fn identify_text_with_missing_paths() -> anyhow::Result<()> {
 #[cfg(unix)] // "executable" tag is different on Windows
 #[test]
 fn identify_json_with_missing_paths() -> anyhow::Result<()> {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
     context
         .work_dir()
         .child("hello.py")

--- a/crates/prek/tests/init.rs
+++ b/crates/prek/tests/init.rs
@@ -8,7 +8,7 @@ mod common;
 
 #[test]
 fn init_defaults_to_git_root() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     let child = context.work_dir().child("child");
     child.create_dir_all()?;
 
@@ -30,7 +30,7 @@ fn init_defaults_to_git_root() -> anyhow::Result<()> {
 
 #[test]
 fn init_child_project_refreshes_parent_workspace() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config("repos: []\n");
+    let context = TestEnv::new_git().with_config("repos: []\n");
     context.list().assert().success();
 
     let child = context.work_dir().child("child");
@@ -64,7 +64,7 @@ fn init_child_project_refreshes_parent_workspace() -> anyhow::Result<()> {
 #[test]
 fn init_preserves_existing_config() {
     let config = "repos: []\n";
-    let context = TestEnv::new().with_config(config);
+    let context = TestEnv::new_git().with_config(config);
 
     cmd_snapshot!(context, context.command().arg("init"), @r#"
     success: true
@@ -82,7 +82,7 @@ fn init_preserves_existing_config() {
 
 #[test]
 fn init_can_create_yaml_config() {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     cmd_snapshot!(context, context.command().args(["init", "--format", "yaml"]), @r#"
     success: true
@@ -100,7 +100,7 @@ fn init_can_create_yaml_config() {
 
 #[test]
 fn init_can_skip_hook_installation() {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     cmd_snapshot!(context, context.command().args(["init", "--no-install"]), @r#"
     success: true

--- a/crates/prek/tests/install.rs
+++ b/crates/prek/tests/install.rs
@@ -185,6 +185,7 @@ fn install_with_local_hooks_path_installs_to_configured_directory() {
 
     context
         .git()
+        .command()
         .args(["config", "core.hooksPath", "custom-hooks"])
         .assert()
         .success();
@@ -231,6 +232,7 @@ fn install_with_git_dir_allows_external_hooks_path_set() {
     let global_gitconfig = context.work_dir().join("global.gitconfig");
     context
         .git()
+        .command()
         .env("GIT_CONFIG_GLOBAL", &global_gitconfig)
         .args(["config", "--global", "core.hooksPath", "custom-hooks"])
         .assert()
@@ -285,6 +287,7 @@ fn install_force_uses_repository_hooks_with_external_hooks_path_set() -> anyhow:
     let global_gitconfig = context.work_dir().join("global.gitconfig");
     context
         .git()
+        .command()
         .env("GIT_CONFIG_GLOBAL", &global_gitconfig)
         .args(["config", "--global", "core.hooksPath", "custom-hooks"])
         .assert()
@@ -323,6 +326,7 @@ fn install_refuses_empty_external_hooks_path_set() {
     let global_gitconfig = context.work_dir().join("global.gitconfig");
     context
         .git()
+        .command()
         .env("GIT_CONFIG_GLOBAL", &global_gitconfig)
         .args(["config", "--global", "core.hooksPath", ""])
         .assert()
@@ -356,6 +360,7 @@ fn install_refuses_empty_local_hooks_path_set() {
 
     context
         .git()
+        .command()
         .args(["config", "core.hooksPath", ""])
         .assert()
         .success();
@@ -376,6 +381,7 @@ fn install_with_dot_hooks_path_installs_to_repo_root() {
 
     context
         .git()
+        .command()
         .args(["config", "core.hooksPath", "."])
         .assert()
         .success();
@@ -406,6 +412,7 @@ fn install_with_included_local_hooks_path_installs_to_configured_directory() -> 
 
     context
         .git()
+        .command()
         .args(["config", "--local", "include.path", "../included-hooks.cfg"])
         .assert()
         .success();
@@ -428,16 +435,17 @@ fn install_with_included_local_hooks_path_installs_to_configured_directory() -> 
 fn install_with_worktree_hooks_path_installs_to_configured_directory() -> anyhow::Result<()> {
     let context = TestEnv::new_git();
     context.work_dir().child("README.md").write_str("hello\n")?;
-    context.git_add_all();
-    context.git_commit("Initial commit");
+    context.git().add_all().commit("Initial commit");
 
     context
         .git()
+        .command()
         .args(["config", "extensions.worktreeConfig", "true"])
         .assert()
         .success();
     context
         .git()
+        .command()
         .args(["worktree", "add", "worktree", "HEAD"])
         .assert()
         .success();
@@ -445,6 +453,7 @@ fn install_with_worktree_hooks_path_installs_to_configured_directory() -> anyhow
     let worktree = context.work_dir().child("worktree");
     let output = context
         .git_at(&worktree)
+        .command()
         .args(["rev-parse", "--path-format=absolute", "--git-dir"])
         .output()?;
     let worktree_git_dir = String::from_utf8(output.stdout)?.trim().to_string();
@@ -453,6 +462,7 @@ fn install_with_worktree_hooks_path_installs_to_configured_directory() -> anyhow
 
     context
         .git_at(&worktree)
+        .command()
         .args([
             "config",
             "--worktree",
@@ -510,6 +520,7 @@ fn install_uses_group_permissions_for_shared_repository() {
     // Set core.sharedRepository = group
     context
         .git()
+        .command()
         .args(["config", "core.sharedRepository", "group"])
         .assert()
         .success();
@@ -536,6 +547,7 @@ fn install_uses_explicit_shared_repository_mode() {
 
     context
         .git()
+        .command()
         .args(["config", "core.sharedRepository", "0640"])
         .assert()
         .success();
@@ -845,6 +857,7 @@ fn uninstall_with_local_hooks_path_removes_configured_hook() {
 
     context
         .git()
+        .command()
         .args(["config", "core.hooksPath", "custom-hooks"])
         .assert()
         .success();
@@ -869,16 +882,17 @@ fn uninstall_with_local_hooks_path_removes_configured_hook() {
 fn uninstall_with_worktree_hooks_path_removes_configured_hook() -> anyhow::Result<()> {
     let context = TestEnv::new_git();
     context.work_dir().child("README.md").write_str("hello\n")?;
-    context.git_add_all();
-    context.git_commit("Initial commit");
+    context.git().add_all().commit("Initial commit");
 
     context
         .git()
+        .command()
         .args(["config", "extensions.worktreeConfig", "true"])
         .assert()
         .success();
     context
         .git()
+        .command()
         .args(["worktree", "add", "worktree", "HEAD"])
         .assert()
         .success();
@@ -886,6 +900,7 @@ fn uninstall_with_worktree_hooks_path_removes_configured_hook() -> anyhow::Resul
     let worktree = context.work_dir().child("worktree");
     let output = context
         .git_at(&worktree)
+        .command()
         .args(["rev-parse", "--path-format=absolute", "--git-dir"])
         .output()?;
     let worktree_git_dir = String::from_utf8(output.stdout)?.trim().to_string();
@@ -894,6 +909,7 @@ fn uninstall_with_worktree_hooks_path_removes_configured_hook() -> anyhow::Resul
 
     context
         .git_at(&worktree)
+        .command()
         .args([
             "config",
             "--worktree",
@@ -949,6 +965,7 @@ fn uninstall_refuses_external_hooks_path_set() {
     let global_gitconfig = context.work_dir().join("global.gitconfig");
     context
         .git()
+        .command()
         .env("GIT_CONFIG_GLOBAL", &global_gitconfig)
         .args(["config", "--global", "core.hooksPath", "custom-hooks"])
         .assert()
@@ -980,6 +997,7 @@ fn uninstall_with_git_dir_allows_external_hooks_path_set() {
     let global_gitconfig = context.work_dir().join("global.gitconfig");
     context
         .git()
+        .command()
         .env("GIT_CONFIG_GLOBAL", &global_gitconfig)
         .args(["config", "--global", "core.hooksPath", "custom-hooks"])
         .assert()
@@ -1019,6 +1037,7 @@ fn uninstall_refuses_empty_external_hooks_path_set() {
     let global_gitconfig = context.work_dir().join("global.gitconfig");
     context
         .git()
+        .command()
         .env("GIT_CONFIG_GLOBAL", &global_gitconfig)
         .args(["config", "--global", "core.hooksPath", ""])
         .assert()
@@ -1049,6 +1068,7 @@ fn uninstall_refuses_empty_local_hooks_path_set() {
 
     context
         .git()
+        .command()
         .args(["config", "core.hooksPath", ""])
         .assert()
         .success();
@@ -1069,6 +1089,7 @@ fn uninstall_with_dot_hooks_path_removes_root_hook() {
 
     context
         .git()
+        .command()
         .args(["config", "core.hooksPath", "."])
         .assert()
         .success();
@@ -1096,6 +1117,7 @@ fn uninstall_with_included_local_hooks_path_removes_configured_hook() -> anyhow:
 
     context
         .git()
+        .command()
         .args(["config", "--local", "include.path", "../included-hooks.cfg"])
         .assert()
         .success();
@@ -1390,7 +1412,7 @@ fn workspace_install() -> anyhow::Result<()> {
         ],
         config,
     )?;
-    context.git_add_all();
+    context.git().add_all();
 
     // Install from root directory.
     cmd_snapshot!(context, context.install(), @r#"
@@ -1536,7 +1558,7 @@ fn workspace_install_hooks() -> anyhow::Result<()> {
         ],
         config,
     )?;
-    context.git_add_all();
+    context.git().add_all();
 
     // Install by selectors
     cmd_snapshot!(context, context.prepare_hooks().arg("project3").arg("--skip").arg("project3/project5/"), @r"
@@ -1599,7 +1621,7 @@ fn workspace_install_only_root_hook_types() -> anyhow::Result<()> {
         .child("project2")
         .child(PRE_COMMIT_CONFIG_YAML)
         .write_str(nested_config)?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.install(), @r#"
     success: true
@@ -1643,7 +1665,7 @@ fn workspace_uninstall() -> anyhow::Result<()> {
         ],
         config,
     )?;
-    context.git_add_all();
+    context.git().add_all();
 
     // Install first
     context.install().assert().success();
@@ -1687,7 +1709,7 @@ fn workspace_init_template_dir() -> anyhow::Result<()> {
         ],
         config,
     )?;
-    context.git_add_all();
+    context.git().add_all();
 
     // Create a template directory
     let template_dir = context.work_dir().child("template");

--- a/crates/prek/tests/install.rs
+++ b/crates/prek/tests/install.rs
@@ -11,7 +11,7 @@ mod common;
 
 #[test]
 fn install() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Install `prek` hook.
     cmd_snapshot!(context, context.install(), @r#"
@@ -142,7 +142,7 @@ fn install() -> anyhow::Result<()> {
 
 #[test]
 fn install_with_git_dir() {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     cmd_snapshot!(context, context.install().arg("--git-dir").arg("custom-git-dir"), @r#"
     success: true
@@ -181,7 +181,7 @@ fn install_with_git_dir() {
 
 #[test]
 fn install_with_local_hooks_path_installs_to_configured_directory() {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     context
         .git()
@@ -226,7 +226,7 @@ fn install_with_local_hooks_path_installs_to_configured_directory() {
 
 #[test]
 fn install_with_git_dir_allows_external_hooks_path_set() {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let global_gitconfig = context.work_dir().join("global.gitconfig");
     context
@@ -274,7 +274,7 @@ fn install_with_git_dir_allows_external_hooks_path_set() {
 
 #[test]
 fn install_force_uses_repository_hooks_with_external_hooks_path_set() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     context.work_dir().child("custom-hooks").create_dir_all()?;
     context
@@ -318,7 +318,7 @@ fn install_force_uses_repository_hooks_with_external_hooks_path_set() -> anyhow:
 
 #[test]
 fn install_refuses_empty_external_hooks_path_set() {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let global_gitconfig = context.work_dir().join("global.gitconfig");
     context
@@ -352,7 +352,7 @@ fn install_refuses_empty_external_hooks_path_set() {
 
 #[test]
 fn install_refuses_empty_local_hooks_path_set() {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     context
         .git()
@@ -372,7 +372,7 @@ fn install_refuses_empty_local_hooks_path_set() {
 
 #[test]
 fn install_with_dot_hooks_path_installs_to_repo_root() {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     context
         .git()
@@ -394,7 +394,7 @@ fn install_with_dot_hooks_path_installs_to_repo_root() {
 
 #[test]
 fn install_with_included_local_hooks_path_installs_to_configured_directory() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     context
         .work_dir()
@@ -426,7 +426,7 @@ fn install_with_included_local_hooks_path_installs_to_configured_directory() -> 
 
 #[test]
 fn install_with_worktree_hooks_path_installs_to_configured_directory() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     context.work_dir().child("README.md").write_str("hello\n")?;
     context.git_add_all();
     context.git_commit("Initial commit");
@@ -485,7 +485,7 @@ fn install_with_worktree_hooks_path_installs_to_configured_directory() -> anyhow
 fn install_uses_standard_permissions_by_default() {
     use std::os::unix::fs::PermissionsExt;
 
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     context.install().assert().success();
 
@@ -505,7 +505,7 @@ fn install_uses_standard_permissions_by_default() {
 fn install_uses_group_permissions_for_shared_repository() {
     use std::os::unix::fs::PermissionsExt;
 
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Set core.sharedRepository = group
     context
@@ -532,7 +532,7 @@ fn install_uses_group_permissions_for_shared_repository() {
 fn install_uses_explicit_shared_repository_mode() {
     use std::os::unix::fs::PermissionsExt;
 
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     context
         .git()
@@ -554,7 +554,7 @@ fn install_uses_explicit_shared_repository_mode() {
 /// Run `prek install --prepare-hooks` to install the git hook and prepare prek hook environments.
 #[test]
 fn install_with_hooks() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/pre-commit/pre-commit-hooks
             rev: v5.0.0
@@ -609,7 +609,7 @@ fn install_with_hooks() -> anyhow::Result<()> {
 
 #[test]
 fn install_with_legacy_install_hooks_flag_alias() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -640,7 +640,7 @@ fn install_with_legacy_install_hooks_flag_alias() -> anyhow::Result<()> {
 
 #[test]
 fn install_with_existing_legacy_hook() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Install our hook script first.
     context.install().assert().success();
@@ -687,7 +687,7 @@ fn install_with_existing_legacy_hook() -> anyhow::Result<()> {
 /// Run `prek prepare-hooks` to prepare prek hook environments without installing the git hook.
 #[test]
 fn install_hooks_only() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/pre-commit/pre-commit-hooks
             rev: v5.0.0
@@ -731,7 +731,7 @@ fn install_hooks_only() -> anyhow::Result<()> {
 
 #[test]
 fn install_with_legacy_install_hooks_subcommand_alias() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -763,7 +763,7 @@ fn install_with_legacy_install_hooks_subcommand_alias() -> anyhow::Result<()> {
 
 #[test]
 fn uninstall() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Hook does not exist.
     cmd_snapshot!(context, context.uninstall(), @r#"
@@ -841,7 +841,7 @@ fn uninstall() -> anyhow::Result<()> {
 
 #[test]
 fn uninstall_with_local_hooks_path_removes_configured_hook() {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     context
         .git()
@@ -867,7 +867,7 @@ fn uninstall_with_local_hooks_path_removes_configured_hook() {
 
 #[test]
 fn uninstall_with_worktree_hooks_path_removes_configured_hook() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     context.work_dir().child("README.md").write_str("hello\n")?;
     context.git_add_all();
     context.git_commit("Initial commit");
@@ -944,7 +944,7 @@ fn uninstall_with_worktree_hooks_path_removes_configured_hook() -> anyhow::Resul
 
 #[test]
 fn uninstall_refuses_external_hooks_path_set() {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let global_gitconfig = context.work_dir().join("global.gitconfig");
     context
@@ -975,7 +975,7 @@ fn uninstall_refuses_external_hooks_path_set() {
 
 #[test]
 fn uninstall_with_git_dir_allows_external_hooks_path_set() {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let global_gitconfig = context.work_dir().join("global.gitconfig");
     context
@@ -1014,7 +1014,7 @@ fn uninstall_with_git_dir_allows_external_hooks_path_set() {
 
 #[test]
 fn uninstall_refuses_empty_external_hooks_path_set() {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let global_gitconfig = context.work_dir().join("global.gitconfig");
     context
@@ -1045,7 +1045,7 @@ fn uninstall_refuses_empty_external_hooks_path_set() {
 
 #[test]
 fn uninstall_refuses_empty_local_hooks_path_set() {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     context
         .git()
@@ -1065,7 +1065,7 @@ fn uninstall_refuses_empty_local_hooks_path_set() {
 
 #[test]
 fn uninstall_with_dot_hooks_path_removes_root_hook() {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     context
         .git()
@@ -1084,7 +1084,7 @@ fn uninstall_with_dot_hooks_path_removes_root_hook() {
 
 #[test]
 fn uninstall_with_included_local_hooks_path_removes_configured_hook() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     context
         .work_dir()
@@ -1114,7 +1114,7 @@ fn uninstall_with_included_local_hooks_path_removes_configured_hook() -> anyhow:
 /// `prek uninstall --all` should remove all prek-managed hooks.
 #[test]
 fn uninstall_all_managed_hooks() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Install both pre-commit and pre-push hooks.
     context
@@ -1152,7 +1152,7 @@ fn uninstall_all_managed_hooks() -> anyhow::Result<()> {
 
 #[test]
 fn uninstall_remove_legacy_hook() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Create the `pre-commit` hook.
     context.install().assert().success();
@@ -1211,7 +1211,7 @@ fn uninstall_remove_legacy_hook() -> anyhow::Result<()> {
 
 #[test]
 fn init_templatedir() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     cmd_snapshot!(context, context.command().arg("init-templatedir").arg(".git"), @r#"
     success: true
@@ -1300,7 +1300,7 @@ fn init_templatedir() -> anyhow::Result<()> {
 /// Tests `prek util init-template-dir` works.
 #[test]
 fn util_init_template_dir() {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     cmd_snapshot!(context, context.command().arg("util").arg("init-template-dir").arg(".git"), @r#"
     success: true
@@ -1332,7 +1332,7 @@ fn util_init_template_dir() {
 /// Tests `prek util init-template-dir` in a non-git repository.
 #[test]
 fn init_template_dir_non_git_repo() {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
 
     cmd_snapshot!(context, context.command().arg("util").arg("init-template-dir").arg(".git"), @r#"
     success: true
@@ -1369,7 +1369,7 @@ fn init_template_dir_non_git_repo() {
 
 #[test]
 fn workspace_install() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let config = indoc! {r#"
     repos:
@@ -1515,7 +1515,7 @@ fn workspace_install() -> anyhow::Result<()> {
 
 #[test]
 fn workspace_install_hooks() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let config = indoc! {r#"
     repos:
@@ -1565,7 +1565,7 @@ fn workspace_install_hooks() -> anyhow::Result<()> {
 /// Only install root config's hook types in a workspace.
 #[test]
 fn workspace_install_only_root_hook_types() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let root_config = indoc! {r#"
     default_install_hook_types: [pre-commit, post-commit]
@@ -1622,7 +1622,7 @@ fn workspace_install_only_root_hook_types() -> anyhow::Result<()> {
 
 #[test]
 fn workspace_uninstall() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let config = indoc! {r#"
     repos:
@@ -1666,7 +1666,7 @@ fn workspace_uninstall() -> anyhow::Result<()> {
 
 #[test]
 fn workspace_init_template_dir() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let config = indoc! {r#"
     repos:
@@ -1728,7 +1728,7 @@ fn workspace_init_template_dir() -> anyhow::Result<()> {
 /// Test that a warning is shown when the config file exists but is invalid.
 #[test]
 fn install_invalid_config_warning() {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Write an invalid config (missing required `rev` field).
     let context = context.with_config(indoc::indoc! {r"

--- a/crates/prek/tests/languages/bun.rs
+++ b/crates/prek/tests/languages/bun.rs
@@ -8,7 +8,7 @@ use crate::common::{TestEnv, cmd_snapshot};
 /// Test basic Bun hook execution.
 #[test]
 fn basic_bun() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -40,7 +40,7 @@ fn basic_bun() {
 /// Test that `additional_dependencies` are installed correctly.
 #[test]
 fn additional_dependencies() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -107,7 +107,7 @@ fn language_version() -> Result<()> {
         return Ok(());
     }
 
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:

--- a/crates/prek/tests/languages/bun.rs
+++ b/crates/prek/tests/languages/bun.rs
@@ -21,7 +21,7 @@ fn basic_bun() {
                 pass_filenames: false
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -54,7 +54,7 @@ fn additional_dependencies() {
                 pass_filenames: false
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -146,7 +146,7 @@ fn language_version() -> Result<()> {
                 additional_dependencies: ["cowsay"] # different dep to force create separate env
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     let bun_dir = context.home_dir().child("tools").child("bun");
     bun_dir.assert(predicates::path::missing());

--- a/crates/prek/tests/languages/conda.rs
+++ b/crates/prek/tests/languages/conda.rs
@@ -19,7 +19,7 @@ fn language_version() {
                 pass_filenames: false
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -49,7 +49,7 @@ fn local_hook_with_additional_dependencies() {
                 pass_filenames: false
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     let context = context.with_filter(r"OpenSSL [^\n]+", "OpenSSL [VERSION]");
 
@@ -92,9 +92,11 @@ fn remote_repo_install() -> anyhow::Result<()> {
               - openssl
         "})?;
 
-    hook_repo.git_add_all();
-    hook_repo.git_commit("Add conda hook");
-    hook_repo.git_tag("v1.0.0");
+    hook_repo
+        .git()
+        .add_all()
+        .commit("Add conda hook")
+        .tag("v1.0.0");
 
     let context = context.with_config(indoc::formatdoc! {r"
         repos:
@@ -107,7 +109,7 @@ fn remote_repo_install() -> anyhow::Result<()> {
                 pass_filenames: false
     ", hook_repo.path().display()});
 
-    context.git_add_all();
+    context.git().add_all();
 
     let context = context.with_filter(r"OpenSSL [^\n]+", "OpenSSL [VERSION]");
 

--- a/crates/prek/tests/languages/conda.rs
+++ b/crates/prek/tests/languages/conda.rs
@@ -5,7 +5,7 @@ use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
 fn language_version() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -35,7 +35,7 @@ fn language_version() {
 
 #[test]
 fn local_hook_with_additional_dependencies() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -69,7 +69,7 @@ fn local_hook_with_additional_dependencies() {
 
 #[test]
 fn remote_repo_install() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     let hook_repo = context.create_repo("conda-hook");
 
     hook_repo

--- a/crates/prek/tests/languages/coursier.rs
+++ b/crates/prek/tests/languages/coursier.rs
@@ -19,7 +19,7 @@ fn additional_dependencies() {
                 pass_filenames: false
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @"
     success: true
@@ -61,9 +61,11 @@ fn pre_commit_channel() -> anyhow::Result<()> {
             }
         "#})?;
 
-    hook_repo.git_add_all();
-    hook_repo.git_commit("Add coursier hook");
-    hook_repo.git_tag("v1.0.0");
+    hook_repo
+        .git()
+        .add_all()
+        .commit("Add coursier hook")
+        .tag("v1.0.0");
 
     let context = context.with_config(indoc::formatdoc! {r"
         repos:
@@ -76,7 +78,7 @@ fn pre_commit_channel() -> anyhow::Result<()> {
                 pass_filenames: false
     ", hook_repo.path().display()});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @"
     success: true
@@ -114,7 +116,7 @@ fn local_pre_commit_channel_is_ignored() -> anyhow::Result<()> {
                 pass_filenames: false
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @"
     success: false

--- a/crates/prek/tests/languages/coursier.rs
+++ b/crates/prek/tests/languages/coursier.rs
@@ -5,7 +5,7 @@ use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
 fn additional_dependencies() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -37,7 +37,7 @@ fn additional_dependencies() {
 
 #[test]
 fn pre_commit_channel() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     let hook_repo = context.create_repo("coursier-hook");
 
     hook_repo
@@ -96,7 +96,7 @@ fn pre_commit_channel() -> anyhow::Result<()> {
 
 #[test]
 fn local_pre_commit_channel_is_ignored() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let channel_dir = context.work_dir().child(".pre-commit-channel");
     channel_dir.create_dir_all()?;

--- a/crates/prek/tests/languages/dart.rs
+++ b/crates/prek/tests/languages/dart.rs
@@ -18,7 +18,7 @@ fn language_version() {
                 pass_filenames: false
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -55,7 +55,7 @@ fn hook_stderr() -> anyhow::Result<()> {
             }
         "})?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -108,7 +108,7 @@ fn script_with_files() -> anyhow::Result<()> {
         .child("test2.dart")
         .write_str("void main() { print('test2'); }")?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -174,7 +174,7 @@ fn with_pubspec_and_dependencies() -> anyhow::Result<()> {
             }
         "#})?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -229,7 +229,7 @@ fn with_pubspec() -> anyhow::Result<()> {
             }
         "})?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -301,7 +301,7 @@ fn with_pubspec_and_additional_dependencies() -> anyhow::Result<()> {
             }
         "})?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -352,7 +352,7 @@ fn additional_dependencies() {
         "})
         .unwrap();
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -395,7 +395,7 @@ fn additional_dependencies_with_version() {
         "})
         .unwrap();
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -449,7 +449,7 @@ fn executable_alias() -> anyhow::Result<()> {
             }
         "})?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -498,7 +498,7 @@ fn dart_environment() {
         "})
         .unwrap();
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -526,7 +526,7 @@ fn remote_hook() {
                 verbose: true
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true

--- a/crates/prek/tests/languages/dart.rs
+++ b/crates/prek/tests/languages/dart.rs
@@ -4,7 +4,7 @@ use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
 fn language_version() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -34,7 +34,7 @@ fn language_version() {
 
 #[test]
 fn hook_stderr() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -75,7 +75,7 @@ fn hook_stderr() -> anyhow::Result<()> {
 
 #[test]
 fn script_with_files() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -131,7 +131,7 @@ fn script_with_files() -> anyhow::Result<()> {
 
 #[test]
 fn with_pubspec_and_dependencies() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -194,7 +194,7 @@ fn with_pubspec_and_dependencies() -> anyhow::Result<()> {
 
 #[test]
 fn with_pubspec() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -254,7 +254,7 @@ fn with_pubspec() -> anyhow::Result<()> {
 
 #[test]
 fn with_pubspec_and_additional_dependencies() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -326,7 +326,7 @@ fn with_pubspec_and_additional_dependencies() -> anyhow::Result<()> {
 
 #[test]
 fn additional_dependencies() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -370,7 +370,7 @@ fn additional_dependencies() {
 
 #[test]
 fn additional_dependencies_with_version() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -413,7 +413,7 @@ fn additional_dependencies_with_version() {
 
 #[test]
 fn executable_alias() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -469,7 +469,7 @@ fn executable_alias() -> anyhow::Result<()> {
 
 #[test]
 fn dart_environment() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -516,7 +516,7 @@ fn dart_environment() {
 
 #[test]
 fn remote_hook() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/prek-ci/dart-hooks
             rev: v1.1.0

--- a/crates/prek/tests/languages/deno.rs
+++ b/crates/prek/tests/languages/deno.rs
@@ -7,7 +7,7 @@ use crate::common::{TestEnv, cmd_snapshot};
 /// Test basic Deno hook execution with an inline script.
 #[test]
 fn basic_deno() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -39,7 +39,7 @@ fn basic_deno() {
 /// Test running a TypeScript script file with an explicit `deno run` entry.
 #[test]
 fn script_file() {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Create a TypeScript script
     context
@@ -82,7 +82,7 @@ fn script_file() {
 /// Test running Deno built-in subcommands with an explicit `deno` prefix.
 #[test]
 fn builtin_commands() {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Create a TypeScript file for formatting check
     context
@@ -125,7 +125,7 @@ fn builtin_commands() {
 /// Test a remote Deno hook whose manifest installs its own executable.
 #[test]
 fn remote_hook() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/prek-ci/deno-hooks
             rev: v3.1.0
@@ -154,7 +154,7 @@ fn remote_hook() {
 /// Test a remote Deno hook whose configured additional dependency installs the executable it runs.
 #[test]
 fn remote_hook_with_additional_dependencies() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: https://github.com/prek-ci/deno-hooks
             rev: v3.1.0
@@ -184,7 +184,7 @@ fn remote_hook_with_additional_dependencies() {
 /// Test a remote Deno hook whose manifest installs a local file as an executable dependency.
 #[test]
 fn remote_hook_with_local_file_additional_dependency() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/prek-ci/deno-hooks
             rev: v3.1.0
@@ -213,7 +213,7 @@ fn remote_hook_with_local_file_additional_dependency() {
 /// Test that `additional_dependencies` are installed as CLI executables.
 #[test]
 fn additional_dependencies() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -260,7 +260,7 @@ fn additional_dependencies() {
 /// Test that an absolute file can be installed as an executable additional dependency.
 #[test]
 fn additional_dependencies_absolute_file() {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let tool = context.work_dir().child("tool.ts");
     tool.write_str(indoc::indoc! {r#"
@@ -309,7 +309,7 @@ fn language_version() {
         return;
     }
 
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -414,7 +414,7 @@ fn language_version() {
 /// Test checksum policy behavior for a Deno release without checksum sidecars.
 #[test]
 fn checksum_policy() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -467,7 +467,7 @@ fn version_range() {
         return;
     }
 
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -502,7 +502,7 @@ fn version_range() {
 /// Test that hook failure is properly reported.
 #[test]
 fn hook_failure() {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Create a TypeScript file with a lint error
     context
@@ -538,7 +538,7 @@ fn hook_failure() {
 /// Note: Permissions must come before the script in the entry, so use explicit `deno run`.
 #[test]
 fn script_with_permissions() {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Create a script that reads an environment variable
     context

--- a/crates/prek/tests/languages/deno.rs
+++ b/crates/prek/tests/languages/deno.rs
@@ -20,7 +20,7 @@ fn basic_deno() {
                 pass_filenames: false
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -63,7 +63,7 @@ fn script_file() {
                 pass_filenames: false
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -106,7 +106,7 @@ fn builtin_commands() {
                 verbose: true
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -135,7 +135,7 @@ fn remote_hook() {
                 verbose: true
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -165,7 +165,7 @@ fn remote_hook_with_additional_dependencies() {
                 verbose: true
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -194,7 +194,7 @@ fn remote_hook_with_local_file_additional_dependency() {
                 verbose: true
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -227,7 +227,7 @@ fn additional_dependencies() {
                 pass_filenames: false
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -284,7 +284,7 @@ fn additional_dependencies_absolute_file() {
                 pass_filenames: false
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -347,7 +347,7 @@ fn language_version() {
                 pass_filenames: false
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     let deno_dir = context.home_dir().child("tools").child("deno");
     deno_dir.assert(predicates::path::missing());
@@ -427,7 +427,7 @@ fn checksum_policy() {
                 verbose: true
                 pass_filenames: false
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     let context = context.with_filter(r"deno-[A-Za-z0-9_-]+\.zip", "deno-[TARGET].zip");
 
@@ -481,7 +481,7 @@ fn version_range() {
                 pass_filenames: false
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     let context = context.with_filter(r"Deno \d+\.\d+\.\d+", "Deno [VERSION]");
 
@@ -527,7 +527,7 @@ fn hook_failure() {
                 verbose: true
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     // The lint should fail due to no-explicit-any
     let output = context.run().output().expect("Failed to run hook");
@@ -563,7 +563,7 @@ fn script_with_permissions() {
                 pass_filenames: false
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().env("TEST_VAR", "hello"), @r"
     success: true

--- a/crates/prek/tests/languages/docker.rs
+++ b/crates/prek/tests/languages/docker.rs
@@ -5,7 +5,7 @@ use crate::common::{TestEnv, cmd_snapshot};
 /// GitHub Action only has docker for linux hosted runners.
 #[test]
 fn docker() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: https://github.com/prek-ci/docker-hooks
             rev: v1.0
@@ -36,7 +36,7 @@ fn docker() {
 
 #[test]
 fn workspace_docker() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     let cwd = context.work_dir();
 
     let config = indoc::indoc! {r"

--- a/crates/prek/tests/languages/docker.rs
+++ b/crates/prek/tests/languages/docker.rs
@@ -18,7 +18,7 @@ fn docker() {
                 always_run: true
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -53,7 +53,7 @@ fn workspace_docker() -> anyhow::Result<()> {
     cwd.child("project1").child("project1.txt").write_str("")?;
     cwd.child("project2").child("project2.txt").write_str("")?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true

--- a/crates/prek/tests/languages/docker_image.rs
+++ b/crates/prek/tests/languages/docker_image.rs
@@ -8,7 +8,7 @@ use crate::common::{TestEnv, cmd_snapshot, make_executable};
 
 #[test]
 fn docker_image() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let cwd = context.work_dir();
     // Test suite from https://github.com/super-linter/super-linter/tree/main/test/linters/gitleaks/bad
@@ -70,7 +70,7 @@ fn docker_image() -> Result<()> {
 /// Test that `docker_image` does not try to resolve entry in the host system PATH.
 #[test]
 fn docker_image_does_not_resolve_entry() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let cwd = context.work_dir();
     let bin_dir = cwd.child("bin");

--- a/crates/prek/tests/languages/docker_image.rs
+++ b/crates/prek/tests/languages/docker_image.rs
@@ -36,7 +36,7 @@ fn docker_image() -> Result<()> {
                 entry: docker.io/zricethezav/gitleaks:v8.21.2 git --pre-commit --redact --staged --verbose --no-banner --log-level=error
                 pass_filenames: false
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -98,7 +98,7 @@ fn docker_image_does_not_resolve_entry() -> Result<()> {
                 always_run: true
                 verbose: true
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     let mut cmd = context.run();
     cmd.env(EnvVars::PATH, prepend_paths(&[bin_dir.path()])?);

--- a/crates/prek/tests/languages/dotnet.rs
+++ b/crates/prek/tests/languages/dotnet.rs
@@ -54,7 +54,7 @@ fn language_version() {
                 pass_filenames: false
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     let context = context.with_filter(r"\b(\d+\.\d+)\.\d+\b", "$1.X");
 
@@ -104,7 +104,7 @@ fn invalid_language_version() {
                 pass_filenames: false
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -147,7 +147,7 @@ fn multiple_sdk_versions() -> anyhow::Result<()> {
                 pass_filenames: false
                 verbose: true
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     let context = context.with_filter(r"\b(\d+\.\d+)\.\d+\b", "$1.X");
 
@@ -215,7 +215,7 @@ fn additional_dependencies_with_version() {
                 verbose: true
                 pass_filenames: false
     "#});
-    context.git_add_all();
+    context.git().add_all();
 
     let context = context.with_filter(r"\b(4\.7\.1\+)[0-9a-f]+\b", "${1}[SHA]");
 
@@ -268,11 +268,7 @@ fn additional_dependencies_in_remote_repo() -> anyhow::Result<()> {
           entry: dotnet-outdated --version
           additional_dependencies: ["dotnet-outdated-tool:4.7.1"]
     "#})?;
-    repo.git_add_all();
-    repo.git_commit("Add manifest");
-    repo.git()
-        .args(["tag", "v0.1.0", "-m", "v0.1.0"])
-        .output()?;
+    repo.git().add_all().commit("Add manifest").tag("v0.1.0");
 
     let context = context.with_config(indoc::formatdoc! {r"
         repos:
@@ -284,7 +280,7 @@ fn additional_dependencies_in_remote_repo() -> anyhow::Result<()> {
                 pass_filenames: false
     ", repo_path.display()});
 
-    context.git_add_all();
+    context.git().add_all();
 
     let context = context.with_filter(r"\b(4\.7\.1\+)[0-9a-f]+\b", "${1}[SHA]");
 
@@ -346,7 +342,7 @@ fn hook_stderr() -> anyhow::Result<()> {
         Environment.Exit(1);
     "#})?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @"
     success: false

--- a/crates/prek/tests/languages/dotnet.rs
+++ b/crates/prek/tests/languages/dotnet.rs
@@ -10,7 +10,7 @@ fn language_version() {
         return;
     }
 
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -90,7 +90,7 @@ fn language_version() {
 /// Test invalid `language_version` format is rejected.
 #[test]
 fn invalid_language_version() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -126,7 +126,7 @@ fn multiple_sdk_versions() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -202,7 +202,7 @@ fn additional_dependencies_with_version() {
         return;
     }
 
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -256,7 +256,7 @@ fn additional_dependencies_in_remote_repo() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     let repo = context.create_repo("dotnet-hook");
     let repo_path = repo.path();
     repo_path
@@ -312,7 +312,7 @@ fn hook_stderr() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:

--- a/crates/prek/tests/languages/fail.rs
+++ b/crates/prek/tests/languages/fail.rs
@@ -23,7 +23,7 @@ fn fail() -> Result<()> {
               files: 'changelog/.*(?<!\.rst)$'
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false

--- a/crates/prek/tests/languages/fail.rs
+++ b/crates/prek/tests/languages/fail.rs
@@ -6,7 +6,7 @@ use crate::common::{TestEnv, cmd_snapshot};
 /// GitHub Action only has docker for linux hosted runners.
 #[test]
 fn fail() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let cwd = context.work_dir();
     cwd.child("changelog").create_dir_all()?;

--- a/crates/prek/tests/languages/golang.rs
+++ b/crates/prek/tests/languages/golang.rs
@@ -61,7 +61,7 @@ fn language_version() -> anyhow::Result<()> {
                 always_run: true
                 pass_filenames: false
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     let go_dir = context.home_dir().child("tools").child("go");
     go_dir.assert(predicates::path::missing());
@@ -150,7 +150,7 @@ fn remote_hook() {
               - id: echo
                 verbose: true
         "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -180,7 +180,7 @@ fn remote_hook() {
                 language_version: '1.23.11' # will auto download
                 pass_filenames: false
     "#});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -215,7 +215,7 @@ fn remote_hook() {
                 verbose: true
                 language_version: '1.23.11' # will auto download
         "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -274,9 +274,7 @@ fn local_additional_deps() -> anyhow::Result<()> {
           language: golang
           additional_dependencies: [ ./cmd ]
     "})?;
-    go_hook.git_add_all();
-    go_hook.git_commit("Initial commit");
-    go_hook.git().args(["tag", "v1.0", "-m", "v1.0"]).output()?;
+    go_hook.git().add_all().commit("Initial commit").tag("v1.0");
 
     let context = TestEnv::new_git();
     let work_dir = context.work_dir();
@@ -292,7 +290,7 @@ fn local_additional_deps() -> anyhow::Result<()> {
               - id: go-hook
                 verbose: true
    ", hook_url = hook_url})?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -337,9 +335,7 @@ fn remote_go_mod_metadata_sets_language_version() -> anyhow::Result<()> {
         verbose: true
       "})?;
 
-    go_hook.git_add_all();
-    go_hook.git_commit("Initial commit");
-    go_hook.git().args(["tag", "v1.0", "-m", "v1.0"]).output()?;
+    go_hook.git().add_all().commit("Initial commit").tag("v1.0");
 
     // Use it as a remote repo in a separate project.
     let context = TestEnv::new_git();
@@ -353,7 +349,7 @@ fn remote_go_mod_metadata_sets_language_version() -> anyhow::Result<()> {
             - id: echo
               verbose: true
       ", hook_url = hook_url});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @"
     success: false

--- a/crates/prek/tests/languages/golang.rs
+++ b/crates/prek/tests/languages/golang.rs
@@ -14,7 +14,7 @@ fn language_version() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -139,7 +139,7 @@ fn language_version() -> anyhow::Result<()> {
 /// Test a remote go hook.
 #[test]
 fn remote_hook() {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Run hooks with system found go.
     let context = context.with_config(indoc::indoc! {r"
@@ -234,7 +234,7 @@ fn remote_hook() {
 /// Fix <https://github.com/j178/prek/issues/901>
 #[test]
 fn local_additional_deps() -> anyhow::Result<()> {
-    let go_hook = TestEnv::new();
+    let go_hook = TestEnv::new_git();
 
     // Create a local go hook with additional_dependencies.
     go_hook
@@ -278,7 +278,7 @@ fn local_additional_deps() -> anyhow::Result<()> {
     go_hook.git_commit("Initial commit");
     go_hook.git().args(["tag", "v1.0", "-m", "v1.0"]).output()?;
 
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     let work_dir = context.work_dir();
 
     let hook_url = go_hook.work_dir().to_str().unwrap();
@@ -315,7 +315,7 @@ fn local_additional_deps() -> anyhow::Result<()> {
 #[test]
 fn remote_go_mod_metadata_sets_language_version() -> anyhow::Result<()> {
     // Create a remote repo containing a golang hook.
-    let go_hook = TestEnv::new();
+    let go_hook = TestEnv::new_git();
 
     go_hook
         .work_dir()
@@ -342,7 +342,7 @@ fn remote_go_mod_metadata_sets_language_version() -> anyhow::Result<()> {
     go_hook.git().args(["tag", "v1.0", "-m", "v1.0"]).output()?;
 
     // Use it as a remote repo in a separate project.
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let hook_url = go_hook.work_dir().to_str().unwrap();
     let context = context.with_config(indoc::formatdoc! {r"

--- a/crates/prek/tests/languages/haskell.rs
+++ b/crates/prek/tests/languages/haskell.rs
@@ -42,7 +42,7 @@ fn local_hook() -> anyhow::Result<()> {
             main = putStrLn "Hello Haskell!"
         "#})?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().env(EnvVars::PREK_INTERNAL__SKIP_CABAL_UPDATE, "1"), @"
     success: true
@@ -90,7 +90,7 @@ fn additional_dependencies() {
                 pass_filenames: false
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().env(EnvVars::PREK_INTERNAL__SKIP_CABAL_UPDATE, "1"), @"
     success: true
@@ -118,7 +118,7 @@ fn remote_hook() {
                 verbose: true
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().env(EnvVars::PREK_INTERNAL__SKIP_CABAL_UPDATE, "1"), @"
     success: true

--- a/crates/prek/tests/languages/haskell.rs
+++ b/crates/prek/tests/languages/haskell.rs
@@ -5,7 +5,7 @@ use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
 fn local_hook() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -76,7 +76,7 @@ fn local_hook() -> anyhow::Result<()> {
 
 #[test]
 fn additional_dependencies() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -108,7 +108,7 @@ fn additional_dependencies() {
 
 #[test]
 fn remote_hook() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/prek-ci/haskell-hooks
             rev: v1.0.0

--- a/crates/prek/tests/languages/julia.rs
+++ b/crates/prek/tests/languages/julia.rs
@@ -15,7 +15,7 @@ fn local_hook() {
                 pass_filenames: false
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -61,7 +61,7 @@ fn additional_dependencies() {
                 pass_filenames: false
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -104,7 +104,7 @@ fn project_toml() -> anyhow::Result<()> {
                 pass_filenames: false
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -146,7 +146,7 @@ fn script_file() -> anyhow::Result<()> {
                 pass_filenames: false
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -176,7 +176,7 @@ fn remote_hook() {
                 verbose: true
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @"
     success: true

--- a/crates/prek/tests/languages/julia.rs
+++ b/crates/prek/tests/languages/julia.rs
@@ -2,7 +2,7 @@ use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
 fn local_hook() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -47,7 +47,7 @@ fn local_hook() {
 
 #[test]
 fn additional_dependencies() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -81,7 +81,7 @@ fn additional_dependencies() {
 fn project_toml() -> anyhow::Result<()> {
     use assert_fs::fixture::{FileWriteStr, PathChild};
 
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     context
         .work_dir()
@@ -126,7 +126,7 @@ fn project_toml() -> anyhow::Result<()> {
 fn script_file() -> anyhow::Result<()> {
     use assert_fs::fixture::{FileWriteStr, PathChild};
 
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     context
         .work_dir()
@@ -166,7 +166,7 @@ fn script_file() -> anyhow::Result<()> {
 
 #[test]
 fn remote_hook() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/prek-ci/julia-hooks
             rev: v1.0.0

--- a/crates/prek/tests/languages/lua.rs
+++ b/crates/prek/tests/languages/lua.rs
@@ -17,7 +17,7 @@ fn health_check() {
                 pass_filenames: false
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -64,7 +64,7 @@ fn language_version() {
                 pass_filenames: false
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -96,7 +96,7 @@ fn hook_stderr() -> anyhow::Result<()> {
         .child("hook.lua")
         .write_str("io.stderr:write('How are you\\n'); os.exit(1)")?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -147,7 +147,7 @@ fn script_with_files() -> anyhow::Result<()> {
         .child("test2.lua")
         .write_str("print('test2')")?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -184,7 +184,7 @@ fn lua_environment() {
                 pass_filenames: false
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     let context = context.with_filter(r"lua-[A-Za-z0-9]+", "lua-[HASH]");
 
@@ -236,7 +236,7 @@ fn additional_dependencies() {
                 pass_filenames: false
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -265,7 +265,7 @@ fn remote_hook() {
                 verbose: true
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true

--- a/crates/prek/tests/languages/lua.rs
+++ b/crates/prek/tests/languages/lua.rs
@@ -4,7 +4,7 @@ use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
 fn health_check() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -50,7 +50,7 @@ fn health_check() {
 /// Test specifying `language_version` for Lua hooks which is not supported for now.
 #[test]
 fn language_version() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -81,7 +81,7 @@ fn language_version() {
 /// Test that stderr from hooks is captured and shown to the user.
 #[test]
 fn hook_stderr() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -117,7 +117,7 @@ fn hook_stderr() -> anyhow::Result<()> {
 /// Test Lua script execution with file arguments.
 #[test]
 fn script_with_files() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -171,7 +171,7 @@ fn script_with_files() -> anyhow::Result<()> {
 /// Test Lua environment variables (`LUA_PATH` and `LUA_CPATH`)
 #[test]
 fn lua_environment() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -222,7 +222,7 @@ fn lua_environment() {
 /// Test Lua hook with additional dependencies.
 #[test]
 fn additional_dependencies() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -255,7 +255,7 @@ fn additional_dependencies() {
 /// Test remote Lua hook from GitHub repository.
 #[test]
 fn remote_hook() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/prek-ci/lua-hooks
             rev: v1.0.0

--- a/crates/prek/tests/languages/mise.rs
+++ b/crates/prek/tests/languages/mise.rs
@@ -12,7 +12,7 @@ fn reuses_managed_mise() {
         return;
     }
 
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -85,7 +85,7 @@ fn system_mise_installs_and_activates_dependencies() -> Result<()> {
         return Ok(());
     }
 
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let hook_repo = context.create_repo("mise-system-hook");
     fs_err::write(

--- a/crates/prek/tests/languages/mise.rs
+++ b/crates/prek/tests/languages/mise.rs
@@ -26,7 +26,7 @@ fn reuses_managed_mise() {
                 verbose: true
                 pass_filenames: false
     "#});
-    context.git_add_all();
+    context.git().add_all();
 
     let context = context.with_filter(
         r"2026\.7\.18 [^\r\n]+ \(\d{4}-\d{2}-\d{2}\)",
@@ -62,7 +62,7 @@ fn reuses_managed_mise() {
                 verbose: true
                 pass_filenames: false
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run()
         .env(EnvVars::PREK_INTERNAL__MISE_BINARY_NAME, "mise-never-exists"), @r#"
@@ -104,9 +104,8 @@ fn system_mise_installs_and_activates_dependencies() -> Result<()> {
     )?;
     // Provisioning must not read configuration from the hook repository.
     fs_err::write(hook_repo.path().join("mise.toml"), "not valid = [")?;
-    hook_repo.git_add_all();
-    hook_repo.git_commit("Add mise hook");
-    let rev = hook_repo.git_rev_parse("HEAD")?;
+    hook_repo.git().add_all().commit("Add mise hook");
+    let rev = hook_repo.git().rev_parse("HEAD")?;
 
     // Keep a conflicting executable beside the real system mise. Activating the private tool must
     // not move this whole directory ahead of the PATH returned by `mise env`.
@@ -133,7 +132,7 @@ fn system_mise_installs_and_activates_dependencies() -> Result<()> {
     ", hook_repo.path().display(), rev});
     // Early miserc discovery must not read configuration from the calling project.
     fs_err::write(context.work_dir().join(".miserc.toml"), "not valid = [")?;
-    context.git_add_all();
+    context.git().add_all();
 
     let ambient_data = context.work_dir().join("ambient-mise-data");
     let path = std::env::join_paths(

--- a/crates/prek/tests/languages/node.rs
+++ b/crates/prek/tests/languages/node.rs
@@ -9,7 +9,7 @@ use crate::common::{TestEnv, cmd_snapshot, make_executable, remove_bin_from_path
 
 #[test]
 fn exec_uses_installed_node_environment() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let package = context.work_dir().child("node-env-tool");
     package.create_dir_all()?;
@@ -66,7 +66,7 @@ fn language_version() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -182,7 +182,7 @@ fn language_version() -> anyhow::Result<()> {
 /// Test that `additional_dependencies` are installed correctly.
 #[test]
 fn additional_dependencies() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -249,7 +249,7 @@ fn additional_dependencies() {
 /// <https://github.com/npm/cli/issues/9189>
 #[test]
 fn remote_package_is_installed_from_git() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     let hook_repo = context.create_repo("remote-node-hook");
 
     hook_repo
@@ -326,7 +326,7 @@ fn remote_package_is_installed_from_git() -> anyhow::Result<()> {
 /// its development dependencies.
 #[test]
 fn remote_prepare_uses_dev_dependencies() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     let hook_repo = context.create_repo("prepared-node-hook");
 
     hook_repo
@@ -421,7 +421,7 @@ fn remote_prepare_uses_dev_dependencies() -> anyhow::Result<()> {
 /// Test that lowercase npm config inherited from `npm exec` cannot redirect installs.
 #[test]
 fn additional_dependencies_ignore_inherited_npm_config_prefix() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let package_dir = context.work_dir().child("prefix-fixture");
     package_dir.create_dir_all()?;
@@ -502,7 +502,7 @@ fn additional_dependencies_ignore_inherited_npm_config_prefix() -> anyhow::Resul
 /// Regression test for #1492: `install()` must use the provisioned toolchain.
 #[test]
 fn additional_dependencies_without_system_node() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -534,7 +534,7 @@ fn additional_dependencies_without_system_node() -> anyhow::Result<()> {
 /// Test that `npm.cmd` can be found on Windows.
 #[test]
 fn npm_version() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -566,7 +566,7 @@ fn npm_version() {
 
 #[test]
 fn node_install_preserves_global_git_config_and_isolates_repository() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Installing this additional dependency forces npm to invoke Git during environment setup.
     let dependency_repo = context.create_repo("sentinel-node-dependency");

--- a/crates/prek/tests/languages/node.rs
+++ b/crates/prek/tests/languages/node.rs
@@ -107,7 +107,7 @@ fn language_version() -> anyhow::Result<()> {
                 language_version: 'lts/iron' # node 20
                 always_run: true
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     let node_dir = context.home_dir().child("tools").child("node");
     node_dir.assert(predicates::path::missing());
@@ -196,7 +196,7 @@ fn additional_dependencies() {
                 pass_filenames: false
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -287,9 +287,11 @@ fn remote_package_is_installed_from_git() -> anyhow::Result<()> {
     "#})?;
     make_executable(cli.path())?;
 
-    hook_repo.git_add_all();
-    hook_repo.git_commit("Add remote Node hook");
-    hook_repo.git_tag("v1.0.0");
+    hook_repo
+        .git()
+        .add_all()
+        .commit("Add remote Node hook")
+        .tag("v1.0.0");
 
     let context = context.with_config(indoc::formatdoc! {r"
         repos:
@@ -299,7 +301,7 @@ fn remote_package_is_installed_from_git() -> anyhow::Result<()> {
               - id: remote-node-hook
                 verbose: true
     ", hook_repo.path().display()});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().env(EnvVars::PREK_HOME, ".prek-cache"), @r"
     success: true
@@ -388,9 +390,11 @@ fn remote_prepare_uses_dev_dependencies() -> anyhow::Result<()> {
         console.log("prepared hook ok");
     "#})?;
 
-    hook_repo.git_add_all();
-    hook_repo.git_commit("Add source-built Node hook");
-    hook_repo.git_tag("v1.0.0");
+    hook_repo
+        .git()
+        .add_all()
+        .commit("Add source-built Node hook")
+        .tag("v1.0.0");
 
     let context = context.with_config(indoc::formatdoc! {r"
         repos:
@@ -400,7 +404,7 @@ fn remote_prepare_uses_dev_dependencies() -> anyhow::Result<()> {
               - id: prepared-node-hook
                 verbose: true
     ", hook_repo.path().display()});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -458,7 +462,7 @@ fn additional_dependencies_ignore_inherited_npm_config_prefix() -> anyhow::Resul
                 pass_filenames: false
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     let fake_prefix = context.home_dir().child("fake-prefix");
     fake_prefix.create_dir_all()?;
@@ -515,7 +519,7 @@ fn additional_dependencies_without_system_node() -> anyhow::Result<()> {
                 pass_filenames: false
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     let new_path = remove_bin_from_path("node", None)?;
 
@@ -546,7 +550,7 @@ fn npm_version() {
                 pass_filenames: false
                 verbose: true
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     let context = context.with_filter(r"\d+\.\d+\.\d+", "[NPM_VERSION]");
 
@@ -579,8 +583,10 @@ fn node_install_preserves_global_git_config_and_isolates_repository() -> anyhow:
           "version": "1.0.0"
         }
     "#})?;
-    dependency_repo.git_add_all();
-    dependency_repo.git_commit("Add sentinel Node dependency");
+    dependency_repo
+        .git()
+        .add_all()
+        .commit("Add sentinel Node dependency");
 
     let hook_repo = context.create_repo("sentinel-node-hook");
 
@@ -614,9 +620,11 @@ fn node_install_preserves_global_git_config_and_isolates_repository() -> anyhow:
           pass_filenames: false
     "})?;
 
-    hook_repo.git_add_all();
-    hook_repo.git_commit("Add sentinel Node hook");
-    hook_repo.git_tag("v1.0.0");
+    hook_repo
+        .git()
+        .add_all()
+        .commit("Add sentinel Node hook")
+        .tag("v1.0.0");
 
     let context = context.with_config(indoc::formatdoc! {r"
         repos:
@@ -627,11 +635,12 @@ fn node_install_preserves_global_git_config_and_isolates_repository() -> anyhow:
                 additional_dependencies:
                   - git+file:///prek-node-git-dependency
     ", repo = hook_repo.path().display()});
-    context.git_add_all();
+    context.git().add_all();
 
     // The regression corrupts the calling repository's index, so capture it before npm runs.
     let staged_before = context
         .git()
+        .command()
         .args(["ls-files", "--stage"])
         .assert()
         .success()
@@ -645,6 +654,7 @@ fn node_install_preserves_global_git_config_and_isolates_repository() -> anyhow:
     // Keep the dependency local while requiring npm's Git subprocess to inherit global config.
     context
         .git()
+        .command()
         .args(["config", "--file"])
         .arg(global_gitconfig.path())
         .arg(format!("url.{dependency_url}.insteadOf"))
@@ -667,6 +677,7 @@ fn node_install_preserves_global_git_config_and_isolates_repository() -> anyhow:
     // Success proves the URL rewrite survived; an unchanged index proves repository isolation.
     let staged_after = context
         .git()
+        .command()
         .args(["ls-files", "--stage"])
         .assert()
         .success()

--- a/crates/prek/tests/languages/perl.rs
+++ b/crates/prek/tests/languages/perl.rs
@@ -30,7 +30,7 @@ fn local_hook() -> anyhow::Result<()> {
             print "Hello from Perl!\n";
         "#})?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().env(EnvVars::HOME, &**context.home_dir()), @r"
     success: true
@@ -102,9 +102,11 @@ fn remote_repo_install() -> anyhow::Result<()> {
             1;
         "#})?;
 
-    hook_repo.git_add_all();
-    hook_repo.git_commit("Add perl hook");
-    hook_repo.git_tag("v1.0.0");
+    hook_repo
+        .git()
+        .add_all()
+        .commit("Add perl hook")
+        .tag("v1.0.0");
 
     let context = context.with_config(indoc::formatdoc! {r"
         repos:
@@ -117,7 +119,7 @@ fn remote_repo_install() -> anyhow::Result<()> {
                 pass_filenames: false
     ", hook_repo.path().display()});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().env(EnvVars::HOME, &**context.home_dir()), @r"
     success: true
@@ -151,7 +153,7 @@ fn additional_dependencies() {
                 pass_filenames: false
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     context
         .run()
@@ -176,7 +178,7 @@ fn language_version() {
                 pass_filenames: false
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false

--- a/crates/prek/tests/languages/perl.rs
+++ b/crates/prek/tests/languages/perl.rs
@@ -7,7 +7,7 @@ use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
 fn local_hook() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -50,7 +50,7 @@ fn local_hook() -> anyhow::Result<()> {
 
 #[test]
 fn remote_repo_install() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     let hook_repo = context.create_repo("perl-hook");
 
     hook_repo
@@ -137,7 +137,7 @@ fn remote_repo_install() -> anyhow::Result<()> {
 
 #[test]
 fn additional_dependencies() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -162,7 +162,7 @@ fn additional_dependencies() {
 
 #[test]
 fn language_version() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:

--- a/crates/prek/tests/languages/php.rs
+++ b/crates/prek/tests/languages/php.rs
@@ -21,7 +21,7 @@ fn local_hook() -> anyhow::Result<()> {
         .work_dir()
         .child("hello.php")
         .write_str("<?php echo \"Hello from PHP!\\n\";\n")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -84,9 +84,11 @@ fn remote_repo_install() -> anyhow::Result<()> {
     "#})?;
     make_executable(hook_binary.path())?;
 
-    hook_repo.git_add_all();
-    hook_repo.git_commit("Add PHP hook");
-    hook_repo.git_tag("v1.0.0");
+    hook_repo
+        .git()
+        .add_all()
+        .commit("Add PHP hook")
+        .tag("v1.0.0");
 
     let context = context.with_config(indoc::formatdoc! {r"
         repos:
@@ -98,7 +100,7 @@ fn remote_repo_install() -> anyhow::Result<()> {
                 verbose: true
                 pass_filenames: false
     ", hook_repo.path().display()});
-    context.git_add_all();
+    context.git().add_all();
 
     let composer_home = context.home_dir().child("composer");
     composer_home.create_dir_all()?;
@@ -154,7 +156,7 @@ fn additional_dependencies() -> anyhow::Result<()> {
                 verbose: true
                 pass_filenames: false
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     let composer_home = context.home_dir().child("composer");
     composer_home.create_dir_all()?;
@@ -206,7 +208,7 @@ fn language_version() {
                 always_run: true
                 pass_filenames: false
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false

--- a/crates/prek/tests/languages/php.rs
+++ b/crates/prek/tests/languages/php.rs
@@ -5,7 +5,7 @@ use crate::common::{TestEnv, cmd_snapshot, make_executable};
 
 #[test]
 fn local_hook() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -55,7 +55,7 @@ fn local_hook() -> anyhow::Result<()> {
 
 #[test]
 fn remote_repo_install() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     let hook_repo = context.create_repo("php-hook");
 
     hook_repo
@@ -123,7 +123,7 @@ fn remote_repo_install() -> anyhow::Result<()> {
 
 #[test]
 fn additional_dependencies() -> anyhow::Result<()> {
-    let dependency = TestEnv::new_without_git();
+    let dependency = TestEnv::new();
     dependency
         .work_dir()
         .child(COMPOSER_JSON)
@@ -141,7 +141,7 @@ fn additional_dependencies() -> anyhow::Result<()> {
     "#})?;
     make_executable(dependency_binary.path())?;
 
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -194,7 +194,7 @@ fn additional_dependencies() -> anyhow::Result<()> {
 
 #[test]
 fn language_version() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:

--- a/crates/prek/tests/languages/pygrep.rs
+++ b/crates/prek/tests/languages/pygrep.rs
@@ -7,7 +7,7 @@ use crate::common::{TestEnv, cmd_snapshot};
 /// Test basic pygrep functionality - case-sensitive matching
 #[test]
 fn basic_case_sensitive() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let cwd = context.work_dir();
     cwd.child("test.py")
@@ -60,7 +60,7 @@ fn basic_case_sensitive() -> Result<()> {
 /// Test case-insensitive matching
 #[test]
 fn case_insensitive() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let cwd = context.work_dir();
     cwd.child("test.py")
@@ -101,7 +101,7 @@ fn case_insensitive() -> Result<()> {
 /// Test multiline mode
 #[test]
 fn multiline_mode() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let cwd = context.work_dir();
     cwd.child("test.py").write_str(
@@ -142,7 +142,7 @@ fn multiline_mode() -> Result<()> {
 /// Test negate mode - passes when pattern is NOT found
 #[test]
 fn negate_mode() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let cwd = context.work_dir();
     cwd.child("good.py").write_str("print('Hello World')\n")?;
@@ -181,7 +181,7 @@ fn negate_mode() -> Result<()> {
 /// Test negate mode with multiline - should output filename if pattern not found
 #[test]
 fn negate_multiline_mode() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let cwd = context.work_dir();
     cwd.child("no_pattern.py")
@@ -222,7 +222,7 @@ fn negate_multiline_mode() -> Result<()> {
 /// Test invalid regex pattern
 #[test]
 fn invalid_regex() {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let cwd = context.work_dir();
     cwd.child("test.py")
@@ -254,7 +254,7 @@ fn invalid_regex() {
 
 #[test]
 fn python_regex_quirks() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let cwd = context.work_dir();
     cwd.child("test.py")
@@ -292,7 +292,7 @@ fn python_regex_quirks() -> Result<()> {
 /// Test complex regex with word boundaries and character classes
 #[test]
 fn complex_regex_patterns() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let cwd = context.work_dir();
     cwd.child("test.py")
@@ -331,7 +331,7 @@ fn complex_regex_patterns() -> Result<()> {
 /// Test combination of case insensitive and multiline
 #[test]
 fn case_insensitive_multiline() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let cwd = context.work_dir();
     cwd.child("test.py")
@@ -371,7 +371,7 @@ fn case_insensitive_multiline() -> Result<()> {
 /// Test successful case where pattern is not found
 #[test]
 fn pattern_not_found() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let cwd = context.work_dir();
     cwd.child("test.py")
@@ -403,7 +403,7 @@ fn pattern_not_found() -> Result<()> {
 
 #[test]
 fn invalid_args() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let cwd = context.work_dir();
     cwd.child("test.py")

--- a/crates/prek/tests/languages/pygrep.rs
+++ b/crates/prek/tests/languages/pygrep.rs
@@ -25,7 +25,7 @@ fn basic_case_sensitive() -> Result<()> {
                 entry: "TODO"
                 files: "\\.py$"
         "#});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -79,7 +79,7 @@ fn case_insensitive() -> Result<()> {
                 args: ["--ignore-case"]
                 files: "\\.py$"
         "#});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -119,7 +119,7 @@ fn multiline_mode() -> Result<()> {
                 args: ["--multiline"]
                 files: "\\.py$"
         "#});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -160,7 +160,7 @@ fn negate_mode() -> Result<()> {
                 args: ["--negate"]
                 files: "\\.py$"
         "#});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -201,7 +201,7 @@ fn negate_multiline_mode() -> Result<()> {
                 args: ["--multiline", "--negate"]
                 files: "\\.py$"
         "#});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -239,7 +239,7 @@ fn invalid_regex() {
                 entry: "[unclosed"
                 files: "\\.py$"
         "#});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -271,7 +271,7 @@ fn python_regex_quirks() -> Result<()> {
                 entry: "def\\s+\\w+\\([^)]*\\w[^)]*\\):"
                 files: "\\.py$"
         "#});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -309,7 +309,7 @@ fn complex_regex_patterns() -> Result<()> {
                 entry: "^import\\s+[a-zA-Z_][a-zA-Z0-9_]*$"
                 files: "\\.py$"
         "#});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -348,7 +348,7 @@ fn case_insensitive_multiline() -> Result<()> {
                 args: ["--ignore-case", "--multiline"]
                 files: "\\.py$"
         "#});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -387,7 +387,7 @@ fn pattern_not_found() -> Result<()> {
                 entry: "TODO"
                 files: "\\.py$"
         "#});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -420,7 +420,7 @@ fn invalid_args() -> Result<()> {
                 args: ["--hello"]
                 files: "\\.py$"
         "#});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false

--- a/crates/prek/tests/languages/python.rs
+++ b/crates/prek/tests/languages/python.rs
@@ -15,7 +15,7 @@ fn language_version() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -142,7 +142,7 @@ fn language_version() -> anyhow::Result<()> {
 
 #[test]
 fn invalid_version() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -173,7 +173,7 @@ fn invalid_version() {
 /// Request a version that neither can be found nor downloaded.
 #[test]
 fn can_not_download() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -221,7 +221,7 @@ fn can_not_download() {
 /// Test that `additional_dependencies` are installed correctly.
 #[test]
 fn additional_dependencies() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -254,7 +254,7 @@ fn additional_dependencies() {
 
 #[test]
 fn additional_dependencies_in_remote_repo() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     let repo = context.create_repo("python-hook");
     let repo_path = repo.path();
     repo_path
@@ -316,7 +316,7 @@ fn additional_dependencies_in_remote_repo() -> anyhow::Result<()> {
 /// Ensure that stderr from hooks is captured and shown to the user.
 #[test]
 fn hook_stderr() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -353,7 +353,7 @@ fn hook_stderr() -> anyhow::Result<()> {
 /// Only if no additional dependencies are specified.
 #[test]
 fn pep723_script() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -415,7 +415,7 @@ fn pep723_script() -> anyhow::Result<()> {
 /// Regression test for <https://github.com/j178/prek/issues/1354>
 #[test]
 fn git_env_vars_not_leaked_to_pip_install() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // setup.py that fails if GIT_DIR leaks into pip install
     context
@@ -464,7 +464,7 @@ fn git_env_vars_not_leaked_to_pip_install() -> anyhow::Result<()> {
 /// Regression test for <https://github.com/j178/prek/issues/1603>.
 #[test]
 fn local_relative_additional_dependency_is_not_resolved_from_worktree() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     context
         .work_dir()
         .child("pyproject.toml")
@@ -531,7 +531,7 @@ fn health_check_with_symlinked_toolchain() -> anyhow::Result<()> {
     use fs_err::os::unix::fs::symlink;
     use prek_consts::prepend_paths;
 
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Find a Python executable, create a symlinked directory to its parent,
     // and prepend that to PATH so that prek picks up the symlinked path.

--- a/crates/prek/tests/languages/python.rs
+++ b/crates/prek/tests/languages/python.rs
@@ -61,7 +61,7 @@ fn language_version() -> anyhow::Result<()> {
                 language_version: '3.11.1' # will auto download
                 always_run: true
     "#});
-    context.git_add_all();
+    context.git().add_all();
 
     let python_dir = context.home_dir().child("tools").child("python");
     python_dir.assert(predicates::path::missing());
@@ -156,7 +156,7 @@ fn invalid_version() {
                 pass_filenames: false
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -184,7 +184,7 @@ fn can_not_download() {
                 language_version: '<=3.6' # not supported version
                 always_run: true
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     let context = context.with_filters([
         (
@@ -236,7 +236,7 @@ fn additional_dependencies() {
                 pass_filenames: false
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -282,9 +282,7 @@ fn additional_dependencies_in_remote_repo() -> anyhow::Result<()> {
             }
         )
     "#})?;
-    repo.git_add_all();
-    repo.git_commit("Add manifest");
-    repo.git_tag("v0.1.0");
+    repo.git().add_all().commit("Add manifest").tag("v0.1.0");
 
     let context = context.with_config(indoc::formatdoc! {r"
         repos:
@@ -296,7 +294,7 @@ fn additional_dependencies_in_remote_repo() -> anyhow::Result<()> {
                 verbose: true
     ", repo_path.display()});
 
-    context.git_add_all();
+    context.git().add_all();
     cmd_snapshot!(context, context.run(), @r"
     success: true
     exit_code: 0
@@ -331,7 +329,7 @@ fn hook_stderr() -> anyhow::Result<()> {
         .child("hook.py")
         .write_str("import sys; print('How are you', file=sys.stderr); sys.exit(1)")?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -385,7 +383,7 @@ fn pep723_script() -> anyhow::Result<()> {
         main()
     "#})?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -445,7 +443,7 @@ fn git_env_vars_not_leaked_to_pip_install() -> anyhow::Result<()> {
                 always_run: true
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     // Simulate worktree environment by setting GIT_DIR (like git does in worktrees)
     cmd_snapshot!(context, context.run()
@@ -499,7 +497,7 @@ fn local_relative_additional_dependency_is_not_resolved_from_worktree() -> anyho
             ),
         ]);
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -551,7 +549,7 @@ fn health_check_with_symlinked_toolchain() -> anyhow::Result<()> {
                 always_run: true
                 pass_filenames: false
     "#});
-    context.git_add_all();
+    context.git().add_all();
 
     // First run installs the hook
     cmd_snapshot!(context, context.run().env(EnvVars::PATH, new_path), @"

--- a/crates/prek/tests/languages/r.rs
+++ b/crates/prek/tests/languages/r.rs
@@ -5,7 +5,7 @@ use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
 fn local_hook() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     context
         .work_dir()
         .child(".Rprofile")
@@ -58,7 +58,7 @@ fn local_hook() -> anyhow::Result<()> {
 
 #[test]
 fn local_hook_with_absolute_additional_dependency() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     write_local_r_package(context.work_dir(), "localdep")?;
     let dependency_path = std::path::absolute(context.work_dir().child("localdep").path())?;
@@ -98,7 +98,7 @@ fn local_hook_with_absolute_additional_dependency() -> anyhow::Result<()> {
 
 #[test]
 fn remote_repo_install() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     let hook_repo = context.create_repo("r-hook");
 
     hook_repo
@@ -153,7 +153,7 @@ fn remote_repo_install() -> anyhow::Result<()> {
 
 #[test]
 fn language_version() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:

--- a/crates/prek/tests/languages/r.rs
+++ b/crates/prek/tests/languages/r.rs
@@ -24,7 +24,7 @@ fn local_hook() -> anyhow::Result<()> {
                 pass_filenames: false
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -78,7 +78,7 @@ fn local_hook_with_absolute_additional_dependency() -> anyhow::Result<()> {
                 pass_filenames: false
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -117,9 +117,7 @@ fn remote_repo_install() -> anyhow::Result<()> {
     write_local_r_package(hook_repo.path(), "localdep")?;
     write_renv_project(hook_repo.path())?;
 
-    hook_repo.git_add_all();
-    hook_repo.git_commit("Add R hook");
-    hook_repo.git_tag("v1.0.0");
+    hook_repo.git().add_all().commit("Add R hook").tag("v1.0.0");
 
     let context = context.with_config(indoc::formatdoc! {r"
         repos:
@@ -133,7 +131,7 @@ fn remote_repo_install() -> anyhow::Result<()> {
                 pass_filenames: false
     ", hook_repo.path().display()});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -167,7 +165,7 @@ fn language_version() {
                 pass_filenames: false
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false

--- a/crates/prek/tests/languages/ruby.rs
+++ b/crates/prek/tests/languages/ruby.rs
@@ -5,7 +5,7 @@ use assert_fs::fixture::{FileWriteStr, PathChild, PathCreateDir};
 use crate::common::{TestEnv, cmd_snapshot};
 
 fn ruby_context() -> TestEnv {
-    TestEnv::new().with_filter(
+    TestEnv::new_git().with_filter(
         r"ruby (\d+\.\d+)\.\d+(?:p\d+)? \(\d{4}-\d{2}-\d{2} revision [0-9a-f]{0,10}\).*?\[.+\]",
         "ruby $1.X ([DATE] revision [HASH]) [FLAGS] [PLATFORM]",
     )
@@ -217,7 +217,7 @@ fn specific_ruby_unavailable() {
 /// Test Ruby hook with `additional_dependencies` and `require` statement
 #[test]
 fn additional_gem_dependencies() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Create a Ruby script that uses a gem from additional_dependencies
     // Use 'rspec' - a gem that's NOT bundled with Ruby
@@ -306,7 +306,7 @@ fn additional_gem_dependencies() -> anyhow::Result<()> {
 /// Test Ruby hook with gemspec
 #[test]
 fn gemspec_workflow() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Create a simple gemspec
     context
@@ -392,7 +392,7 @@ fn gemspec_workflow() -> anyhow::Result<()> {
 /// Test environment isolation between Ruby hooks
 #[test]
 fn environment_isolation() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -552,7 +552,7 @@ fn environment_isolation() -> anyhow::Result<()> {
 /// Test local Ruby hook repository with gemspec build and install
 #[test]
 fn local_hook_with_gemspec() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     let hook_repo = context.create_repo("ruby-hook");
 
     // Create the gemspec
@@ -635,7 +635,7 @@ fn local_hook_with_gemspec() -> anyhow::Result<()> {
 /// Test Ruby hook with native gem (C extension)
 #[test]
 fn native_gem_dependency() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Create a Ruby script that uses msgpack (small native gem that compiles quickly)
     context
@@ -688,7 +688,7 @@ fn native_gem_dependency() -> anyhow::Result<()> {
 /// Test Ruby hook that processes files
 #[test]
 fn process_files() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Create a Ruby script that validates file extensions
     context

--- a/crates/prek/tests/languages/ruby.rs
+++ b/crates/prek/tests/languages/ruby.rs
@@ -33,7 +33,7 @@ fn system_ruby() {
                 pass_filenames: false
                 always_run: true
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("-v"), @r"
     success: true
@@ -71,7 +71,7 @@ fn language_version_default() {
                 pass_filenames: false
                 always_run: true
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("-v"), @r"
     success: true
@@ -131,7 +131,7 @@ fn specific_ruby_available() {
                 pass_filenames: false
                 always_run: true
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("-v"), @r"
     success: true
@@ -183,7 +183,7 @@ fn specific_ruby_unavailable() {
                 pass_filenames: false
                 always_run: true
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     #[cfg(target_os = "windows")]
     cmd_snapshot!(context, context.run().arg("-v"), @r"
@@ -257,7 +257,7 @@ fn additional_gem_dependencies() -> anyhow::Result<()> {
                 pass_filenames: false
                 always_run: true
     "#});
-    context.git_add_all();
+    context.git().add_all();
 
     let context = context.with_filters([
         // Normalize unpinned rspec version (only for test-gem-require, not test-gem-require-versioned)
@@ -358,7 +358,7 @@ fn gemspec_workflow() -> anyhow::Result<()> {
                 pass_filenames: false
                 always_run: true
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("-v"), @r"
     success: true
@@ -440,7 +440,7 @@ fn environment_isolation() -> anyhow::Result<()> {
                 always_run: true
                 verbose: true
     "#});
-    context.git_add_all();
+    context.git().add_all();
 
     let output = context.run().output()?;
 
@@ -594,9 +594,8 @@ fn local_hook_with_gemspec() -> anyhow::Result<()> {
               pass_filenames: false
         "})?;
 
-    hook_repo.git_add_all();
-    hook_repo.git_commit("Initial commit");
-    let rev = hook_repo.git_rev_parse("HEAD")?;
+    hook_repo.git().add_all().commit("Initial commit");
+    let rev = hook_repo.git().rev_parse("HEAD")?;
 
     // Configure prek to use this local repo
     let context = context.with_config(indoc::formatdoc! {r"
@@ -614,7 +613,7 @@ fn local_hook_with_gemspec() -> anyhow::Result<()> {
         hook_repo.path().display(),
         rev
     });
-    context.git_add(".pre-commit-config.yaml");
+    context.git().add(".pre-commit-config.yaml");
 
     cmd_snapshot!(context, context.run().arg("-v"), @r"
     success: true
@@ -666,7 +665,7 @@ fn native_gem_dependency() -> anyhow::Result<()> {
                 pass_filenames: false
                 always_run: true
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("-v"), @r"
     success: true
@@ -725,7 +724,7 @@ fn process_files() -> anyhow::Result<()> {
     // Create a text file
     context.work_dir().child("test.txt").write_str("hello")?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -780,7 +779,7 @@ fn auto_download() -> anyhow::Result<()> {
                 pass_filenames: false
                 always_run: true
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     let ruby_dir = context.home_dir().child("tools").child("ruby");
     ruby_dir.assert(predicates::path::missing());
@@ -850,7 +849,7 @@ fn auto_download() -> anyhow::Result<()> {
                 pass_filenames: false
                 always_run: true
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("-v"), @r"
     success: true

--- a/crates/prek/tests/languages/rust.rs
+++ b/crates/prek/tests/languages/rust.rs
@@ -39,7 +39,7 @@ fn language_version() -> Result<()> {
                 always_run: true
                 pass_filenames: false
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     let rust_dir = context.home_dir().child("tools/rustup/toolchains");
     rust_dir.assert(predicates::path::missing());
@@ -111,7 +111,7 @@ fn rustup_installer() {
                 language: rust
                 entry: rustc --version
    "});
-    context.git_add_all();
+    context.git().add_all();
     let context = context.with_filter(r"rustc 1\.\d{1,3}\.\d{1,2} .+", "rustc 1.X.X");
 
     cmd_snapshot!(context, context.run().arg("-v").env(EnvVars::PREK_INTERNAL__RUSTUP_BINARY_NAME, "non-exist-rustup"), @r#"
@@ -145,7 +145,7 @@ fn additional_dependencies_cli() {
                 pass_filenames: false
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -175,7 +175,7 @@ fn remote_hooks() {
                 always_run: true
                 args: ["Hello World"]
     "#});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -205,7 +205,7 @@ fn remote_hook_non_workspace() {
                 pass_filenames: false
                 always_run: true
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -237,7 +237,7 @@ fn remote_hooks_with_lib_deps() {
                 pass_filenames: false
                 always_run: true
     "#});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true

--- a/crates/prek/tests/languages/rust.rs
+++ b/crates/prek/tests/languages/rust.rs
@@ -13,7 +13,7 @@ fn language_version() -> Result<()> {
         return Ok(());
     }
 
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -102,7 +102,7 @@ fn language_version() -> Result<()> {
 /// Test `rustup` installer.
 #[test]
 fn rustup_installer() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -131,7 +131,7 @@ fn rustup_installer() {
 /// Test that `additional_dependencies` with cli: prefix are installed correctly.
 #[test]
 fn additional_dependencies_cli() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -164,7 +164,7 @@ fn additional_dependencies_cli() {
 /// Test that remote Rust hooks are installed and run correctly.
 #[test]
 fn remote_hooks() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: https://github.com/prek-ci/rust-hooks
             rev: v1.0.0
@@ -195,7 +195,7 @@ fn remote_hooks() {
 /// Test that remote Rust hooks from non-workspace repos are installed and run correctly.
 #[test]
 fn remote_hook_non_workspace() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/prek-ci/rust-hooks-non-workspace
             rev: v1.0.0
@@ -226,7 +226,7 @@ fn remote_hook_non_workspace() {
 /// This verifies that the shared repo is not modified when adding dependencies.
 #[test]
 fn remote_hooks_with_lib_deps() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: https://github.com/prek-ci/rust-hooks
             rev: v1.0.0

--- a/crates/prek/tests/languages/script.rs
+++ b/crates/prek/tests/languages/script.rs
@@ -28,7 +28,7 @@ mod unix {
                   VAR2: galaxy
                 verbose: true
         "});
-        context.git_add_all();
+        context.git().add_all();
 
         cmd_snapshot!(context, context.run(), @r"
         success: true
@@ -84,7 +84,7 @@ mod unix {
 
         make_executable(context.work_dir().child("script.sh"))?;
         make_executable(child.child("script.sh"))?;
-        context.git_add_all();
+        context.git().add_all();
 
         cmd_snapshot!(context, context.run(), @r#"
         success: true
@@ -142,7 +142,7 @@ mod unix {
         "#})?;
         make_executable(&script)?;
 
-        context.git_add_all();
+        context.git().add_all();
 
         cmd_snapshot!(context, context.run(), @r"
         success: true
@@ -181,7 +181,7 @@ mod unix {
                 verbose: true
         "#});
         context.work_dir().child("a.txt").write_str("a")?;
-        context.git_add_all();
+        context.git().add_all();
 
         cmd_snapshot!(context, context.run(), @r"
         success: true
@@ -222,7 +222,7 @@ fn windows_script_run() -> Result<()> {
     "#})?;
     make_executable(&script)?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true

--- a/crates/prek/tests/languages/script.rs
+++ b/crates/prek/tests/languages/script.rs
@@ -13,7 +13,7 @@ mod unix {
 
     #[test]
     fn script_run() {
-        let context = TestEnv::new().with_config(indoc::indoc! {r"
+        let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/prek-ci/script-hooks
             rev: v1.0.0
@@ -51,7 +51,7 @@ mod unix {
 
     #[test]
     fn workspace_script_run() -> Result<()> {
-        let context = TestEnv::new();
+        let context = TestEnv::new_git();
 
         let config = indoc::indoc! {r#"
         repos:
@@ -124,7 +124,7 @@ mod unix {
 
     #[test]
     fn local_repo_bash_shebang() -> Result<()> {
-        let context = TestEnv::new().with_config(indoc::indoc! {r"
+        let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -162,7 +162,7 @@ mod unix {
 
     #[test]
     fn script_shell_runs_entry_as_shell_source() -> Result<()> {
-        let context = TestEnv::new().with_config(indoc::indoc! {r#"
+        let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -204,7 +204,7 @@ mod unix {
 /// The interpreter must exist in the PATH, the script is not needed to be executable.
 #[test]
 fn windows_script_run() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
     repos:
       - repo: local
         hooks:

--- a/crates/prek/tests/languages/shell.rs
+++ b/crates/prek/tests/languages/shell.rs
@@ -5,7 +5,7 @@ use crate::common::{TestEnv, cmd_snapshot};
 #[cfg(unix)]
 #[test]
 fn bash_shell_adapter_runs_entry() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -45,7 +45,7 @@ fn pwsh_shell_adapter_runs_entry() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -81,7 +81,7 @@ fn pwsh_shell_adapter_runs_entry() -> anyhow::Result<()> {
 #[cfg(windows)]
 #[test]
 fn powershell_shell_adapter_runs_entry() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -117,7 +117,7 @@ fn powershell_shell_adapter_runs_entry() -> anyhow::Result<()> {
 #[cfg(windows)]
 #[test]
 fn cmd_shell_adapter_runs_entry() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -153,7 +153,7 @@ fn cmd_shell_adapter_runs_entry() -> anyhow::Result<()> {
 
 #[test]
 fn shell_rejected_for_pygrep() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:

--- a/crates/prek/tests/languages/shell.rs
+++ b/crates/prek/tests/languages/shell.rs
@@ -21,7 +21,7 @@ fn bash_shell_adapter_runs_entry() -> anyhow::Result<()> {
                 verbose: true
     "#});
     context.work_dir().child("input.txt").write_str("input")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -60,7 +60,7 @@ fn pwsh_shell_adapter_runs_entry() -> anyhow::Result<()> {
                 verbose: true
     "#});
     context.work_dir().child("input.txt").write_str("input")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -96,7 +96,7 @@ fn powershell_shell_adapter_runs_entry() -> anyhow::Result<()> {
                 verbose: true
     "#});
     context.work_dir().child("input.txt").write_str("input")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -133,7 +133,7 @@ fn cmd_shell_adapter_runs_entry() -> anyhow::Result<()> {
                 verbose: true
     "});
     context.work_dir().child("input.txt").write_str("input")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -165,7 +165,7 @@ fn shell_rejected_for_pygrep() {
                 always_run: true
                 pass_filenames: false
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false

--- a/crates/prek/tests/languages/swift.rs
+++ b/crates/prek/tests/languages/swift.rs
@@ -24,7 +24,7 @@ fn local_hook_system_command() {
                 pass_filenames: false
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -60,7 +60,7 @@ fn language_version_rejected() {
                 pass_filenames: false
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -94,7 +94,7 @@ fn health_check() {
                 pass_filenames: false
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     // First run - installs
     cmd_snapshot!(context, context.run(), @r"
@@ -165,12 +165,11 @@ fn local_package_build() -> anyhow::Result<()> {
           entry: prek-swift-test
           language: swift
     "})?;
-    swift_hook.git_add_all();
-    swift_hook.git_commit("Initial commit");
     swift_hook
         .git()
-        .args(["tag", "v1.0", "-m", "v1.0"])
-        .output()?;
+        .add_all()
+        .commit("Initial commit")
+        .tag("v1.0");
 
     let context = TestEnv::new_git();
 
@@ -185,7 +184,7 @@ fn local_package_build() -> anyhow::Result<()> {
                 always_run: true
                 pass_filenames: false
     ", hook_url = hook_url});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true

--- a/crates/prek/tests/languages/swift.rs
+++ b/crates/prek/tests/languages/swift.rs
@@ -11,7 +11,7 @@ fn local_hook_system_command() {
         return;
     }
 
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -47,7 +47,7 @@ fn language_version_rejected() {
         return;
     }
 
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -81,7 +81,7 @@ fn health_check() {
         return;
     }
 
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -132,7 +132,7 @@ fn local_package_build() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let swift_hook = TestEnv::new();
+    let swift_hook = TestEnv::new_git();
 
     // Create a minimal Swift package
     swift_hook
@@ -172,7 +172,7 @@ fn local_package_build() -> anyhow::Result<()> {
         .args(["tag", "v1.0", "-m", "v1.0"])
         .output()?;
 
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let hook_url = swift_hook.work_dir().to_str().unwrap();
     let context = context.with_config(indoc::formatdoc! {r"

--- a/crates/prek/tests/languages/system.rs
+++ b/crates/prek/tests/languages/system.rs
@@ -19,7 +19,7 @@ fn multiline_entry_without_shell_uses_argv_semantics() {
             pass_filenames: false
             verbose: true
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -52,7 +52,7 @@ fn shell_runs_multiline_entry_as_one_script() {
             pass_filenames: false
             verbose: true
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -91,7 +91,7 @@ fn shell_entry_receives_hook_args_before_filenames() -> anyhow::Result<()> {
             verbose: true
     "#});
     context.work_dir().child("a.txt").write_str("a")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true

--- a/crates/prek/tests/languages/system.rs
+++ b/crates/prek/tests/languages/system.rs
@@ -6,7 +6,7 @@ use assert_fs::fixture::{FileWriteStr, PathChild};
 #[cfg(unix)]
 #[test]
 fn multiline_entry_without_shell_uses_argv_semantics() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
     repos:
       - repo: local
         hooks:
@@ -38,7 +38,7 @@ fn multiline_entry_without_shell_uses_argv_semantics() {
 #[cfg(unix)]
 #[test]
 fn shell_runs_multiline_entry_as_one_script() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
     repos:
       - repo: local
         hooks:
@@ -72,7 +72,7 @@ fn shell_runs_multiline_entry_as_one_script() {
 #[cfg(unix)]
 #[test]
 fn shell_entry_receives_hook_args_before_filenames() -> anyhow::Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
     repos:
       - repo: local
         hooks:

--- a/crates/prek/tests/languages/unsupported.rs
+++ b/crates/prek/tests/languages/unsupported.rs
@@ -27,7 +27,7 @@ fn unsupported_language() -> anyhow::Result<()> {
             #!/usr/bin/env bash
             echo "Hello, World!"
         "#})?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true

--- a/crates/prek/tests/languages/unsupported.rs
+++ b/crates/prek/tests/languages/unsupported.rs
@@ -5,7 +5,7 @@ fn unsupported_language() -> anyhow::Result<()> {
     use crate::common::{TestEnv, cmd_snapshot};
     use assert_fs::fixture::{FileWriteStr, PathChild};
 
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:

--- a/crates/prek/tests/list.rs
+++ b/crates/prek/tests/list.rs
@@ -5,7 +5,7 @@ mod common;
 
 #[test]
 fn list_basic() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -35,7 +35,7 @@ fn list_basic() {
 
 #[test]
 fn list_verbose() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -118,7 +118,7 @@ fn list_verbose() {
 
 #[test]
 fn list_with_hook_ids_filter() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -163,7 +163,7 @@ fn list_with_hook_ids_filter() {
 
 #[test]
 fn list_with_language_filter() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -206,7 +206,7 @@ fn list_with_language_filter() {
 
 #[test]
 fn list_with_stage_filter() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -254,7 +254,7 @@ fn list_with_stage_filter() {
 
 #[test]
 fn list_with_group_filter() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -364,7 +364,7 @@ fn list_with_group_filter() {
 
 #[test]
 fn list_group_excluded_remote_repo_is_not_cloned() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -394,7 +394,7 @@ fn list_group_excluded_remote_repo_is_not_cloned() {
 
 #[test]
 fn list_with_aliases() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -440,7 +440,7 @@ fn list_with_aliases() {
 
 #[test]
 fn list_empty_config() {
-    let context = TestEnv::new().with_config("repos: []");
+    let context = TestEnv::new_git().with_config("repos: []");
 
     cmd_snapshot!(context, context.list(), @r#"
     success: true
@@ -461,7 +461,7 @@ fn list_empty_config() {
 
 #[test]
 fn list_no_config_file() {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // No config file exists
     cmd_snapshot!(context, context.list(), @r"
@@ -478,7 +478,7 @@ fn list_no_config_file() {
 
 #[test]
 fn list_json_output() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -584,7 +584,7 @@ fn list_json_output() {
 
 #[test]
 fn workspace_list() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     let cwd = context.work_dir().to_path_buf();
 
     let config = indoc! {r"
@@ -773,7 +773,7 @@ fn workspace_list() -> anyhow::Result<()> {
 
 #[test]
 fn list_with_selectors() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let config = indoc! {r"
     repos:

--- a/crates/prek/tests/list.rs
+++ b/crates/prek/tests/list.rs
@@ -377,7 +377,7 @@ fn list_group_excluded_remote_repo_is_not_cloned() {
               - id: ruff-check
                 groups: [local]
         "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context,
         context.list().arg("--group").arg("ci"),
@@ -607,7 +607,7 @@ fn workspace_list() -> anyhow::Result<()> {
         ],
         config,
     )?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.list(), @r"
     success: true
@@ -795,7 +795,7 @@ fn list_with_selectors() -> anyhow::Result<()> {
         ],
         config,
     )?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.list().arg("project2/"), @r"
     success: true

--- a/crates/prek/tests/list_builtins.rs
+++ b/crates/prek/tests/list_builtins.rs
@@ -4,7 +4,7 @@ mod common;
 
 #[test]
 fn list_builtins_basic() {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
 
     cmd_snapshot!(context, context.command().arg("util").arg("list-builtins"), @r"
     success: true
@@ -45,7 +45,7 @@ fn list_builtins_basic() {
 
 #[test]
 fn list_builtins_verbose() {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
 
     cmd_snapshot!(context, context.command().arg("util").arg("list-builtins").arg("--verbose"), @r#"
     success: true
@@ -181,7 +181,7 @@ fn list_builtins_verbose() {
 
 #[test]
 fn list_builtins_json() {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
 
     cmd_snapshot!(context, context.command().arg("util").arg("list-builtins").arg("--output-format=json"), @r#"
     success: true

--- a/crates/prek/tests/meta_hooks.rs
+++ b/crates/prek/tests/meta_hooks.rs
@@ -6,16 +6,13 @@ use assert_fs::fixture::{FileWriteStr, PathChild, PathCreateDir};
 use prek_consts::PRE_COMMIT_CONFIG_YAML;
 
 #[test]
-fn meta_hooks() -> anyhow::Result<()> {
-    let context = TestEnv::new();
-
-    let cwd = context.work_dir();
-    cwd.child("file.txt").write_str("Hello, world!\n")?;
-    cwd.child("valid.json").write_str("{}")?;
-    cwd.child("invalid.json").write_str("{}")?;
-    cwd.child("main.py").write_str(r#"print "abc"  "#)?;
-
-    let context = context.with_config(indoc::indoc! {r"
+fn meta_hooks() {
+    let context = TestEnv::new_git()
+        .with_file("file.txt", "Hello, world!\n")
+        .with_file("valid.json", "{}")
+        .with_file("invalid.json", "{}")
+        .with_file("main.py", r#"print "abc"  "#)
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: meta
             hooks:
@@ -65,13 +62,11 @@ fn meta_hooks() -> anyhow::Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
 fn meta_hooks_unknown_hook() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: meta
             hooks:
@@ -98,7 +93,7 @@ fn meta_hooks_unknown_hook() {
 
 #[test]
 fn check_useless_excludes_remote() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // When checking useless excludes, remote hooks are not actually cloned,
     // so hook options defined from HookManifest are not used.
@@ -149,7 +144,7 @@ fn check_useless_excludes_remote() -> anyhow::Result<()> {
 
 #[test]
 fn meta_hooks_workspace() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let app = context.work_dir().child("app");
     app.create_dir_all()?;
@@ -218,7 +213,7 @@ fn meta_hooks_workspace() -> anyhow::Result<()> {
 
 #[test]
 fn check_useless_excludes_workspace_paths_are_project_relative() -> anyhow::Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Workspace layout:
     // - Root project has no hooks.

--- a/crates/prek/tests/meta_hooks.rs
+++ b/crates/prek/tests/meta_hooks.rs
@@ -32,7 +32,7 @@ fn meta_hooks() {
                 entry: python3 -c 'import sys; sys.exit(0)'
                 exclude: $nonexistent^
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -72,7 +72,7 @@ fn meta_hooks_unknown_hook() {
             hooks:
               - id: this-hook-does-not-exist
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @"
     success: false
@@ -125,7 +125,7 @@ fn check_useless_excludes_remote() -> anyhow::Result<()> {
         .write_str("<!DOCTYPE html>")?;
 
     let context = context.with_config(&pre_commit_config);
-    context.git_add_all();
+    context.git().add_all();
     cmd_snapshot!(context, context.run().arg("check-useless-excludes"), @r"
     success: false
     exit_code: 1
@@ -176,7 +176,7 @@ fn meta_hooks_workspace() -> anyhow::Result<()> {
     app.child("main.py").write_str(r#"print "abc"  "#)?;
 
     let context = context.with_config("repos: []");
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -245,7 +245,7 @@ fn check_useless_excludes_workspace_paths_are_project_relative() -> anyhow::Resu
     app.child("hook_excluded").write_str("ignored\n")?;
 
     let context = context.with_config("repos: []");
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("check-useless-excludes"), @r#"
     success: true

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -48,7 +48,7 @@ fn run_basic() -> Result<()> {
     cwd.child("valid.json").write_str("{}")?;
     cwd.child("main.py").write_str(r#"print "abc"  "#)?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("-q"), @"
     success: false
@@ -82,7 +82,7 @@ fn run_basic() -> Result<()> {
 
     assert_eq!(context.read("file.txt"), "a-project\nz-project\n");
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("trailing-whitespace"), @r#"
     success: true
@@ -113,7 +113,7 @@ fn fast_path_checks_filenames_from_entry_and_args() -> Result<()> {
     cwd.child("from-entry.json").write_str("invalid")?;
     cwd.child("from-args.json").write_str("invalid")?;
     cwd.child("selected.json").write_str("{}")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -160,7 +160,7 @@ fn run_preserves_stdout_stderr_order() -> Result<()> {
                 pass_filenames: false
                 verbose: true
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().args(["--all-files", "--color=never"]), @r"
     success: true
@@ -205,7 +205,7 @@ fn hook_details_include_first_description_line() {
                 pass_filenames: false
                 verbose: true
     "#});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -238,7 +238,7 @@ fn run_does_not_rewrite_unchanged_config_tracking_file() -> Result<()> {
                 entry: "true"
                 always_run: true
     "#});
-    context.git_add_all();
+    context.git().add_all();
 
     context.run().arg("--all-files").assert().success();
 
@@ -278,7 +278,7 @@ fn run_tracks_relative_config_as_absolute_path() -> Result<()> {
                 entry: "true"
                 always_run: true
     "#});
-    context.git_add_all();
+    context.git().add_all();
 
     context
         .run()
@@ -336,7 +336,7 @@ fn run_glob_patterns_with_multiple_hooks() -> Result<()> {
     cwd.child("docs/readme.md").write_str("# Docs")?;
     cwd.child("notes.txt").write_str("note")?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--all-files"), @r"
     success: true
@@ -385,7 +385,7 @@ fn run_in_non_git_repo() {
 #[test]
 fn invalid_config() {
     let context = TestEnv::new_git().with_config("invalid: config");
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @"
     success: false
@@ -405,7 +405,7 @@ fn invalid_config() {
         files: 12
         repos: []
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @"
     success: false
@@ -428,7 +428,7 @@ fn invalid_config() {
           glog: "*.rs"
         repos: []
     "#});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @"
     success: false
@@ -457,7 +457,7 @@ fn invalid_config() {
                 additional_dependencies: ["swift-format@5.0.0"]
                 entry: echo Hello, world!
     "#});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -480,7 +480,7 @@ fn invalid_config() {
                 language_version: '6'
                 entry: echo Hello, world!
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -519,7 +519,7 @@ fn same_repo() -> Result<()> {
     cwd.child("valid.json").write_str("{}")?;
     cwd.child("invalid.json").write_str("{}")?;
     cwd.child("main.py").write_str(r#"print "abc"  "#)?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -554,7 +554,7 @@ fn local() {
                 always_run: true
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -580,8 +580,7 @@ fn hook_repo_placeholder_expands_to_local_project() -> Result<()> {
                 pass_filenames: false
     "#});
     context.work_dir().child("hook-repo-marker").write_str("")?;
-    context.git_add_all();
-    context.git_commit("Add local hook");
+    context.git().add_all().commit("Add local hook");
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -611,9 +610,11 @@ fn hook_repo_placeholder_expands_to_remote_checkout() -> Result<()> {
               pass_filenames: false
     "#})?;
     hook_repo.path().child("hook-repo-marker").write_str("")?;
-    hook_repo.git_add_all();
-    hook_repo.git_commit("Add remote hook");
-    hook_repo.git_tag("v1.0.0");
+    hook_repo
+        .git()
+        .add_all()
+        .commit("Add remote hook")
+        .tag("v1.0.0");
 
     let context = context.with_config(indoc::formatdoc! {r"
         repos:
@@ -622,7 +623,7 @@ fn hook_repo_placeholder_expands_to_remote_checkout() -> Result<()> {
             hooks:
               - id: hook-repo-remote
     ", hook_repo.path().display()});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -662,7 +663,7 @@ fn multiple_hook_ids() {
                 alias: shared-name
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     // Multiple repeated hook-id (should deduplicate)
     cmd_snapshot!(context, context.run().arg("hook1").arg("hook1").arg("hook1"), @r#"
@@ -780,7 +781,7 @@ fn run_displays_aliases_for_repeated_hook_ids() {
                 verbose: true
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("repeated"), @r"
     success: true
@@ -825,7 +826,7 @@ fn priorities_respected() {
                 priority: 5
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -868,7 +869,7 @@ fn priority_aliases_are_resolved_before_scheduling() {
                 priority: 5
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -924,7 +925,7 @@ fn run_group_without_stage_selects_hooks_across_stages() {
                 stages: [pre-commit]
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--all-files").arg("--group").arg("ci"), @r#"
     success: true
@@ -968,7 +969,7 @@ fn run_ungrouped_group_selects_hooks_without_groups() {
                 groups: [other]
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context,
         context
@@ -1012,7 +1013,7 @@ fn run_required_group_without_stage_warns_when_only_message_file_hooks_match() {
                 groups: [ci]
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--all-files").arg("--require-group").arg("ci"), @r#"
     success: false
@@ -1043,7 +1044,7 @@ fn run_no_group_excludes_matching_hooks_and_keeps_ungrouped_hooks() {
                 always_run: true
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--all-files").arg("--no-group").arg("format"), @r#"
     success: true
@@ -1075,7 +1076,7 @@ fn run_group_exclusion_wins_over_inclusion() {
                 groups: [ci, slow]
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--all-files").arg("--group").arg("ci").arg("--no-group").arg("slow"), @r#"
     success: true
@@ -1125,7 +1126,7 @@ fn run_required_groups_intersect_and_compose_with_other_group_filters() {
                 groups: [format, slow, ci, fast]
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context,
         context
@@ -1212,7 +1213,7 @@ fn run_unknown_group_selectors_warn_and_empty_selection_fails() {
                 groups: [ci]
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--all-files").arg("--group").arg("missing"), @r#"
     success: false
@@ -1249,7 +1250,7 @@ fn run_group_selectors_reject_invalid_names() {
                 groups: [ci]
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--all-files").arg("--group").arg("ci slow"), @r#"
     success: false
@@ -1311,7 +1312,7 @@ fn run_required_group_and_stage_filters_intersect() {
                 groups: [other]
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--all-files").arg("--require-group").arg("ci").arg("--stage").arg("pre-push"), @r#"
     success: true
@@ -1350,7 +1351,7 @@ fn priority_fail_fast_stops_later_groups() {
                 priority: 10
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -1405,7 +1406,7 @@ fn priority_group_modified_files_is_group_failure_and_output_is_indented() -> Re
                 priority: 10
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -1439,7 +1440,7 @@ fn config_not_staged() -> Result<()> {
     let context = TestEnv::new_git();
 
     context.work_dir().child(PRE_COMMIT_CONFIG_YAML).touch()?;
-    context.git_add_all();
+    context.git().add_all();
 
     let context = context.with_config(indoc::indoc! {r"
         repos:
@@ -1471,7 +1472,7 @@ fn config_outside_repo() -> Result<()> {
     // Initialize a git repository in ./work.
     let root = context.work_dir().child("work");
     root.create_dir_all()?;
-    context.git_at(&root).arg("init").assert().success();
+    context.git_at(&root).init();
 
     // Create a configuration file in . (outside the repository).
     context
@@ -1516,7 +1517,7 @@ fn cjk_hook_name() {
                 entry: python3 -V
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -1549,7 +1550,7 @@ fn skips() {
                 language: system
                 entry: python3 -c "exit(1)"
     "#});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().env("SKIP", "end-of-file-fixer"), @r"
     success: false
@@ -1600,7 +1601,7 @@ fn stage() {
                 entry: echo post-commit-stage
                 stages: [ post-commit ]
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     // By default, run hooks with `pre-commit` stage.
     cmd_snapshot!(context, context.run(), @r#"
@@ -1661,7 +1662,7 @@ fn fallback_to_manual_stage() {
                 entry: echo pre-push
                 stages: [ pre-push ]
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     // With pre-commit hooks present, default `prek run` stays on pre-commit.
     cmd_snapshot!(context, context.run(), @r"
@@ -1748,7 +1749,7 @@ fn files_and_exclude() -> Result<()> {
                 entry: python3 -c 'import sys; print(sys.argv[1:]); exit(1)'
                 types: [json]
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -1790,7 +1791,7 @@ fn files_and_exclude() -> Result<()> {
                 language: system
                 entry: python3 -c 'import sys; print(sys.argv[1:]); exit(1)'
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -1856,7 +1857,7 @@ fn file_types() -> Result<()> {
                 types: ["json" ]
                 exclude_types: ["json"]
     "#});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -1915,7 +1916,7 @@ fn fail_fast() {
                 entry: python3 -V
                 always_run: true
     "#});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -1954,7 +1955,7 @@ fn fail_fast_cli_flag() {
                 entry: python3 -c 'print("Passed")'
                 always_run: true
     "#});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -2003,7 +2004,7 @@ fn no_fail_fast_cli_flag() {
                 entry: python3 -c 'print("Passed")'
                 always_run: true
     "#});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -2054,7 +2055,7 @@ fn subdirectory() -> Result<()> {
                 always_run: true
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().current_dir(&child).arg("--files").arg("file.txt"), @r"
     success: false
@@ -2090,7 +2091,7 @@ fn global_path_options_expand_tilde() -> Result<()> {
     let context = TestEnv::new();
     let cd = context.home_dir().child("project");
     cd.create_dir_all()?;
-    context.git_at(&cd).arg("init").assert().success();
+    context.git_at(&cd).init();
     context
         .home_dir()
         .child("prek.toml")
@@ -2131,7 +2132,7 @@ fn log_file() -> Result<()> {
                 always_run: true
                 log_file: log.txt
     "#})?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("-c").arg(config_file.path()), @r#"
     success: false
@@ -2196,7 +2197,7 @@ fn staged_files_only() -> Result<()> {
         .work_dir()
         .child("file.txt")
         .write_str("Hello, world!")?;
-    context.git_add_all();
+    context.git().add_all();
 
     // Non-staged files should be stashed and restored.
     context
@@ -2239,11 +2240,12 @@ fn intent_to_add_file_survives_conflicted_stash_restore() -> Result<()> {
    "#});
 
     let cwd = context.work_dir();
-    context.git_add(PRE_COMMIT_CONFIG_YAML);
+    context.git().add(PRE_COMMIT_CONFIG_YAML);
 
     cwd.child("intent.txt").write_str("preserve me\n")?;
     context
         .git_at(cwd)
+        .command()
         .arg("add")
         .arg("--intent-to-add")
         .arg("intent.txt")
@@ -2251,7 +2253,7 @@ fn intent_to_add_file_survives_conflicted_stash_restore() -> Result<()> {
         .success();
 
     cwd.child("test.py").write_str("a=1\n")?;
-    context.git_add("test.py");
+    context.git().add("test.py");
     cwd.child("test.py").write_str("a=1\nb = 2\n")?;
 
     cmd_snapshot!(context, context.run(), @r#"
@@ -2273,6 +2275,7 @@ fn intent_to_add_file_survives_conflicted_stash_restore() -> Result<()> {
 
     let output = context
         .git_at(cwd)
+        .command()
         .arg("diff")
         .arg("--diff-filter=A")
         .arg("--name-only")
@@ -2306,7 +2309,7 @@ fn restore_on_interrupt() -> Result<()> {
         .work_dir()
         .child("file.txt")
         .write_str("Hello, world!")?;
-    context.git_add_all();
+    context.git().add_all();
 
     // Non-staged files should be stashed and restored.
     context
@@ -2346,33 +2349,20 @@ fn merge_conflicts() -> Result<()> {
     // Create a merge conflict.
     let cwd = context.work_dir();
     cwd.child("file.txt").write_str("Hello, world!")?;
-    context.git_add_all();
-    context.git_commit("Initial commit");
+    context.git().add_all().commit("Initial commit");
 
-    context
-        .git_at(cwd)
-        .arg("checkout")
-        .arg("-b")
-        .arg("feature")
-        .assert()
-        .success();
+    context.git().branch("feature").checkout("feature");
     cwd.child("file.txt").write_str("Hello, world again!")?;
-    context.git_add_all();
-    context.git_commit("Feature commit");
+    context.git().add_all().commit("Feature commit");
 
-    context
-        .git_at(cwd)
-        .arg("checkout")
-        .arg("master")
-        .assert()
-        .success();
+    context.git().checkout("master");
     cwd.child("file.txt")
         .write_str("Hello, world from master!")?;
-    context.git_add_all();
-    context.git_commit("Master commit");
+    context.git().add_all().commit("Master commit");
 
     context
         .git_at(cwd)
+        .command()
         .arg("merge")
         .arg("feature")
         .assert()
@@ -2400,7 +2390,7 @@ fn merge_conflicts() -> Result<()> {
     "#);
 
     // Fix the conflict and run again.
-    context.git_add_all();
+    context.git().add_all();
     cmd_snapshot!(context, context.run(), @r"
     success: true
     exit_code: 0
@@ -2430,7 +2420,7 @@ fn local_python_hook() {
                 entry: python3 -c 'import sys; print("Hello, world!"); sys.exit(1)'
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -2459,7 +2449,7 @@ fn invalid_entry() {
                 entry: '"'
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -2484,7 +2474,7 @@ fn init_nonexistent_repo() {
               - id: nonexistent
                 name: nonexistent
         "});
-    context.git_add_all();
+    context.git().add_all();
 
     let context = with_remote_fetch_error_filters(context);
 
@@ -2519,7 +2509,7 @@ fn skipped_remote_repo_is_not_cloned() {
             hooks:
               - id: ruff-check
         "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context,
         context.run().arg("--all-files").arg("--skip").arg("ruff-check"),
@@ -2550,9 +2540,11 @@ fn skipped_same_key_remote_repo_entry_is_not_initialized() -> Result<()> {
           always_run: true
     "})?;
 
-    hook_repo.git_add_all();
-    hook_repo.git_commit("Initial commit");
-    hook_repo.git_tag("v1.0.0");
+    hook_repo
+        .git()
+        .add_all()
+        .commit("Initial commit")
+        .tag("v1.0.0");
 
     let context = context.with_config(indoc::formatdoc! {r"
         repos:
@@ -2566,7 +2558,7 @@ fn skipped_same_key_remote_repo_entry_is_not_initialized() -> Result<()> {
             hooks:
               - id: test-hook
     ", repo = hook_repo.path().display()});
-    context.git_add_all();
+    context.git().add_all();
 
     context
         .run()
@@ -2594,7 +2586,7 @@ fn required_group_excluded_remote_repo_is_not_cloned() {
               - id: ruff-check
                 groups: [ci]
         "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context,
         context
@@ -2628,7 +2620,7 @@ fn unmatched_skip_does_not_suppress_remote_clone() {
             hooks:
               - id: ruff-check
         "});
-    context.git_add_all();
+    context.git().add_all();
 
     let context = with_remote_fetch_error_filters(context);
 
@@ -2672,7 +2664,7 @@ fn types_directory() -> Result<()> {
         .work_dir()
         .child("dir/file.txt")
         .write_str("Hello, world!")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -2730,15 +2722,13 @@ fn run_last_commit() -> Result<()> {
     cwd.child("file1.txt").write_str("Hello, world!\n")?;
     cwd.child("file2.txt")
         .write_str("Initial content with trailing spaces   \n")?; // This has issues but won't be in last commit
-    context.git_add_all();
-    context.git_commit("Initial commit");
+    context.git().add_all().commit("Initial commit");
 
     // Modify files and make second commit with trailing whitespace
     cwd.child("file1.txt").write_str("Hello, world!   \n")?; // trailing whitespace
     cwd.child("file3.txt").write_str("New file")?; // missing newline
     // Note: file2.txt is NOT modified in this commit, so it should be filtered out by --last-commit
-    context.git_add_all();
-    context.git_commit("Second commit with issues");
+    context.git().add_all().commit("Second commit with issues");
 
     // Run with --last-commit should only check files from the last commit
     // This should only process file1.txt and file3.txt, NOT file2.txt
@@ -2813,7 +2803,7 @@ fn run_multiple_files() -> Result<()> {
     let cwd = context.work_dir();
     cwd.child("file1.txt").write_str("Hello, world!")?;
     cwd.child("file2.txt").write_str("Hello, world!")?;
-    context.git_add_all();
+    context.git().add_all();
     // `--files` with multiple files
     cmd_snapshot!(context, context.run().arg("--files").arg("file1.txt").arg("file2.txt"), @r#"
     success: true
@@ -2852,7 +2842,7 @@ fn run_glob() -> Result<()> {
     cwd.child("src/nested/mod.rs")
         .write_str("pub mod nested;")?;
     cwd.child("docs/readme.md").write_str("# Readme")?;
-    context.git_add_all();
+    context.git().add_all();
     cwd.child("src/untracked.rs")
         .write_str("pub fn untracked() {}")?;
 
@@ -2916,7 +2906,7 @@ fn run_no_files() {
                 entry: echo
                 verbose: true
     "});
-    context.git_add_all();
+    context.git().add_all();
     // `--files` with no files
     cmd_snapshot!(context, context.run().arg("--files"), @r"
     success: true
@@ -2951,7 +2941,7 @@ fn run_directory() -> Result<()> {
     cwd.child("dir1/file.txt").write_str("Hello, world!")?;
     cwd.child("dir2").create_dir_all()?;
     cwd.child("dir2/file.txt").write_str("Hello, world!")?;
-    context.git_add_all();
+    context.git().add_all();
 
     // one `--directory`
     cmd_snapshot!(context, context.run().arg("--directory").arg("dir1"), @r"
@@ -3080,7 +3070,7 @@ fn minimum_prek_version() {
                 entry: echo
                 verbose: true
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @"
     success: false
@@ -3126,7 +3116,7 @@ fn color() -> Result<()> {
   "};
     context.work_dir().child("color.py").write_str(script)?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     // Run default. In integration tests, we don't have a TTY.
     // So this prints without color.
@@ -3190,7 +3180,7 @@ fn tty_output_preserves_color_without_replaying_terminal_controls() -> Result<()
         .child("terminal_output.py")
         .write_str(script)?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context,
         context.run().arg("--color=always"),
@@ -3238,7 +3228,7 @@ fn shebang_script() -> Result<()> {
               pass_filenames: false
               always_run: true
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -3287,13 +3277,12 @@ fn git_commit_a() -> Result<()> {
     ----- stderr -----
     "#);
 
-    context.git_add_all();
-    context.git_commit("Initial commit");
+    context.git().add_all().commit("Initial commit");
 
     // Edit the file
     file.write_str("Hello, world again!\n")?;
 
-    let mut commit = context.git_at(cwd);
+    let mut commit = context.git_at(cwd).command();
     commit.arg("commit").arg("-a").arg("-m").arg("Update file");
 
     cmd_snapshot!(context, commit, @r"
@@ -3371,14 +3360,13 @@ fn git_commit_a_currently_fails_when_hook_writes_to_temp_git_index() -> Result<(
     ----- stderr -----
     "#);
 
-    context.git_add_all();
-    context.git_commit("Initial commit");
+    context.git().add_all().commit("Initial commit");
 
     // `git commit` does not set `GIT_INDEX_FILE`; `git commit -a` does.
     // The repro only triggers on the `-a` path.
     file.write_str("Hello again!\n")?;
 
-    let mut commit = context.git_at(cwd);
+    let mut commit = context.git_at(cwd).command();
     commit.arg("commit").arg("-a").arg("-m").arg("Update file");
 
     cmd_snapshot!(context, commit, @r"
@@ -3630,7 +3618,7 @@ fn reuse_env() -> Result<()> {
             additional_dependencies: [{dependency}]
             verbose: true
     "#});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -3657,7 +3645,7 @@ fn reuse_env() -> Result<()> {
             pass_filenames: false
             verbose: true
     "#});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -3689,7 +3677,7 @@ fn dry_run() {
                 entry: fail
                 language: fail
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     // Run with `--dry-run`
     cmd_snapshot!(context, context.run().arg("--dry-run").arg("-v"), @r"
@@ -3724,7 +3712,7 @@ fn alternate_config_file() -> Result<()> {
                 language: python
                 entry: python3 -c 'import sys; print("Hello, world!")'
     "#})?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("-v"), @r"
     success: true
@@ -3751,7 +3739,7 @@ fn alternate_config_file() -> Result<()> {
                 language: python
                 entry: python3 -c 'import sys; print("Hello, world!")'
     "#})?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--refresh").arg("-v"), @r"
     success: true
@@ -3782,7 +3770,7 @@ fn alternate_config_file() -> Result<()> {
           }
         ]
     "#})?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--refresh").arg("-v"), @r"
     success: true
@@ -3821,7 +3809,7 @@ fn prek_toml() -> Result<()> {
           }
         ]
     "#})?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("-v"), @r"
     success: true
@@ -3872,7 +3860,7 @@ fn prek_toml_resolves_priority_aliases() -> Result<()> {
           },
         ]
     "#})?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -3907,7 +3895,7 @@ fn show_diff_on_failure() -> Result<()> {
         .work_dir()
         .child("file.txt")
         .write_str("Original line\n")?;
-    context.git_add_all();
+    context.git().add_all();
 
     // When failed in CI environment
     cmd_snapshot!(context, context.run().env(EnvVars::CI, "1").arg("--show-diff-on-failure").arg("-v"), @"
@@ -3939,7 +3927,7 @@ fn show_diff_on_failure() -> Result<()> {
         .work_dir()
         .child("file.txt")
         .write_str("Original line\n")?;
-    context.git_add_all();
+    context.git().add_all();
     // When failed in non-CI environment
     cmd_snapshot!(context, context.run().env_remove(EnvVars::CI).arg("--show-diff-on-failure").arg("-v"), @r"
     success: false
@@ -3967,7 +3955,7 @@ fn show_diff_on_failure() -> Result<()> {
     app.child("file.txt").write_str("Original line\n")?;
     app.child(PRE_COMMIT_CONFIG_YAML).write_str(config)?;
 
-    context.git_at(&app).arg("add").arg(".").assert().success();
+    context.git_at(&app).add(".");
 
     cmd_snapshot!(context, context.run().env_remove(EnvVars::CI).current_dir(&app).arg("--show-diff-on-failure"), @r"
     success: false
@@ -3988,7 +3976,7 @@ fn show_diff_on_failure() -> Result<()> {
     ----- stderr -----
     ");
 
-    context.git_add_all();
+    context.git().add_all();
 
     // Run in the root
     // Since we add a new subproject, use `--refresh` to find that.
@@ -4043,7 +4031,7 @@ fn run_quiet() {
                 entry: fail
                 language: fail
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     // Run with `--quiet`, only print failed hooks.
     cmd_snapshot!(context, context.run().arg("--quiet"), @r"
@@ -4087,7 +4075,7 @@ fn run_quiet_env() {
                 entry: fail
                 language: fail
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     // Run with `PREK_QUIET=1`, only print failed hooks.
     cmd_snapshot!(context, context.run().env(EnvVars::PREK_QUIET, "1"), @r"
@@ -4127,7 +4115,7 @@ fn run_log_file() {
                 entry: fail
                 language: fail
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     // Run with `--no-log-file`, no `prek.log` is created.
     cmd_snapshot!(context, context.run().arg("--no-log-file"), @r"
@@ -4207,7 +4195,7 @@ fn system_language_version() {
                 entry: dotnet --version
                 pass_filenames: false
    "});
-    context.git_add_all();
+    context.git().add_all();
 
     // Binaries can't be found, `system` must fail.
     cmd_snapshot!(context,
@@ -4280,7 +4268,7 @@ fn empty_entry() {
                 entry: ''
                 pass_filenames: false
    "});
-    context.git_add_all();
+    context.git().add_all();
 
     // Go and Node can't be found, `system` must fail.
     cmd_snapshot!(context, context.run(), @r"
@@ -4309,7 +4297,7 @@ fn run_with_stdin_closed() {
                 pass_filenames: false
                 verbose: true
     "#});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -4370,7 +4358,7 @@ fn expands_tilde_in_prek_home() -> Result<()> {
                 entry: echo ok
                 language: system
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     let fake_home = context.work_dir().child("fake-home");
     fake_home.create_dir_all()?;
@@ -4420,16 +4408,16 @@ fn run_with_tree_object_as_ref() -> Result<()> {
 
     // Create initial commit
     cwd.child("file1.txt").write_str("hello")?;
-    context.git_add_all();
-    context.git_commit("Initial commit");
+    context.git().add_all().commit("Initial commit");
 
     // Create some changes and stage them
     cwd.child("file2.txt").write_str("world")?;
-    context.git_add("file2.txt");
+    context.git().add("file2.txt");
 
     // Get the tree object from the staged changes
     let tree_output = context
         .git_at(cwd)
+        .command()
         .arg("write-tree")
         .output()
         .expect("Failed to run git write-tree");
@@ -4477,7 +4465,7 @@ fn pass_filenames_1_limits_batch_size() -> Result<()> {
     cwd.child("a.txt").write_str("a")?;
     cwd.child("b.txt").write_str("b")?;
     cwd.child("c.txt").write_str("c")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--all-files"), @r"
     success: true
@@ -4520,7 +4508,7 @@ fn pass_filenames_2_limits_batch_size() -> Result<()> {
     cwd.child("c.txt").write_str("c")?;
     cwd.child("d.txt").write_str("d")?;
     cwd.child("e.txt").write_str("e")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--all-files"), @r"
     success: true

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -30,7 +30,7 @@ fn with_remote_fetch_error_filters(context: TestEnv) -> TestEnv {
 
 #[test]
 fn run_basic() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/pre-commit/pre-commit-hooks
             rev: v5.0.0
@@ -98,7 +98,7 @@ fn run_basic() -> Result<()> {
 
 #[test]
 fn fast_path_checks_filenames_from_entry_and_args() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/pre-commit/pre-commit-hooks
             rev: v5.0.0
@@ -135,7 +135,7 @@ fn fast_path_checks_filenames_from_entry_and_args() -> Result<()> {
 
 #[test]
 fn run_preserves_stdout_stderr_order() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     context
         .work_dir()
@@ -183,7 +183,7 @@ fn run_preserves_stdout_stderr_order() -> Result<()> {
 
 #[test]
 fn hook_details_include_first_description_line() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -228,7 +228,7 @@ fn hook_details_include_first_description_line() {
 
 #[test]
 fn run_does_not_rewrite_unchanged_config_tracking_file() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -268,7 +268,7 @@ fn run_does_not_rewrite_unchanged_config_tracking_file() -> Result<()> {
 
 #[test]
 fn run_tracks_relative_config_as_absolute_path() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -307,7 +307,7 @@ fn run_tracks_relative_config_as_absolute_path() -> Result<()> {
 
 #[test]
 fn run_glob_patterns_with_multiple_hooks() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -361,7 +361,7 @@ fn run_glob_patterns_with_multiple_hooks() -> Result<()> {
 
 #[test]
 fn run_in_non_git_repo() {
-    let context = TestEnv::new_without_git().with_filter(
+    let context = TestEnv::new().with_filter(
         r"Command `[^`]*git(?:\.exe)? rev-parse --show-toplevel`",
         "Command `[GIT] rev-parse --show-toplevel`",
     );
@@ -384,7 +384,7 @@ fn run_in_non_git_repo() {
 
 #[test]
 fn invalid_config() {
-    let context = TestEnv::new().with_config("invalid: config");
+    let context = TestEnv::new_git().with_config("invalid: config");
     context.git_add_all();
 
     cmd_snapshot!(context, context.run(), @"
@@ -497,7 +497,7 @@ fn invalid_config() {
 /// Use same repo multiple times, with same or different revisions.
 #[test]
 fn same_repo() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/pre-commit/pre-commit-hooks
             rev: v5.0.0
@@ -543,7 +543,7 @@ fn same_repo() -> Result<()> {
 
 #[test]
 fn local() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -568,7 +568,7 @@ fn local() {
 
 #[test]
 fn hook_repo_placeholder_expands_to_local_project() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -597,7 +597,7 @@ fn hook_repo_placeholder_expands_to_local_project() -> Result<()> {
 
 #[test]
 fn hook_repo_placeholder_expands_to_remote_checkout() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     let hook_repo = context.create_repo("hook-repo-placeholder");
     hook_repo
         .path()
@@ -639,7 +639,7 @@ fn hook_repo_placeholder_expands_to_remote_checkout() -> Result<()> {
 /// Test multiple hook IDs scenarios.
 #[test]
 fn multiple_hook_ids() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -758,7 +758,7 @@ fn multiple_hook_ids() {
 
 #[test]
 fn run_displays_aliases_for_repeated_hook_ids() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -801,7 +801,7 @@ fn run_displays_aliases_for_repeated_hook_ids() {
 
 #[test]
 fn priorities_respected() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -841,7 +841,7 @@ fn priorities_respected() {
 
 #[test]
 fn priority_aliases_are_resolved_before_scheduling() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         priorities:
           early: 0
           late: 10
@@ -884,7 +884,7 @@ fn priority_aliases_are_resolved_before_scheduling() {
 
 #[test]
 fn run_group_without_stage_selects_hooks_across_stages() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -939,7 +939,7 @@ fn run_group_without_stage_selects_hooks_across_stages() {
 
 #[test]
 fn run_ungrouped_group_selects_hooks_without_groups() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -992,7 +992,7 @@ fn run_ungrouped_group_selects_hooks_without_groups() {
 
 #[test]
 fn run_required_group_without_stage_warns_when_only_message_file_hooks_match() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -1026,7 +1026,7 @@ fn run_required_group_without_stage_warns_when_only_message_file_hooks_match() {
 
 #[test]
 fn run_no_group_excludes_matching_hooks_and_keeps_ungrouped_hooks() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -1057,7 +1057,7 @@ fn run_no_group_excludes_matching_hooks_and_keeps_ungrouped_hooks() {
 
 #[test]
 fn run_group_exclusion_wins_over_inclusion() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -1089,7 +1089,7 @@ fn run_group_exclusion_wins_over_inclusion() {
 
 #[test]
 fn run_required_groups_intersect_and_compose_with_other_group_filters() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -1200,7 +1200,7 @@ fn run_required_groups_intersect_and_compose_with_other_group_filters() {
 
 #[test]
 fn run_unknown_group_selectors_warn_and_empty_selection_fails() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -1237,7 +1237,7 @@ fn run_unknown_group_selectors_warn_and_empty_selection_fails() {
 
 #[test]
 fn run_group_selectors_reject_invalid_names() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -1284,7 +1284,7 @@ fn run_group_selectors_reject_invalid_names() {
 
 #[test]
 fn run_required_group_and_stage_filters_intersect() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -1325,7 +1325,7 @@ fn run_required_group_and_stage_filters_intersect() {
 
 #[test]
 fn priority_fail_fast_stops_later_groups() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -1367,7 +1367,7 @@ fn priority_fail_fast_stops_later_groups() {
 
 #[test]
 fn priority_group_modified_files_is_group_failure_and_output_is_indented() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let cwd = context.work_dir();
     cwd.child("file.txt").write_str("hello\n")?;
@@ -1436,7 +1436,7 @@ fn priority_group_modified_files_is_group_failure_and_output_is_indented() -> Re
 /// `.pre-commit-config.yaml` is not staged.
 #[test]
 fn config_not_staged() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     context.work_dir().child(PRE_COMMIT_CONFIG_YAML).touch()?;
     context.git_add_all();
@@ -1466,7 +1466,7 @@ fn config_not_staged() -> Result<()> {
 /// `.pre-commit-config.yaml` outside the repository should not be checked.
 #[test]
 fn config_outside_repo() -> Result<()> {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
 
     // Initialize a git repository in ./work.
     let root = context.work_dir().child("work");
@@ -1502,7 +1502,7 @@ fn config_outside_repo() -> Result<()> {
 /// Test the output format for a hook with a CJK name.
 #[test]
 fn cjk_hook_name() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -1532,7 +1532,7 @@ fn cjk_hook_name() {
 /// Skips hooks based on the `SKIP` environment variable.
 #[test]
 fn skips() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -1580,7 +1580,7 @@ fn skips() {
 /// Run hooks with matched `stage`.
 #[test]
 fn stage() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -1637,7 +1637,7 @@ fn stage() {
 
 #[test]
 fn fallback_to_manual_stage() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -1718,7 +1718,7 @@ fn fallback_to_manual_stage() {
 /// Test global `files`, `exclude`, and hook level `files`, `exclude`.
 #[test]
 fn files_and_exclude() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let cwd = context.work_dir();
     cwd.child("file.txt").write_str("Hello, world!  \n")?;
@@ -1817,7 +1817,7 @@ fn files_and_exclude() -> Result<()> {
 /// Test selecting files by type, `types`, `types_or`, and `exclude_types`.
 #[test]
 fn file_types() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let cwd = context.work_dir();
     cwd.child("file.txt").write_str("Hello, world!  ")?;
@@ -1888,7 +1888,7 @@ fn file_types() -> Result<()> {
 /// Abort the run if a hook fails.
 #[test]
 fn fail_fast() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -1939,7 +1939,7 @@ fn fail_fast() {
 /// Test --fail-fast CLI flag stops execution after first failure.
 #[test]
 fn fail_fast_cli_flag() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -1987,7 +1987,7 @@ fn fail_fast_cli_flag() {
 /// Test --no-fail-fast CLI flag overrides config-level `fail_fast`.
 #[test]
 fn no_fail_fast_cli_flag() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         fail_fast: true
         repos:
           - repo: local
@@ -2036,7 +2036,7 @@ fn no_fail_fast_cli_flag() {
 /// Run from a subdirectory. File arguments should be fixed to be relative to the root.
 #[test]
 fn subdirectory() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let cwd = context.work_dir();
     let child = cwd.child("foo/bar/baz");
@@ -2087,7 +2087,7 @@ fn subdirectory() -> Result<()> {
 
 #[test]
 fn global_path_options_expand_tilde() -> Result<()> {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
     let cd = context.home_dir().child("project");
     cd.create_dir_all()?;
     context.git_at(&cd).arg("init").assert().success();
@@ -2115,7 +2115,7 @@ fn global_path_options_expand_tilde() -> Result<()> {
 /// Test hook `log_file` option.
 #[test]
 fn log_file() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let config_dir = context.work_dir().child("config");
     config_dir.create_dir_all()?;
@@ -2153,7 +2153,7 @@ fn log_file() -> Result<()> {
 /// Pass pre-commit environment variables to the hook.
 #[test]
 fn pass_env_vars() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -2180,7 +2180,7 @@ fn pass_env_vars() {
 
 #[test]
 fn staged_files_only() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -2227,7 +2227,7 @@ fn staged_files_only() -> Result<()> {
 
 #[test]
 fn intent_to_add_file_survives_conflicted_stash_restore() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -2288,7 +2288,7 @@ fn intent_to_add_file_survives_conflicted_stash_restore() -> Result<()> {
 #[cfg(unix)]
 #[test]
 fn restore_on_interrupt() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     // The hook will sleep for 3 seconds.
     let context = context.with_config(indoc::indoc! {r#"
         repos:
@@ -2341,7 +2341,7 @@ fn restore_on_interrupt() -> Result<()> {
 /// When in merge conflict, runs on files that have conflicts fixed.
 #[test]
 fn merge_conflicts() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Create a merge conflict.
     let cwd = context.work_dir();
@@ -2420,7 +2420,7 @@ fn merge_conflicts() -> Result<()> {
 /// Local python hook with no additional dependencies.
 #[test]
 fn local_python_hook() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -2449,7 +2449,7 @@ fn local_python_hook() {
 /// Invalid `entry`
 #[test]
 fn invalid_entry() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -2476,7 +2476,7 @@ fn invalid_entry() {
 /// Initialize a repo that does not exist.
 #[test]
 fn init_nonexistent_repo() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: https://notexistentatallnevergonnahappen.com/nonexistent/repo
             rev: v1.0.0
@@ -2508,7 +2508,7 @@ fn init_nonexistent_repo() {
 
 #[test]
 fn skipped_remote_repo_is_not_cloned() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -2536,7 +2536,7 @@ fn skipped_remote_repo_is_not_cloned() {
 
 #[test]
 fn skipped_same_key_remote_repo_entry_is_not_initialized() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     let hook_repo = context.create_repo("duplicate-key-hook");
 
     hook_repo
@@ -2581,7 +2581,7 @@ fn skipped_same_key_remote_repo_entry_is_not_initialized() -> Result<()> {
 
 #[test]
 fn required_group_excluded_remote_repo_is_not_cloned() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -2617,7 +2617,7 @@ fn required_group_excluded_remote_repo_is_not_cloned() {
 
 #[test]
 fn unmatched_skip_does_not_suppress_remote_clone() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -2657,7 +2657,7 @@ fn unmatched_skip_does_not_suppress_remote_clone() {
 /// Test hooks that specifies `types: [directory]`.
 #[test]
 fn types_directory() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -2715,7 +2715,7 @@ fn types_directory() -> Result<()> {
 
 #[test]
 fn run_last_commit() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/pre-commit/pre-commit-hooks
             rev: v5.0.0
@@ -2799,7 +2799,7 @@ fn run_last_commit() -> Result<()> {
 /// Test `prek run --files` with multiple files.
 #[test]
 fn run_multiple_files() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -2833,7 +2833,7 @@ fn run_multiple_files() -> Result<()> {
 /// Test `prek run --glob` and its interaction with other explicit file selectors.
 #[test]
 fn run_glob() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -2906,7 +2906,7 @@ fn run_glob() -> Result<()> {
 /// Test `prek run --files` with no files.
 #[test]
 fn run_no_files() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -2935,7 +2935,7 @@ fn run_no_files() {
 /// Test `prek run --directory` flags.
 #[test]
 fn run_directory() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -3064,7 +3064,7 @@ fn run_directory() -> Result<()> {
 /// Test `minimum_prek_version` option.
 #[test]
 fn minimum_prek_version() {
-    let context = TestEnv::new()
+    let context = TestEnv::new_git()
         .with_filter(
             r"but version `\d+\.\d+\.\d+(?:-[0-9A-Za-z]+(?:\.[0-9A-Za-z]+)*)?` is installed",
             "but version `[CURRENT_VERSION]` is installed",
@@ -3104,7 +3104,7 @@ fn minimum_prek_version() {
 #[test]
 #[cfg(not(windows))]
 fn color() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
       repos:
         - repo: local
           hooks:
@@ -3163,7 +3163,7 @@ fn color() -> Result<()> {
 #[test]
 #[cfg(not(windows))]
 fn tty_output_preserves_color_without_replaying_terminal_controls() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
       repos:
         - repo: local
           hooks:
@@ -3215,7 +3215,7 @@ fn tty_output_preserves_color_without_replaying_terminal_controls() -> Result<()
 /// Test running hook whose `entry` is script with shebang on Windows.
 #[test]
 fn shebang_script() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Create a script with shebang.
     let script = indoc::indoc! {r"
@@ -3259,7 +3259,8 @@ fn shebang_script() -> Result<()> {
 /// Test `git commit -a` works without `.git/index.lock exists` error.
 #[test]
 fn git_commit_a() -> Result<()> {
-    let context = TestEnv::new().with_filter("7c8398204bbc95c33a6d2543f86a27621647cf78", "[HASH]");
+    let context =
+        TestEnv::new_git().with_filter("7c8398204bbc95c33a6d2543f86a27621647cf78", "[HASH]");
 
     let context = context.with_config(indoc::indoc! {r"
         repos:
@@ -3316,7 +3317,7 @@ fn git_commit_a() -> Result<()> {
 #[cfg(unix)]
 #[test]
 fn git_commit_a_currently_fails_when_hook_writes_to_temp_git_index() -> Result<()> {
-    let context = TestEnv::new().with_filter(
+    let context = TestEnv::new_git().with_filter(
         r"invalid object 100644 [0-9a-f]{40}",
         "invalid object 100644 [HASH]",
     );
@@ -3426,7 +3427,7 @@ fn write_project_config(path: &Path, hooks: &[(&str, &str)]) -> Result<()> {
 #[cfg(unix)]
 #[test]
 fn selectors_completion() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     let cwd = context.work_dir();
 
     // Root project with regular and colon-containing hook ids
@@ -3599,7 +3600,7 @@ fn selectors_completion() -> Result<()> {
 /// Test reusing hook environments only when dependencies are exactly same. (ignore order)
 #[test]
 fn reuse_env() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let pkg_dir = context.work_dir().child("local_pkg");
     pkg_dir.create_dir_all()?;
@@ -3679,7 +3680,7 @@ fn reuse_env() -> Result<()> {
 
 #[test]
 fn dry_run() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -3709,7 +3710,7 @@ fn dry_run() {
 /// Supports reading `pre-commit-config.yml` as well.
 #[test]
 fn alternate_config_file() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     context
         .work_dir()
@@ -3803,7 +3804,7 @@ fn alternate_config_file() -> Result<()> {
 /// Supports `prek.toml` as configuration file.
 #[test]
 fn prek_toml() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     context
         .work_dir()
@@ -3840,7 +3841,7 @@ fn prek_toml() -> Result<()> {
 
 #[test]
 fn prek_toml_resolves_priority_aliases() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     context
         .work_dir()
@@ -3889,7 +3890,7 @@ fn prek_toml_resolves_priority_aliases() -> Result<()> {
 #[test]
 fn show_diff_on_failure() -> Result<()> {
     let context =
-        TestEnv::new().with_filter(r"index \w{7}\.\.\w{7} \d{6}", "index [OLD]..[NEW] 100644");
+        TestEnv::new_git().with_filter(r"index \w{7}\.\.\w{7} \d{6}", "index [OLD]..[NEW] 100644");
 
     let config = indoc::indoc! {r#"
         repos:
@@ -4029,7 +4030,7 @@ fn show_diff_on_failure() -> Result<()> {
 
 #[test]
 fn run_quiet() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -4073,7 +4074,7 @@ fn run_quiet() {
 /// Test `PREK_QUIET` environment variable.
 #[test]
 fn run_quiet_env() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -4117,7 +4118,7 @@ fn run_quiet_env() {
 /// Test `prek run --log-file <file>` flag.
 #[test]
 fn run_log_file() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -4177,7 +4178,7 @@ fn system_language_version() {
         return;
     }
 
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -4269,7 +4270,7 @@ fn system_language_version() {
 /// Tests that empty `entry` field.
 #[test]
 fn empty_entry() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -4297,7 +4298,7 @@ fn empty_entry() {
 /// Test that hooks are run with stdin closed.
 #[test]
 fn run_with_stdin_closed() {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -4344,7 +4345,7 @@ fn version_info() {
     if option_env!("PREK_COMMIT_HASH").is_none() {
         return;
     }
-    let context = TestEnv::new_without_git().with_filter(
+    let context = TestEnv::new().with_filter(
         r"prek \d+\.\d+\.\d+(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)?(\+\d+)? \(\w{9} [\d\-T:\.]+\)",
         "prek [CURRENT_VERSION] ([COMMIT] [DATE])",
     );
@@ -4360,7 +4361,7 @@ fn version_info() {
 
 #[test]
 fn expands_tilde_in_prek_home() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -4404,7 +4405,7 @@ fn expands_tilde_in_prek_home() -> Result<()> {
 
 #[test]
 fn run_with_tree_object_as_ref() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -4455,7 +4456,7 @@ fn run_with_tree_object_as_ref() -> Result<()> {
 /// With n=1, each matched file gets its own invocation.
 #[test]
 fn pass_filenames_1_limits_batch_size() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Use a script that errors if it receives more than one filename argument.
     let context = context.with_config(indoc::indoc! {r#"
@@ -4496,7 +4497,7 @@ fn pass_filenames_1_limits_batch_size() -> Result<()> {
 /// With n=2 and more than 2 matching files, multiple batches are spawned.
 #[test]
 fn pass_filenames_2_limits_batch_size() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Use a script that errors if it receives more than two filename arguments.
     let context = context.with_config(indoc::indoc! {r#"

--- a/crates/prek/tests/sample_config.rs
+++ b/crates/prek/tests/sample_config.rs
@@ -6,7 +6,7 @@ mod common;
 
 #[test]
 fn sample_config() -> anyhow::Result<()> {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
 
     cmd_snapshot!(context, context.sample_config(), @"
     success: true
@@ -99,7 +99,7 @@ fn sample_config() -> anyhow::Result<()> {
 
 #[test]
 fn sample_config_toml() {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
 
     cmd_snapshot!(context, context.sample_config().arg("-f").arg("prek.toml"), @r#"
     success: true
@@ -127,7 +127,7 @@ fn sample_config_toml() {
 
 #[test]
 fn sample_config_format() {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
 
     cmd_snapshot!(context, context.sample_config().arg("--format").arg("toml"), @r#"
     success: true
@@ -181,7 +181,7 @@ fn sample_config_format() {
 
 #[test]
 fn respect_format() {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
 
     // Write YAML format even with `.toml` extension.
     cmd_snapshot!(context, context.sample_config().arg("--format").arg("yaml").arg("-f").arg("prek.toml"), @"
@@ -209,7 +209,7 @@ fn respect_format() {
 
 #[test]
 fn respect_format_if_filename_missing() {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
 
     // Create `prek.toml` when TOML format is specified but filename is not given.
     cmd_snapshot!(context, context.sample_config().arg("--format").arg("toml").arg("-f"), @"

--- a/crates/prek/tests/skipped_hooks.rs
+++ b/crates/prek/tests/skipped_hooks.rs
@@ -42,7 +42,7 @@ fn remove_loose_blob(context: &TestEnv, filename: &str) -> Result<()> {
 /// All hooks skip when no staged files match their file patterns.
 #[test]
 fn all_hooks_skipped_no_matching_files() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -88,7 +88,7 @@ fn all_hooks_skipped_no_matching_files() -> Result<()> {
 /// Installable hooks with no matching files should not create environments.
 #[test]
 fn skipped_installable_hook_does_not_install_env() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -121,7 +121,7 @@ fn skipped_installable_hook_does_not_install_env() -> Result<()> {
 /// Installable hooks excluded by group selection should not create environments.
 #[test]
 fn group_excluded_installable_hook_does_not_install_env() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -158,7 +158,7 @@ fn group_excluded_installable_hook_does_not_install_env() -> Result<()> {
 /// `always_run` installable hooks still install and run without matching files.
 #[test]
 fn always_run_installable_hook_installs_without_matching_files() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -193,7 +193,7 @@ fn always_run_installable_hook_installs_without_matching_files() -> Result<()> {
 /// `--dry-run` skips hooks without executing them.
 #[test]
 fn dry_run_skips_all_hooks() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -232,7 +232,7 @@ fn dry_run_skips_all_hooks() -> Result<()> {
 /// Hooks that match staged files run; others are skipped.
 #[test]
 fn mixed_skipped_and_executed_hooks() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -275,7 +275,7 @@ fn mixed_skipped_and_executed_hooks() -> Result<()> {
 /// Skipped hooks in untouched workspace projects should not install environments.
 #[test]
 fn skipped_workspace_project_installable_hook_does_not_install_env() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let cwd = context.work_dir();
     let proj_a = cwd.child("proj-a");
@@ -334,7 +334,7 @@ fn skipped_workspace_project_installable_hook_does_not_install_env() -> Result<(
 
 #[test]
 fn orphan_project_early_match_still_hides_child_files_from_parent_install() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let cwd = context.work_dir();
     let child = cwd.child("child");
@@ -396,7 +396,7 @@ fn orphan_project_early_match_still_hides_child_files_from_parent_install() -> R
 /// contains non-deterministic timestamps and timing data unsuitable for snapshots.
 #[test]
 fn all_hooks_skipped_multiple_priority_groups() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -450,7 +450,7 @@ fn all_hooks_skipped_multiple_priority_groups() -> Result<()> {
 
 #[test]
 fn external_hook_without_changes_uses_quiet_diff_check() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -490,7 +490,7 @@ fn external_hook_without_changes_uses_quiet_diff_check() -> Result<()> {
 #[test]
 #[cfg(unix)]
 fn identical_rewrite_with_stat_change_is_not_modified() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -549,7 +549,7 @@ fn identical_rewrite_with_stat_change_is_not_modified() -> Result<()> {
 
 #[test]
 fn modifying_hook_uses_clean_baseline_diff_detection() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -595,7 +595,7 @@ fn modifying_hook_uses_clean_baseline_diff_detection() -> Result<()> {
 
 #[test]
 fn binary_diff_snapshots_use_full_object_ids() -> Result<()> {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
     let cwd = context.work_dir();
     let status = context
         .git_at(cwd)
@@ -658,7 +658,7 @@ fn binary_diff_snapshots_use_full_object_ids() -> Result<()> {
 
 #[test]
 fn all_files_with_existing_unstaged_changes_uses_snapshot_baseline() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -710,7 +710,7 @@ fn all_files_with_existing_unstaged_changes_uses_snapshot_baseline() -> Result<(
 
 #[test]
 fn all_files_clean_missing_blob_ignores_diff_snapshot_errors() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -772,7 +772,7 @@ fn all_files_clean_missing_blob_ignores_diff_snapshot_errors() -> Result<()> {
 
 #[test]
 fn later_project_snapshots_diff_left_by_previous_project() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let cwd = context.work_dir();
     let child = cwd.child("child");
@@ -834,7 +834,7 @@ fn later_project_snapshots_diff_left_by_previous_project() -> Result<()> {
 
 #[test]
 fn read_only_builtin_hook_does_not_run_diff_detection() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -868,7 +868,7 @@ fn read_only_builtin_hook_does_not_run_diff_detection() -> Result<()> {
 
 #[test]
 fn read_only_languages_do_not_run_diff_detection() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -921,7 +921,7 @@ fn read_only_languages_do_not_run_diff_detection() -> Result<()> {
 
 #[test]
 fn same_group_known_modification_skips_diff_detection() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: builtin
             hooks:
@@ -976,7 +976,7 @@ fn same_group_known_modification_skips_diff_detection() -> Result<()> {
 
 #[test]
 fn same_group_known_modification_rebaselines_later_external_hook() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: builtin
             hooks:
@@ -1037,7 +1037,7 @@ fn same_group_known_modification_rebaselines_later_external_hook() -> Result<()>
 
 #[test]
 fn modifying_builtin_invalidates_baseline_for_later_external_hook() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
         repos:
           - repo: builtin
             hooks:
@@ -1091,7 +1091,7 @@ fn modifying_builtin_invalidates_baseline_for_later_external_hook() -> Result<()
 
 #[test]
 fn failed_non_modifying_builtin_skips_diff_detection() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:

--- a/crates/prek/tests/skipped_hooks.rs
+++ b/crates/prek/tests/skipped_hooks.rs
@@ -26,7 +26,12 @@ fn hook_env_count(context: &TestEnv) -> Result<usize> {
 
 fn remove_loose_blob(context: &TestEnv, filename: &str) -> Result<()> {
     let cwd = context.work_dir();
-    let output = context.git().arg("hash-object").arg(filename).output()?;
+    let output = context
+        .git()
+        .command()
+        .arg("hash-object")
+        .arg(filename)
+        .output()?;
     assert!(output.status.success(), "git hash-object should succeed");
     let blob = String::from_utf8(output.stdout)?;
     let blob = blob.trim_ascii();
@@ -69,7 +74,7 @@ fn all_hooks_skipped_no_matching_files() -> Result<()> {
     cwd.child("data.json").write_str("{}")?;
     cwd.child("config.yaml").write_str("key: value")?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -102,7 +107,7 @@ fn skipped_installable_hook_does_not_install_env() -> Result<()> {
     let cwd = context.work_dir();
 
     cwd.child("README.md").write_str("Hello")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -139,7 +144,7 @@ fn group_excluded_installable_hook_does_not_install_env() -> Result<()> {
                 groups: [slow]
     "#});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--all-files").arg("--group").arg("ci"), @r#"
     success: true
@@ -174,7 +179,7 @@ fn always_run_installable_hook_installs_without_matching_files() -> Result<()> {
     let cwd = context.work_dir();
 
     cwd.child("README.md").write_str("Hello")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -212,7 +217,7 @@ fn dry_run_skips_all_hooks() -> Result<()> {
     let cwd = context.work_dir();
 
     cwd.child("file.txt").write_str("content")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--dry-run"), @r#"
     success: true
@@ -256,7 +261,7 @@ fn mixed_skipped_and_executed_hooks() -> Result<()> {
     let cwd = context.work_dir();
 
     cwd.child("readme.txt").write_str("Hello")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -319,7 +324,7 @@ fn skipped_workspace_project_installable_hook_does_not_install_env() -> Result<(
     "#})?;
 
     proj_a.child("README.txt").write_str("Hello")?;
-    context.git_add_all();
+    context.git().add_all();
 
     let output = context.run().output()?;
     assert!(output.status.success(), "prek should succeed");
@@ -366,7 +371,7 @@ fn orphan_project_early_match_still_hides_child_files_from_parent_install() -> R
     "#})?;
 
     child.child("child.py").write_str("print('child')\n")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--all-files"), @r#"
     success: true
@@ -423,7 +428,7 @@ fn all_hooks_skipped_multiple_priority_groups() -> Result<()> {
     let cwd = context.work_dir();
 
     cwd.child("data.json").write_str("{}")?;
-    context.git_add_all();
+    context.git().add_all();
 
     // Run with trace logging to verify #1335 fix
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
@@ -464,7 +469,7 @@ fn external_hook_without_changes_uses_quiet_diff_check() -> Result<()> {
     let cwd = context.work_dir();
 
     cwd.child("file.txt").write_str("original\n")?;
-    context.git_add_all();
+    context.git().add_all();
 
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
 
@@ -516,7 +521,7 @@ fn identical_rewrite_with_stat_change_is_not_modified() -> Result<()> {
     "})?;
 
     cwd.child("file.txt").write_str("original\n")?;
-    context.git_add_all();
+    context.git().add_all();
 
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
 
@@ -563,7 +568,7 @@ fn modifying_hook_uses_clean_baseline_diff_detection() -> Result<()> {
     let cwd = context.work_dir();
 
     cwd.child("file.txt").write_str("original\n")?;
-    context.git_add_all();
+    context.git().add_all();
 
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
 
@@ -599,6 +604,7 @@ fn binary_diff_snapshots_use_full_object_ids() -> Result<()> {
     let cwd = context.work_dir();
     let status = context
         .git_at(cwd)
+        .command()
         .args(["init", "--object-format=sha1"])
         .status()?;
     assert!(
@@ -631,10 +637,11 @@ fn binary_diff_snapshots_use_full_object_ids() -> Result<()> {
     cwd.child(".gitattributes")
         .write_str("binary.dat -diff\n")?;
     cwd.child("binary.dat").write_str("original\n")?;
-    context.git_add_all();
+    context.git().add_all();
 
     let status = context
         .git_at(cwd)
+        .command()
         .args(["config", "core.abbrev", "7"])
         .status()?;
     assert!(status.success(), "setting core.abbrev should succeed");
@@ -673,7 +680,7 @@ fn all_files_with_existing_unstaged_changes_uses_snapshot_baseline() -> Result<(
 
     cwd.child("file.txt").write_str("original\n")?;
     cwd.child("hook.txt").write_str("original\n")?;
-    context.git_add_all();
+    context.git().add_all();
     cwd.child("file.txt").write_str("unstaged\n")?;
 
     let output = context
@@ -724,8 +731,7 @@ fn all_files_clean_missing_blob_ignores_diff_snapshot_errors() -> Result<()> {
     let cwd = context.work_dir();
 
     cwd.child("file.txt").write_str("original\n")?;
-    context.git_add_all();
-    context.git_commit("init");
+    context.git().add_all().commit("init");
 
     remove_loose_blob(&context, "file.txt")?;
 
@@ -804,7 +810,7 @@ fn later_project_snapshots_diff_left_by_previous_project() -> Result<()> {
     "#})?;
 
     child.child("child.txt").write_str("original\n")?;
-    context.git_add_all();
+    context.git().add_all();
 
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
 
@@ -845,7 +851,7 @@ fn read_only_builtin_hook_does_not_run_diff_detection() -> Result<()> {
 
     cwd.child("pyproject.toml")
         .write_str("[project]\nname = \"demo\"\n")?;
-    context.git_add_all();
+    context.git().add_all();
 
     let output = context
         .run()
@@ -887,7 +893,7 @@ fn read_only_languages_do_not_run_diff_detection() -> Result<()> {
     let cwd = context.work_dir();
 
     cwd.child("file.txt").write_str("original\n")?;
-    context.git_add_all();
+    context.git().add_all();
 
     let output = context
         .run()
@@ -940,7 +946,7 @@ fn same_group_known_modification_skips_diff_detection() -> Result<()> {
     let cwd = context.work_dir();
 
     cwd.child("file.txt").write_str("missing newline")?;
-    context.git_add_all();
+    context.git().add_all();
 
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
 
@@ -1001,7 +1007,7 @@ fn same_group_known_modification_rebaselines_later_external_hook() -> Result<()>
     let cwd = context.work_dir();
 
     cwd.child("file.txt").write_str("missing newline")?;
-    context.git_add_all();
+    context.git().add_all();
 
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
 
@@ -1056,7 +1062,7 @@ fn modifying_builtin_invalidates_baseline_for_later_external_hook() -> Result<()
     let cwd = context.work_dir();
 
     cwd.child("file.txt").write_str("missing newline")?;
-    context.git_add_all();
+    context.git().add_all();
 
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
 
@@ -1102,7 +1108,7 @@ fn failed_non_modifying_builtin_skips_diff_detection() -> Result<()> {
     let cwd = context.work_dir();
 
     cwd.child("mixed.txt").write_str("first\r\nsecond\n")?;
-    context.git_add_all();
+    context.git().add_all();
 
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
 

--- a/crates/prek/tests/try_repo.rs
+++ b/crates/prek/tests/try_repo.rs
@@ -35,8 +35,7 @@ fn create_hook_repo(context: &TestEnv, repo_name: &str) -> Result<PathBuf> {
         .child("setup.py")
         .write_str("from setuptools import setup; setup(name='dummy-pkg', version='0.0.1')")?;
 
-    repo.git_add_all();
-    repo.git_commit("Initial commit");
+    repo.git_add_all().git_commit("Initial commit");
 
     Ok(repo.path().to_path_buf())
 }
@@ -54,17 +53,14 @@ fn create_failing_hook_repo(context: &TestEnv, repo_name: &str) -> Result<PathBu
           language: system
         "#})?;
 
-    repo.git_add_all();
-    repo.git_commit("Initial commit");
+    repo.git_add_all().git_commit("Initial commit");
 
     Ok(repo.path().to_path_buf())
 }
 
 #[test]
 fn try_repo_basic() -> Result<()> {
-    let context = TestEnv::new();
-
-    context.work_dir().child("test.txt").write_str("test")?;
+    let context = TestEnv::new_git().with_file("test.txt", "test");
     context.git_add_all();
 
     let repo_path = create_hook_repo(&context, "try-repo-basic")?;
@@ -93,9 +89,7 @@ fn try_repo_basic() -> Result<()> {
 
 #[test]
 fn try_repo_failing_hook() -> Result<()> {
-    let context = TestEnv::new();
-
-    context.work_dir().child("test.txt").write_str("test")?;
+    let context = TestEnv::new_git().with_file("test.txt", "test");
     context.git_add_all();
 
     let repo_path = create_failing_hook_repo(&context, "try-repo-failing")?;
@@ -126,11 +120,10 @@ fn try_repo_failing_hook() -> Result<()> {
 
 #[test]
 fn try_repo_specific_hook() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git().with_file("test.txt", "test");
 
     let repo_path = create_hook_repo(&context, "try-repo-specific-hook")?;
 
-    context.work_dir().child("test.txt").write_str("test")?;
     context.git_add_all();
 
     let context = with_try_repo_filters(context);
@@ -157,9 +150,7 @@ fn try_repo_specific_hook() -> Result<()> {
 
 #[test]
 fn try_repo_specific_rev() -> Result<()> {
-    let context = TestEnv::new();
-
-    context.work_dir().child("test.txt").write_str("test")?;
+    let context = TestEnv::new_git().with_file("test.txt", "test");
     context.git_add_all();
 
     let repo_path = create_hook_repo(&context, "try-repo-specific-rev")?;
@@ -223,7 +214,7 @@ fn try_repo_specific_rev() -> Result<()> {
 
 #[test]
 fn try_repo_uncommitted_changes() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_hook_repo(&context, "try-repo-uncommitted")?;
 
@@ -246,7 +237,7 @@ fn try_repo_uncommitted_changes() -> Result<()> {
         .assert()
         .success();
 
-    context.work_dir().child("test.txt").write_str("test")?;
+    context.write_file("test.txt", "test");
     context.git_add_all();
 
     let context = context.with_filters([
@@ -278,9 +269,7 @@ fn try_repo_uncommitted_changes() -> Result<()> {
 
 #[test]
 fn try_repo_relative_path() -> Result<()> {
-    let context = TestEnv::new();
-
-    context.work_dir().child("test.txt").write_str("test")?;
+    let context = TestEnv::new_git().with_file("test.txt", "test");
     context.git_add_all();
 
     let _repo_path = create_hook_repo(&context, "try-repo-relative")?;
@@ -312,7 +301,7 @@ fn try_repo_relative_path() -> Result<()> {
 
 #[test]
 fn try_repo_dot_path() -> Result<()> {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
     let repo_path = create_hook_repo(&context, "try-repo-dot")?;
 
     ChildPath::new(&repo_path)
@@ -357,10 +346,8 @@ fn try_repo_dot_path() -> Result<()> {
 }
 
 #[test]
-fn try_repo_builtin_hook() -> Result<()> {
-    let context = TestEnv::new();
-
-    context.work_dir().child("test.txt").write_str("test\n")?;
+fn try_repo_builtin_hook() {
+    let context = TestEnv::new_git().with_file("test.txt", "test\n");
     context.git_add_all();
 
     cmd_snapshot!(context, context.try_repo().arg("builtin").arg("check-merge-conflict").arg("--all-files"), @r#"
@@ -378,15 +365,11 @@ fn try_repo_builtin_hook() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
-fn try_repo_meta_hook() -> Result<()> {
-    let context = TestEnv::new();
-
-    context.work_dir().child("test.txt").write_str("test\n")?;
+fn try_repo_meta_hook() {
+    let context = TestEnv::new_git().with_file("test.txt", "test\n");
     context.git_add_all();
 
     cmd_snapshot!(context, context.try_repo().arg("meta").arg("identity").arg("--all-files"), @r#"
@@ -408,6 +391,4 @@ fn try_repo_meta_hook() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }

--- a/crates/prek/tests/try_repo.rs
+++ b/crates/prek/tests/try_repo.rs
@@ -1,7 +1,6 @@
 mod common;
 
 use anyhow::Result;
-use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
 use std::path::PathBuf;
 
@@ -35,7 +34,7 @@ fn create_hook_repo(context: &TestEnv, repo_name: &str) -> Result<PathBuf> {
         .child("setup.py")
         .write_str("from setuptools import setup; setup(name='dummy-pkg', version='0.0.1')")?;
 
-    repo.git_add_all().git_commit("Initial commit");
+    repo.git().add_all().commit("Initial commit");
 
     Ok(repo.path().to_path_buf())
 }
@@ -53,7 +52,7 @@ fn create_failing_hook_repo(context: &TestEnv, repo_name: &str) -> Result<PathBu
           language: system
         "#})?;
 
-    repo.git_add_all().git_commit("Initial commit");
+    repo.git().add_all().commit("Initial commit");
 
     Ok(repo.path().to_path_buf())
 }
@@ -61,7 +60,7 @@ fn create_failing_hook_repo(context: &TestEnv, repo_name: &str) -> Result<PathBu
 #[test]
 fn try_repo_basic() -> Result<()> {
     let context = TestEnv::new_git().with_file("test.txt", "test");
-    context.git_add_all();
+    context.git().add_all();
 
     let repo_path = create_hook_repo(&context, "try-repo-basic")?;
 
@@ -90,7 +89,7 @@ fn try_repo_basic() -> Result<()> {
 #[test]
 fn try_repo_failing_hook() -> Result<()> {
     let context = TestEnv::new_git().with_file("test.txt", "test");
-    context.git_add_all();
+    context.git().add_all();
 
     let repo_path = create_failing_hook_repo(&context, "try-repo-failing")?;
 
@@ -124,7 +123,7 @@ fn try_repo_specific_hook() -> Result<()> {
 
     let repo_path = create_hook_repo(&context, "try-repo-specific-hook")?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     let context = with_try_repo_filters(context);
 
@@ -151,17 +150,11 @@ fn try_repo_specific_hook() -> Result<()> {
 #[test]
 fn try_repo_specific_rev() -> Result<()> {
     let context = TestEnv::new_git().with_file("test.txt", "test");
-    context.git_add_all();
+    context.git().add_all();
 
     let repo_path = create_hook_repo(&context, "try-repo-specific-rev")?;
-
-    let initial_rev = context
-        .git_at(&repo_path)
-        .arg("rev-parse")
-        .arg("HEAD")
-        .output()?
-        .stdout;
-    let initial_rev = String::from_utf8_lossy(&initial_rev).trim().to_string();
+    let git = context.git_at(&repo_path);
+    let initial_rev = git.rev_parse("HEAD")?;
 
     // Make a new commit
     ChildPath::new(&repo_path)
@@ -172,19 +165,7 @@ fn try_repo_specific_rev() -> Result<()> {
           entry: echo new
           language: system
         "})?;
-    context
-        .git_at(&repo_path)
-        .arg("add")
-        .arg(".")
-        .assert()
-        .success();
-    context
-        .git_at(&repo_path)
-        .arg("commit")
-        .arg("-m")
-        .arg("second")
-        .assert()
-        .success();
+    git.add(".").commit("second");
 
     let context = with_try_repo_filters(context).with_filter(initial_rev.clone(), "[COMMIT_SHA]");
 
@@ -230,15 +211,10 @@ fn try_repo_uncommitted_changes() -> Result<()> {
     ChildPath::new(&repo_path)
         .child("new-file.txt")
         .write_str("new")?;
-    context
-        .git_at(&repo_path)
-        .arg("add")
-        .arg("new-file.txt")
-        .assert()
-        .success();
+    context.git_at(&repo_path).add("new-file.txt");
 
     context.write_file("test.txt", "test");
-    context.git_add_all();
+    context.git().add_all();
 
     let context = context.with_filters([
         (r"try-repo-[^/\\]+", "[REPO]"),
@@ -270,7 +246,7 @@ fn try_repo_uncommitted_changes() -> Result<()> {
 #[test]
 fn try_repo_relative_path() -> Result<()> {
     let context = TestEnv::new_git().with_file("test.txt", "test");
-    context.git_add_all();
+    context.git().add_all();
 
     let _repo_path = create_hook_repo(&context, "try-repo-relative")?;
     let relative_path = "../home/test-repos/try-repo-relative".to_string();
@@ -307,19 +283,7 @@ fn try_repo_dot_path() -> Result<()> {
     ChildPath::new(&repo_path)
         .child("test.txt")
         .write_str("test")?;
-    context
-        .git_at(&repo_path)
-        .arg("add")
-        .arg(".")
-        .assert()
-        .success();
-    context
-        .git_at(&repo_path)
-        .arg("commit")
-        .arg("-m")
-        .arg("Add test file")
-        .assert()
-        .success();
+    context.git_at(&repo_path).add(".").commit("Add test file");
 
     let context = context.with_filter(r"[a-f0-9]{40}", "[COMMIT_SHA]");
 
@@ -348,7 +312,7 @@ fn try_repo_dot_path() -> Result<()> {
 #[test]
 fn try_repo_builtin_hook() {
     let context = TestEnv::new_git().with_file("test.txt", "test\n");
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.try_repo().arg("builtin").arg("check-merge-conflict").arg("--all-files"), @r#"
     success: true
@@ -370,7 +334,7 @@ fn try_repo_builtin_hook() {
 #[test]
 fn try_repo_meta_hook() {
     let context = TestEnv::new_git().with_file("test.txt", "test\n");
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.try_repo().arg("meta").arg("identity").arg("--all-files"), @r#"
     success: true

--- a/crates/prek/tests/update.rs
+++ b/crates/prek/tests/update.rs
@@ -14,7 +14,7 @@ const INCREMENTING_STEP_SECS: u64 = 100;
 const FIXED_STEP_SECS: u64 = 0;
 
 fn context_with_commit_sha_filter() -> TestEnv {
-    TestEnv::new().with_filter(r"[a-f0-9]{40}", "[COMMIT_SHA]")
+    TestEnv::new_git().with_filter(r"[a-f0-9]{40}", "[COMMIT_SHA]")
 }
 
 /// Helper function to create a local git repository with hooks and incrementing timestamps.
@@ -142,7 +142,7 @@ fn create_local_git_repo_with_tag_timestamps(
 
 #[test]
 fn update_basic() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo(&context, "test-repo", &["v1.0.0", "v1.1.0", "v2.0.0"])?;
 
@@ -178,7 +178,7 @@ fn update_basic() -> Result<()> {
 
 #[test]
 fn update_already_up_to_date() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo(&context, "up-to-date-repo", &["v1.0.0"])?;
 
@@ -213,7 +213,7 @@ fn update_already_up_to_date() -> Result<()> {
 
 #[test]
 fn update_cooldown_does_not_downgrade_current_rev() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo_with_tag_ages(
         &context,
@@ -295,7 +295,7 @@ fn update_freeze_still_freezes_skipped_cooldown_downgrade() -> Result<()> {
 
 #[test]
 fn update_already_up_to_date_verbose() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo(&context, "up-to-date-repo-verbose", &["v1.0.0"])?;
 
@@ -327,7 +327,7 @@ fn update_already_up_to_date_verbose() -> Result<()> {
 fn update_does_not_rewrite_config_when_up_to_date() -> Result<()> {
     use std::time::UNIX_EPOCH;
 
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo(&context, "up-to-date-repo-mtime", &["v1.0.0"])?;
 
@@ -367,7 +367,7 @@ fn update_does_not_rewrite_config_when_up_to_date() -> Result<()> {
 
 #[test]
 fn update_multiple_repos_mixed() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo1_path = create_local_git_repo(&context, "repo1", &["v1.0.0", "v1.1.0"])?;
     let repo2_path = create_local_git_repo(&context, "repo2", &["v2.0.0"])?;
@@ -424,7 +424,7 @@ fn update_multiple_repos_mixed() -> Result<()> {
 /// Test that `prek update` ignores the `GIT_DIR` environment variable.
 #[test]
 fn test_resolve_revision_ignores_git_dir_env_var() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo(&context, "target-repo", &["v0.1.0", "v0.2.0"])?;
     let external_repo_path = create_local_git_repo(&context, "external-repo", &["v9.9.9"])?;
@@ -466,7 +466,7 @@ fn test_resolve_revision_ignores_git_dir_env_var() -> Result<()> {
 
 #[test]
 fn update_specific_repos() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo1_path = create_local_git_repo(&context, "repo1", &["v1.0.0", "v1.1.0"])?;
     let repo2_path = create_local_git_repo(&context, "repo2", &["v2.0.0", "v2.1.0"])?;
@@ -536,7 +536,7 @@ fn update_specific_repos() -> Result<()> {
 
 #[test]
 fn update_warns_for_missing_repos() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo(&context, "configured-repo", &["v1.0.0", "v1.1.0"])?;
 
@@ -575,7 +575,7 @@ fn update_warns_for_missing_repos() -> Result<()> {
 
 #[test]
 fn update_warns_when_repo_override_matches_another_project() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo1_path = create_local_git_repo(&context, "project-repo-1", &["v1.0.0", "v1.1.0"])?;
     let repo2_path = create_local_git_repo(&context, "project-repo-2", &["v1.0.0", "v1.1.0"])?;
@@ -636,7 +636,7 @@ fn update_warns_when_repo_override_matches_another_project() -> Result<()> {
 
 #[test]
 fn update_repo_options_match_relative_config_value() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let selected_path = create_local_git_repo(
         &context,
@@ -691,7 +691,7 @@ fn update_repo_options_match_relative_config_value() -> Result<()> {
 
 #[test]
 fn update_exclude_repo_skips_fetching_repo() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo(&context, "included-repo", &["v1.0.0", "v1.1.0"])?;
     let missing_repo_path = context
@@ -741,7 +741,7 @@ fn update_exclude_repo_skips_fetching_repo() -> Result<()> {
 
 #[test]
 fn update_exclude_repo_matches_relative_config_value() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     create_local_git_repo(&context, "relative-excluded", &["v1.0.0", "v2.0.0"])?;
     create_local_git_repo(&context, "relative-included", &["v1.0.0", "v2.0.0"])?;
@@ -790,7 +790,7 @@ fn update_exclude_repo_matches_relative_config_value() -> Result<()> {
 
 #[test]
 fn update_tag_filters_include_then_exclude() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo(
         &context,
@@ -835,7 +835,7 @@ fn update_tag_filters_include_then_exclude() -> Result<()> {
 
 #[test]
 fn update_uses_project_tag_filter_config() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo1_path = create_local_git_repo(
         &context,
@@ -906,7 +906,7 @@ fn update_uses_project_tag_filter_config() -> Result<()> {
 
 #[test]
 fn update_tag_filters_can_select_older_track_without_cooldown() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo(
         &context,
@@ -949,7 +949,7 @@ fn update_tag_filters_can_select_older_track_without_cooldown() -> Result<()> {
 
 #[test]
 fn update_repo_include_tag_is_repo_specific() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo1_path = create_local_git_repo(
         &context,
@@ -1011,7 +1011,7 @@ fn update_repo_include_tag_is_repo_specific() -> Result<()> {
 
 #[test]
 fn update_repo_include_tag_overrides_global_include_tag() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo(
         &context,
@@ -1057,7 +1057,7 @@ fn update_repo_include_tag_overrides_global_include_tag() -> Result<()> {
 
 #[test]
 fn update_repo_exclude_tag_can_leave_repo_unchanged() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo1_path = create_local_git_repo(&context, "repo-exclude-tag-1", &["v1.0.0", "v2.0.0"])?;
     let repo2_path = create_local_git_repo(&context, "repo-exclude-tag-2", &["v1.0.0", "v2.0.0"])?;
@@ -1198,7 +1198,7 @@ fn update_freeze() -> Result<()> {
 
 #[test]
 fn update_freeze_uses_dereferenced_commit_for_annotated_tags() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path =
         create_local_git_repo(&context, "freeze-annotated-repo", &["v1.0.0", "v1.1.0"])?;
@@ -1258,7 +1258,7 @@ fn update_freeze_uses_dereferenced_commit_for_annotated_tags() -> Result<()> {
 
 #[test]
 fn update_shared_target_with_different_frozen_comments_displays_sha() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo(
         &context,
@@ -1325,7 +1325,7 @@ fn update_shared_target_with_different_frozen_comments_displays_sha() -> Result<
 
 #[test]
 fn update_preserve_quote_style() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo1_path = create_local_git_repo(&context, "repo1", &["v1.0.0", "v1.1.0"])?;
     let repo2_path = create_local_git_repo(&context, "repo2", &["v1.0.0", "v1.1.0"])?;
@@ -1398,7 +1398,7 @@ fn update_preserve_quote_style() -> Result<()> {
 
 #[test]
 fn update_with_existing_frozen_comment() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path =
         create_local_git_repo(&context, "frozen-repo", &["v1.0.0", "v1.1.0", "v1.2.0"])?;
@@ -1447,7 +1447,7 @@ fn update_with_existing_frozen_comment() -> Result<()> {
 
 #[test]
 fn update_updates_mismatched_frozen_comment() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo(&context, "check-frozen-repo", &["v1.0.0", "v1.1.0"])?;
 
@@ -1500,7 +1500,7 @@ fn update_updates_mismatched_frozen_comment() -> Result<()> {
 
 #[test]
 fn update_updates_unresolvable_frozen_comment() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo(
         &context,
@@ -1557,7 +1557,7 @@ fn update_updates_unresolvable_frozen_comment() -> Result<()> {
 
 #[test]
 fn update_removes_frozen_comment_when_pinned_commit_has_no_tag() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo(
         &context,
@@ -1614,7 +1614,7 @@ fn update_removes_frozen_comment_when_pinned_commit_has_no_tag() -> Result<()> {
 
 #[test]
 fn update_warns_for_branch_only_pinned_commit_with_frozen_comment() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo(
         &context,
@@ -1694,7 +1694,7 @@ fn update_warns_for_branch_only_pinned_commit_with_frozen_comment() -> Result<()
 
 #[test]
 fn update_warns_for_invalid_pinned_commit_with_frozen_comment() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo(
         &context,
@@ -1749,7 +1749,7 @@ fn update_warns_for_invalid_pinned_commit_with_frozen_comment() -> Result<()> {
 
 #[test]
 fn update_dry_run_warns_for_mismatched_frozen_comment() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path =
         create_local_git_repo(&context, "check-frozen-dry-run-repo", &["v1.0.0", "v1.1.0"])?;
@@ -1803,7 +1803,7 @@ fn update_dry_run_warns_for_mismatched_frozen_comment() -> Result<()> {
 
 #[test]
 fn update_check_fails_for_mismatched_frozen_comment() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path =
         create_local_git_repo(&context, "check-frozen-check-repo", &["v1.0.0", "v1.1.0"])?;
@@ -1857,7 +1857,7 @@ fn update_check_fails_for_mismatched_frozen_comment() -> Result<()> {
 
 #[test]
 fn update_updates_mismatched_frozen_comment_toml() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path =
         create_local_git_repo(&context, "check-frozen-repo-toml", &["v1.0.0", "v1.1.0"])?;
@@ -1916,7 +1916,7 @@ fn update_updates_mismatched_frozen_comment_toml() -> Result<()> {
 
 #[test]
 fn update_local_repo_ignored() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo(&context, "remote-repo", &["v1.0.0", "v1.1.0"])?;
 
@@ -1965,7 +1965,7 @@ fn update_local_repo_ignored() -> Result<()> {
 
 #[test]
 fn missing_hook_ids() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo(&context, "missing-hook-repo", &["v1.0.0"])?;
 
@@ -2025,7 +2025,7 @@ fn missing_hook_ids() -> Result<()> {
 
 #[test]
 fn update_workspace() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo1_path =
         create_local_git_repo(&context, "workspace-repo1", &["v1.0.0", "v1.1.0", "v2.0.0"])?;
@@ -2116,7 +2116,7 @@ fn update_workspace() -> Result<()> {
 
 #[test]
 fn update_workspace_same_repo_uses_project_cooldown() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     context.write_user_config(indoc::indoc! {r"
         [update]
         cooldown_days = 1
@@ -2213,7 +2213,7 @@ fn update_workspace_same_repo_uses_project_cooldown() -> Result<()> {
 // - is most similar to the current revision, as measured by Levenshtein distance.
 #[test]
 fn prefer_similar_tags() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo(&context, "remote-repo", &["v1.0.0", "v1.1.0"])?;
     // Add a second tag (`foo-v1.1.0`) pointing at the same commit as `v1.1.0`.
@@ -2287,7 +2287,7 @@ fn prefer_similar_tags() -> Result<()> {
 
 #[test]
 fn update_dry_run() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo(&context, "test-repo", &["v1.0.0", "v1.1.0", "v2.0.0"])?;
 
@@ -2323,7 +2323,7 @@ fn update_dry_run() -> Result<()> {
 
 #[test]
 fn update_check() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path =
         create_local_git_repo(&context, "check-test-repo", &["v1.0.0", "v1.1.0", "v2.0.0"])?;
@@ -2360,7 +2360,7 @@ fn update_check() -> Result<()> {
 
 #[test]
 fn update_dry_run_exit_code() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo(
         &context,
@@ -2400,7 +2400,7 @@ fn update_dry_run_exit_code() -> Result<()> {
 
 #[test]
 fn update_exit_code_updates_config() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo(
         &context,
@@ -2440,7 +2440,7 @@ fn update_exit_code_updates_config() -> Result<()> {
 
 #[test]
 fn update_exit_code_succeeds_when_up_to_date() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo(
         &context,
@@ -2478,7 +2478,7 @@ fn update_exit_code_succeeds_when_up_to_date() -> Result<()> {
 
 #[test]
 fn quoting_float_like_version_number() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo(&context, "test-repo", &["0.49", "0.50"])?;
 
@@ -2516,7 +2516,7 @@ fn quoting_float_like_version_number() -> Result<()> {
 
 #[test]
 fn quoting_float_like_version_number_without_existing_quotes() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo(&context, "test-repo", &["v0.19", "0.51"])?;
 
@@ -2552,7 +2552,7 @@ fn quoting_float_like_version_number_without_existing_quotes() -> Result<()> {
 
 #[test]
 fn update_with_invalid_config_file() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Write an invalid config file
     context
@@ -2579,7 +2579,7 @@ fn update_with_invalid_config_file() -> Result<()> {
 
 #[test]
 fn update_toml() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path =
         create_local_git_repo(&context, "test-repo-toml", &["v1.0.0", "v1.1.0", "v2.0.0"])?;
@@ -2621,7 +2621,7 @@ fn update_toml() -> Result<()> {
 
 #[test]
 fn update_toml_with_comment() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path =
         create_local_git_repo(&context, "test-repo-toml", &["v1.0.0", "v1.1.0", "v2.0.0"])?;
@@ -2755,7 +2755,7 @@ fn update_freeze_toml() -> Result<()> {
 
 #[test]
 fn update_equal_timestamp_tags_picks_highest_version() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo_fixed_ts(
         &context,
@@ -2798,7 +2798,7 @@ fn update_equal_timestamp_tags_picks_highest_version() -> Result<()> {
 // semver tags should be preferred and sorted highest-first.
 #[test]
 fn update_equal_timestamp_prefers_semver_over_nonsemver() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let repo_path = create_local_git_repo_fixed_ts(
         &context,
@@ -2841,7 +2841,7 @@ fn update_equal_timestamp_prefers_semver_over_nonsemver() -> Result<()> {
 // Within an equal-timestamp group, semver tiebreaker picks the highest version.
 #[test]
 fn update_mixed_timestamps_with_equal_subgroups() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Create base repo with v1.0.x tags at incrementing timestamps.
     let repo_path = create_local_git_repo(&context, "mixed-ts-repo", &["v1.0.0", "v1.0.1"])?;

--- a/crates/prek/tests/update.rs
+++ b/crates/prek/tests/update.rs
@@ -93,9 +93,10 @@ fn create_local_git_repo_with_tag_timestamps(
           language: python
     "#})?;
 
-    repo.git().arg("add").arg(".").assert().success();
+    repo.git().add(".");
 
     repo.git()
+        .command()
         .arg("commit")
         .arg("-m")
         .arg("Initial commit")
@@ -107,6 +108,7 @@ fn create_local_git_repo_with_tag_timestamps(
     // Create tags
     for (tag, timestamp) in tags {
         repo.git()
+            .command()
             .arg("commit")
             .arg("-m")
             .arg(format!("Release {tag}"))
@@ -116,6 +118,7 @@ fn create_local_git_repo_with_tag_timestamps(
             .assert()
             .success();
         repo.git()
+            .command()
             .arg("tag")
             .arg(tag)
             .arg("-m")
@@ -128,6 +131,7 @@ fn create_local_git_repo_with_tag_timestamps(
 
     // Add an extra commit to the tip
     repo.git()
+        .command()
         .arg("commit")
         .arg("-m")
         .arg("tip")
@@ -153,7 +157,7 @@ fn update_basic() -> Result<()> {
             hooks:
               - id: test-hook
     ", repo_path});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -190,7 +194,7 @@ fn update_already_up_to_date() -> Result<()> {
               - id: test-hook
     ", repo_path});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -229,7 +233,7 @@ fn update_cooldown_does_not_downgrade_current_rev() -> Result<()> {
               - id: test-hook
     ", repo_path});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("7"), @"
     success: true
@@ -270,7 +274,7 @@ fn update_freeze_still_freezes_skipped_cooldown_downgrade() -> Result<()> {
               - id: test-hook
     ", repo_path});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--freeze").arg("--cooldown-days").arg("7"), @"
     success: true
@@ -307,7 +311,7 @@ fn update_already_up_to_date_verbose() -> Result<()> {
               - id: test-hook
     ", repo_path});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("-v").arg("--cooldown-days").arg("0"), @"
     success: true
@@ -338,7 +342,7 @@ fn update_does_not_rewrite_config_when_up_to_date() -> Result<()> {
             hooks:
               - id: test-hook
     ", repo_path});
-    context.git_add_all();
+    context.git().add_all();
 
     let config_path = context.work_dir().child(PRE_COMMIT_CONFIG_YAML);
 
@@ -388,7 +392,7 @@ fn update_multiple_repos_mixed() -> Result<()> {
               - id: another-hook
     ", repo1_path, repo1_path, repo2_path});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: false
@@ -436,7 +440,7 @@ fn test_resolve_revision_ignores_git_dir_env_var() -> Result<()> {
             hooks:
               - id: test-hook
     ", repo_path});
-    context.git_add_all();
+    context.git().add_all();
 
     let mut cmd = context.update();
     cmd.arg("--cooldown-days")
@@ -483,7 +487,7 @@ fn update_specific_repos() -> Result<()> {
               - id: another-hook
     ", repo1_path, repo2_path});
 
-    context.git_add_all();
+    context.git().add_all();
 
     // Update only repo1
     cmd_snapshot!(context, context.update().arg("--repo").arg(&repo1_path).arg("--cooldown-days").arg("0"), @"
@@ -547,7 +551,7 @@ fn update_warns_for_missing_repos() -> Result<()> {
             hooks:
               - id: test-hook
     ", repo_path});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update()
         .arg("--repo").arg(&repo_path)
@@ -609,7 +613,7 @@ fn update_warns_when_repo_override_matches_another_project() -> Result<()> {
             hooks:
               - id: test-hook
     "#, repo1_path, repo2_path})?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--jobs").arg("1"), @"
     success: true
@@ -656,7 +660,7 @@ fn update_repo_options_match_relative_config_value() -> Result<()> {
             hooks:
               - id: test-hook
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     let include_filter = format!("{selected_repo}=v1.*");
     let exclude_filter = format!("{selected_repo}=v1.2.0");
@@ -712,7 +716,7 @@ fn update_exclude_repo_skips_fetching_repo() -> Result<()> {
               - id: another-hook
     ", repo_path, missing_repo_path});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--exclude-repo").arg(&missing_repo_path).arg("--cooldown-days").arg("0"), @"
     success: true
@@ -759,7 +763,7 @@ fn update_exclude_repo_matches_relative_config_value() -> Result<()> {
             hooks:
               - id: test-hook
     "});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update()
         .arg("--exclude-repo").arg(excluded_repo)
@@ -806,7 +810,7 @@ fn update_tag_filters_include_then_exclude() -> Result<()> {
               - id: test-hook
     ", repo_path});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update()
         .arg("--include-tag").arg("v1.*")
@@ -867,7 +871,7 @@ fn update_uses_project_tag_filter_config() -> Result<()> {
               - id: test-hook
     "#, repo1_path, repo1_path, repo2_path});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--jobs").arg("1"), @"
     success: true
@@ -922,7 +926,7 @@ fn update_tag_filters_can_select_older_track_without_cooldown() -> Result<()> {
               - id: test-hook
     ", repo_path});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update()
         .arg("--include-tag").arg("v1.*")
@@ -974,7 +978,7 @@ fn update_repo_include_tag_is_repo_specific() -> Result<()> {
               - id: test-hook
     ", repo1_path, repo2_path});
 
-    context.git_add_all();
+    context.git().add_all();
 
     let repo1_filter = format!("{repo1_path}=v1.*");
 
@@ -1027,7 +1031,7 @@ fn update_repo_include_tag_overrides_global_include_tag() -> Result<()> {
               - id: test-hook
     ", repo_path});
 
-    context.git_add_all();
+    context.git().add_all();
 
     let repo_filter = format!("{repo_path}=v*.1.0");
 
@@ -1074,7 +1078,7 @@ fn update_repo_exclude_tag_can_leave_repo_unchanged() -> Result<()> {
               - id: test-hook
     ", repo1_path, repo2_path});
 
-    context.git_add_all();
+    context.git().add_all();
 
     let repo1_filter = format!("{repo1_path}=v2.*");
 
@@ -1121,7 +1125,7 @@ fn update_bleeding_edge() -> Result<()> {
               - id: test-hook
     ", repo_path});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--bleeding-edge"), @"
     success: true
@@ -1152,6 +1156,7 @@ fn update_freeze() -> Result<()> {
     // Make sure the "# frozen: v1.1.0" comment works correctly by adding a tag without dot
     context
         .git_at(&repo_path)
+        .command()
         .arg("tag")
         .arg("v1")
         .arg("-m")
@@ -1170,7 +1175,7 @@ fn update_freeze() -> Result<()> {
               - id: test-hook
     ", repo_path});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -1203,19 +1208,9 @@ fn update_freeze_uses_dereferenced_commit_for_annotated_tags() -> Result<()> {
     let repo_path =
         create_local_git_repo(&context, "freeze-annotated-repo", &["v1.0.0", "v1.1.0"])?;
 
-    let tag_object_sha = context
-        .git_at(&repo_path)
-        .args(["rev-parse", "v1.1.0"])
-        .output()?
-        .stdout;
-    let tag_object_sha = str::from_utf8(&tag_object_sha)?.trim();
-
-    let commit_sha = context
-        .git_at(&repo_path)
-        .args(["rev-parse", "v1.1.0^{}"])
-        .output()?
-        .stdout;
-    let commit_sha = str::from_utf8(&commit_sha)?.trim();
+    let git = context.git_at(&repo_path);
+    let tag_object_sha = git.rev_parse("v1.1.0")?;
+    let commit_sha = git.rev_parse("v1.1.0^{}")?;
 
     assert_ne!(
         tag_object_sha, commit_sha,
@@ -1229,7 +1224,7 @@ fn update_freeze_uses_dereferenced_commit_for_annotated_tags() -> Result<()> {
             hooks:
               - id: test-hook
     ", repo_path});
-    context.git_add_all();
+    context.git().add_all();
 
     context
         .update()
@@ -1249,7 +1244,7 @@ fn update_freeze_uses_dereferenced_commit_for_annotated_tags() -> Result<()> {
         "expected config to preserve the original tag in the frozen comment"
     );
     assert!(
-        !config.contains(tag_object_sha),
+        !config.contains(&tag_object_sha),
         "expected config to not contain the annotated tag object SHA"
     );
 
@@ -1268,18 +1263,14 @@ fn update_shared_target_with_different_frozen_comments_displays_sha() -> Result<
 
     context
         .git_at(&repo_path)
+        .command()
         .arg("tag")
         .arg("v1")
         .arg("v1.0.0^{}")
         .assert()
         .success();
 
-    let old_commit_sha = context
-        .git_at(&repo_path)
-        .args(["rev-parse", "v1.0.0^{}"])
-        .output()?
-        .stdout;
-    let old_commit_sha = str::from_utf8(&old_commit_sha)?.trim().to_string();
+    let old_commit_sha = context.git_at(&repo_path).rev_parse("v1.0.0^{}")?;
 
     let context = context.with_config(indoc::formatdoc! {r"
         repos:
@@ -1293,7 +1284,7 @@ fn update_shared_target_with_different_frozen_comments_displays_sha() -> Result<
               - id: test-hook
     ", repo_path, old_commit_sha, repo_path, old_commit_sha});
 
-    context.git_add_all();
+    context.git().add_all();
 
     let context = context.with_filter(old_commit_sha.clone(), "[OLD_COMMIT_SHA]");
 
@@ -1354,7 +1345,7 @@ fn update_preserve_quote_style() -> Result<()> {
                 name: Test Hook
     "#, repo1_path, repo1_path, repo2_path });
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -1413,7 +1404,7 @@ fn update_with_existing_frozen_comment() -> Result<()> {
               - id: test-hook
     ", repo_path, commit_sha});
 
-    context.git_add_all();
+    context.git().add_all();
 
     let context = context.with_filter(commit_sha, "[COMMIT_SHA]");
 
@@ -1451,12 +1442,7 @@ fn update_updates_mismatched_frozen_comment() -> Result<()> {
 
     let repo_path = create_local_git_repo(&context, "check-frozen-repo", &["v1.0.0", "v1.1.0"])?;
 
-    let commit_sha = context
-        .git_at(&repo_path)
-        .args(["rev-parse", "v1.1.0^{}"])
-        .output()?
-        .stdout;
-    let commit_sha = str::from_utf8(&commit_sha)?.trim().to_string();
+    let commit_sha = context.git_at(&repo_path).rev_parse("v1.1.0^{}")?;
 
     let context = context.with_config(indoc::formatdoc! {r"
         repos:
@@ -1466,7 +1452,7 @@ fn update_updates_mismatched_frozen_comment() -> Result<()> {
               - id: test-hook
     ", repo_path, commit_sha});
 
-    context.git_add_all();
+    context.git().add_all();
 
     let context = context.with_filter(commit_sha.clone(), "[COMMIT_SHA]");
 
@@ -1508,12 +1494,7 @@ fn update_updates_unresolvable_frozen_comment() -> Result<()> {
         &["v1.0.0", "v1.1.0"],
     )?;
 
-    let commit_sha = context
-        .git_at(&repo_path)
-        .args(["rev-parse", "v1.1.0^{}"])
-        .output()?
-        .stdout;
-    let commit_sha = str::from_utf8(&commit_sha)?.trim().to_string();
+    let commit_sha = context.git_at(&repo_path).rev_parse("v1.1.0^{}")?;
 
     let context = context.with_config(indoc::formatdoc! {r"
         repos:
@@ -1523,7 +1504,7 @@ fn update_updates_unresolvable_frozen_comment() -> Result<()> {
               - id: test-hook
     ", repo_path, commit_sha});
 
-    context.git_add_all();
+    context.git().add_all();
 
     let context = context.with_filter(commit_sha.clone(), "[COMMIT_SHA]");
 
@@ -1565,12 +1546,7 @@ fn update_removes_frozen_comment_when_pinned_commit_has_no_tag() -> Result<()> {
         &["v1.0.0", "v1.1.0"],
     )?;
 
-    let commit_sha = context
-        .git_at(&repo_path)
-        .args(["rev-parse", "HEAD"])
-        .output()?
-        .stdout;
-    let commit_sha = str::from_utf8(&commit_sha)?.trim().to_string();
+    let commit_sha = context.git_at(&repo_path).rev_parse("HEAD")?;
 
     let context = context.with_config(indoc::formatdoc! {r"
         repos:
@@ -1580,7 +1556,7 @@ fn update_removes_frozen_comment_when_pinned_commit_has_no_tag() -> Result<()> {
               - id: test-hook
     ", repo_path, commit_sha});
 
-    context.git_add_all();
+    context.git().add_all();
 
     let context = context.with_filter(commit_sha.clone(), "[COMMIT_SHA]");
 
@@ -1624,6 +1600,7 @@ fn update_warns_for_branch_only_pinned_commit_with_frozen_comment() -> Result<()
 
     context
         .git_at(&repo_path)
+        .command()
         .arg("checkout")
         .arg("-b")
         .arg("side")
@@ -1632,24 +1609,15 @@ fn update_warns_for_branch_only_pinned_commit_with_frozen_comment() -> Result<()
         .success();
     context
         .git_at(&repo_path)
+        .command()
         .arg("commit")
         .arg("-m")
         .arg("side")
         .arg("--allow-empty")
         .assert()
         .success();
-    let branch_commit = context
-        .git_at(&repo_path)
-        .args(["rev-parse", "HEAD"])
-        .output()?
-        .stdout;
-    let branch_commit = str::from_utf8(&branch_commit)?.trim().to_string();
-    context
-        .git_at(&repo_path)
-        .arg("checkout")
-        .arg("master")
-        .assert()
-        .success();
+    let branch_commit = context.git_at(&repo_path).rev_parse("HEAD")?;
+    context.git_at(&repo_path).checkout("master");
 
     let context = context.with_config(indoc::formatdoc! {r"
         repos:
@@ -1659,7 +1627,7 @@ fn update_warns_for_branch_only_pinned_commit_with_frozen_comment() -> Result<()
               - id: test-hook
     ", repo_path, branch_commit});
 
-    context.git_add_all();
+    context.git().add_all();
 
     let context = context.with_filter(branch_commit.clone(), "[BRANCH_ONLY_COMMIT]");
     let context = context.with_filter(r"[a-f0-9]{40}", "[COMMIT_SHA]");
@@ -1712,7 +1680,7 @@ fn update_warns_for_invalid_pinned_commit_with_frozen_comment() -> Result<()> {
               - id: test-hook
     ", repo_path, invalid_commit});
 
-    context.git_add_all();
+    context.git().add_all();
 
     let context = context.with_filters([
         (invalid_commit, "[INVALID_COMMIT]"),
@@ -1754,12 +1722,7 @@ fn update_dry_run_warns_for_mismatched_frozen_comment() -> Result<()> {
     let repo_path =
         create_local_git_repo(&context, "check-frozen-dry-run-repo", &["v1.0.0", "v1.1.0"])?;
 
-    let commit_sha = context
-        .git_at(&repo_path)
-        .args(["rev-parse", "v1.1.0^{}"])
-        .output()?
-        .stdout;
-    let commit_sha = str::from_utf8(&commit_sha)?.trim().to_string();
+    let commit_sha = context.git_at(&repo_path).rev_parse("v1.1.0^{}")?;
 
     let context = context.with_config(indoc::formatdoc! {r"
         repos:
@@ -1769,7 +1732,7 @@ fn update_dry_run_warns_for_mismatched_frozen_comment() -> Result<()> {
               - id: test-hook
     ", repo_path, commit_sha});
 
-    context.git_add_all();
+    context.git().add_all();
 
     let context = context.with_filter(commit_sha.clone(), "[COMMIT_SHA]");
 
@@ -1808,12 +1771,7 @@ fn update_check_fails_for_mismatched_frozen_comment() -> Result<()> {
     let repo_path =
         create_local_git_repo(&context, "check-frozen-check-repo", &["v1.0.0", "v1.1.0"])?;
 
-    let commit_sha = context
-        .git_at(&repo_path)
-        .args(["rev-parse", "v1.1.0^{}"])
-        .output()?
-        .stdout;
-    let commit_sha = str::from_utf8(&commit_sha)?.trim().to_string();
+    let commit_sha = context.git_at(&repo_path).rev_parse("v1.1.0^{}")?;
 
     let context = context.with_config(indoc::formatdoc! {r"
         repos:
@@ -1823,7 +1781,7 @@ fn update_check_fails_for_mismatched_frozen_comment() -> Result<()> {
               - id: test-hook
     ", repo_path, commit_sha});
 
-    context.git_add_all();
+    context.git().add_all();
 
     let context = context.with_filter(commit_sha.clone(), "[COMMIT_SHA]");
 
@@ -1862,12 +1820,7 @@ fn update_updates_mismatched_frozen_comment_toml() -> Result<()> {
     let repo_path =
         create_local_git_repo(&context, "check-frozen-repo-toml", &["v1.0.0", "v1.1.0"])?;
 
-    let commit_sha = context
-        .git_at(&repo_path)
-        .args(["rev-parse", "v1.1.0^{}"])
-        .output()?
-        .stdout;
-    let commit_sha = str::from_utf8(&commit_sha)?.trim().to_string();
+    let commit_sha = context.git_at(&repo_path).rev_parse("v1.1.0^{}")?;
 
     context
         .work_dir()
@@ -1881,7 +1834,7 @@ fn update_updates_mismatched_frozen_comment_toml() -> Result<()> {
         ]
         "#, repo_path, commit_sha})?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     let context = context.with_filter(commit_sha.clone(), "[COMMIT_SHA]");
 
@@ -1934,7 +1887,7 @@ fn update_local_repo_ignored() -> Result<()> {
               - id: test-hook
     ", repo_path});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -1981,25 +1934,9 @@ fn missing_hook_ids() -> Result<()> {
 
     context
         .git_at(&repo_path)
-        .arg("add")
-        .arg(".")
-        .assert()
-        .success();
-    context
-        .git_at(&repo_path)
-        .arg("commit")
-        .arg("-m")
-        .arg("Remove test-hook")
-        .assert()
-        .success();
-    context
-        .git_at(&repo_path)
-        .arg("tag")
-        .arg("v2.0.0")
-        .arg("-m")
-        .arg("v2.0.0")
-        .assert()
-        .success();
+        .add(".")
+        .commit("Remove test-hook")
+        .tag("v2.0.0");
 
     let context = context.with_config(indoc::formatdoc! {r"
         repos:
@@ -2008,7 +1945,7 @@ fn missing_hook_ids() -> Result<()> {
             hooks:
               - id: test-hook
     ", repo_path});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: false
@@ -2067,7 +2004,7 @@ fn update_workspace() -> Result<()> {
               - id: test-hook
     ", repo2_path, repo3_path})?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2126,20 +2063,14 @@ fn update_workspace_same_repo_uses_project_cooldown() -> Result<()> {
         create_local_git_repo(&context, "workspace-cooldown-repo", &["v1.0.0", "v1.1.0"])?;
     context
         .git_at(&repo_path)
+        .command()
         .arg("commit")
         .arg("-m")
         .arg("Release v2.0.0")
         .arg("--allow-empty")
         .assert()
         .success();
-    context
-        .git_at(&repo_path)
-        .arg("tag")
-        .arg("v2.0.0")
-        .arg("-m")
-        .arg("v2.0.0")
-        .assert()
-        .success();
+    context.git_at(&repo_path).tag("v2.0.0");
 
     context.setup_workspace(
         &["project-a", "project-b"],
@@ -2170,7 +2101,7 @@ fn update_workspace_same_repo_uses_project_cooldown() -> Result<()> {
               - id: test-hook
     ", repo_path})?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update(), @"
     success: true
@@ -2224,6 +2155,7 @@ fn prefer_similar_tags() -> Result<()> {
     // But if the newest SemVer-like tag (e.g v1.1.111111) were less similar than `foo-v1.1.0`, we would select `foo-v1.1.0` instead.
     context
         .git_at(&repo_path)
+        .command()
         .arg("tag")
         .arg("foo-v1.1.0")
         .arg("-m")
@@ -2234,6 +2166,7 @@ fn prefer_similar_tags() -> Result<()> {
     // Add tag v1 pointing to the same commit as v1.1.0
     context
         .git_at(&repo_path)
+        .command()
         .arg("tag")
         .arg("v1")
         .arg("-m")
@@ -2256,7 +2189,7 @@ fn prefer_similar_tags() -> Result<()> {
               - id: test-hook
     ", repo_path});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2298,7 +2231,7 @@ fn update_dry_run() -> Result<()> {
             hooks:
               - id: test-hook
     ", repo_path});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--dry-run").arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2335,7 +2268,7 @@ fn update_check() -> Result<()> {
             hooks:
               - id: test-hook
     ", repo_path});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--check").arg("--cooldown-days").arg("0"), @"
     success: false
@@ -2375,7 +2308,7 @@ fn update_dry_run_exit_code() -> Result<()> {
             hooks:
               - id: test-hook
     ", repo_path});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--dry-run").arg("--exit-code").arg("--cooldown-days").arg("0"), @"
     success: false
@@ -2415,7 +2348,7 @@ fn update_exit_code_updates_config() -> Result<()> {
             hooks:
               - id: test-hook
     ", repo_path});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--exit-code").arg("--cooldown-days").arg("0"), @"
     success: false
@@ -2455,7 +2388,7 @@ fn update_exit_code_succeeds_when_up_to_date() -> Result<()> {
             hooks:
               - id: test-hook
     ", repo_path});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--exit-code").arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2491,7 +2424,7 @@ fn quoting_float_like_version_number() -> Result<()> {
             hooks:
               - id: test-hook
     "#, repo_path});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2527,7 +2460,7 @@ fn quoting_float_like_version_number_without_existing_quotes() -> Result<()> {
             hooks:
               - id: test-hook
     ", repo_path});
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2595,7 +2528,7 @@ fn update_toml() -> Result<()> {
           {{ id = "test-hook" }},
         ]
       "#, repo_path})?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2638,7 +2571,7 @@ fn update_toml_with_comment() -> Result<()> {
         ]
       "#, repo_path})?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2672,7 +2605,7 @@ fn update_toml_with_comment() -> Result<()> {
         ]
       "#, repo_path})?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2708,6 +2641,7 @@ fn update_freeze_toml() -> Result<()> {
     // Make sure the "# frozen: v1.1.0" comment works correctly by adding a tag without dot
     context
         .git_at(&repo_path)
+        .command()
         .arg("tag")
         .arg("v1")
         .arg("-m")
@@ -2728,7 +2662,7 @@ fn update_freeze_toml() -> Result<()> {
         ]
     "#, repo_path})?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2771,7 +2705,7 @@ fn update_equal_timestamp_tags_picks_highest_version() -> Result<()> {
               - id: test-hook
     ", repo_path});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2814,7 +2748,7 @@ fn update_equal_timestamp_prefers_semver_over_nonsemver() -> Result<()> {
               - id: test-hook
     ", repo_path});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2852,6 +2786,7 @@ fn update_mixed_timestamps_with_equal_subgroups() -> Result<()> {
     for tag in &["v2.0.1", "v2.0.0"] {
         context
             .git_at(&repo_path)
+            .command()
             .arg("commit")
             .arg("-m")
             .arg(format!("Release {tag}"))
@@ -2862,6 +2797,7 @@ fn update_mixed_timestamps_with_equal_subgroups() -> Result<()> {
             .success();
         context
             .git_at(&repo_path)
+            .command()
             .arg("tag")
             .arg(tag)
             .arg("-m")
@@ -2880,7 +2816,7 @@ fn update_mixed_timestamps_with_equal_subgroups() -> Result<()> {
               - id: test-hook
     ", repo_path});
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2911,6 +2847,7 @@ fn update_freeze_toml_with_comment() -> Result<()> {
     // Make sure the "# frozen: v1.1.0" comment works correctly by adding a tag without dot
     context
         .git_at(&repo_path)
+        .command()
         .arg("tag")
         .arg("v1")
         .arg("-m")
@@ -2933,7 +2870,7 @@ fn update_freeze_toml_with_comment() -> Result<()> {
         ]
     "#, repo_path})?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--freeze").arg("--cooldown-days").arg("0"), @"
     success: true

--- a/crates/prek/tests/validate.rs
+++ b/crates/prek/tests/validate.rs
@@ -7,7 +7,7 @@ mod common;
 
 #[test]
 fn validate_config() -> anyhow::Result<()> {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
 
     // No files to validate.
     cmd_snapshot!(context, context.validate_config(), @r"
@@ -67,7 +67,7 @@ fn validate_config() -> anyhow::Result<()> {
 
 #[test]
 fn mutable_revision_warning_has_actionable_guidance() {
-    let context = TestEnv::new_without_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new().with_config(indoc::indoc! {r"
         repos:
           - repo: https://example.com/hooks
             rev: main
@@ -91,7 +91,7 @@ fn mutable_revision_warning_has_actionable_guidance() {
 
 #[test]
 fn invalid_config_error() {
-    let context = TestEnv::new_without_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new().with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/pre-commit/pre-commit-hooks
             hooks:
@@ -141,7 +141,7 @@ fn invalid_config_error() {
 
 #[test]
 fn unknown_priority_alias_is_invalid() {
-    let context = TestEnv::new_without_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new().with_config(indoc::indoc! {r"
         priorities:
           checks: 10
         repos:
@@ -166,7 +166,7 @@ fn unknown_priority_alias_is_invalid() {
 
 #[test]
 fn priority_aliases_cannot_contain_whitespace() {
-    let context = TestEnv::new_without_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new().with_config(indoc::indoc! {r#"
         priorities:
           "static checks": 10
         repos: []
@@ -192,7 +192,7 @@ fn priority_aliases_cannot_contain_whitespace() {
 
 #[test]
 fn duplicate_and_unused_priority_aliases_are_valid() {
-    let context = TestEnv::new_without_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new().with_config(indoc::indoc! {r"
         priorities:
           checks: 10
           verification: 10
@@ -224,7 +224,7 @@ fn duplicate_and_unused_priority_aliases_are_valid() {
 
 #[test]
 fn validate_manifest() -> anyhow::Result<()> {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
 
     // No files to validate.
     cmd_snapshot!(context, context.validate_manifest(), @r"
@@ -293,7 +293,7 @@ fn validate_manifest() -> anyhow::Result<()> {
 
 #[test]
 fn unexpected_keys_warning() {
-    let context = TestEnv::new_without_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new().with_config(indoc::indoc! {r"
         x-anchor: &anchor
           language: system
         repos:

--- a/crates/prek/tests/workspace.rs
+++ b/crates/prek/tests/workspace.rs
@@ -34,7 +34,7 @@ fn basic_discovery() -> Result<()> {
         ],
         config,
     )?;
-    context.git_add_all();
+    context.git().add_all();
 
     // Run from the root directory
     cmd_snapshot!(context, context.run(), @r#"
@@ -160,7 +160,7 @@ fn basic_discovery() -> Result<()> {
         .work_dir()
         .child("project3/.prekignore")
         .write_str("project5/\n")?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--refresh").arg("--cd").arg(cwd.join("project3")), @r#"
     success: true
@@ -181,7 +181,7 @@ fn basic_discovery() -> Result<()> {
         .work_dir()
         .child("project3/.prekignore")
         .write_str("*\n")?;
-    context.git_add_all();
+    context.git().add_all();
     cmd_snapshot!(context, context.run().arg("--refresh").arg("--cd").arg(cwd.join("project3")), @r#"
     success: true
     exit_code: 0
@@ -246,7 +246,7 @@ fn same_depth_project_concurrency_has_stable_output() -> Result<()> {
             .write_str(config)?;
         project_dir.child("file.txt").write_str("")?;
     }
-    context.git_add_all();
+    context.git().add_all();
 
     let mut run = context.run();
     run.arg("--all-files")
@@ -313,7 +313,7 @@ fn fail_fast_stops_after_current_project_level() -> Result<()> {
         .child(".pre-commit-config.yaml")
         .write_str(passing_config)?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     let mut run = context.run();
     run.arg("--all-files")
@@ -359,7 +359,7 @@ fn config_not_staged() -> Result<()> {
         ],
         config,
     )?;
-    context.git_add_all();
+    context.git().add_all();
 
     let config = indoc! {r"
     repos:
@@ -445,7 +445,7 @@ fn run_with_selectors() -> Result<()> {
         ],
         config,
     )?;
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("project2/"), @r#"
     success: true
@@ -761,7 +761,7 @@ fn run_with_mixed_project_and_hook_selectors() -> Result<()> {
         .child(".pre-commit-config.yaml")
         .write_str("invalid: config\n")?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--all-files").arg("sub/").arg(".:root-hook"), @r"
     success: true
@@ -815,7 +815,7 @@ fn skips() -> Result<()> {
     "};
 
     context.setup_workspace(&["project2", "project3", "project3/project4"], config)?;
-    context.git_add_all();
+    context.git().add_all();
 
     // Test CLI skip
     cmd_snapshot!(context, context.run().arg("--skip").arg("project2/"), @r#"
@@ -988,7 +988,7 @@ fn skips() -> Result<()> {
         .work_dir()
         .child("project3/.pre-commit-config.yaml")
         .write_str("invalid_yaml: [")?;
-    context.git_add_all();
+    context.git().add_all();
 
     // Should error out because of the invalid config
     cmd_snapshot!(context, context.run(), @"
@@ -1034,7 +1034,7 @@ fn skips() -> Result<()> {
 #[test]
 fn workspace_no_projects() {
     let context = TestEnv::new_git().with_config("repos: []");
-    context.git_add_all();
+    context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--skip").arg("."), @r"
     success: false
@@ -1079,7 +1079,7 @@ fn gitignore_respected() -> Result<()> {
         .child(".gitignore")
         .write_str("node_modules/\ntarget/\n")?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     // Run from the root - should not discover projects in node_modules or target
     cmd_snapshot!(context, context.run(), @r#"
@@ -1148,7 +1148,7 @@ fn nested_project_exclude_is_relative() -> Result<()> {
         .child("nested/excluded_by_project")
         .write_str("")?;
 
-    context.git_add_all();
+    context.git().add_all();
 
     // When running from the root with --all-files, the nested project's exclude
     // pattern should see paths relative to `nested/`, so `noinclude` is excluded
@@ -1201,7 +1201,7 @@ fn reference_files_across_projects() -> Result<()> {
     let cwd = context.work_dir();
     cwd.child("backend/app.py")
         .write_str("print('Hello from backend')")?;
-    context.git_add_all();
+    context.git().add_all();
     // Run with --files referencing a file in another project
     cmd_snapshot!(context, context.run().current_dir(cwd.child("frontend")).arg("--files").arg("../backend/app.py").arg("../backend/non-exist.py"), @r"
     success: true
@@ -1237,16 +1237,16 @@ fn submodule_discovery() -> Result<()> {
     // Create a submodule
     let submodule_path = cwd.child("submodule");
     let submodule_context = TestEnv::new_git_at(&submodule_path).with_config(config);
-    submodule_context.git_add_all();
-    submodule_context.git_commit("Initial commit");
+    submodule_context.git().add_all().commit("Initial commit");
 
     // Add submodule to the main project
     context
         .git_at(cwd)
+        .command()
         .args(["submodule", "add", "./submodule"])
         .assert()
         .success();
-    context.git_add_all();
+    context.git().add_all();
 
     // 1. Test that workspace discovery does not recurse into git submodules
     cmd_snapshot!(context, context.run().arg("--all-files"), @r#"
@@ -1289,8 +1289,7 @@ fn submodule_discovery() -> Result<()> {
     // 3. Test that current directory is in the submodule without .pre-commit-config
     // Remove the config file in the submodule
     fs_err::remove_file(submodule_path.join(".pre-commit-config.yaml"))?;
-    submodule_context.git_add_all();
-    submodule_context.git_commit("Remove config");
+    submodule_context.git().add_all().commit("Remove config");
 
     cmd_snapshot!(context, context.run().current_dir(&submodule_path), @r"
     success: false
@@ -1324,8 +1323,10 @@ fn cookiecutter_template_directories_are_skipped() -> Result<()> {
     context.setup_workspace(&["project2", "{{cookiecutter.project_slug}}"], config)?;
 
     // Stage only the configs that should participate in discovery.
-    context.git_add(".pre-commit-config.yaml");
-    context.git_add("project2/.pre-commit-config.yaml");
+    context
+        .git()
+        .add(".pre-commit-config.yaml")
+        .add("project2/.pre-commit-config.yaml");
 
     // The cookiecutter directory would otherwise be discovered as a project.
     cmd_snapshot!(context, context.run().arg("--refresh").arg("--all-files"), @r#"
@@ -1392,7 +1393,7 @@ fn orphan_projects() -> Result<()> {
         .write_str("")?;
     context.work_dir().child("src/test.py").write_str("")?;
     context.work_dir().child("test.py").write_str("")?;
-    context.git_add_all();
+    context.git().add_all();
 
     // Without `orphan`: files in subprojects are processed multiple times
     cmd_snapshot!(context, context.run().arg("--all-files"), @r#"
@@ -1531,8 +1532,6 @@ fn setup_relative_repo_path_project() -> Result<TestEnv> {
     let hook_repo = context.work_dir().child("hook-repo");
     hook_repo.create_dir_all()?;
 
-    context.git_at(&hook_repo).args(["init"]).assert().success();
-
     hook_repo.child(PRE_COMMIT_HOOKS_YAML).write_str(indoc! {r"
         - id: test-hook
           name: Test Hook
@@ -1541,24 +1540,11 @@ fn setup_relative_repo_path_project() -> Result<TestEnv> {
           always_run: true
     "})?;
 
-    context
-        .git_at(&hook_repo)
-        .args(["add", "."])
-        .assert()
-        .success();
-
-    context
-        .git_at(&hook_repo)
-        .args(["commit", "-m", "Initial commit"])
-        .assert()
-        .success();
+    let git = context.git_at(&hook_repo);
+    git.init().add(".").commit("Initial commit");
 
     // Get the commit SHA
-    let output = context
-        .git_at(&hook_repo)
-        .args(["rev-parse", "HEAD"])
-        .output()?;
-    let commit_sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let commit_sha = git.rev_parse("HEAD")?;
 
     // Create a subproject that references the hook repo with a relative path
     let subproject = context.work_dir().child("subproject");
@@ -1590,7 +1576,7 @@ fn setup_relative_repo_path_project() -> Result<TestEnv> {
                 always_run: true
     "});
 
-    context.git_add_all();
+    context.git().add_all();
 
     Ok(context)
 }

--- a/crates/prek/tests/workspace.rs
+++ b/crates/prek/tests/workspace.rs
@@ -11,7 +11,7 @@ use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
 fn basic_discovery() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     let cwd = context.work_dir();
 
     let config = indoc! {r"
@@ -201,7 +201,7 @@ fn basic_discovery() -> Result<()> {
 
 #[test]
 fn same_depth_project_concurrency_has_stable_output() -> Result<()> {
-    let context = TestEnv::new().with_config("repos: []");
+    let context = TestEnv::new_git().with_config("repos: []");
     context
         .work_dir()
         .child("concurrent_hook.py")
@@ -268,7 +268,7 @@ fn same_depth_project_concurrency_has_stable_output() -> Result<()> {
 
 #[test]
 fn fail_fast_stops_after_current_project_level() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
     repos:
       - repo: local
         hooks:
@@ -337,7 +337,7 @@ fn fail_fast_stops_after_current_project_level() -> Result<()> {
 
 #[test]
 fn config_not_staged() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     let cwd = context.work_dir();
 
     let config = indoc! {r"
@@ -423,7 +423,7 @@ fn config_not_staged() -> Result<()> {
 
 #[test]
 fn run_with_selectors() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let config = indoc! {r"
     repos:
@@ -724,7 +724,7 @@ fn run_with_selectors() -> Result<()> {
 
 #[test]
 fn run_with_mixed_project_and_hook_selectors() -> Result<()> {
-    let context = TestEnv::new().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
     repos:
       - repo: local
         hooks:
@@ -801,7 +801,7 @@ fn run_with_mixed_project_and_hook_selectors() -> Result<()> {
 
 #[test]
 fn skips() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let config = indoc! {r"
     repos:
@@ -1033,7 +1033,7 @@ fn skips() -> Result<()> {
 
 #[test]
 fn workspace_no_projects() {
-    let context = TestEnv::new().with_config("repos: []");
+    let context = TestEnv::new_git().with_config("repos: []");
     context.git_add_all();
 
     cmd_snapshot!(context, context.run().arg("--skip").arg("."), @r"
@@ -1050,7 +1050,7 @@ fn workspace_no_projects() {
 
 #[test]
 fn gitignore_respected() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let config = indoc! {r"
     repos:
@@ -1109,7 +1109,7 @@ fn gitignore_respected() -> Result<()> {
 
 #[test]
 fn nested_project_exclude_is_relative() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Regression test for nested workspaces:
     // `exclude` must be evaluated against paths *relative to each project root*.
@@ -1182,7 +1182,7 @@ fn nested_project_exclude_is_relative() -> Result<()> {
 /// Tests that `--files` arguments references files in other projects, should be filtered out properly.
 #[test]
 fn reference_files_across_projects() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let config = indoc! {r"
     repos:
@@ -1218,7 +1218,7 @@ fn reference_files_across_projects() -> Result<()> {
 
 #[test]
 fn submodule_discovery() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
     let cwd = context.work_dir();
 
     let config = indoc! {r"
@@ -1236,7 +1236,7 @@ fn submodule_discovery() -> Result<()> {
 
     // Create a submodule
     let submodule_path = cwd.child("submodule");
-    let submodule_context = TestEnv::new_at(&submodule_path).with_config(config);
+    let submodule_context = TestEnv::new_git_at(&submodule_path).with_config(config);
     submodule_context.git_add_all();
     submodule_context.git_commit("Initial commit");
 
@@ -1308,7 +1308,7 @@ fn submodule_discovery() -> Result<()> {
 
 #[test]
 fn cookiecutter_template_directories_are_skipped() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     let config = indoc! {r"
     repos:
@@ -1355,7 +1355,7 @@ fn cookiecutter_template_directories_are_skipped() -> Result<()> {
 
 #[test]
 fn orphan_projects() -> Result<()> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Create a hook that shows which files it processes
     let config = indoc! {r#"
@@ -1525,7 +1525,7 @@ fn orphan_projects() -> Result<()> {
 }
 
 fn setup_relative_repo_path_project() -> Result<TestEnv> {
-    let context = TestEnv::new();
+    let context = TestEnv::new_git();
 
     // Create a local hook repository at the root level
     let hook_repo = context.work_dir().child("hook-repo");

--- a/crates/prek/tests/yaml_to_toml.rs
+++ b/crates/prek/tests/yaml_to_toml.rs
@@ -58,7 +58,7 @@ repos:
 
 #[test]
 fn yaml_to_toml_writes_default_output() -> anyhow::Result<()> {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
 
     context
         .work_dir()
@@ -154,7 +154,7 @@ fn yaml_to_toml_writes_default_output() -> anyhow::Result<()> {
 
 #[test]
 fn yaml_to_toml_force_overwrite() -> anyhow::Result<()> {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
 
     context
         .work_dir()
@@ -195,7 +195,7 @@ fn yaml_to_toml_force_overwrite() -> anyhow::Result<()> {
 
 #[test]
 fn yaml_to_toml_rejects_invalid_config() -> anyhow::Result<()> {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
 
     context
         .work_dir()
@@ -226,7 +226,7 @@ fn yaml_to_toml_rejects_invalid_config() -> anyhow::Result<()> {
 
 #[test]
 fn yaml_to_toml_same_output() -> anyhow::Result<()> {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
 
     context
         .work_dir()
@@ -257,7 +257,7 @@ fn yaml_to_toml_same_output() -> anyhow::Result<()> {
 
 #[test]
 fn yaml_to_toml_discovers_pre_commit_config_yaml() -> anyhow::Result<()> {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
 
     context
         .work_dir()
@@ -286,7 +286,7 @@ fn yaml_to_toml_discovers_pre_commit_config_yaml() -> anyhow::Result<()> {
 
 #[test]
 fn yaml_to_toml_discovers_pre_commit_config_yml() -> anyhow::Result<()> {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
 
     context
         .work_dir()
@@ -315,7 +315,7 @@ fn yaml_to_toml_discovers_pre_commit_config_yml() -> anyhow::Result<()> {
 
 #[test]
 fn yaml_to_toml_prefers_yaml_over_yml() -> anyhow::Result<()> {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
 
     // Write different content to each file so we can verify which was used.
     let yaml_only = indoc::indoc! {r"
@@ -364,7 +364,7 @@ fn yaml_to_toml_prefers_yaml_over_yml() -> anyhow::Result<()> {
 
 #[test]
 fn yaml_to_toml_error_when_no_config_found() {
-    let context = TestEnv::new_without_git();
+    let context = TestEnv::new();
 
     cmd_snapshot!(context,
         context.command().args(["util", "yaml-to-toml"]),


### PR DESCRIPTION
Simplify integration test setup with file-writing and chainable Git helpers.

Make Git repository construction explicit with `new_git()` while keeping `new()` for filesystem-only tests.
