### PR TITLE
Show hooks excluded by skip selectors

### DIFF
--- a/crates/prek/src/cli/mod.rs
+++ b/crates/prek/src/cli/mod.rs
@@ -693,7 +693,7 @@ pub(crate) struct RunOptions {
         value_delimiter = ',',
         help_heading = "Run options"
     )]
-    pub(crate) hide_status: Vec<run::RunStatus>,
+    pub(crate) hide_status: Vec<run::HideStatus>,
 
     #[command(flatten)]
     pub(crate) extra: RunExtraArgs,

--- a/crates/prek/src/cli/run/mod.rs
+++ b/crates/prek/src/cli/run/mod.rs
@@ -6,7 +6,7 @@ pub(crate) use filter::{
 };
 pub(crate) use install::{InstallCache, install_hooks};
 pub(crate) use reporter::{HookRunReporter, project_status_marker};
-pub(crate) use run::{RunStatus, run};
+pub(crate) use run::{HideStatus, run};
 pub(crate) use selector::{ConfiguredHook, GroupFilters, SelectorSource, Selectors};
 
 mod diff;

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -958,9 +958,13 @@ impl<'a> HookRunSession<'a> {
         let modifications_belong_to_single_hook =
             group.modification == Some(ModificationScope::SingleHook);
         let show_group_failure = group.shows_group_failure(self.report_filter);
+
+        // Hooks that did not run cannot have modified files, so report them outside
+        // the modification group.
         let mut visible_results = group_results
             .iter()
             .filter(|result| self.report_filter.shows(result.status))
+            .filter(|result| !show_group_failure || result.status.was_executed())
             .peekable();
         let mut first_result = true;
         let group_output_prefix = if show_group_failure {
@@ -1002,6 +1006,15 @@ impl<'a> HookRunSession<'a> {
                     group_output_prefix.as_deref(),
                     modifications_belong_to_single_hook,
                 )?;
+            }
+        }
+
+        if show_group_failure {
+            for result in group_results {
+                if !result.status.was_executed() && self.report_filter.shows(result.status) {
+                    self.status_printer
+                        .write(&result.hook.name, hook_prefix, result.status)?;
+                }
             }
         }
 

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -1,5 +1,6 @@
 use std::fmt::Write as _;
 use std::io::Write as _;
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::slice;
@@ -9,7 +10,7 @@ use anyhow::{Context, Result};
 use asyncband::semaphore::Semaphore;
 use futures_util::TryStreamExt;
 use futures_util::stream::FuturesUnordered;
-use owo_colors::OwoColorize;
+use owo_colors::{OwoColorize, Styled};
 use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use prek_consts::{PRE_COMMIT_CONFIG_YAML, PREK_TOML};
 use prek_identify::{TagSet, tags_from_path};
@@ -38,7 +39,40 @@ use crate::terminal::{USE_COLOR, sanitize_output};
 use crate::workspace::{HookInitFilters, Project, Workspace};
 use crate::{fs, git, hooks, warn_user};
 
+use super::selector::HookSelection;
 use super::{DRY_RUN, FAILED, PASSED, SKIPPED};
+
+#[derive(Clone)]
+enum HookPlan<T> {
+    Run(T),
+    Skip(Arc<Hook>),
+}
+
+impl<T> HookPlan<T> {
+    fn as_run(&self) -> Option<&T> {
+        match self {
+            Self::Run(hook) => Some(hook),
+            Self::Skip(_) => None,
+        }
+    }
+}
+
+impl<T> Deref for HookPlan<T>
+where
+    T: Deref<Target = Hook>,
+{
+    type Target = Hook;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Run(hook) => hook,
+            Self::Skip(hook) => hook,
+        }
+    }
+}
+
+type SelectedHook = HookPlan<Arc<Hook>>;
+type ScheduledHook = HookPlan<InstalledHook>;
 
 pub(crate) async fn run(
     store: &Store,
@@ -112,12 +146,17 @@ pub(crate) async fn run(
             .await
             .context("Failed to init hooks")?
     };
-    let mut selected_hooks: Vec<_> = hooks
-        .into_iter()
-        .filter(|h| selectors.matches_hook(h))
-        .filter(|h| group_filters.matches_hook(h))
-        .map(Arc::new)
-        .collect();
+    let mut selected_hooks = Vec::new();
+    for hook in hooks {
+        let hook = match selectors.select_hook(&hook) {
+            HookSelection::Selected => HookPlan::Run(Arc::new(hook)),
+            HookSelection::Skipped => HookPlan::Skip(Arc::new(hook)),
+            HookSelection::NotSelected => continue,
+        };
+        if group_filters.matches_hook(&hook) {
+            selected_hooks.push(hook);
+        }
+    }
 
     selectors.report_unused();
     group_filters.report_unused();
@@ -207,7 +246,7 @@ pub(crate) async fn run(
         &workspace,
         &input,
         &file_index,
-        &selected_hooks,
+        selected_hooks,
     )
     .await?;
 
@@ -231,7 +270,7 @@ pub(crate) async fn run(
 fn infer_stage_and_input_mode(
     explicit_stage: Option<Stage>,
     has_group_filters: bool,
-    selected_hooks: &[Arc<Hook>],
+    selected_hooks: &[SelectedHook],
     selectors: &Selectors,
 ) -> (Option<Stage>, RunInputMode) {
     if let Some(stage) = explicit_stage {
@@ -244,11 +283,11 @@ fn infer_stage_and_input_mode(
 
     // Preserve legacy direct-hook execution: try `manual` only when the user
     // named hooks directly and none of those hooks can run as `pre-commit`.
-    let stage = if selectors.includes_only_hook_targets()
-        && !selected_hooks
-            .iter()
-            .any(|hook| hook.stages.contains(Stage::PreCommit))
-    {
+    let has_runnable_pre_commit_hook = selected_hooks
+        .iter()
+        .filter_map(HookPlan::as_run)
+        .any(|hook| hook.stages.contains(Stage::PreCommit));
+    let stage = if selectors.includes_only_hook_targets() && !has_runnable_pre_commit_hook {
         Stage::Manual
     } else {
         Stage::PreCommit
@@ -311,56 +350,54 @@ fn set_env_vars(from_ref: Option<&str>, to_ref: Option<&str>, args: &RunExtraArg
 
 /// Ensure installable hooks have environments and return the form expected by the runner.
 ///
-/// Hooks that do not need an environment are returned as-is. Hooks that need an
-/// environment but would not run for this input are also returned without resolving
-/// an environment; `run_hook` will report them as skipped before trying to execute them.
+/// Hooks that do not need an environment are returned as-is. Hooks that will be skipped,
+/// either explicitly or because they have no matching input, are returned without resolving
+/// an environment; `run_hook` reports them before trying to execute them.
 async fn ensure_hooks_installed<'paths>(
     store: &Store,
     printer: Printer,
     workspace: &Workspace,
     input: &'paths RunInput,
     file_index: &RunFileIndex<'paths>,
-    hooks: &[Arc<Hook>],
-) -> Result<Vec<InstalledHook>> {
-    let runnable_env_hooks = select_runnable_env_hooks(workspace, input, file_index, hooks)?;
-
-    if runnable_env_hooks.is_empty() {
-        return Ok(hooks
-            .iter()
-            .map(|hook| InstalledHook::NoNeedInstall(hook.clone()))
-            .collect());
-    }
-
-    let _lock = store.lock_async().await?;
-    let mut install_cache = InstallCache::new();
+    hooks: Vec<SelectedHook>,
+) -> Result<Vec<ScheduledHook>> {
+    let runnable_env_hooks = select_runnable_env_hooks(workspace, input, file_index, &hooks)?;
     let mut installed_by_hook = FxHashMap::default();
-    let mut missing_env_hooks = Vec::new();
 
-    for hook in runnable_env_hooks {
-        if let Some(installed_hook) = install_cache.installed_hook(store, hook.clone()).await {
-            installed_by_hook.insert(hook_key(&hook), installed_hook);
-        } else {
-            missing_env_hooks.push(hook.clone());
+    if !runnable_env_hooks.is_empty() {
+        let _lock = store.lock_async().await?;
+        let mut install_cache = InstallCache::new();
+        let mut missing_env_hooks = Vec::new();
+
+        for hook in runnable_env_hooks {
+            if let Some(installed_hook) = install_cache.installed_hook(store, hook.clone()).await {
+                installed_by_hook.insert(hook_key(&hook), installed_hook);
+            } else {
+                missing_env_hooks.push(hook.clone());
+            }
         }
-    }
 
-    if !missing_env_hooks.is_empty() {
-        let reporter = HookInstallReporter::new(printer);
-        let installed_hooks =
-            install_hooks(missing_env_hooks, store, &reporter, &mut install_cache).await?;
-        reporter.on_complete();
+        if !missing_env_hooks.is_empty() {
+            let reporter = HookInstallReporter::new(printer);
+            let installed_hooks =
+                install_hooks(missing_env_hooks, store, &reporter, &mut install_cache).await?;
+            reporter.on_complete();
 
-        for installed_hook in installed_hooks {
-            installed_by_hook.insert(hook_key(&installed_hook), installed_hook);
+            for installed_hook in installed_hooks {
+                installed_by_hook.insert(hook_key(&installed_hook), installed_hook);
+            }
         }
     }
 
     Ok(hooks
-        .iter()
-        .map(|hook| {
-            installed_by_hook
-                .remove(&hook_key(hook))
-                .unwrap_or_else(|| InstalledHook::NoNeedInstall(hook.clone()))
+        .into_iter()
+        .map(|hook| match hook {
+            HookPlan::Run(hook) => HookPlan::Run(
+                installed_by_hook
+                    .remove(&hook_key(&hook))
+                    .unwrap_or_else(|| InstalledHook::NoNeedInstall(hook)),
+            ),
+            HookPlan::Skip(hook) => HookPlan::Skip(hook),
         })
         .collect())
 }
@@ -373,12 +410,15 @@ fn select_runnable_env_hooks<'paths>(
     workspace: &Workspace,
     input: &'paths RunInput,
     file_index: &RunFileIndex<'paths>,
-    hooks: &[Arc<Hook>],
+    hooks: &[SelectedHook],
 ) -> Result<Vec<Arc<Hook>>> {
     #[allow(clippy::mutable_key_type)]
     let mut project_to_hooks: FxHashMap<&Project, Vec<Arc<Hook>>> =
         FxHashMap::with_capacity_and_hasher(workspace.all_projects().len(), FxBuildHasher);
-    for hook in hooks.iter().filter(|hook| hook.needs_install_env()) {
+    for hook in hooks.iter().filter_map(HookPlan::as_run) {
+        if !hook.needs_install_env() {
+            continue;
+        }
         project_to_hooks
             .entry(hook.project())
             .or_default()
@@ -429,12 +469,12 @@ async fn run_hooks<'paths>(
     workspace: &Workspace,
     input: &'paths RunInput,
     file_index: &RunFileIndex<'paths>,
-    hooks: &[InstalledHook],
+    hooks: &[ScheduledHook],
     store: &Store,
     show_diff_on_failure: bool,
     fail_fast: Option<bool>,
     dry_run: bool,
-    hide_status: &[RunStatus],
+    hide_status: &[HideStatus],
     worktree_cleaned: bool,
     verbose: bool,
     printer: Printer,
@@ -443,7 +483,7 @@ async fn run_hooks<'paths>(
 
     // Group hooks by project to run them in order of their depth in the workspace.
     #[allow(clippy::mutable_key_type)]
-    let mut project_to_hooks: FxHashMap<&Project, Vec<InstalledHook>> =
+    let mut project_to_hooks: FxHashMap<&Project, Vec<ScheduledHook>> =
         FxHashMap::with_capacity_and_hasher(hooks.len(), FxBuildHasher);
     for hook in hooks {
         project_to_hooks
@@ -465,7 +505,7 @@ async fn run_hooks<'paths>(
     );
 
     for projects in ProjectDepthGroups::new(workspace.all_projects()) {
-        let clean_baseline = worktree_cleaned && !session.outcome.modified_files;
+        let clean_baseline = worktree_cleaned && !session.modified_files;
         let mut project_runs = Vec::new();
 
         for project in projects {
@@ -541,7 +581,7 @@ impl<'a> Iterator for ProjectDepthGroups<'a> {
 struct ProjectRun<'project> {
     project: &'project Project,
     project_fail_fast: bool,
-    groups: Vec<Vec<InstalledHook>>,
+    groups: Vec<Vec<ScheduledHook>>,
 }
 
 struct ProjectRunResult<'project> {
@@ -562,25 +602,50 @@ impl ProjectRunResult<'_> {
     }
 }
 
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum ModificationScope {
+    SingleHook,
+    PriorityGroup,
+}
+
+impl ModificationScope {
+    fn from_results(results: &mut [HookRunResult], modified_files: bool) -> Option<Self> {
+        if !modified_files {
+            return None;
+        }
+
+        let mut executed_results = results
+            .iter_mut()
+            .filter(|result| result.status.was_executed());
+        let Some(result) = executed_results.next() else {
+            return Some(Self::PriorityGroup);
+        };
+        if executed_results.next().is_some() {
+            return Some(Self::PriorityGroup);
+        }
+
+        result.status = RunStatus::Failed;
+        Some(Self::SingleHook)
+    }
+}
+
 struct PriorityGroupResult {
     results: Vec<HookRunResult>,
-    modified_files: bool,
+    modification: Option<ModificationScope>,
 }
 
 impl PriorityGroupResult {
     fn new(mut results: Vec<HookRunResult>, modified_files: bool) -> Self {
-        // A single hook owns the group's modifications, so its final status is failed.
-        if modified_files && let [result] = results.as_mut_slice() {
-            result.status = RunStatus::Failed;
-        }
+        let modification = ModificationScope::from_results(&mut results, modified_files);
         Self {
             results,
-            modified_files,
+            modification,
         }
     }
 
     fn shows_group_failure(&self, filter: ReportFilter<'_>) -> bool {
-        self.modified_files && self.results.len() > 1 && filter.shows(RunStatus::Failed)
+        self.modification == Some(ModificationScope::PriorityGroup)
+            && filter.shows(RunStatus::Failed)
     }
 
     fn has_visible_report(&self, filter: ReportFilter<'_>) -> bool {
@@ -593,12 +658,14 @@ impl PriorityGroupResult {
 
     fn hook_fail_fast(&self) -> bool {
         self.results.iter().any(|result| {
-            (self.modified_files || result.status.is_failure()) && result.hook.fail_fast
+            result.status.was_executed()
+                && result.hook.fail_fast
+                && (self.modification.is_some() || result.status.is_failure())
         })
     }
 
     fn failed(&self) -> bool {
-        self.modified_files || self.results.iter().any(|result| result.status.is_failure())
+        self.modification.is_some() || self.results.iter().any(|result| result.status.is_failure())
     }
 
     fn should_stop_project(&self, project_fail_fast: bool) -> bool {
@@ -608,36 +675,23 @@ impl PriorityGroupResult {
 
 #[derive(Clone, Copy)]
 struct ReportFilter<'a> {
-    hidden_statuses: &'a [RunStatus],
+    hidden_statuses: &'a [HideStatus],
 }
 
 impl<'a> ReportFilter<'a> {
-    fn new(hidden_statuses: &'a [RunStatus]) -> Self {
+    fn new(hidden_statuses: &'a [HideStatus]) -> Self {
         Self { hidden_statuses }
     }
 
     fn shows(self, status: RunStatus) -> bool {
-        if status == RunStatus::DryRun {
-            true
-        } else {
-            !self.hidden_statuses.contains(&status)
-        }
+        let Some(hide_status) = status.hide_status() else {
+            return true;
+        };
+        !self.hidden_statuses.contains(&hide_status)
     }
 }
 
-#[derive(Default)]
-struct RunOutcome {
-    failed: bool,
-    modified_files: bool,
-}
-
-impl RunOutcome {
-    fn record(&mut self, group: &PriorityGroupResult) {
-        self.failed |= group.failed();
-        self.modified_files |= group.modified_files;
-    }
-}
-
+#[expect(clippy::struct_excessive_bools)]
 struct HookRunSession<'a> {
     store: &'a Store,
     reporter: HookRunReporter,
@@ -646,15 +700,16 @@ struct HookRunSession<'a> {
     dry_run: bool,
     report_filter: ReportFilter<'a>,
     verbose: bool,
-    outcome: RunOutcome,
+    failed: bool,
+    modified_files: bool,
 }
 
 impl<'a> HookRunSession<'a> {
     fn new(
-        hooks: &[InstalledHook],
+        hooks: &[ScheduledHook],
         store: &'a Store,
         dry_run: bool,
-        hidden_statuses: &'a [RunStatus],
+        hidden_statuses: &'a [HideStatus],
         verbose: bool,
         show_project_headers: bool,
         printer: Printer,
@@ -671,7 +726,8 @@ impl<'a> HookRunSession<'a> {
             dry_run,
             report_filter: ReportFilter::new(hidden_statuses),
             verbose,
-            outcome: RunOutcome::default(),
+            failed: false,
+            modified_files: false,
         }
     }
 
@@ -760,6 +816,7 @@ impl<'a> HookRunSession<'a> {
             let group_requires_diff_tracking = !self.dry_run
                 && group_hooks
                     .iter()
+                    .filter_map(HookPlan::as_run)
                     .any(|hook| hooks::requires_diff_tracking(hook));
             diff_tracker
                 .prepare_for_group(group_requires_diff_tracking)
@@ -809,7 +866,7 @@ impl<'a> HookRunSession<'a> {
 
     async fn run_priority_group(
         &self,
-        group_hooks: Vec<InstalledHook>,
+        group_hooks: Vec<ScheduledHook>,
         project_input: &ProjectHookInput<'_, '_>,
         tag_cache: &FileTagCache,
         semaphore: Rc<Semaphore>,
@@ -847,7 +904,7 @@ impl<'a> HookRunSession<'a> {
                 RunStatus::Passed | RunStatus::Failed => {
                     self.reporter.hide_run_result(&result.hook);
                 }
-                RunStatus::DryRun | RunStatus::Skipped => {}
+                RunStatus::DryRun | RunStatus::Skipped(_) => {}
             }
         }
     }
@@ -881,7 +938,8 @@ impl<'a> HookRunSession<'a> {
         // Print results in a stable order (same order as config within the project).
         group.results.sort_unstable_by_key(|result| result.hook.idx);
 
-        self.outcome.record(&group);
+        self.failed |= group.failed();
+        self.modified_files |= group.modification.is_some();
 
         self.reporter.clear_completed();
         for result in &group.results {
@@ -897,7 +955,8 @@ impl<'a> HookRunSession<'a> {
 
     fn render_priority_group(&self, group: &PriorityGroupResult, hook_prefix: &str) -> Result<()> {
         let group_results = &group.results;
-        let group_modified_files = group.modified_files;
+        let modifications_belong_to_single_hook =
+            group.modification == Some(ModificationScope::SingleHook);
         let show_group_failure = group.shows_group_failure(self.report_filter);
         let mut visible_results = group_results
             .iter()
@@ -933,16 +992,15 @@ impl<'a> HookRunSession<'a> {
             };
             first_result = false;
             let prefix = format!("{hook_prefix}{connector}");
-
             self.status_printer
                 .write(&result.hook.name, &prefix, status)?;
 
-            if status != RunStatus::Skipped && result.shows_details(self.verbose) {
+            if !status.is_skipped() && result.shows_details(self.verbose) {
                 self.render_hook_details(
                     result,
                     hook_prefix,
                     group_output_prefix.as_deref(),
-                    group_modified_files && group_results.len() == 1,
+                    modifications_belong_to_single_hook,
                 )?;
             }
         }
@@ -958,9 +1016,10 @@ impl<'a> HookRunSession<'a> {
         modified_files: bool,
     ) -> Result<()> {
         let detail_prefix = group_output_prefix.unwrap_or(hook_prefix);
-        let mut stdout = match result.status {
-            RunStatus::Failed => self.printer.stdout_important(),
-            _ => self.printer.stdout(),
+        let mut stdout = if result.status.is_failure() {
+            self.printer.stdout_important()
+        } else {
+            self.printer.stdout()
         };
 
         writeln!(
@@ -1042,7 +1101,7 @@ impl<'a> HookRunSession<'a> {
     ) -> Result<ExitStatus> {
         self.reporter.on_complete();
 
-        if self.outcome.failed && show_diff_on_failure && self.outcome.modified_files {
+        if self.failed && show_diff_on_failure && self.modified_files {
             if EnvVars::is_under_ci() {
                 writeln!(
                     self.printer.stdout(),
@@ -1081,7 +1140,7 @@ impl<'a> HookRunSession<'a> {
                 .await?;
         }
 
-        if self.outcome.failed {
+        if self.failed {
             Ok(ExitStatus::Failure)
         } else {
             Ok(ExitStatus::Success)
@@ -1090,17 +1149,17 @@ impl<'a> HookRunSession<'a> {
 }
 
 struct PriorityGroups {
-    hooks: Vec<InstalledHook>,
+    hooks: Vec<ScheduledHook>,
 }
 
 impl PriorityGroups {
-    fn new(hooks: Vec<InstalledHook>) -> Self {
+    fn new(hooks: Vec<ScheduledHook>) -> Self {
         Self { hooks }
     }
 }
 
 impl Iterator for PriorityGroups {
-    type Item = Vec<InstalledHook>;
+    type Item = Vec<ScheduledHook>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let first = self.hooks.first()?;
@@ -1245,18 +1304,62 @@ impl<'a> HookRunInput<'a> {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, clap::ValueEnum)]
-pub(crate) enum RunStatus {
+pub(crate) enum HideStatus {
     Passed,
     Failed,
-    // Dry-run is a mode, not a filterable hook outcome.
-    #[value(skip)]
-    DryRun,
     Skipped,
 }
 
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum RunStatus {
+    Passed,
+    Failed,
+    DryRun,
+    Skipped(SkipReason),
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum SkipReason {
+    Explicit,
+    NoFiles,
+}
+
 impl RunStatus {
+    fn hide_status(self) -> Option<HideStatus> {
+        match self {
+            Self::Passed => Some(HideStatus::Passed),
+            Self::Failed => Some(HideStatus::Failed),
+            Self::Skipped(_) => Some(HideStatus::Skipped),
+            Self::DryRun => None,
+        }
+    }
+
     fn is_failure(self) -> bool {
         self == Self::Failed
+    }
+
+    fn was_executed(self) -> bool {
+        matches!(self, Self::Passed | Self::Failed)
+    }
+
+    fn is_skipped(self) -> bool {
+        matches!(self, Self::Skipped(_))
+    }
+
+    fn label(self) -> Styled<&'static str> {
+        match self {
+            Self::Passed => PASSED,
+            Self::Failed => FAILED,
+            Self::DryRun => DRY_RUN,
+            Self::Skipped(_) => SKIPPED,
+        }
+    }
+
+    fn suffix(self) -> &'static str {
+        match self {
+            Self::Skipped(SkipReason::NoFiles) => "(no files to check)",
+            Self::Passed | Self::Failed | Self::DryRun | Self::Skipped(SkipReason::Explicit) => "",
+        }
     }
 }
 
@@ -1266,21 +1369,21 @@ struct StatusPrinter {
 }
 
 impl StatusPrinter {
-    const NO_FILES: &'static str = "(no files to check)";
-
     fn for_hooks<T>(hooks: &[T], printer: Printer) -> Self
     where
-        T: std::ops::Deref<Target = Hook>,
+        T: Deref<Target = Hook>,
     {
         let name_len = hooks
             .iter()
             .map(|hook| hook.name.width())
             .max()
             .unwrap_or(0);
+        let widest_status = RunStatus::Skipped(SkipReason::NoFiles);
+        let status_width = widest_status.suffix().width() + widest_status.label().inner().width();
         let columns = std::cmp::max(
             79,
             // Hook name...(no files to check)Skipped
-            name_len + 3 + Self::NO_FILES.len() + SKIPPED.inner().width(),
+            name_len + 3 + status_width,
         );
         Self { printer, columns }
     }
@@ -1290,7 +1393,7 @@ impl StatusPrinter {
     }
 
     fn bar_len(&self) -> usize {
-        self.columns - PASSED.inner().width()
+        self.columns - RunStatus::Passed.label().inner().width()
     }
 
     fn write(
@@ -1299,12 +1402,8 @@ impl StatusPrinter {
         prefix: &str,
         status: RunStatus,
     ) -> Result<(), std::fmt::Error> {
-        let (suffix, status_line) = match status {
-            RunStatus::Skipped => (Self::NO_FILES, SKIPPED),
-            RunStatus::DryRun => ("", DRY_RUN),
-            RunStatus::Passed => ("", PASSED),
-            RunStatus::Failed => ("", FAILED),
-        };
+        let suffix = status.suffix();
+        let status_line = status.label();
         let (prefix, prefix_width) = if prefix.is_empty() {
             (String::new(), 0)
         } else {
@@ -1315,17 +1414,16 @@ impl StatusPrinter {
         let dots = self.columns.saturating_sub(used_width);
         let dots = ".".repeat(dots).green().to_string();
         let line = format!("{prefix}{hook_name}{dots}{suffix}{status_line}");
-        match status {
-            RunStatus::Failed => {
-                writeln!(self.printer.stdout_important(), "{line}")
-            }
-            _ => writeln!(self.printer.stdout(), "{line}"),
+        if status.is_failure() {
+            writeln!(self.printer.stdout_important(), "{line}")
+        } else {
+            writeln!(self.printer.stdout(), "{line}")
         }
     }
 }
 
 struct HookRunResult {
-    hook: InstalledHook,
+    hook: ScheduledHook,
     status: RunStatus,
     duration: std::time::Duration,
     exit_status: i32,
@@ -1334,10 +1432,18 @@ struct HookRunResult {
 }
 
 impl HookRunResult {
-    fn skipped(hook: InstalledHook) -> Self {
+    fn skipped(hook: ScheduledHook) -> Self {
+        Self::not_run(hook, SkipReason::Explicit)
+    }
+
+    fn no_files(hook: ScheduledHook) -> Self {
+        Self::not_run(hook, SkipReason::NoFiles)
+    }
+
+    fn not_run(hook: ScheduledHook, reason: SkipReason) -> Self {
         Self {
             hook,
-            status: RunStatus::Skipped,
+            status: RunStatus::Skipped(reason),
             duration: std::time::Duration::ZERO,
             exit_status: 0,
             output: Vec::new(),
@@ -1346,7 +1452,7 @@ impl HookRunResult {
     }
 
     fn shows_details(&self, verbose: bool) -> bool {
-        verbose || self.hook.verbose || self.status == RunStatus::Failed
+        verbose || self.hook.verbose || self.status.is_failure()
     }
 
     fn write_log_file(&self) -> Result<()> {
@@ -1380,7 +1486,7 @@ impl HookRunResult {
 }
 
 async fn run_hook(
-    hook: InstalledHook,
+    hook: ScheduledHook,
     project_input: &ProjectHookInput<'_, '_>,
     tag_cache: &FileTagCache,
     store: &Store,
@@ -1388,13 +1494,18 @@ async fn run_hook(
     reporter: &HookRunReporter,
     semaphore: Rc<Semaphore>,
 ) -> Result<HookRunResult> {
+    let installed_hook = match &hook {
+        HookPlan::Run(hook) => hook,
+        HookPlan::Skip(_) => return Ok(HookRunResult::skipped(hook)),
+    };
+
     let _permit = if dry_run {
         None
     } else {
         Some(semaphore.acquire(1).await)
     };
 
-    let mut input = project_input.run_input_for_hook(&hook, tag_cache);
+    let mut input = project_input.run_input_for_hook(installed_hook, tag_cache);
     let matched = input.matched();
     let filename_count = input.filename_count();
     trace!(
@@ -1404,29 +1515,36 @@ async fn run_hook(
         hook.id,
     );
 
-    if !matched && !hook.always_run {
-        return Ok(HookRunResult::skipped(hook));
+    if !matched && !installed_hook.always_run {
+        return Ok(HookRunResult::no_files(hook));
     }
     let start = std::time::Instant::now();
 
     let hook_output = if dry_run {
-        hooks::HookOutput::unchanged(0, dry_run_hook(&hook, &input)?)
+        hooks::HookOutput::unchanged(0, dry_run_hook(installed_hook, &input)?)
     } else {
         input.shuffle();
         match &input {
             HookRunInput::Filenames(filenames) => {
-                hook.language.run(store, &hook, filenames, reporter).await
+                installed_hook
+                    .language
+                    .run(store, installed_hook, filenames, reporter)
+                    .await
             }
             HookRunInput::Filename(filename) => {
-                hook.language
-                    .run(store, &hook, slice::from_ref(filename), reporter)
+                installed_hook
+                    .language
+                    .run(store, installed_hook, slice::from_ref(filename), reporter)
                     .await
             }
             HookRunInput::WithoutFilenames { .. } => {
-                hook.language.run(store, &hook, &[], reporter).await
+                installed_hook
+                    .language
+                    .run(store, installed_hook, &[], reporter)
+                    .await
             }
         }
-        .with_context(|| format!("Failed to run hook `{hook}`"))?
+        .with_context(|| format!("Failed to run hook `{installed_hook}`"))?
     };
     let hooks::HookOutput {
         exit_status,

--- a/crates/prek/src/cli/run/selector.rs
+++ b/crates/prek/src/cli/run/selector.rs
@@ -192,6 +192,13 @@ pub(crate) struct Selectors {
     usage: Arc<Mutex<FilterUsage>>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum HookSelection {
+    Selected,
+    Skipped,
+    NotSelected,
+}
+
 impl Selectors {
     /// Create selectors for one explicit include without applying skip environment variables.
     pub(crate) fn from_include(include: &str, workspace_root: &Path) -> Result<Self, Error> {
@@ -283,8 +290,8 @@ impl Selectors {
             })
     }
 
-    /// Check if a hook matches any of the selection criteria.
-    pub(crate) fn matches_hook(&self, hook: &Hook) -> bool {
+    /// Select a hook and retain whether an explicit skip caused its exclusion.
+    pub(super) fn select_hook(&self, hook: &Hook) -> HookSelection {
         let mut usage = self.usage.lock().unwrap();
 
         // Always check every selector to track usage
@@ -295,22 +302,31 @@ impl Selectors {
                 skipped = true;
             }
         }
-        if skipped {
-            return false;
-        }
-
-        if self.includes.is_empty() {
-            return true; // No `includes` mean all hooks are included
-        }
-
-        let mut included = false;
-        for (idx, include) in self.includes.iter().enumerate() {
-            if include.matches_hook(hook) {
-                usage.use_include(idx);
-                included = true;
+        let included = if self.includes.is_empty() {
+            true
+        } else {
+            let mut included = false;
+            for (idx, include) in self.includes.iter().enumerate() {
+                if include.matches_hook(hook) {
+                    usage.use_include(idx);
+                    included = true;
+                }
             }
+            included
+        };
+
+        if !included {
+            HookSelection::NotSelected
+        } else if skipped {
+            HookSelection::Skipped
+        } else {
+            HookSelection::Selected
         }
-        included
+    }
+
+    /// Check if a hook matches any of the selection criteria.
+    pub(crate) fn matches_hook(&self, hook: &Hook) -> bool {
+        self.select_hook(hook) == HookSelection::Selected
     }
 
     /// Return whether skip selectors rule out a hook from config alone.

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -1436,6 +1436,12 @@ fn priority_group_modified_files_is_group_failure_and_output_is_indented() -> Re
         repos:
           - repo: local
             hooks:
+              - id: skipped
+                name: Skipped Check
+                language: system
+                entry: python3 -c "raise SystemExit(1)"
+                always_run: true
+                priority: 0
               - id: modify
                 name: Modifies File
                 language: system
@@ -1467,7 +1473,7 @@ fn priority_group_modified_files_is_group_failure_and_output_is_indented() -> Re
 
     context.git().add_all();
 
-    cmd_snapshot!(context, context.run(), @r"
+    cmd_snapshot!(context, context.run().arg("--skip").arg("skipped"), @r"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1481,6 +1487,7 @@ fn priority_group_modified_files_is_group_failure_and_output_is_indented() -> Re
       │
       │ hello from loud
       └ No Output............................................................Passed
+    Skipped Check...........................................................Skipped
     Later Hook...............................................................Passed
     - hook id: later
     - duration: [TIME]
@@ -1491,11 +1498,12 @@ fn priority_group_modified_files_is_group_failure_and_output_is_indented() -> Re
     ");
 
     context.work_dir().child("file.txt").write_str("hello\n")?;
-    cmd_snapshot!(context, context.run().arg("--hide-status").arg("passed"), @r#"
+    cmd_snapshot!(context, context.run().arg("--skip").arg("skipped").arg("--hide-status").arg("passed"), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
     Files were modified by following hooks...................................Failed
+    Skipped Check...........................................................Skipped
 
     ----- stderr -----
     "#);

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -1367,6 +1367,65 @@ fn priority_fail_fast_stops_later_groups() {
 }
 
 #[test]
+fn explicitly_skipped_hook_does_not_affect_priority_group_outcome() -> Result<()> {
+    let context = TestEnv::new_git();
+    context.work_dir().child("file.txt").write_str("hello\n")?;
+
+    let context = context.with_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: skipped
+                name: Skipped Check
+                language: system
+                entry: python3 -c "raise SystemExit(1)"
+                always_run: true
+                fail_fast: true
+                priority: 0
+              - id: modify
+                name: Modifies File
+                language: system
+                entry: python3 -c "from pathlib import Path; p = Path('file.txt'); p.write_text(p.read_text() + 'x')"
+                always_run: true
+                priority: 0
+              - id: later
+                name: Later Hook
+                language: system
+                entry: python3 -c "print('later ran')"
+                always_run: true
+                priority: 10
+    "#});
+
+    context.git().add_all();
+
+    cmd_snapshot!(context, context.run().arg("--skip").arg("skipped"), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    Skipped Check...........................................................Skipped
+    Modifies File............................................................Failed
+    - hook id: modify
+    - files were modified by this hook
+    Later Hook...............................................................Passed
+
+    ----- stderr -----
+    "#);
+
+    context.work_dir().child("file.txt").write_str("hello\n")?;
+    cmd_snapshot!(context, context.run().arg("--skip").arg("skipped").arg("--hide-status").arg("failed"), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    Skipped Check...........................................................Skipped
+    Later Hook...............................................................Passed
+
+    ----- stderr -----
+    "#);
+
+    Ok(())
+}
+
+#[test]
 fn priority_group_modified_files_is_group_failure_and_output_is_indented() -> Result<()> {
     let context = TestEnv::new_git();
 
@@ -1562,30 +1621,33 @@ fn skips() {
     "#});
     context.git().add_all();
 
-    cmd_snapshot!(context, context.run().env("SKIP", "end-of-file-fixer"), @r"
+    cmd_snapshot!(context, context.run().env("SKIP", "end-of-file-fixer"), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
     trailing-whitespace......................................................Failed
     - hook id: trailing-whitespace
     - exit code: 1
+    fix end of files........................................................Skipped
     check json...............................................................Failed
     - hook id: check-json
     - exit code: 1
 
     ----- stderr -----
-    ");
+    "#);
 
-    cmd_snapshot!(context, context.run().env("SKIP", "trailing-whitespace,end-of-file-fixer"), @r"
+    cmd_snapshot!(context, context.run().env("SKIP", "trailing-whitespace,end-of-file-fixer"), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
+    trailing-whitespace.....................................................Skipped
+    fix end of files........................................................Skipped
     check json...............................................................Failed
     - hook id: check-json
     - exit code: 1
 
     ----- stderr -----
-    ");
+    "#);
 }
 
 #[test]
@@ -1613,7 +1675,7 @@ fn hide_status_filters_hook_reports() {
     "#});
     context.git().add_all();
 
-    cmd_snapshot!(context, context.run().arg("--hide-status").arg("passed,skipped"), @r#"
+    cmd_snapshot!(context, context.run().arg("--skip").arg("pass").arg("--hide-status").arg("passed,skipped"), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1811,6 +1873,17 @@ fn fallback_to_manual_stage() {
 
     ----- stderr -----
     ");
+
+    // A skipped pre-commit hook should not prevent a runnable manual hook from falling back.
+    cmd_snapshot!(context, context.run().arg("--skip").arg("default-stage").arg("manual-only").arg("default-stage"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    manual-only..............................................................Passed
+    default-stage...........................................................Skipped
+
+    ----- stderr -----
+    "#);
 
     // Selecting only manual hooks should still succeed via fallback.
     cmd_snapshot!(context, context.run().arg("manual-only").arg("another-manual"), @r"

--- a/crates/prek/tests/workspace.rs
+++ b/crates/prek/tests/workspace.rs
@@ -608,14 +608,23 @@ fn run_with_selectors() -> Result<()> {
     ----- stderr -----
     "#);
 
-    cmd_snapshot!(context, context.run().arg("--skip").arg("show-cwd"), @r"
-    success: false
-    exit_code: 1
+    cmd_snapshot!(context, context.run().arg("--skip").arg("show-cwd"), @r#"
+    success: true
+    exit_code: 0
     ----- stdout -----
+    ✓ nested/project4
+      Show CWD..............................................................Skipped
+    ✓ project3/project5
+      Show CWD..............................................................Skipped
+    ✓ project2
+      Show CWD..............................................................Skipped
+    ✓ project3
+      Show CWD..............................................................Skipped
+    ✓ <workspace>
+      Show CWD..............................................................Skipped
 
     ----- stderr -----
-    error: No hooks found after filtering with the given selectors
-    ");
+    "#);
 
     cmd_snapshot!(context, context.run().arg("--skip").arg("project2:show-cwd").arg("--skip").arg("nested:show-cwd"), @r#"
     success: true
@@ -635,6 +644,8 @@ fn run_with_selectors() -> Result<()> {
 
         [TEMP_DIR]/project3/project5
         ['.pre-commit-config.yaml']
+    ✓ project2
+      Show CWD..............................................................Skipped
     ✓ project3
       Show CWD...............................................................Passed
       - hook id: show-cwd


### PR DESCRIPTION
Refs #1240
Refs #1777

Report initialized hooks excluded by `--skip`, `SKIP`, or `PREK_SKIP` as `Skipped` in their normal run order. `--hide-status skipped` hides both selector-skipped and no-files results.
