### PR TITLE
Centralize hook keys on Hook

### DIFF
--- a/crates/prek/src/cli/run/reporter.rs
+++ b/crates/prek/src/cli/run/reporter.rs
@@ -68,7 +68,7 @@ use rustc_hash::FxHashMap;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::cli::reporter::{ProgressReporter, SPINNER_TICKS, set_current_reporter};
-use crate::hook::Hook;
+use crate::hook::{Hook, HookKey};
 use crate::printer::Printer;
 use crate::process::OutputSink;
 use crate::workspace;
@@ -104,7 +104,7 @@ struct HookBar {
 impl HookBar {
     fn new(hook: &Hook, line_order: usize, progress: ProgressBar) -> Self {
         Self {
-            hook_key: HookKey::from_hook(hook),
+            hook_key: hook.key(),
             line_order,
             progress,
             output_bars: Vec::new(),
@@ -159,21 +159,6 @@ impl HookBar {
 
     fn visual_tail(&self) -> &ProgressBar {
         self.output_bars.last().unwrap_or(&self.progress)
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct HookKey {
-    project_idx: usize,
-    hook_idx: usize,
-}
-
-impl HookKey {
-    fn from_hook(hook: &Hook) -> Self {
-        Self {
-            project_idx: hook.project().idx(),
-            hook_idx: hook.idx,
-        }
     }
 }
 
@@ -674,7 +659,7 @@ impl HookRunReporter {
 
     pub fn hide_run_result(&self, hook: &Hook) {
         // Hidden results never record `passed`, so they cannot enter the collapsed summary.
-        let hook_key = HookKey::from_hook(hook);
+        let hook_key = hook.key();
         let completed = {
             let mut groups = self.groups.lock().unwrap();
             groups
@@ -687,7 +672,7 @@ impl HookRunReporter {
     }
 
     pub fn on_run_result(&self, hook: &Hook, passed: bool) {
-        let hook_key = HookKey::from_hook(hook);
+        let hook_key = hook.key();
         let progress = {
             let mut groups = self.groups.lock().unwrap();
             let Some(group) = groups.get_mut(&hook_key.project_idx) else {

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -371,7 +371,7 @@ async fn ensure_hooks_installed<'paths>(
 
         for hook in runnable_env_hooks {
             if let Some(installed_hook) = install_cache.installed_hook(store, hook.clone()).await {
-                installed_by_hook.insert(hook_key(&hook), installed_hook);
+                installed_by_hook.insert(hook.key(), installed_hook);
             } else {
                 missing_env_hooks.push(hook.clone());
             }
@@ -384,7 +384,7 @@ async fn ensure_hooks_installed<'paths>(
             reporter.on_complete();
 
             for installed_hook in installed_hooks {
-                installed_by_hook.insert(hook_key(&installed_hook), installed_hook);
+                installed_by_hook.insert(installed_hook.key(), installed_hook);
             }
         }
     }
@@ -394,7 +394,7 @@ async fn ensure_hooks_installed<'paths>(
         .map(|hook| match hook {
             HookPlan::Run(hook) => HookPlan::Run(
                 installed_by_hook
-                    .remove(&hook_key(&hook))
+                    .remove(&hook.key())
                     .unwrap_or_else(|| InstalledHook::NoNeedInstall(hook)),
             ),
             HookPlan::Skip(hook) => HookPlan::Skip(hook),
@@ -457,11 +457,6 @@ fn select_runnable_env_hooks<'paths>(
     }
 
     Ok(runnable_env_hooks)
-}
-
-fn hook_key(hook: &Hook) -> (usize, usize) {
-    // Hook indexes are scoped to a project config, so workspace runs need the project index too.
-    (hook.project().idx(), hook.idx)
 }
 
 #[allow(clippy::fn_params_excessive_bools)]

--- a/crates/prek/src/hook.rs
+++ b/crates/prek/src/hook.rs
@@ -346,6 +346,15 @@ fn hook_error(hook: &str, error: impl Into<anyhow::Error>) -> Error {
     }
 }
 
+/// Workspace-local identity of a configured hook.
+///
+/// Hook indexes are scoped to a project config, so the project index is part of the key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct HookKey {
+    pub(crate) project_idx: usize,
+    pub(crate) hook_idx: usize,
+}
+
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone)]
 pub(crate) struct Hook {
@@ -498,6 +507,13 @@ impl Hook {
 
     pub(crate) fn project(&self) -> &Project {
         &self.project
+    }
+
+    pub(crate) fn key(&self) -> HookKey {
+        HookKey {
+            project_idx: self.project.idx(),
+            hook_idx: self.idx,
+        }
     }
 
     pub(crate) fn repo(&self) -> &Repo {


### PR DESCRIPTION
Define `HookKey` alongside `Hook` and reuse `Hook::key()` across installation scheduling and run reporting.
