### PR TITLE
Simplify integration test fixture setup

### DIFF
--- a/crates/prek/tests/builtin_hooks.rs
+++ b/crates/prek/tests/builtin_hooks.rs
@@ -542,11 +542,11 @@ fn forbid_new_submodules_hook_in_workspace_project() {
         "},
     );
 
-    let cwd = context.work_dir();
     context.git().add_all().commit("Initial commit");
 
+    let context = context.with_file("project2/sub module/README.md", "submodule\n");
+    let cwd = context.work_dir();
     let submodule_path = cwd.child("project2/sub module");
-    context.write_file("project2/sub module/README.md", "submodule\n");
     context
         .git_at(&submodule_path)
         .init()
@@ -694,13 +694,15 @@ fn check_yaml_multiple_document() {
 
 #[test]
 fn check_vcs_permalinks_builtin() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-vcs-permalinks
                 args: [--additional-github-domain=github.example.com]
-    "}).with_file("links.md", indoc::indoc! {r"
+    "})
+        .with_file("links.md", indoc::indoc! {r"
         See https://github.com/owner/repo/blob/main/file.py#L10 and https://github.example.com/owner/repo/blob/master/src/lib.rs#L5 for context.
         https://github.com/owner/repo/blob/abcdef1234567890abcdef1234567890abcdef12/file.py#L10
     "});
@@ -1010,28 +1012,28 @@ fn check_added_large_files_hook() {
 
 #[test]
 fn check_added_large_files_workspace_mode_respects_project_relative_lfs_paths() {
-    let context = TestEnv::new_git().with_config("repos: []\n");
-
     // Regression: builtin hooks receive project-relative filenames even in workspace mode.
     // `check-added-large-files` must therefore resolve git-lfs attributes relative to the
     // nested project root, not the workspace root.
     // Use `--enforce-all` so this regression isolates git-lfs attribute lookup in workspace
     // mode instead of depending on the separate staged-file path filtering behavior.
-    context.write_file(
-        "app/.pre-commit-config.yaml",
-        indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_config("repos: []\n")
+        .with_file(
+            "app/.pre-commit-config.yaml",
+            indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-added-large-files
                 args: ['--maxkb', '1', '--enforce-all']
     "},
-    );
-    context.write_file(
-        "app/.gitattributes",
-        "*.dat filter=lfs diff=lfs merge=lfs -text",
-    );
-    context.write_file("app/large.dat", [0; 2048]);
+        )
+        .with_file(
+            "app/.gitattributes",
+            "*.dat filter=lfs diff=lfs merge=lfs -text",
+        )
+        .with_file("app/large.dat", [0; 2048]);
 
     context.git().add_all();
 
@@ -1048,19 +1050,19 @@ fn check_added_large_files_workspace_mode_respects_project_relative_lfs_paths() 
 
 #[test]
 fn check_added_large_files_workspace_mode_respects_project_relative_added_files() {
-    let context = TestEnv::new_git().with_config("repos: []\n");
-
-    context.write_file(
-        "app/.pre-commit-config.yaml",
-        indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_config("repos: []\n")
+        .with_file(
+            "app/.pre-commit-config.yaml",
+            indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-added-large-files
                 args: ['--maxkb', '1']
     "},
-    );
-    context.write_file("app/large.bin", [0; 2048]);
+        )
+        .with_file("app/large.bin", [0; 2048]);
 
     context.git().add_all();
 
@@ -1082,16 +1084,15 @@ fn check_added_large_files_workspace_mode_respects_project_relative_added_files(
 
 #[test]
 fn tracked_file_exceeds_large_file_limit() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-added-large-files
                 args: ['--maxkb', '1']
-    "});
-
-    // Create and commit a large file
-    context.write_file("large_file.txt", [0; 2048]); // 2KB file
+    "})
+        .with_file("large_file.txt", [0; 2048]); // 2KB file
     context.git().add_all().commit("Add large file");
     // Modify the large file
     context.write_file("large_file.txt", [0; 4096]); // 4KB file
@@ -1110,17 +1111,16 @@ fn tracked_file_exceeds_large_file_limit() {
 
 #[test]
 fn builtin_hooks_workspace_mode() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: meta
             hooks:
               - id: identity
-    "});
-
-    // Subproject with built-in hooks.
-    context.write_file(
-        "app/.pre-commit-config.yaml",
-        indoc::indoc! {r"
+    "})
+        .with_file(
+            "app/.pre-commit-config.yaml",
+            indoc::indoc! {r"
         repos:
           - repo: meta
             hooks:
@@ -1135,24 +1135,19 @@ fn builtin_hooks_workspace_mode() {
               - id: check-added-large-files
                 args: ['--maxkb', '1']
     "},
-    );
-
-    context.write_file("app/eof_no_newline.txt", "No trailing newline");
-    context.write_file("app/eof_multiple_lf.txt", "Multiple\n\n");
-    context.write_file("app/mixed.txt", "line1\nline2\r\n");
-    context.write_file("app/trailing_ws.txt", "line with trailing space \n");
-    context.write_file("app/correct.txt", "All good here\n");
-
-    context.write_file("app/invalid.yaml", "a: b: c");
-    context.write_file("app/duplicate.yaml", "a: 1\na: 2");
-    context.write_file("app/empty.yaml", "");
-
-    context.write_file("app/invalid.json", r#"{"a": 1,}"#);
-    context.write_file("app/duplicate.json", r#"{"a": 1, "a": 2}"#);
-    context.write_file("app/empty.json", "");
-
-    // 2KB file to trigger check-added-large-files (1 KB threshold).
-    context.write_file("app/large.bin", [0u8; 2048]);
+        )
+        .with_file("app/eof_no_newline.txt", "No trailing newline")
+        .with_file("app/eof_multiple_lf.txt", "Multiple\n\n")
+        .with_file("app/mixed.txt", "line1\nline2\r\n")
+        .with_file("app/trailing_ws.txt", "line with trailing space \n")
+        .with_file("app/correct.txt", "All good here\n")
+        .with_file("app/invalid.yaml", "a: b: c")
+        .with_file("app/duplicate.yaml", "a: 1\na: 2")
+        .with_file("app/empty.yaml", "")
+        .with_file("app/invalid.json", r#"{"a": 1,}"#)
+        .with_file("app/duplicate.json", r#"{"a": 1, "a": 2}"#)
+        .with_file("app/empty.json", "")
+        .with_file("app/large.bin", [0u8; 2048]);
 
     context.git().add_all();
 
@@ -3075,8 +3070,9 @@ fn check_case_conflict_hook() -> Result<()> {
     }
 
     // Create initial files and commit
-    context.write_file("README.md", "Initial commit");
-    context.write_file("src/foo.txt", "existing file");
+    let context = context
+        .with_file("README.md", "Initial commit")
+        .with_file("src/foo.txt", "existing file");
     context.git().add_all().commit("Initial commit");
 
     let context = context
@@ -3136,7 +3132,7 @@ fn check_case_conflict_directory() -> Result<()> {
     }
 
     // Create directory with file
-    context.write_file("src/utils/helper.py", "helper");
+    let context = context.with_file("src/utils/helper.py", "helper");
     context.git().add_all().commit("Initial commit");
 
     let context = context
@@ -3220,10 +3216,10 @@ fn check_case_conflict_workspace_mode_includes_added_files() -> Result<()> {
         return Ok(());
     }
 
-    let context = context.with_config("repos: []\n");
-
-    context.write_file("app/foo.txt", "existing file");
-    context.write_file("app/trigger.txt", "tracked trigger");
+    let context = context
+        .with_config("repos: []\n")
+        .with_file("app/foo.txt", "existing file")
+        .with_file("app/trigger.txt", "tracked trigger");
     context.git().add_all().commit("Initial commit");
 
     context.write_file(

--- a/crates/prek/tests/builtin_hooks.rs
+++ b/crates/prek/tests/builtin_hooks.rs
@@ -7,7 +7,6 @@ use anyhow::Result;
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
 use insta::assert_snapshot;
-use prek_consts::PRE_COMMIT_CONFIG_YAML;
 
 use crate::common::{TestEnv, cmd_snapshot};
 
@@ -72,22 +71,20 @@ fn builtin_hooks_unknown_hook() {
 }
 
 #[test]
-fn deny_filename_pattern_hook_matches_only_basename() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn deny_filename_pattern_hook_matches_only_basename() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: deny-filename-pattern
                 args: [--ignore-case, 'readme']
                 files: '\.md$'
-    "});
+    "})
+        .with_file("docs/README.md", "")
+        .with_file("README/guide.md", "")
+        .with_file("docs/guide.md", "");
 
-    let cwd = context.work_dir();
-    cwd.child("docs").create_dir_all()?;
-    cwd.child("README").create_dir_all()?;
-    cwd.child("docs/README.md").touch()?;
-    cwd.child("README/guide.md").touch()?;
-    cwd.child("docs/guide.md").touch()?;
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
@@ -103,13 +100,12 @@ fn deny_filename_pattern_hook_matches_only_basename() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn deny_pattern_hook_reports_matching_lines() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn deny_pattern_hook_reports_matching_lines() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -120,16 +116,17 @@ fn deny_pattern_hook_reports_matching_lines() -> Result<()> {
                   - 'remove'
                   - '^#import\s+.+:\s+\*$'
                 files: '\.typ$'
-    "});
-
-    let cwd = context.work_dir();
-    cwd.child("policy.typ").write_str(indoc::indoc! {"
+    "})
+        .with_file(
+            "policy.typ",
+            indoc::indoc! {"
         permitted content
         TODO: remove this
         #import package: *
-    "})?;
-    cwd.child("ignored.txt")
-        .write_str("TODO: ignored by files filter\n")?;
+    "},
+        )
+        .with_file("ignored.txt", "TODO: ignored by files filter\n");
+
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
@@ -146,24 +143,20 @@ fn deny_pattern_hook_reports_matching_lines() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn deny_pattern_hook_rejects_invalid_regex() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn deny_pattern_hook_rejects_invalid_regex() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: deny-pattern
                 args: ['*invalid-pattern*']
-    "});
+    "})
+        .with_file("file.txt", "content\n");
 
-    context
-        .work_dir()
-        .child("file.txt")
-        .write_str("content\n")?;
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
@@ -180,35 +173,34 @@ fn deny_pattern_hook_rejects_invalid_regex() -> Result<()> {
         ^
     error: repetition operator missing expression
     "#);
-
-    Ok(())
 }
 
 #[test]
-fn deny_pattern_hook_reports_earliest_multiline_match() -> Result<()> {
+fn deny_pattern_hook_reports_earliest_multiline_match() {
     let context = TestEnv::new_git();
 
     // `END` is listed first, but `BEGIN.*END` starts earlier in the file.
     // Multiline matching should report the earliest match, not the first pattern.
-    let context = context.with_config(indoc::indoc! {r"
+    let context = context
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: deny-pattern
                 args: [-m, 'END', 'BEGIN.*END']
                 files: '\.txt$'
-    "});
-
-    context
-        .work_dir()
-        .child("block.txt")
-        .write_str(indoc::indoc! {"
+    "})
+        .with_file(
+            "block.txt",
+            indoc::indoc! {"
         before
         BEGIN
         middle
         END
         after
-    "})?;
+    "},
+        );
+
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
@@ -226,13 +218,12 @@ fn deny_pattern_hook_reports_earliest_multiline_match() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn require_filename_pattern_hook_accepts_any_pattern_for_basename() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn require_filename_pattern_hook_accepts_any_pattern_for_basename() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -242,16 +233,13 @@ fn require_filename_pattern_hook_accepts_any_pattern_for_basename() -> Result<()
                   - '^__init__\.py$'
                   - '^conftest\.py$'
                 files: '(^|/)tests/.+\.py$'
-    "});
+    "})
+        .with_file("tests/unit/test_parser.py", "")
+        .with_file("tests/unit/parser_test.py", "")
+        .with_file("tests/unit/__init__.py", "")
+        .with_file("tests/unit/conftest.py", "")
+        .with_file("tests/test_unit/parser.py", "");
 
-    let cwd = context.work_dir();
-    cwd.child("tests/unit").create_dir_all()?;
-    cwd.child("tests/test_unit").create_dir_all()?;
-    cwd.child("tests/unit/test_parser.py").touch()?;
-    cwd.child("tests/unit/parser_test.py").touch()?;
-    cwd.child("tests/unit/__init__.py").touch()?;
-    cwd.child("tests/unit/conftest.py").touch()?;
-    cwd.child("tests/test_unit/parser.py").touch()?;
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
@@ -268,25 +256,23 @@ fn require_filename_pattern_hook_accepts_any_pattern_for_basename() -> Result<()
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn require_pattern_hook_reports_files_without_any_match() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn require_pattern_hook_reports_files_without_any_match() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: require-pattern
                 args: [--ignore-case, --multiline, 'begin.*end', 'copyright']
                 files: '\.txt$'
-    "});
+    "})
+        .with_file("block.txt", "BEGIN\nmiddle\nEND\n")
+        .with_file("copyright.txt", "Copyright 2026\n")
+        .with_file("missing.txt", "No required marker\n");
 
-    let cwd = context.work_dir();
-    cwd.child("block.txt").write_str("BEGIN\nmiddle\nEND\n")?;
-    cwd.child("copyright.txt").write_str("Copyright 2026\n")?;
-    cwd.child("missing.txt").write_str("No required marker\n")?;
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
@@ -302,33 +288,25 @@ fn require_pattern_hook_reports_files_without_any_match() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn end_of_file_fixer_hook() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn end_of_file_fixer_hook() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: end-of-file-fixer
-    "});
-
-    let cwd = context.work_dir();
-
-    // Create test files
-    cwd.child("correct_lf.txt").write_str("Hello World\n")?;
-    cwd.child("correct_crlf.txt").write_str("Hello World\r\n")?;
-    cwd.child("no_newline.txt")
-        .write_str("No trailing newline")?;
-    cwd.child("multiple_lf.txt")
-        .write_str("Multiple newlines\n\n\n")?;
-    cwd.child("multiple_crlf.txt")
-        .write_str("Multiple newlines\r\n\r\n")?;
-    cwd.child("empty.txt").touch()?;
-    cwd.child("only_newlines.txt").write_str("\n\n")?;
-    cwd.child("only_win_newlines.txt").write_str("\r\n\r\n")?;
+    "})
+        .with_file("correct_lf.txt", "Hello World\n")
+        .with_file("correct_crlf.txt", "Hello World\r\n")
+        .with_file("no_newline.txt", "No trailing newline")
+        .with_file("multiple_lf.txt", "Multiple newlines\n\n\n")
+        .with_file("multiple_crlf.txt", "Multiple newlines\r\n\r\n")
+        .with_file("empty.txt", "")
+        .with_file("only_newlines.txt", "\n\n")
+        .with_file("only_win_newlines.txt", "\r\n\r\n");
 
     context.git().add_all();
 
@@ -373,25 +351,21 @@ fn end_of_file_fixer_hook() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn file_contents_sorter_hook() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn file_contents_sorter_hook() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: file-contents-sorter
                 files: ^allowlist\.txt$
                 args: [--ignore-case]
-    "});
-
-    let cwd = context.work_dir();
-    cwd.child("allowlist.txt")
-        .write_str("Banana\n\napple\nApricot\n")?;
-    cwd.child("ignored.txt").write_str("zebra\nant\n")?;
+    "})
+        .with_file("allowlist.txt", "Banana\n\napple\nApricot\n")
+        .with_file("ignored.txt", "zebra\nant\n");
 
     context.git().add_all();
 
@@ -430,24 +404,22 @@ fn file_contents_sorter_hook() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn builtin_hook_checks_filename_from_args_after_options() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn builtin_hook_checks_filename_from_args_after_options() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: file-contents-sorter
                 args: [--ignore-case, configured.txt, configured.txt, selected.txt]
                 files: ^selected\.txt$
-    "});
+    "})
+        .with_file("configured.txt", "beta\nAlpha\n")
+        .with_file("selected.txt", "Beta\nalpha\n");
 
-    let cwd = context.work_dir();
-    cwd.child("configured.txt").write_str("beta\nAlpha\n")?;
-    cwd.child("selected.txt").write_str("Beta\nalpha\n")?;
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
@@ -468,29 +440,29 @@ fn builtin_hook_checks_filename_from_args_after_options() -> Result<()> {
 
     assert_eq!(context.read("configured.txt"), "Alpha\nbeta\n");
     assert_eq!(context.read("selected.txt"), "alpha\nBeta\n");
-
-    Ok(())
 }
 
 #[test]
-fn requirements_txt_fixer_hook() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn requirements_txt_fixer_hook() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: requirements-txt-fixer
-    "});
-
-    let cwd = context.work_dir();
-    cwd.child("requirements.txt").write_str(indoc::indoc! {"
+    "})
+        .with_file(
+            "requirements.txt",
+            indoc::indoc! {"
         requests==2
         # Flask is needed by the web application.
         Flask==3
         requests==2
         pkg-resources==0.0.0
-    "})?;
-    cwd.child("requirements.in")
-        .write_str("z-project\na-project\n")?;
+    "},
+        )
+        .with_file("requirements.in", "z-project\na-project\n");
+
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
@@ -536,9 +508,8 @@ fn requirements_txt_fixer_hook() -> Result<()> {
               - id: check-json
         "});
 
-    cwd.child("requirements.txt")
-        .write_str("flask\n  requests==2\n")?;
-    cwd.child("valid.json").write_str("{}\n")?;
+    context.write_file("requirements.txt", "flask\n  requests==2\n");
+    context.write_file("valid.json", "{}\n");
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
@@ -557,30 +528,25 @@ fn requirements_txt_fixer_hook() -> Result<()> {
     ");
 
     assert_eq!(context.read("requirements.txt"), "flask\n  requests==2\n");
-
-    Ok(())
 }
 
 #[test]
-fn forbid_new_submodules_hook_in_workspace_project() -> Result<()> {
-    let context = TestEnv::new_git().with_config("repos: []\n");
-
-    let cwd = context.work_dir();
-    cwd.child("project2").create_dir_all()?;
-    cwd.child("project2")
-        .child(PRE_COMMIT_CONFIG_YAML)
-        .write_str(indoc::indoc! {r"
+fn forbid_new_submodules_hook_in_workspace_project() {
+    let context = TestEnv::new_git().with_config("repos: []\n").with_file(
+        "project2/.pre-commit-config.yaml",
+        indoc::indoc! {r"
             repos:
               - repo: builtin
                 hooks:
                   - id: forbid-new-submodules
-        "})?;
+        "},
+    );
 
+    let cwd = context.work_dir();
     context.git().add_all().commit("Initial commit");
 
     let submodule_path = cwd.child("project2/sub module");
-    submodule_path.create_dir_all()?;
-    submodule_path.child("README.md").write_str("submodule\n")?;
+    context.write_file("project2/sub module/README.md", "submodule\n");
     context
         .git_at(&submodule_path)
         .init()
@@ -618,26 +584,21 @@ fn forbid_new_submodules_hook_in_workspace_project() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
-fn check_yaml_hook() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn check_yaml_hook() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-yaml
-    "});
-
-    let cwd = context.work_dir();
-
-    // Create test files
-    cwd.child("valid.yaml").write_str("a: 1")?;
-    cwd.child("invalid.yaml").write_str("a: b: c")?;
-    cwd.child("duplicate.yaml").write_str("a: 1\na: 2")?;
-    cwd.child("empty.yaml").touch()?;
+    "})
+        .with_file("valid.yaml", "a: 1")
+        .with_file("invalid.yaml", "a: b: c")
+        .with_file("duplicate.yaml", "a: 1\na: 2")
+        .with_file("empty.yaml", "");
 
     context.git().add_all();
 
@@ -667,8 +628,8 @@ fn check_yaml_hook() -> Result<()> {
     ");
 
     // Fix the files
-    cwd.child("invalid.yaml").write_str("a:\n  b: c")?;
-    cwd.child("duplicate.yaml").write_str("a: 1\nb: 2")?;
+    context.write_file("invalid.yaml", "a:\n  b: c");
+    context.write_file("duplicate.yaml", "a: 1\nb: 2");
 
     context.git().add_all();
 
@@ -681,13 +642,12 @@ fn check_yaml_hook() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn check_yaml_multiple_document() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn check_yaml_multiple_document() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -696,18 +656,17 @@ fn check_yaml_multiple_document() -> Result<()> {
                 args: [ --allow-multiple-documents ]
               - id: check-yaml
                 name: disallow multiple documents
-    "});
-
-    context
-        .work_dir()
-        .child("multiple.yaml")
-        .write_str(indoc::indoc! {r"
+    "})
+        .with_file(
+            "multiple.yaml",
+            indoc::indoc! {r"
         ---
         a: 1
         ---
         b: 2
         "
-        })?;
+            },
+        );
 
     context.git().add_all();
 
@@ -731,27 +690,20 @@ fn check_yaml_multiple_document() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn check_vcs_permalinks_builtin() -> Result<()> {
+fn check_vcs_permalinks_builtin() {
     let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-vcs-permalinks
                 args: [--additional-github-domain=github.example.com]
-    "});
-
-    context
-        .work_dir()
-        .child("links.md")
-        .write_str(indoc::indoc! {r"
+    "}).with_file("links.md", indoc::indoc! {r"
         See https://github.com/owner/repo/blob/main/file.py#L10 and https://github.example.com/owner/repo/blob/master/src/lib.rs#L5 for context.
         https://github.com/owner/repo/blob/abcdef1234567890abcdef1234567890abcdef12/file.py#L10
-    "})?;
+    "});
 
     context.git().add_all();
 
@@ -769,27 +721,21 @@ fn check_vcs_permalinks_builtin() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn check_json_hook() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn check_json_hook() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-json
-    "});
-
-    let cwd = context.work_dir();
-
-    // Create test files
-    cwd.child("valid.json").write_str(r#"{"a": 1}"#)?;
-    cwd.child("invalid.json").write_str(r#"{"a": 1,}"#)?;
-    cwd.child("duplicate.json")
-        .write_str(r#"{"a": 1, "a": 2}"#)?;
-    cwd.child("empty.json").touch()?;
+    "})
+        .with_file("valid.json", r#"{"a": 1}"#)
+        .with_file("invalid.json", r#"{"a": 1,}"#)
+        .with_file("duplicate.json", r#"{"a": 1, "a": 2}"#)
+        .with_file("empty.json", "");
 
     context.git().add_all();
 
@@ -810,9 +756,8 @@ fn check_json_hook() -> Result<()> {
     ");
 
     // Fix the files
-    cwd.child("invalid.json").write_str(r#"{"a": 1}"#)?;
-    cwd.child("duplicate.json")
-        .write_str(r#"{"a": 1, "b": 2}"#)?;
+    context.write_file("invalid.json", r#"{"a": 1}"#);
+    context.write_file("duplicate.json", r#"{"a": 1, "b": 2}"#);
 
     context.git().add_all();
 
@@ -825,28 +770,22 @@ fn check_json_hook() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn mixed_line_ending_hook() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn mixed_line_ending_hook() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: mixed-line-ending
-    "});
-
-    let cwd = context.work_dir();
-
-    // Create test files
-    cwd.child("mixed.txt")
-        .write_str("line1\nline2\r\nline3\r\n")?;
-    cwd.child("only_lf.txt").write_str("line1\nline2\n")?;
-    cwd.child("only_crlf.txt").write_str("line1\r\nline2\r\n")?;
-    cwd.child("no_endings.txt").write_str("hello world")?;
-    cwd.child("empty.txt").touch()?;
+    "})
+        .with_file("mixed.txt", "line1\nline2\r\nline3\r\n")
+        .with_file("only_lf.txt", "line1\nline2\n")
+        .with_file("only_crlf.txt", "line1\r\nline2\r\n")
+        .with_file("no_endings.txt", "hello world")
+        .with_file("empty.txt", "");
 
     context.git().add_all();
 
@@ -901,10 +840,7 @@ fn mixed_line_ending_hook() -> Result<()> {
               - id: mixed-line-ending
                 args: ['--fix=no']
     "});
-    context
-        .work_dir()
-        .child("mixed.txt")
-        .write_str("line1\nline2\r\n")?;
+    context.write_file("mixed.txt", "line1\nline2\r\n");
     context.git().add_all();
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -932,10 +868,7 @@ fn mixed_line_ending_hook() -> Result<()> {
               - id: mixed-line-ending
                 args: ['--fix', 'crlf']
     "});
-    context
-        .work_dir()
-        .child("mixed.txt")
-        .write_str("line1\nline2\r\n")?;
+    context.write_file("mixed.txt", "line1\nline2\r\n");
     context.git().add_all();
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -966,10 +899,7 @@ fn mixed_line_ending_hook() -> Result<()> {
               - id: mixed-line-ending
                 args: ['--fix']
     "});
-    context
-        .work_dir()
-        .child("mixed.txt")
-        .write_str("line1\nline2\r\nline3\n")?;
+    context.write_file("mixed.txt", "line1\nline2\r\nline3\n");
     context.git().add_all();
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -981,8 +911,6 @@ fn mixed_line_ending_hook() -> Result<()> {
       caused by: error: a value is required for '--fix <FIX>' but none was supplied
       [possible values: auto, no, lf, crlf, cr]
     ");
-
-    Ok(())
 }
 
 #[test]
@@ -1081,27 +1009,29 @@ fn check_added_large_files_hook() {
 }
 
 #[test]
-fn check_added_large_files_workspace_mode_respects_project_relative_lfs_paths() -> Result<()> {
+fn check_added_large_files_workspace_mode_respects_project_relative_lfs_paths() {
     let context = TestEnv::new_git().with_config("repos: []\n");
 
     // Regression: builtin hooks receive project-relative filenames even in workspace mode.
     // `check-added-large-files` must therefore resolve git-lfs attributes relative to the
     // nested project root, not the workspace root.
-    let app = context.work_dir().child("app");
-    app.create_dir_all()?;
     // Use `--enforce-all` so this regression isolates git-lfs attribute lookup in workspace
     // mode instead of depending on the separate staged-file path filtering behavior.
-    app.child(PRE_COMMIT_CONFIG_YAML)
-        .write_str(indoc::indoc! {r"
+    context.write_file(
+        "app/.pre-commit-config.yaml",
+        indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-added-large-files
                 args: ['--maxkb', '1', '--enforce-all']
-    "})?;
-    app.child(".gitattributes")
-        .write_str("*.dat filter=lfs diff=lfs merge=lfs -text")?;
-    app.child("large.dat").write_binary(&[0; 2048])?;
+    "},
+    );
+    context.write_file(
+        "app/.gitattributes",
+        "*.dat filter=lfs diff=lfs merge=lfs -text",
+    );
+    context.write_file("app/large.dat", [0; 2048]);
 
     context.git().add_all();
 
@@ -1114,25 +1044,23 @@ fn check_added_large_files_workspace_mode_respects_project_relative_lfs_paths() 
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
-fn check_added_large_files_workspace_mode_respects_project_relative_added_files() -> Result<()> {
+fn check_added_large_files_workspace_mode_respects_project_relative_added_files() {
     let context = TestEnv::new_git().with_config("repos: []\n");
 
-    let app = context.work_dir().child("app");
-    app.create_dir_all()?;
-    app.child(PRE_COMMIT_CONFIG_YAML)
-        .write_str(indoc::indoc! {r"
+    context.write_file(
+        "app/.pre-commit-config.yaml",
+        indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-added-large-files
                 args: ['--maxkb', '1']
-    "})?;
-    app.child("large.bin").write_binary(&[0; 2048])?;
+    "},
+    );
+    context.write_file("app/large.bin", [0; 2048]);
 
     context.git().add_all();
 
@@ -1150,12 +1078,10 @@ fn check_added_large_files_workspace_mode_respects_project_relative_added_files(
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
-fn tracked_file_exceeds_large_file_limit() -> Result<()> {
+fn tracked_file_exceeds_large_file_limit() {
     let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -1164,14 +1090,11 @@ fn tracked_file_exceeds_large_file_limit() -> Result<()> {
                 args: ['--maxkb', '1']
     "});
 
-    let cwd = context.work_dir();
-
     // Create and commit a large file
-    let large_file = cwd.child("large_file.txt");
-    large_file.write_binary(&[0; 2048])?; // 2KB file
+    context.write_file("large_file.txt", [0; 2048]); // 2KB file
     context.git().add_all().commit("Add large file");
     // Modify the large file
-    large_file.write_binary(&[0; 4096])?; // 4KB file
+    context.write_file("large_file.txt", [0; 4096]); // 4KB file
     context.git().add_all();
 
     // Run the hook: it should pass because the file is already tracked
@@ -1183,12 +1106,10 @@ fn tracked_file_exceeds_large_file_limit() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn builtin_hooks_workspace_mode() -> Result<()> {
+fn builtin_hooks_workspace_mode() {
     let context = TestEnv::new_git().with_config(indoc::indoc! {r"
         repos:
           - repo: meta
@@ -1197,10 +1118,9 @@ fn builtin_hooks_workspace_mode() -> Result<()> {
     "});
 
     // Subproject with built-in hooks.
-    let app = context.work_dir().child("app");
-    app.create_dir_all()?;
-    app.child(PRE_COMMIT_CONFIG_YAML)
-        .write_str(indoc::indoc! {r"
+    context.write_file(
+        "app/.pre-commit-config.yaml",
+        indoc::indoc! {r"
         repos:
           - repo: meta
             hooks:
@@ -1214,27 +1134,25 @@ fn builtin_hooks_workspace_mode() -> Result<()> {
               - id: trailing-whitespace
               - id: check-added-large-files
                 args: ['--maxkb', '1']
-    "})?;
+    "},
+    );
 
-    app.child("eof_no_newline.txt")
-        .write_str("No trailing newline")?;
-    app.child("eof_multiple_lf.txt").write_str("Multiple\n\n")?;
-    app.child("mixed.txt").write_str("line1\nline2\r\n")?;
-    app.child("trailing_ws.txt")
-        .write_str("line with trailing space \n")?;
-    app.child("correct.txt").write_str("All good here\n")?;
+    context.write_file("app/eof_no_newline.txt", "No trailing newline");
+    context.write_file("app/eof_multiple_lf.txt", "Multiple\n\n");
+    context.write_file("app/mixed.txt", "line1\nline2\r\n");
+    context.write_file("app/trailing_ws.txt", "line with trailing space \n");
+    context.write_file("app/correct.txt", "All good here\n");
 
-    app.child("invalid.yaml").write_str("a: b: c")?;
-    app.child("duplicate.yaml").write_str("a: 1\na: 2")?;
-    app.child("empty.yaml").touch()?;
+    context.write_file("app/invalid.yaml", "a: b: c");
+    context.write_file("app/duplicate.yaml", "a: 1\na: 2");
+    context.write_file("app/empty.yaml", "");
 
-    app.child("invalid.json").write_str(r#"{"a": 1,}"#)?;
-    app.child("duplicate.json")
-        .write_str(r#"{"a": 1, "a": 2}"#)?;
-    app.child("empty.json").touch()?;
+    context.write_file("app/invalid.json", r#"{"a": 1,}"#);
+    context.write_file("app/duplicate.json", r#"{"a": 1, "a": 2}"#);
+    context.write_file("app/empty.json", "");
 
     // 2KB file to trigger check-added-large-files (1 KB threshold).
-    app.child("large.bin").write_binary(&[0u8; 2048])?;
+    context.write_file("app/large.bin", [0u8; 2048]);
 
     context.git().add_all();
 
@@ -1340,13 +1258,11 @@ fn builtin_hooks_workspace_mode() -> Result<()> {
     "#);
 
     // Manually fix the files that can't be auto-fixed.
-    app.child("invalid.yaml").write_str("a:\n  b: c\n")?;
-    app.child("duplicate.yaml").write_str("a: 1\nb: 2\n")?;
-    app.child("invalid.json")
-        .write_str(concat!(r#"{"a": 1}"#, "\n"))?;
-    app.child("duplicate.json")
-        .write_str(concat!(r#"{"a": 1, "b": 2}"#, "\n"))?;
-    app.child("large.bin").write_binary(&[0u8; 100])?;
+    context.write_file("app/invalid.yaml", "a:\n  b: c\n");
+    context.write_file("app/duplicate.yaml", "a: 1\nb: 2\n");
+    context.write_file("app/invalid.json", concat!(r#"{"a": 1}"#, "\n"));
+    context.write_file("app/duplicate.json", concat!(r#"{"a": 1, "b": 2}"#, "\n"));
+    context.write_file("app/large.bin", [0u8; 100]);
     context.git().add_all();
 
     // Second run: all hooks should now pass.
@@ -1400,30 +1316,27 @@ fn builtin_hooks_workspace_mode() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
-fn fix_byte_order_marker_hook() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn fix_byte_order_marker_hook() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: fix-byte-order-marker
-    "});
-
-    let cwd = context.work_dir();
-
-    // Create test files
-    cwd.child("without_bom.txt").write_str("Hello, World!")?;
-    cwd.child("with_bom.txt").write_binary(&[
-        0xef, 0xbb, 0xbf, b'H', b'e', b'l', b'l', b'o', b',', b' ', b'W', b'o', b'r', b'l', b'd',
-        b'!',
-    ])?;
-    cwd.child("bom_only.txt")
-        .write_binary(&[0xef, 0xbb, 0xbf])?;
-    cwd.child("empty.txt").touch()?;
+    "})
+        .with_file("without_bom.txt", "Hello, World!")
+        .with_file(
+            "with_bom.txt",
+            [
+                0xef, 0xbb, 0xbf, b'H', b'e', b'l', b'l', b'o', b',', b' ', b'W', b'o', b'r', b'l',
+                b'd', b'!',
+            ],
+        )
+        .with_file("bom_only.txt", [0xef, 0xbb, 0xbf])
+        .with_file("empty.txt", "");
 
     context.git().add_all();
 
@@ -1461,25 +1374,21 @@ fn fix_byte_order_marker_hook() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn pretty_format_json_hook() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn pretty_format_json_hook() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: pretty-format-json
                 args: ['--autofix']
-    "});
-
-    let cwd = context.work_dir();
-
-    // Create test files
-    cwd.child("valid_pretty.json").write_str(
-        r#"{
+    "})
+        .with_file(
+            "valid_pretty.json",
+            r#"{
   "alist": [
     2,
     34,
@@ -1489,25 +1398,29 @@ fn pretty_format_json_hook() -> Result<()> {
   "foo": "bar"
 }
 "#,
-    )?;
-    cwd.child("unsorted.json").write_str(
-        r#"{
+        )
+        .with_file(
+            "unsorted.json",
+            r#"{
   "foo": "bar",
   "alist": [2, 34, 234],
   "blah": null
 }
 "#,
-    )?;
-    cwd.child("compact.json")
-        .write_str(r#"{"foo":"bar","alist":[2,34,234],"blah":null}"#)?;
-    cwd.child("uppercase_unicode.json").write_str(
-        r#"{
+        )
+        .with_file(
+            "compact.json",
+            r#"{"foo":"bar","alist":[2,34,234],"blah":null}"#,
+        )
+        .with_file(
+            "uppercase_unicode.json",
+            r#"{
   "text": "\u4E2D\u6587"
 }
 "#,
-    )?;
-    cwd.child("invalid.json").write_str(r#"{"a": 1,}"#)?;
-    cwd.child("empty.json").touch()?;
+        )
+        .with_file("invalid.json", r#"{"a": 1,}"#)
+        .with_file("empty.json", "");
 
     context.git().add_all();
 
@@ -1572,18 +1485,20 @@ fn pretty_format_json_hook() -> Result<()> {
     "#);
 
     // Fix invalid files with proper formatting
-    cwd.child("invalid.json").write_str(
+    context.write_file(
+        "invalid.json",
         r#"{
   "a": 1
 }
 "#,
-    )?;
-    cwd.child("empty.json").write_str(
+    );
+    context.write_file(
+        "empty.json",
         r#"{
   "b": 2
 }
 "#,
-    )?;
+    );
 
     context.git().add_all();
 
@@ -1596,23 +1511,19 @@ fn pretty_format_json_hook() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
-fn pretty_format_json_with_options() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn pretty_format_json_with_options() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: pretty-format-json
                 args: ['--autofix', '--indent=4', '--no-sort-keys']
-    "});
-
-    let cwd = context.work_dir();
-
-    cwd.child("test.json").write_str(r#"{"z":1,"a":2,"m":3}"#)?;
+    "})
+        .with_file("test.json", r#"{"z":1,"a":2,"m":3}"#);
 
     context.git().add_all();
 
@@ -1650,25 +1561,22 @@ fn pretty_format_json_with_options() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
-fn pretty_format_json_with_top_keys() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn pretty_format_json_with_top_keys() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: pretty-format-json
                 args: ['--autofix', '--top-keys=version,name']
-    "});
-
-    let cwd = context.work_dir();
-
-    cwd.child("package.json").write_str(
-        r#"{"description":"test","name":"my-package","author":"me","version":"1.0.0"}"#,
-    )?;
+    "})
+        .with_file(
+            "package.json",
+            r#"{"description":"test","name":"my-package","author":"me","version":"1.0.0"}"#,
+        );
 
     context.git().add_all();
 
@@ -1706,24 +1614,22 @@ fn pretty_format_json_with_top_keys() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
-fn pretty_format_json_no_ensure_ascii() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn pretty_format_json_no_ensure_ascii() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: pretty-format-json
                 args: ['--autofix', '--no-ensure-ascii']
-    "});
-
-    let cwd = context.work_dir();
-
-    cwd.child("unicode.json")
-        .write_str(r#"{"text":"\u4E2D\u6587\u306B\u307B\u3093\u3054"}"#)?;
+    "})
+        .with_file(
+            "unicode.json",
+            r#"{"text":"\u4E2D\u6587\u306B\u307B\u3093\u3054"}"#,
+        );
 
     context.git().add_all();
 
@@ -1759,23 +1665,19 @@ fn pretty_format_json_no_ensure_ascii() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
-fn pretty_format_json_custom_space_indent() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn pretty_format_json_custom_space_indent() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: pretty-format-json
                 args: ['--autofix', '--indent=  ']
-    "});
-
-    let cwd = context.work_dir();
-
-    cwd.child("test.json").write_str(r#"{"a":1,"b":2}"#)?;
+    "})
+        .with_file("test.json", r#"{"a":1,"b":2}"#);
 
     context.git().add_all();
 
@@ -1811,25 +1713,22 @@ fn pretty_format_json_custom_space_indent() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
 #[cfg(unix)]
 fn check_symlinks_hook_unix() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-symlinks
-    "});
+    "})
+        .with_file("regular.txt", "regular file")
+        .with_file("target.txt", "target content");
 
     let cwd = context.work_dir();
-
-    // Create test files
-    cwd.child("regular.txt").write_str("regular file")?;
-    cwd.child("target.txt").write_str("target content")?;
 
     // Create valid symlink
     fs_err::os::unix::fs::symlink(
@@ -1880,18 +1779,17 @@ fn check_symlinks_hook_unix() -> Result<()> {
 #[test]
 #[cfg(windows)]
 fn check_symlinks_hook_windows() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-symlinks
-    "});
+    "})
+        .with_file("regular.txt", "regular file")
+        .with_file("target.txt", "target content");
 
     let cwd = context.work_dir();
-
-    // Create test files
-    cwd.child("regular.txt").write_str("regular file")?;
-    cwd.child("target.txt").write_str("target content")?;
 
     // Try to create valid symlink (may fail without admin/developer mode)
     let valid_link_result = fs_err::os::windows::fs::symlink_file(
@@ -2030,10 +1928,7 @@ fn destroyed_symlinks_hook() -> Result<()> {
     ----- stderr -----
     ");
 
-    context
-        .work_dir()
-        .child(TEST_SYMLINK)
-        .write_str(&format!("{TEST_SYMLINK_TARGET}\n"))?;
+    context.write_file(TEST_SYMLINK, format!("{TEST_SYMLINK_TARGET}\n"));
     context.git().add(TEST_SYMLINK);
 
     cmd_snapshot!(context, context.run(), @r"
@@ -2055,10 +1950,10 @@ fn destroyed_symlinks_hook() -> Result<()> {
     ----- stderr -----
     ");
 
-    context
-        .work_dir()
-        .child(TEST_SYMLINK)
-        .write_str(&format!("{}\n", "0".repeat(TEST_SYMLINK_TARGET.len())))?;
+    context.write_file(
+        TEST_SYMLINK,
+        format!("{}\n", "0".repeat(TEST_SYMLINK_TARGET.len())),
+    );
     context.git().add(TEST_SYMLINK);
 
     cmd_snapshot!(context, context.run(), @r"
@@ -2070,10 +1965,10 @@ fn destroyed_symlinks_hook() -> Result<()> {
     ----- stderr -----
     ");
 
-    context
-        .work_dir()
-        .child(TEST_SYMLINK)
-        .write_str(&format!("{}\n", "0".repeat(TEST_SYMLINK_TARGET.len() + 3)))?;
+    context.write_file(
+        TEST_SYMLINK,
+        format!("{}\n", "0".repeat(TEST_SYMLINK_TARGET.len() + 3)),
+    );
     context.git().add(TEST_SYMLINK);
 
     cmd_snapshot!(context, context.run(), @r"
@@ -2089,42 +1984,55 @@ fn destroyed_symlinks_hook() -> Result<()> {
 }
 
 #[test]
-fn detect_private_key_hook() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn detect_private_key_hook() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: detect-private-key
-    "});
-
-    let cwd = context.work_dir();
-
-    // Create test files - various private key types
-    cwd.child("id_rsa")
-        .write_str("-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----\n")?;
-    cwd.child("id_dsa")
-        .write_str("-----BEGIN DSA PRIVATE KEY-----\nAAAAA...\n-----END DSA PRIVATE KEY-----\n")?;
-    cwd.child("id_ecdsa")
-        .write_str("-----BEGIN EC PRIVATE KEY-----\nMHc...\n-----END EC PRIVATE KEY-----\n")?;
-    cwd.child("id_ed25519").write_str(
-        "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNz...\n-----END OPENSSH PRIVATE KEY-----\n",
-    )?;
-    cwd.child("key.ppk")
-        .write_str("PuTTY-User-Key-File-2: ssh-rsa\nEncryption: none\n")?;
-    cwd.child("private.asc")
-        .write_str("-----BEGIN PGP PRIVATE KEY BLOCK-----\nVersion: GnuPG...\n")?;
-    cwd.child("ta.key").write_str(
-        "#\n# 2048 bit OpenVPN static key\n#\n-----BEGIN OpenVPN Static key V1-----\n",
-    )?;
-    cwd.child("doc.txt").write_str(
-        "Some documentation\n\nHere is a key:\n-----BEGIN RSA PRIVATE KEY-----\ndata\n",
-    )?;
-    cwd.child("safe1.txt")
-        .write_str("This file talks about BEGIN_RSA_PRIVATE_KEY but doesn't contain one\n")?;
-
-    cwd.child("safe2.txt")
-        .write_str("This is just a regular file\nwith some content\n")?;
-    cwd.child("empty.txt").touch()?;
+    "})
+        .with_file(
+            "id_rsa",
+            "-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----\n",
+        )
+        .with_file(
+            "id_dsa",
+            "-----BEGIN DSA PRIVATE KEY-----\nAAAAA...\n-----END DSA PRIVATE KEY-----\n",
+        )
+        .with_file(
+            "id_ecdsa",
+            "-----BEGIN EC PRIVATE KEY-----\nMHc...\n-----END EC PRIVATE KEY-----\n",
+        )
+        .with_file(
+            "id_ed25519",
+            "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNz...\n-----END OPENSSH PRIVATE KEY-----\n",
+        )
+        .with_file(
+            "key.ppk",
+            "PuTTY-User-Key-File-2: ssh-rsa\nEncryption: none\n",
+        )
+        .with_file(
+            "private.asc",
+            "-----BEGIN PGP PRIVATE KEY BLOCK-----\nVersion: GnuPG...\n",
+        )
+        .with_file(
+            "ta.key",
+            "#\n# 2048 bit OpenVPN static key\n#\n-----BEGIN OpenVPN Static key V1-----\n",
+        )
+        .with_file(
+            "doc.txt",
+            "Some documentation\n\nHere is a key:\n-----BEGIN RSA PRIVATE KEY-----\ndata\n",
+        )
+        .with_file(
+            "safe1.txt",
+            "This file talks about BEGIN_RSA_PRIVATE_KEY but doesn't contain one\n",
+        )
+        .with_file(
+            "safe2.txt",
+            "This is just a regular file\nwith some content\n",
+        )
+        .with_file("empty.txt", "");
 
     context.git().add_all();
 
@@ -2173,24 +2081,21 @@ fn detect_private_key_hook() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn check_merge_conflict_hook() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn check_merge_conflict_hook() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-merge-conflict
                 args: ['--assume-in-merge']
-    "});
-
-    let cwd = context.work_dir();
-
-    // Create test files with conflict markers
-    cwd.child("conflict.txt").write_str(indoc::indoc! {r"
+    "})
+        .with_file(
+            "conflict.txt",
+            indoc::indoc! {r"
         Before conflict
         <<<<<<< HEAD
         Our changes
@@ -2198,24 +2103,26 @@ fn check_merge_conflict_hook() -> Result<()> {
         Their changes
         >>>>>>> branch
         After conflict
-    "})?;
-
-    cwd.child("clean.txt").write_str("No conflicts here\n")?;
-
-    cwd.child("partial_conflict.txt")
-        .write_str(indoc::indoc! {r"
+    "},
+        )
+        .with_file("clean.txt", "No conflicts here\n")
+        .with_file(
+            "partial_conflict.txt",
+            indoc::indoc! {r"
         Some content
         <<<<<<< HEAD
         Conflicting line
-    "})?;
-
-    cwd.child("partial_separator_conflict.txt")
-        .write_str(indoc::indoc! {r"
+    "},
+        )
+        .with_file(
+            "partial_separator_conflict.txt",
+            indoc::indoc! {r"
         Some content
         <<<<<<< HEAD
         Conflicting line
         =======
-    "})?;
+    "},
+        );
 
     context.git().add_all();
 
@@ -2240,17 +2147,21 @@ fn check_merge_conflict_hook() -> Result<()> {
     "#);
 
     // Fix the files by removing conflict markers
-    cwd.child("conflict.txt").write_str(indoc::indoc! {r"
+    context.write_file(
+        "conflict.txt",
+        indoc::indoc! {r"
         Before conflict
         Our changes
         After conflict
-    "})?;
+    "},
+    );
 
-    cwd.child("partial_conflict.txt")
-        .write_str("Some content\nResolved line\n")?;
+    context.write_file("partial_conflict.txt", "Some content\nResolved line\n");
 
-    cwd.child("partial_separator_conflict.txt")
-        .write_str("Some content\nResolved line\n")?;
+    context.write_file(
+        "partial_separator_conflict.txt",
+        "Some content\nResolved line\n",
+    );
 
     context.git().add_all();
 
@@ -2263,25 +2174,25 @@ fn check_merge_conflict_hook() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn check_merge_conflict_ignores_rst_headings() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn check_merge_conflict_ignores_rst_headings() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-merge-conflict
                 args: ['--assume-in-merge']
-    "});
-
-    let cwd = context.work_dir();
-    cwd.child("doc.rst").write_str(indoc::indoc! {r"
+    "})
+        .with_file(
+            "doc.rst",
+            indoc::indoc! {r"
         Depends
         =======
-    "})?;
+    "},
+        );
 
     context.git().add_all();
 
@@ -2293,22 +2204,21 @@ fn check_merge_conflict_ignores_rst_headings() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn check_merge_conflict_diff3_hook() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn check_merge_conflict_diff3_hook() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-merge-conflict
                 args: ['--assume-in-merge']
-    "});
-
-    let cwd = context.work_dir();
-    cwd.child("diff3.txt").write_str(indoc::indoc! {r"
+    "})
+        .with_file(
+            "diff3.txt",
+            indoc::indoc! {r"
         Before conflict
         <<<<<<< HEAD
         Our changes
@@ -2318,7 +2228,8 @@ fn check_merge_conflict_diff3_hook() -> Result<()> {
         Their changes
         >>>>>>> branch
         After conflict
-    "})?;
+    "},
+        );
 
     context.git().add_all();
 
@@ -2338,32 +2249,31 @@ fn check_merge_conflict_diff3_hook() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
-fn check_merge_conflict_without_assume_flag() -> Result<()> {
+fn check_merge_conflict_without_assume_flag() {
     let context = TestEnv::new_git();
 
     // Without --assume-in-merge, hook should pass even with conflict markers
     // if we're not actually in a merge state
-    let context = context.with_config(indoc::indoc! {r"
+    let context = context
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-merge-conflict
-    "});
-
-    let cwd = context.work_dir();
-
-    cwd.child("conflict.txt").write_str(indoc::indoc! {r"
+    "})
+        .with_file(
+            "conflict.txt",
+            indoc::indoc! {r"
         <<<<<<< HEAD
         Our changes
         =======
         Their changes
         >>>>>>> branch
-    "})?;
+    "},
+        );
 
     context.git().add_all();
 
@@ -2376,46 +2286,45 @@ fn check_merge_conflict_without_assume_flag() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn check_xml_hook() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn check_xml_hook() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-xml
-    "});
-
-    let cwd = context.work_dir();
-
-    // Create test files
-    cwd.child("valid.xml").write_str(
-        r#"<?xml version="1.0" encoding="UTF-8"?>
+    "})
+        .with_file(
+            "valid.xml",
+            r#"<?xml version="1.0" encoding="UTF-8"?>
 <root>
     <element>value</element>
 </root>"#,
-    )?;
-    cwd.child("invalid_unclosed.xml").write_str(
-        r#"<?xml version="1.0" encoding="UTF-8"?>
+        )
+        .with_file(
+            "invalid_unclosed.xml",
+            r#"<?xml version="1.0" encoding="UTF-8"?>
 <root>
     <element>value
 </root>"#,
-    )?;
-    cwd.child("invalid_mismatched.xml").write_str(
-        r#"<?xml version="1.0" encoding="UTF-8"?>
+        )
+        .with_file(
+            "invalid_mismatched.xml",
+            r#"<?xml version="1.0" encoding="UTF-8"?>
 <root>
     <element>value</different>
 </root>"#,
-    )?;
-    cwd.child("multiple_roots.xml").write_str(
-        r#"<?xml version="1.0" encoding="UTF-8"?>
+        )
+        .with_file(
+            "multiple_roots.xml",
+            r#"<?xml version="1.0" encoding="UTF-8"?>
 <element>value</element>
 <another>value</another>"#,
-    )?;
-    cwd.child("empty.xml").touch()?;
+        )
+        .with_file("empty.xml", "");
 
     context.git().add_all();
 
@@ -2438,25 +2347,28 @@ fn check_xml_hook() -> Result<()> {
     "#);
 
     // Fix the files
-    cwd.child("invalid_unclosed.xml").write_str(
+    context.write_file(
+        "invalid_unclosed.xml",
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <root>
     <element>value</element>
 </root>"#,
-    )?;
-    cwd.child("invalid_mismatched.xml").write_str(
+    );
+    context.write_file(
+        "invalid_mismatched.xml",
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <root>
     <element>value</element>
 </root>"#,
-    )?;
-    cwd.child("multiple_roots.xml").write_str(
+    );
+    context.write_file(
+        "multiple_roots.xml",
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <root>
     <element>value</element>
     <another>value</another>
 </root>"#,
-    )?;
+    );
 
     context.git().add_all();
 
@@ -2474,48 +2386,47 @@ fn check_xml_hook() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn check_xml_with_features() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn check_xml_with_features() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-xml
-    "});
-
-    let cwd = context.work_dir();
-
-    // Create test files with various XML features
-    cwd.child("with_attributes.xml").write_str(
-        r#"<?xml version="1.0" encoding="UTF-8"?>
+    "})
+        .with_file(
+            "with_attributes.xml",
+            r#"<?xml version="1.0" encoding="UTF-8"?>
 <root xmlns="http://example.com">
     <element id="1" type="test">value</element>
 </root>"#,
-    )?;
-    cwd.child("with_cdata.xml").write_str(
-        r#"<?xml version="1.0" encoding="UTF-8"?>
+        )
+        .with_file(
+            "with_cdata.xml",
+            r#"<?xml version="1.0" encoding="UTF-8"?>
 <root>
     <element><![CDATA[Some <special> characters & symbols]]></element>
 </root>"#,
-    )?;
-    cwd.child("with_comments.xml").write_str(
-        r#"<?xml version="1.0" encoding="UTF-8"?>
+        )
+        .with_file(
+            "with_comments.xml",
+            r#"<?xml version="1.0" encoding="UTF-8"?>
 <root>
     <!-- This is a comment -->
     <element>value</element>
 </root>"#,
-    )?;
-    cwd.child("with_doctype.xml").write_str(
-        r#"<?xml version="1.0" encoding="UTF-8"?>
+        )
+        .with_file(
+            "with_doctype.xml",
+            r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE root SYSTEM "root.dtd">
 <root>
     <element>value</element>
 </root>"#,
-    )?;
+        );
 
     context.git().add_all();
 
@@ -2528,23 +2439,19 @@ fn check_xml_with_features() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn no_commit_to_branch_hook() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn no_commit_to_branch_hook() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: no-commit-to-branch
-    "});
+    "})
+        .with_file("test.txt", "Hello World");
 
-    let cwd = context.work_dir();
-
-    // Create a test file
-    cwd.child("test.txt").write_str("Hello World")?;
     context.git().add_all().commit("Initial commit");
 
     // Test 1: Try to commit to master branch (should fail)
@@ -2568,7 +2475,7 @@ fn no_commit_to_branch_hook() -> Result<()> {
         .branch("feature/new-feature")
         .checkout("feature/new-feature");
 
-    cwd.child("feature.txt").write_str("Feature content")?;
+    context.write_file("feature.txt", "Feature content");
     context.git().add_all().commit("Add feature");
 
     cmd_snapshot!(context, context.run(), @r"
@@ -2583,7 +2490,7 @@ fn no_commit_to_branch_hook() -> Result<()> {
     // Test 3: Try to commit to main branch (should fail)
     context.git().branch("main").checkout("main");
 
-    cwd.child("main.txt").write_str("Main content")?;
+    context.write_file("main.txt", "Main content");
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
@@ -2599,24 +2506,20 @@ fn no_commit_to_branch_hook() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn no_commit_to_branch_hook_with_custom_branches() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn no_commit_to_branch_hook_with_custom_branches() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: no-commit-to-branch
                 args: ['--branch', 'develop', '--branch', 'production']
-    "});
+    "})
+        .with_file("test.txt", "Hello World");
 
-    let cwd = context.work_dir();
-
-    // Create a test file
-    cwd.child("test.txt").write_str("Hello World")?;
     context.git().add_all().commit("Initial commit");
 
     // Test 1: Try to commit to master branch (should pass - not in custom list)
@@ -2632,7 +2535,7 @@ fn no_commit_to_branch_hook_with_custom_branches() -> Result<()> {
     // Test 2: Create and switch to develop branch (should fail)
     context.git().branch("develop").checkout("develop");
 
-    cwd.child("develop.txt").write_str("Develop content")?;
+    context.write_file("develop.txt", "Develop content");
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
@@ -2652,8 +2555,7 @@ fn no_commit_to_branch_hook_with_custom_branches() -> Result<()> {
     // Test 3: Create and switch to production branch (should fail)
     context.git().branch("production").checkout("production");
 
-    cwd.child("production.txt")
-        .write_str("Production content")?;
+    context.write_file("production.txt", "Production content");
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
@@ -2669,24 +2571,20 @@ fn no_commit_to_branch_hook_with_custom_branches() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn no_commit_to_branch_hook_with_patterns() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn no_commit_to_branch_hook_with_patterns() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: no-commit-to-branch
                 args: ['--pattern', '^feature/.*', '--pattern', '.*-wip$']
-    "});
+    "})
+        .with_file("test.txt", "Hello World");
 
-    let cwd = context.work_dir();
-
-    // Create a test file
-    cwd.child("test.txt").write_str("Hello World")?;
     context.git().add_all().commit("Initial commit");
 
     // Test 1: Try to commit to master branch (should fail - If branch is not specified, branch defaults to master and main)
@@ -2710,7 +2608,7 @@ fn no_commit_to_branch_hook_with_patterns() -> Result<()> {
         .branch("feature/new-feature")
         .checkout("feature/new-feature");
 
-    cwd.child("feature.txt").write_str("Feature content")?;
+    context.write_file("feature.txt", "Feature content");
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
@@ -2733,7 +2631,7 @@ fn no_commit_to_branch_hook_with_patterns() -> Result<()> {
         .branch("my-branch-wip")
         .checkout("my-branch-wip");
 
-    cwd.child("wip.txt").write_str("WIP content")?;
+    context.write_file("wip.txt", "WIP content");
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
@@ -2756,7 +2654,7 @@ fn no_commit_to_branch_hook_with_patterns() -> Result<()> {
         .branch("normal-branch")
         .checkout("normal-branch");
 
-    cwd.child("normal.txt").write_str("Normal content")?;
+    context.write_file("normal.txt", "Normal content");
     context.git().add_all().commit("Add normal content");
 
     cmd_snapshot!(context, context.run(), @r"
@@ -2793,7 +2691,7 @@ fn no_commit_to_branch_hook_with_patterns() -> Result<()> {
         .branch("invalid-branch")
         .checkout("invalid-branch");
 
-    cwd.child("invalid.txt").write_str("Invalid content")?;
+    context.write_file("invalid.txt", "Invalid content");
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
@@ -2806,30 +2704,24 @@ fn no_commit_to_branch_hook_with_patterns() -> Result<()> {
       caused by: Failed to compile regex pattern `*invalid-pattern*`
       caused by: Parsing error at position 0: Target of repeat operator is invalid
     ");
-
-    Ok(())
 }
 
 #[cfg(unix)]
 #[test]
 fn check_executables_have_shebangs_hook() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-executables-have-shebangs
-    "});
+    "})
+        .with_file("script_with_shebang.sh", "#!/bin/bash\necho ok\n")
+        .with_file("script_without_shebang.sh", "echo missing shebang\n")
+        .with_file("not_executable.txt", "not executable\n")
+        .with_file("empty.sh", "");
 
     let cwd = context.work_dir();
-
-    // Create test files
-    cwd.child("script_with_shebang.sh")
-        .write_str("#!/bin/bash\necho ok\n")?;
-    cwd.child("script_without_shebang.sh")
-        .write_str("echo missing shebang\n")?;
-    cwd.child("not_executable.txt")
-        .write_str("not executable\n")?;
-    cwd.child("empty.sh").touch()?;
 
     // Mark scripts as executable
     fs_err::set_permissions(
@@ -2870,8 +2762,7 @@ fn check_executables_have_shebangs_hook() -> Result<()> {
     ");
 
     // Fix the files: remove executable bit or add shebang
-    cwd.child("script_without_shebang.sh")
-        .write_str("#!/bin/sh\necho fixed\n")?;
+    context.write_file("script_without_shebang.sh", "#!/bin/sh\necho fixed\n");
     fs_err::set_permissions(
         cwd.child("empty.sh").path(),
         std::fs::Permissions::from_mode(0o644),
@@ -2895,19 +2786,17 @@ fn check_executables_have_shebangs_hook() -> Result<()> {
 #[cfg(windows)]
 #[test]
 fn check_executables_have_shebangs_win() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-executables-have-shebangs
-    "});
+    "})
+        .with_file("win_script_with_shebang.sh", "#!/bin/bash\necho ok\n")
+        .with_file("win_script_without_shebang.sh", "missing shebang\n");
 
     let cwd = context.work_dir();
-
-    cwd.child("win_script_with_shebang.sh")
-        .write_str("#!/bin/bash\necho ok\n")?;
-    cwd.child("win_script_without_shebang.sh")
-        .write_str("missing shebang\n")?;
 
     context.git().add_all();
 
@@ -2950,25 +2839,20 @@ fn check_executables_have_shebangs_win() -> Result<()> {
 #[cfg(unix)]
 #[test]
 fn check_executables_have_shebangs_various_cases() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-executables-have-shebangs
-    "});
+    "})
+        .with_file("partial_shebang.sh", "#\necho partial\n")
+        .with_file("shebang_with_space.sh", "#! /bin/bash\necho ok\n")
+        .with_file("non_executable.txt", "not executable\n")
+        .with_file("whitespace.sh", "   \n")
+        .with_file("invalid_shebang.sh", "##!/bin/bash\necho bad\n");
 
     let cwd = context.work_dir();
-
-    // Create test files
-    cwd.child("partial_shebang.sh")
-        .write_str("#\necho partial\n")?;
-    cwd.child("shebang_with_space.sh")
-        .write_str("#! /bin/bash\necho ok\n")?;
-    cwd.child("non_executable.txt")
-        .write_str("not executable\n")?;
-    cwd.child("whitespace.sh").write_str("   \n")?;
-    cwd.child("invalid_shebang.sh")
-        .write_str("##!/bin/bash\necho bad\n")?;
 
     // Mark scripts as executable
     fs_err::set_permissions(
@@ -3018,11 +2902,9 @@ fn check_executables_have_shebangs_various_cases() -> Result<()> {
     "#);
 
     // Fix the files: add valid shebangs or remove executable bit
-    cwd.child("partial_shebang.sh")
-        .write_str("#!/bin/sh\necho fixed\n")?;
-    cwd.child("whitespace.sh").write_str("#!/bin/sh\n")?;
-    cwd.child("invalid_shebang.sh")
-        .write_str("#!/bin/bash\necho fixed\n")?;
+    context.write_file("partial_shebang.sh", "#!/bin/sh\necho fixed\n");
+    context.write_file("whitespace.sh", "#!/bin/sh\n");
+    context.write_file("invalid_shebang.sh", "#!/bin/bash\necho fixed\n");
 
     context.git().add_all();
 
@@ -3042,24 +2924,20 @@ fn check_executables_have_shebangs_various_cases() -> Result<()> {
 #[cfg(windows)]
 #[test]
 fn check_executables_have_shebangs_various_cases_win() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-executables-have-shebangs
-    "});
+    "})
+        .with_file("partial_shebang.sh", "#\necho partial\n")
+        .with_file("shebang_with_space.sh", "#! /bin/bash\necho ok\n")
+        .with_file("non_executable.txt", "not executable\n")
+        .with_file("whitespace.sh", "   \n")
+        .with_file("invalid_shebang.sh", "##!/bin/bash\necho bad\n");
 
     let cwd = context.work_dir();
-
-    cwd.child("partial_shebang.sh")
-        .write_str("#\necho partial\n")?;
-    cwd.child("shebang_with_space.sh")
-        .write_str("#! /bin/bash\necho ok\n")?;
-    cwd.child("non_executable.txt")
-        .write_str("not executable\n")?;
-    cwd.child("whitespace.sh").write_str("   \n")?;
-    cwd.child("invalid_shebang.sh")
-        .write_str("##!/bin/bash\necho bad\n")?;
 
     context.git().add_all();
 
@@ -3109,19 +2987,18 @@ fn check_executables_have_shebangs_various_cases_win() -> Result<()> {
 
 #[test]
 fn check_shebang_scripts_are_executable() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-shebang-scripts-are-executable
-    "});
+    "})
+        .with_file("plain.txt", "plain text\n")
+        .with_file("script.sh", "#!/bin/sh\necho hi\n")
+        .with_file("script_exec.sh", "#!/bin/sh\necho hi\n");
 
     let cwd = context.work_dir();
-
-    cwd.child("plain.txt").write_str("plain text\n")?;
-    cwd.child("script.sh").write_str("#!/bin/sh\necho hi\n")?;
-    cwd.child("script_exec.sh")
-        .write_str("#!/bin/sh\necho hi\n")?;
 
     #[cfg(unix)]
     fs_err::set_permissions(
@@ -3202,17 +3079,15 @@ fn check_case_conflict_hook() -> Result<()> {
     context.write_file("src/foo.txt", "existing file");
     context.git().add_all().commit("Initial commit");
 
-    let context = context.with_config(indoc::indoc! {r"
+    let context = context
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-case-conflict
-    "});
+    "})
+        .with_file("src/FOO.txt", "conflicting case");
 
-    let cwd = context.work_dir();
-
-    // Try to add a file with conflicting case
-    cwd.child("src/FOO.txt").write_str("conflicting case")?;
     context.git().add_all();
 
     // First run: should fail due to case conflict
@@ -3235,7 +3110,7 @@ fn check_case_conflict_hook() -> Result<()> {
     context.git().rm("src/FOO.txt");
 
     // Add a non-conflicting file
-    cwd.child("src/bar.txt").write_str("no conflict")?;
+    context.write_file("src/bar.txt", "no conflict");
     context.git().add_all();
 
     // Second run: should pass
@@ -3264,17 +3139,15 @@ fn check_case_conflict_directory() -> Result<()> {
     context.write_file("src/utils/helper.py", "helper");
     context.git().add_all().commit("Initial commit");
 
-    let context = context.with_config(indoc::indoc! {r"
+    let context = context
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-case-conflict
-    "});
+    "})
+        .with_file("src/UTILS/other.py", "conflict");
 
-    let cwd = context.work_dir();
-
-    // Try to add a file that conflicts with directory name
-    cwd.child("src/UTILS/other.py").write_str("conflict")?;
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
@@ -3304,23 +3177,20 @@ fn check_case_conflict_among_new_files() -> Result<()> {
         return Ok(());
     }
 
-    let cwd = context.work_dir();
-    cwd.child("README.md").write_str("Initial")?;
+    let context = context.with_file("README.md", "Initial");
     context.git().add_all().commit("Initial commit");
 
-    let context = context.with_config(indoc::indoc! {r"
+    let context = context
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-case-conflict
-    "});
+    "})
+        .with_file("NewFile.txt", "file 1")
+        .with_file("newfile.txt", "file 2")
+        .with_file("NEWFILE.TXT", "file 3");
 
-    let cwd = context.work_dir();
-
-    // Add multiple new files with conflicting cases
-    cwd.child("NewFile.txt").write_str("file 1")?;
-    cwd.child("newfile.txt").write_str("file 2")?;
-    cwd.child("NEWFILE.TXT").write_str("file 3")?;
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
@@ -3352,21 +3222,21 @@ fn check_case_conflict_workspace_mode_includes_added_files() -> Result<()> {
 
     let context = context.with_config("repos: []\n");
 
-    let app = context.work_dir().child("app");
-    app.create_dir_all()?;
-    app.child("foo.txt").write_str("existing file")?;
-    app.child("trigger.txt").write_str("tracked trigger")?;
+    context.write_file("app/foo.txt", "existing file");
+    context.write_file("app/trigger.txt", "tracked trigger");
     context.git().add_all().commit("Initial commit");
 
-    app.child(PRE_COMMIT_CONFIG_YAML)
-        .write_str(indoc::indoc! {r"
+    context.write_file(
+        "app/.pre-commit-config.yaml",
+        indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-case-conflict
-    "})?;
+    "},
+    );
 
-    app.child("FOO.txt").write_str("conflicting case")?;
+    context.write_file("app/FOO.txt", "conflicting case");
     context.git().add("app/FOO.txt");
 
     // Regression: in workspace mode, staged additions must be reported relative to the nested
@@ -3399,31 +3269,33 @@ fn check_case_conflict_workspace_mode_includes_added_files() -> Result<()> {
 }
 
 #[test]
-fn check_json5() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn check_json5() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-json5
-    "});
-
-    let cwd = context.work_dir();
-
-    // Create test files
-    cwd.child("valid.json5").write_str(indoc::indoc! {r"
+    "})
+        .with_file(
+            "valid.json5",
+            indoc::indoc! {r"
         // This is a comment
         {
             unquotedKey: 'value', // Trailing comma
             anotherKey: 12345,
         }
-    "})?;
-    cwd.child("invalid_missing_comma.json5")
-        .write_str(indoc::indoc! {r"
+    "},
+        )
+        .with_file(
+            "invalid_missing_comma.json5",
+            indoc::indoc! {r"
         {
             key1: 'value1'
             key2: 'value2', // Missing comma between key-value pairs
         }
-    "})?;
+    "},
+        );
 
     context.git().add_all();
 
@@ -3443,13 +3315,15 @@ fn check_json5() -> Result<()> {
     ");
 
     // Fix the files
-    cwd.child("invalid_missing_comma.json5")
-        .write_str(indoc::indoc! {r"
+    context.write_file(
+        "invalid_missing_comma.json5",
+        indoc::indoc! {r"
         {
             key1: 'value1',
             key2: 'value2',
         }
-    "})?;
+    "},
+    );
     context.git().add_all();
 
     // Second run: hooks should now pass
@@ -3461,23 +3335,21 @@ fn check_json5() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[cfg(unix)]
 #[test]
-fn check_illegal_windows_names() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn check_illegal_windows_names() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-illegal-windows-names
-    "});
+    "})
+        .with_file("normal.txt", "ok")
+        .with_file("CON.txt", "bad");
 
-    let cwd = context.work_dir();
-    cwd.child("normal.txt").write_str("ok")?;
-    cwd.child("CON.txt").write_str("bad")?;
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @"
@@ -3493,8 +3365,6 @@ fn check_illegal_windows_names() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 /// Test that builtin hooks work correctly even when a system-wide binary with the
@@ -3518,15 +3388,15 @@ fn builtin_hooks_ignore_system_path_binaries() -> Result<()> {
     fake_binary.write_str("#!/usr/bin/python3\n# fake binary\n")?;
     fs_err::set_permissions(fake_binary.path(), std::fs::Permissions::from_mode(0o755))?;
 
-    let context = context.with_config(indoc::indoc! {r"
+    let context = context
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: trailing-whitespace
-    "});
+    "})
+        .with_file("test.txt", "hello world   \n");
 
-    let cwd = context.work_dir();
-    cwd.child("test.txt").write_str("hello world   \n")?;
     context.git().add_all();
 
     // Prepend the fake bin directory to PATH so the fake binary is found first.

--- a/crates/prek/tests/builtin_hooks.rs
+++ b/crates/prek/tests/builtin_hooks.rs
@@ -8,7 +8,7 @@ use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
 use insta::assert_snapshot;
 
-use crate::common::{TestEnv, cmd_snapshot};
+use crate::common::{TestEnv, cmd_snapshot, make_executable};
 
 mod common;
 
@@ -2995,11 +2995,7 @@ fn check_shebang_scripts_are_executable() -> Result<()> {
 
     let cwd = context.work_dir();
 
-    #[cfg(unix)]
-    fs_err::set_permissions(
-        cwd.child("script_exec.sh").path(),
-        std::fs::Permissions::from_mode(0o755),
-    )?;
+    make_executable(cwd.child("script_exec.sh"))?;
 
     context.git().add_all();
     context
@@ -3026,11 +3022,7 @@ fn check_shebang_scripts_are_executable() -> Result<()> {
     ----- stderr -----
     ");
 
-    #[cfg(unix)]
-    fs_err::set_permissions(
-        cwd.child("script.sh").path(),
-        std::fs::Permissions::from_mode(0o755),
-    )?;
+    make_executable(cwd.child("script.sh"))?;
 
     context
         .git_at(cwd.path())

--- a/crates/prek/tests/cache.rs
+++ b/crates/prek/tests/cache.rs
@@ -1,7 +1,7 @@
 use assert_fs::assert::PathAssert;
 use assert_fs::fixture::{ChildPath, PathChild, PathCreateDir};
 use assert_fs::prelude::FileWriteStr;
-use prek_consts::{PRE_COMMIT_CONFIG_YAML, PRE_COMMIT_HOOKS_YAML};
+use prek_consts::PRE_COMMIT_CONFIG_YAML;
 use serde_json::json;
 use std::time::{Duration, SystemTime};
 
@@ -106,17 +106,15 @@ fn cache_gc_verbose_shows_removed_entries() {
 }
 
 #[test]
-fn cache_clean() -> anyhow::Result<()> {
+fn cache_clean() {
     let context = TestEnv::new().with_filter(
         r"(?m)^Removed \d+ files? \([^)]+\)\n",
         "Removed [N] file(s) ([SIZE])\n",
     );
 
     let home = context.work_dir().child("home");
-    home.create_dir_all()?;
-    home.child("cache/nested").create_dir_all()?;
-    home.child("cache/data.bin").write_str("hello")?;
-    home.child("cache/nested/data.bin").write_str("world!")?;
+    context.write_file("home/cache/data.bin", "hello");
+    context.write_file("home/cache/nested/data.bin", "world!");
 
     cmd_snapshot!(context, context.command().arg("cache").arg("clean").env("PREK_HOME", &*home), @"
     success: true
@@ -130,9 +128,7 @@ fn cache_clean() -> anyhow::Result<()> {
     home.assert(predicates::path::missing());
 
     // Test `prek clean` works for backward compatibility
-    home.create_dir_all()?;
-    home.child("cache").create_dir_all()?;
-    home.child("cache/one.txt").write_str("abc")?;
+    context.write_file("home/cache/one.txt", "abc");
     cmd_snapshot!(context, context.command().arg("clean").env("PREK_HOME", &*home), @"
     success: true
     exit_code: 0
@@ -143,8 +139,6 @@ fn cache_clean() -> anyhow::Result<()> {
     ");
 
     home.assert(predicates::path::missing());
-
-    Ok(())
 }
 
 #[test]
@@ -180,7 +174,7 @@ fn cache_size_output_formats() {
 }
 
 #[test]
-fn cache_size_with_populated_cache() -> anyhow::Result<()> {
+fn cache_size_with_populated_cache() {
     let context = TestEnv::new_git()
         .with_filter(r"(?m)^\d+\n", "[BYTES]\n")
         .with_config(indoc::indoc! {r"
@@ -189,11 +183,9 @@ fn cache_size_with_populated_cache() -> anyhow::Result<()> {
             rev: v5.0.0
             hooks:
               - id: end-of-file-fixer
-    "});
+    "})
+        .with_file("file.txt", "Hello, world!\n");
 
-    let cwd = context.work_dir();
-
-    cwd.child("file.txt").write_str("Hello, world!\n")?;
     context.git().add_all();
 
     context.run();
@@ -215,13 +207,12 @@ fn cache_size_with_populated_cache() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
 fn cache_gc_removes_unreferenced_entries() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: https://github.com/pre-commit/pre-commit-hooks
             rev: v6.0.0
@@ -233,11 +224,9 @@ fn cache_gc_removes_unreferenced_entries() -> anyhow::Result<()> {
                 name: Python Hook
                 entry: python -c "print('Hello from Python')"
                 language: python
-    "#});
+    "#})
+        .with_file("valid.yaml", "a: 1\n");
 
-    let cwd = context.work_dir();
-
-    cwd.child("valid.yaml").write_str("a: 1\n")?;
     context.git().add_all();
 
     let home = context.home_dir();
@@ -291,16 +280,16 @@ fn cache_gc_keeps_relative_remote_repo() -> anyhow::Result<()> {
     let context = TestEnv::new_git();
 
     let hook_repo = context.work_dir().child("hook-repo");
-    hook_repo.create_dir_all()?;
-    hook_repo
-        .child(PRE_COMMIT_HOOKS_YAML)
-        .write_str(indoc::indoc! {r"
+    context.write_file(
+        "hook-repo/.pre-commit-hooks.yaml",
+        indoc::indoc! {r"
         - id: test-hook
           name: Test Hook
           entry: echo test
           language: system
           always_run: true
-    "})?;
+    "},
+    );
     let git = context.git_at(&hook_repo);
     let revision = git
         .init()
@@ -308,17 +297,16 @@ fn cache_gc_keeps_relative_remote_repo() -> anyhow::Result<()> {
         .commit("Initial commit")
         .rev_parse("HEAD")?;
 
-    let subproject = context.work_dir().child("subproject");
-    subproject.create_dir_all()?;
-    subproject
-        .child(PRE_COMMIT_CONFIG_YAML)
-        .write_str(&indoc::formatdoc! {r"
+    context.write_file(
+        "subproject/.pre-commit-config.yaml",
+        indoc::formatdoc! {r"
             repos:
               - repo: ../hook-repo
                 rev: {revision}
                 hooks:
                   - id: test-hook
-        "})?;
+        "},
+    );
     context.git().add_all();
 
     cmd_snapshot!(context, context.run()
@@ -595,7 +583,8 @@ fn cache_gc_prunes_tool_versions_without_positive_identification() -> anyhow::Re
 
 #[test]
 fn cache_gc_keeps_local_hook_env() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -603,11 +592,9 @@ fn cache_gc_keeps_local_hook_env() -> anyhow::Result<()> {
                 name: Local Python Hook
                 entry: python -c "print('hello')"
                 language: python
-    "#});
+    "#})
+        .with_file("file.txt", "Hello\n");
 
-    let cwd = context.work_dir();
-
-    cwd.child("file.txt").write_str("Hello\n")?;
     context.git().add_all();
 
     // Install + run the local hook so it creates a hook env under PREK_HOME/hooks.
@@ -790,11 +777,10 @@ fn cache_gc_drops_missing_tracked_config() -> anyhow::Result<()> {
 
 #[test]
 fn cache_gc_keeps_tracked_config_on_parse_error() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
+    // Keep the tracked config intentionally invalid while exercising GC.
+    let context = TestEnv::new_git().with_file(PRE_COMMIT_CONFIG_YAML, "repos: [\n");
 
     let cwd = context.work_dir();
-    // Intentionally invalid YAML.
-    cwd.child(PRE_COMMIT_CONFIG_YAML).write_str("repos: [\n")?;
     context.git().add_all();
 
     let home = context.home_dir();

--- a/crates/prek/tests/cache.rs
+++ b/crates/prek/tests/cache.rs
@@ -107,14 +107,14 @@ fn cache_gc_verbose_shows_removed_entries() {
 
 #[test]
 fn cache_clean() {
-    let context = TestEnv::new().with_filter(
-        r"(?m)^Removed \d+ files? \([^)]+\)\n",
-        "Removed [N] file(s) ([SIZE])\n",
-    );
-
+    let context = TestEnv::new()
+        .with_filter(
+            r"(?m)^Removed \d+ files? \([^)]+\)\n",
+            "Removed [N] file(s) ([SIZE])\n",
+        )
+        .with_file("home/cache/data.bin", "hello")
+        .with_file("home/cache/nested/data.bin", "world!");
     let home = context.work_dir().child("home");
-    context.write_file("home/cache/data.bin", "hello");
-    context.write_file("home/cache/nested/data.bin", "world!");
 
     cmd_snapshot!(context, context.command().arg("cache").arg("clean").env("PREK_HOME", &*home), @"
     success: true
@@ -277,10 +277,7 @@ fn cache_gc_removes_unreferenced_entries() -> anyhow::Result<()> {
 
 #[test]
 fn cache_gc_keeps_relative_remote_repo() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
-
-    let hook_repo = context.work_dir().child("hook-repo");
-    context.write_file(
+    let context = TestEnv::new_git().with_file(
         "hook-repo/.pre-commit-hooks.yaml",
         indoc::indoc! {r"
         - id: test-hook
@@ -290,6 +287,7 @@ fn cache_gc_keeps_relative_remote_repo() -> anyhow::Result<()> {
           always_run: true
     "},
     );
+    let hook_repo = context.work_dir().child("hook-repo");
     let git = context.git_at(&hook_repo);
     let revision = git
         .init()
@@ -297,7 +295,7 @@ fn cache_gc_keeps_relative_remote_repo() -> anyhow::Result<()> {
         .commit("Initial commit")
         .rev_parse("HEAD")?;
 
-    context.write_file(
+    let context = context.with_file(
         "subproject/.pre-commit-config.yaml",
         indoc::formatdoc! {r"
             repos:

--- a/crates/prek/tests/common/mod.rs
+++ b/crates/prek/tests/common/mod.rs
@@ -495,20 +495,12 @@ impl TestEnv {
 
     /// Setup a workspace with multiple projects, each with the same config.
     /// This creates a tree-like directory structure for testing workspace functionality.
-    pub fn setup_workspace(&self, project_paths: &[&str], config: &str) -> anyhow::Result<()> {
-        self.work_dir
-            .child(PRE_COMMIT_CONFIG_YAML)
-            .write_str(config)?;
+    pub fn setup_workspace(&self, project_paths: &[&str], config: &str) {
+        self.write_config(config);
 
         for path in project_paths {
-            let project_dir = self.work_dir.child(path);
-            project_dir.create_dir_all()?;
-            project_dir
-                .child(PRE_COMMIT_CONFIG_YAML)
-                .write_str(config)?;
+            self.write_file(Path::new(path).join(PRE_COMMIT_CONFIG_YAML), config);
         }
-
-        Ok(())
     }
 }
 

--- a/crates/prek/tests/exec.rs
+++ b/crates/prek/tests/exec.rs
@@ -107,9 +107,9 @@ fn exec_propagates_child_exit_status() {
 }
 
 #[test]
-fn exec_rejects_ambiguous_hook_selector() -> Result<()> {
+fn exec_rejects_ambiguous_hook_selector() {
     let context = TestEnv::new_git();
-    context.setup_workspace(&["frontend"], config())?;
+    context.setup_workspace(&["frontend"], config());
 
     cmd_snapshot!(context, context.exec().args([
         "exec-test",
@@ -128,13 +128,12 @@ fn exec_rejects_ambiguous_hook_selector() -> Result<()> {
       - .:exec-test
     Use a `project-path:hook-id` selector to select one hook
     ");
-    Ok(())
 }
 
 #[test]
-fn exec_keeps_current_working_directory() -> Result<()> {
+fn exec_keeps_current_working_directory() {
     let context = TestEnv::new_git();
-    context.setup_workspace(&["frontend"], config())?;
+    context.setup_workspace(&["frontend"], config());
 
     cmd_snapshot!(context, context.exec().args([
             "frontend:exec-test",
@@ -150,14 +149,13 @@ fn exec_keeps_current_working_directory() -> Result<()> {
 
     ----- stderr -----
     ");
-    Ok(())
 }
 
 #[cfg(unix)]
 #[test]
 fn exec_resolves_relative_command_from_current_working_directory() -> Result<()> {
     let context = TestEnv::new_git();
-    context.setup_workspace(&["frontend"], config())?;
+    context.setup_workspace(&["frontend"], config());
 
     let command = context.work_dir().join("exec-tool");
     fs_err::write(&command, "#!/bin/sh\necho relative command ok\n")?;

--- a/crates/prek/tests/exec.rs
+++ b/crates/prek/tests/exec.rs
@@ -1,11 +1,12 @@
 mod common;
 
-use anyhow::Result;
 use indoc::indoc;
 
 #[cfg(unix)]
 use crate::common::make_executable;
 use crate::common::{TestEnv, cmd_snapshot};
+#[cfg(unix)]
+use anyhow::Result;
 
 fn config() -> &'static str {
     indoc! {r#"

--- a/crates/prek/tests/hook_impl.rs
+++ b/crates/prek/tests/hook_impl.rs
@@ -1,5 +1,5 @@
 use assert_cmd::assert::OutputAssertExt;
-use assert_fs::fixture::{FileWriteStr, PathChild, PathCreateDir};
+use assert_fs::fixture::PathChild;
 use indoc::indoc;
 use prek_consts::PRE_COMMIT_CONFIG_YAML;
 use prek_consts::env_vars::EnvVars;
@@ -66,11 +66,14 @@ fn hook_impl_allows_missing_hook_dir() -> anyhow::Result<()> {
     "#});
 
     let legacy_hook = context.work_dir().child(".git/hooks/pre-commit.legacy");
-    legacy_hook.write_str(indoc::indoc! {r#"
+    context.write_file(
+        ".git/hooks/pre-commit.legacy",
+        indoc::indoc! {r#"
         #!/bin/sh
         python3 -c 'print("legacy pre-commit ran")'
         exit 1
-    "#})?;
+    "#},
+    );
     make_executable(legacy_hook.path())?;
 
     // Git 2.54+ config-based hooks can invoke `hook-impl` without
@@ -206,7 +209,8 @@ fn hook_impl_pre_push_force_push_after_rebase() -> anyhow::Result<()> {
     // Regression test for https://github.com/j178/prek/issues/2088.
     // The hook fails after printing its filenames so the assertion can inspect
     // the exact file set selected by the pre-push range calculation.
-    let context = context.with_config(indoc::indoc! {r"
+    let context = context
+        .with_config(indoc::indoc! {r"
         repos:
         - repo: local
           hooks:
@@ -215,18 +219,19 @@ fn hook_impl_pre_push_force_push_after_rebase() -> anyhow::Result<()> {
              language: system
              entry: python3 print_filenames.py
              stages: [ pre-push ]
-    "});
-    context
-        .work_dir()
-        .child("print_filenames.py")
-        .write_str(indoc! { r"
+    "})
+        .with_file(
+            "print_filenames.py",
+            indoc! { r"
             import sys
 
             for filename in sys.argv[1:]:
                 print(filename)
 
             raise SystemExit(1)
-        "})?;
+        "},
+        );
+
     context.git().add_all().commit("Initial commit");
 
     let remote_repo_path = context.home_dir().join("remote.git");
@@ -259,10 +264,7 @@ fn hook_impl_pre_push_force_push_after_rebase() -> anyhow::Result<()> {
     checkout_feature.arg("checkout").arg("-b").arg("feature");
     checkout_feature.output()?.assert().success();
 
-    context
-        .work_dir()
-        .child("feature.txt")
-        .write_str("feature")?;
+    context.write_file("feature.txt", "feature");
     context.git().add_all().commit("Add feature file");
 
     let mut push_feature = context.git().command();
@@ -273,7 +275,7 @@ fn hook_impl_pre_push_force_push_after_rebase() -> anyhow::Result<()> {
     // rebased onto this commit, main.txt must not appear in the pre-push file
     // list because it is default-branch churn, not a feature-branch change.
     context.git().checkout("master");
-    context.work_dir().child("main.txt").write_str("main")?;
+    context.write_file("main.txt", "main");
     context.git().add_all().commit("Update master");
 
     let mut push_master = context.git().command();
@@ -331,12 +333,10 @@ fn hook_impl_pre_push_force_push_after_rebase() -> anyhow::Result<()> {
 
 #[test]
 fn hook_impl_runs_legacy_hook() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
-
-    context
-        .work_dir()
-        .child(PRE_COMMIT_CONFIG_YAML)
-        .write_str(indoc! {r"
+    let context = TestEnv::new_git()
+        .with_file(
+            PRE_COMMIT_CONFIG_YAML,
+            indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -345,9 +345,10 @@ fn hook_impl_runs_legacy_hook() -> anyhow::Result<()> {
                 language: system
                 entry: echo manual-only
                 stages: [ manual ]
-  "})?;
+  "},
+        )
+        .with_file("file.txt", "x");
 
-    context.work_dir().child("file.txt").write_str("x")?;
     context.git().add_all();
 
     cmd_snapshot!(context, context.install(), @r#"
@@ -360,11 +361,14 @@ fn hook_impl_runs_legacy_hook() -> anyhow::Result<()> {
     "#);
 
     let legacy_hook = context.work_dir().child(".git/hooks/pre-commit.legacy");
-    legacy_hook.write_str(indoc::indoc! {r#"
+    context.write_file(
+        ".git/hooks/pre-commit.legacy",
+        indoc::indoc! {r#"
         #!/bin/sh
         python3 -c 'print("legacy pre-commit ran")'
         exit 1
-    "#})?;
+    "#},
+    );
     make_executable(legacy_hook.path())?;
 
     let mut commit = context.git().command();
@@ -406,11 +410,14 @@ fn hook_impl_pre_push_runs_legacy_and_prek() -> anyhow::Result<()> {
     "#);
 
     let legacy_hook = context.work_dir().child(".git/hooks/pre-push.legacy");
-    legacy_hook.write_str(indoc::indoc! {r#"
+    context.write_file(
+        ".git/hooks/pre-push.legacy",
+        indoc::indoc! {r#"
         #!/bin/sh
         python3 -c 'print("legacy pre-push ran")'
         exit 1
-    "#})?;
+    "#},
+    );
     make_executable(legacy_hook.path())?;
 
     let remote_repo_path = context.home_dir().join("remote.git");
@@ -432,7 +439,7 @@ fn hook_impl_pre_push_runs_legacy_and_prek() -> anyhow::Result<()> {
         .arg(&remote_repo_path);
     add_remote.output()?.assert().success();
 
-    context.work_dir().child("file.txt").write_str("x")?;
+    context.write_file("file.txt", "x");
     context.git().add_all().commit("Second commit");
 
     let mut push_cmd = context.git().command();
@@ -489,10 +496,7 @@ fn run_worktree() -> anyhow::Result<()> {
         .success();
 
     // Modify the config in the main worktree
-    context
-        .work_dir()
-        .child(PRE_COMMIT_CONFIG_YAML)
-        .write_str("")?;
+    context.write_file(PRE_COMMIT_CONFIG_YAML, "");
 
     let mut commit = context
         .git_at(context.work_dir().child("worktree"))
@@ -607,7 +611,7 @@ fn git_dir_synthesized_git_work_tree_not_leaked_to_hook() {
 /// work tree root. A workspace hook runs in its own project directory, so a Git command
 /// it runs must still resolve the repository root, not the project directory.
 #[test]
-fn workspace_hook_in_linked_worktree_keeps_git_index() -> anyhow::Result<()> {
+fn workspace_hook_in_linked_worktree_keeps_git_index() {
     let context = TestEnv::new_git()
         .with_filter("[a-f0-9]{7}", "abc1234")
         .with_config(indoc::indoc! {r"
@@ -620,11 +624,10 @@ fn workspace_hook_in_linked_worktree_keeps_git_index() -> anyhow::Result<()> {
              entry: true
              always_run: true
              pass_filenames: false
-    "});
-
-    let project = context.work_dir().child("sub");
-    project.create_dir_all()?;
-    project.child(PRE_COMMIT_CONFIG_YAML).write_str(indoc! { r"
+    "})
+        .with_file(
+            "sub/.pre-commit-config.yaml",
+            indoc! { r"
         repos:
         - repo: local
           hooks:
@@ -634,14 +637,12 @@ fn workspace_hook_in_linked_worktree_keeps_git_index() -> anyhow::Result<()> {
              entry: git add -u
              always_run: true
              pass_filenames: false
-    "})?;
-
-    context.work_dir().child("README.md").write_str("root\n")?;
-    context.work_dir().child("tracked.txt").write_str("b\n")?;
-    project.child("README.md").write_str("sub\n")?;
-    let nested = context.work_dir().child("deep").child("nested");
-    nested.create_dir_all()?;
-    nested.child("a.txt").write_str("a\n")?;
+    "},
+        )
+        .with_file("README.md", "root\n")
+        .with_file("tracked.txt", "b\n")
+        .with_file("sub/README.md", "sub\n")
+        .with_file("deep/nested/a.txt", "a\n");
 
     context.git().add_all().commit("Initial commit");
 
@@ -662,7 +663,7 @@ fn workspace_hook_in_linked_worktree_keeps_git_index() -> anyhow::Result<()> {
         .success();
 
     let worktree = context.work_dir().child("worktree");
-    worktree.child("tracked.txt").write_str("b2\n")?;
+    context.write_file("worktree/tracked.txt", "b2\n");
     context.git_at(&worktree).add("tracked.txt");
 
     let mut commit = context.git_at(&worktree).command();
@@ -711,12 +712,10 @@ fn workspace_hook_in_linked_worktree_keeps_git_index() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn workspace_hook_impl_root() -> anyhow::Result<()> {
+fn workspace_hook_impl_root() {
     let context = TestEnv::new_git().with_filter("[a-f0-9]{7}", "abc1234");
 
     let config = indoc! {r#"
@@ -730,7 +729,7 @@ fn workspace_hook_impl_root() -> anyhow::Result<()> {
           verbose: true
     "#};
 
-    context.setup_workspace(&["project2", "project3"], config)?;
+    context.setup_workspace(&["project2", "project3"], config);
     context.git().add_all();
 
     // Install from root
@@ -779,12 +778,10 @@ fn workspace_hook_impl_root() -> anyhow::Result<()> {
 
         cwd: [TEMP_DIR]/
     "#);
-
-    Ok(())
 }
 
 #[test]
-fn workspace_commit_msg_hook_receives_message_file_for_each_project() -> anyhow::Result<()> {
+fn workspace_commit_msg_hook_receives_message_file_for_each_project() {
     let context = TestEnv::new_git().with_filter("[a-f0-9]{7}", "abc1234");
 
     let config = indoc! {r#"
@@ -802,7 +799,7 @@ fn workspace_commit_msg_hook_receives_message_file_for_each_project() -> anyhow:
           verbose: true
     "#};
 
-    context.setup_workspace(&["template"], config)?;
+    context.setup_workspace(&["template"], config);
     context.git().add_all();
 
     cmd_snapshot!(context, context.install(), @r#"
@@ -842,8 +839,6 @@ fn workspace_commit_msg_hook_receives_message_file_for_each_project() -> anyhow:
         cwd: [TEMP_DIR]/
         args: ['.git/COMMIT_EDITMSG']
     "#);
-
-    Ok(())
 }
 
 #[test]
@@ -886,7 +881,7 @@ fn commit_msg_builtin_hook_respects_message_file_filters() {
 }
 
 #[test]
-fn workspace_hook_impl_subdirectory() -> anyhow::Result<()> {
+fn workspace_hook_impl_subdirectory() {
     let context = TestEnv::new_git().with_filter("[a-f0-9]{7}", "abc1234");
     let cwd = context.work_dir();
 
@@ -901,7 +896,7 @@ fn workspace_hook_impl_subdirectory() -> anyhow::Result<()> {
           verbose: true
     "#};
 
-    context.setup_workspace(&["project2", "project3"], config)?;
+    context.setup_workspace(&["project2", "project3"], config);
     context.git().add_all();
 
     // Install from a subdirectory
@@ -940,8 +935,6 @@ fn workspace_hook_impl_subdirectory() -> anyhow::Result<()> {
 
       cwd: [TEMP_DIR]/project2
     ");
-
-    Ok(())
 }
 
 /// Install from a subdirectory, and run commit in another worktree.
@@ -961,7 +954,7 @@ fn workspace_hook_impl_worktree_subdirectory() -> anyhow::Result<()> {
           verbose: true
     "#};
 
-    context.setup_workspace(&["project2", "project3"], config)?;
+    context.setup_workspace(&["project2", "project3"], config);
     context.git().add_all().commit("Initial commit");
 
     // Install from a subdirectory
@@ -989,11 +982,7 @@ fn workspace_hook_impl_worktree_subdirectory() -> anyhow::Result<()> {
         .success();
 
     // Modify the config in the main worktree
-    context
-        .work_dir()
-        .child("project2")
-        .child(PRE_COMMIT_CONFIG_YAML)
-        .write_str("")?;
+    context.write_file("project2/.pre-commit-config.yaml", "");
 
     let mut commit = context.git_at(cwd.child("worktree")).command();
     commit
@@ -1017,13 +1006,12 @@ fn workspace_hook_impl_worktree_subdirectory() -> anyhow::Result<()> {
 }
 
 #[test]
-fn workspace_hook_impl_no_project_found() -> anyhow::Result<()> {
+fn workspace_hook_impl_no_project_found() {
     let context = TestEnv::new_git().with_filter("[a-f0-9]{7}", "1d5e501");
 
     // Create a directory without .pre-commit-config.yaml
     let empty_dir = context.work_dir().child("empty");
-    empty_dir.create_dir_all()?;
-    empty_dir.child("file.txt").write_str("Some content")?;
+    context.write_file("empty/file.txt", "Some content");
     context.git().add_all();
 
     // Install hook that allows missing config
@@ -1075,10 +1063,9 @@ fn workspace_hook_impl_no_project_found() -> anyhow::Result<()> {
     ");
 
     // Create the root `.pre-commit-config.yaml`
-    context
-        .work_dir()
-        .child(PRE_COMMIT_CONFIG_YAML)
-        .write_str(indoc::indoc! {r"
+    context.write_file(
+        PRE_COMMIT_CONFIG_YAML,
+        indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -1086,7 +1073,8 @@ fn workspace_hook_impl_no_project_found() -> anyhow::Result<()> {
                 name: fail
                 entry: fail
                 language: fail
-    "})?;
+    "},
+    );
     context.git().add_all();
 
     // Commit with `PREK_ALLOW_NO_CONFIG=1` again, the hooks should run (and fail)
@@ -1111,19 +1099,15 @@ fn workspace_hook_impl_no_project_found() -> anyhow::Result<()> {
 
       .pre-commit-config.yaml
     ");
-
-    Ok(())
 }
 
 #[test]
-fn hook_impl_does_not_fail_when_no_hooks_match_stage() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_filter("[a-f0-9]{7}", "abc1234");
-
-    // Only a manual-stage hook; a pre-commit hook run should find nothing for the stage.
-    context
-        .work_dir()
-        .child(PRE_COMMIT_CONFIG_YAML)
-        .write_str(indoc::indoc! {r"
+fn hook_impl_does_not_fail_when_no_hooks_match_stage() {
+    let context = TestEnv::new_git()
+        .with_filter("[a-f0-9]{7}", "abc1234")
+        .with_file(
+            PRE_COMMIT_CONFIG_YAML,
+            indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -1132,9 +1116,12 @@ fn hook_impl_does_not_fail_when_no_hooks_match_stage() -> anyhow::Result<()> {
                 language: system
                 entry: echo manual-only
                 stages: [ manual ]
-    "})?;
+    "},
+        )
+        .with_file("file.txt", "x");
 
-    context.work_dir().child("file.txt").write_str("x")?;
+    // Only a manual-stage hook; a pre-commit hook run should find nothing for the stage.
+
     context.git().add_all();
 
     // Install the git hook (which invokes `prek hook-impl`).
@@ -1162,12 +1149,10 @@ fn hook_impl_does_not_fail_when_no_hooks_match_stage() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn workspace_hook_impl_with_selectors() -> anyhow::Result<()> {
+fn workspace_hook_impl_with_selectors() {
     let context = TestEnv::new_git().with_filter("[a-f0-9]{7}", "abc1234");
     let cwd = context.work_dir();
 
@@ -1182,7 +1167,7 @@ fn workspace_hook_impl_with_selectors() -> anyhow::Result<()> {
           verbose: true
     "#};
 
-    context.setup_workspace(&["project2", "project3"], config)?;
+    context.setup_workspace(&["project2", "project3"], config);
     context.git().add_all();
 
     cmd_snapshot!(context, context.install().arg("project2/"), @r#"
@@ -1218,6 +1203,4 @@ fn workspace_hook_impl_with_selectors() -> anyhow::Result<()> {
 
         cwd: [TEMP_DIR]/project2
     "#);
-
-    Ok(())
 }

--- a/crates/prek/tests/hook_impl.rs
+++ b/crates/prek/tests/hook_impl.rs
@@ -54,7 +54,8 @@ fn hook_impl() {
 
 #[test]
 fn hook_impl_allows_missing_hook_dir() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
         - repo: local
           hooks:
@@ -63,17 +64,16 @@ fn hook_impl_allows_missing_hook_dir() -> anyhow::Result<()> {
              language: system
              entry: echo "hook ran successfully"
              always_run: true
-    "#});
-
-    let legacy_hook = context.work_dir().child(".git/hooks/pre-commit.legacy");
-    context.write_file(
-        ".git/hooks/pre-commit.legacy",
-        indoc::indoc! {r#"
+    "#})
+        .with_file(
+            ".git/hooks/pre-commit.legacy",
+            indoc::indoc! {r#"
         #!/bin/sh
         python3 -c 'print("legacy pre-commit ran")'
         exit 1
-    "#},
-    );
+        "#},
+        );
+    let legacy_hook = context.work_dir().child(".git/hooks/pre-commit.legacy");
     make_executable(legacy_hook.path())?;
 
     // Git 2.54+ config-based hooks can invoke `hook-impl` without
@@ -1007,11 +1007,12 @@ fn workspace_hook_impl_worktree_subdirectory() -> anyhow::Result<()> {
 
 #[test]
 fn workspace_hook_impl_no_project_found() {
-    let context = TestEnv::new_git().with_filter("[a-f0-9]{7}", "1d5e501");
+    let context = TestEnv::new_git()
+        .with_filter("[a-f0-9]{7}", "1d5e501")
+        .with_file("empty/file.txt", "Some content");
 
     // Create a directory without .pre-commit-config.yaml
     let empty_dir = context.work_dir().child("empty");
-    context.write_file("empty/file.txt", "Some content");
     context.git().add_all();
 
     // Install hook that allows missing config

--- a/crates/prek/tests/identify.rs
+++ b/crates/prek/tests/identify.rs
@@ -1,18 +1,12 @@
 #[cfg(unix)]
 use crate::common::{TestEnv, cmd_snapshot};
 #[cfg(unix)]
-use assert_fs::fixture::{FileWriteStr, PathChild};
-
 mod common;
 
 #[cfg(unix)] // "executable" tag is different on Windows
 #[test]
-fn identify_text_with_missing_paths() -> anyhow::Result<()> {
-    let context = TestEnv::new();
-    context
-        .work_dir()
-        .child("hello.py")
-        .write_str("print('hi')\n")?;
+fn identify_text_with_missing_paths() {
+    let context = TestEnv::new().with_file("hello.py", "print('hi')\n");
 
     cmd_snapshot!(context,
         context
@@ -33,18 +27,12 @@ fn identify_text_with_missing_paths() -> anyhow::Result<()> {
     error: missing.py: failed to query metadata of symlink `missing.py`: No such file or directory (os error 2)
     "
     );
-
-    Ok(())
 }
 
 #[cfg(unix)] // "executable" tag is different on Windows
 #[test]
-fn identify_json_with_missing_paths() -> anyhow::Result<()> {
-    let context = TestEnv::new();
-    context
-        .work_dir()
-        .child("hello.py")
-        .write_str("print('hi')\n")?;
+fn identify_json_with_missing_paths() {
+    let context = TestEnv::new().with_file("hello.py", "print('hi')\n");
 
     cmd_snapshot!(context,
         context
@@ -81,6 +69,4 @@ fn identify_json_with_missing_paths() -> anyhow::Result<()> {
     ----- stderr -----
     error: missing.py: failed to query metadata of symlink `missing.py`: No such file or directory (os error 2)
     "#);
-
-    Ok(())
 }

--- a/crates/prek/tests/install.rs
+++ b/crates/prek/tests/install.rs
@@ -1,7 +1,7 @@
 use crate::common::{TestEnv, cmd_snapshot, snapshot};
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::assert::PathAssert;
-use assert_fs::fixture::{FileWriteStr, PathChild, PathCreateDir};
+use assert_fs::fixture::{PathChild, PathCreateDir};
 use indoc::indoc;
 use insta::assert_snapshot;
 use prek_consts::PRE_COMMIT_CONFIG_YAML;
@@ -10,7 +10,7 @@ use prek_consts::env_vars::EnvVars;
 mod common;
 
 #[test]
-fn install() -> anyhow::Result<()> {
+fn install() {
     let context = TestEnv::new_git();
 
     // Install `prek` hook.
@@ -40,10 +40,7 @@ fn install() -> anyhow::Result<()> {
             "#);
 
     // Install `pre-commit` and `post-commit` hook.
-    context
-        .work_dir()
-        .child(".git/hooks/pre-commit")
-        .write_str("#!/bin/sh\necho 'pre-commit'\n")?;
+    context.write_file(".git/hooks/pre-commit", "#!/bin/sh\necho 'pre-commit'\n");
 
     cmd_snapshot!(context, context.install().arg("--hook-type").arg("pre-commit").arg("--hook-type").arg("post-commit"), @r#"
     success: true
@@ -136,8 +133,6 @@ fn install() -> anyhow::Result<()> {
 
             exec "$PREK" hook-impl --hook-dir "$HERE" --script-version 4 --hook-type=post-commit -- "$@"
             "#);
-
-    Ok(())
 }
 
 #[test]
@@ -275,14 +270,9 @@ fn install_with_git_dir_allows_external_hooks_path_set() {
 }
 
 #[test]
-fn install_force_uses_repository_hooks_with_external_hooks_path_set() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
-
-    context.work_dir().child("custom-hooks").create_dir_all()?;
-    context
-        .work_dir()
-        .child("custom-hooks/pre-commit")
-        .write_str("#!/bin/sh\necho global hook\n")?;
+fn install_force_uses_repository_hooks_with_external_hooks_path_set() {
+    let context =
+        TestEnv::new_git().with_file("custom-hooks/pre-commit", "#!/bin/sh\necho global hook\n");
 
     let global_gitconfig = context.work_dir().join("global.gitconfig");
     context
@@ -315,8 +305,6 @@ fn install_force_uses_repository_hooks_with_external_hooks_path_set() -> anyhow:
         context.read("custom-hooks/pre-commit"),
         "#!/bin/sh\necho global hook\n"
     );
-
-    Ok(())
 }
 
 #[test]
@@ -399,16 +387,14 @@ fn install_with_dot_hooks_path_installs_to_repo_root() {
 }
 
 #[test]
-fn install_with_included_local_hooks_path_installs_to_configured_directory() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
-
-    context
-        .work_dir()
-        .child("included-hooks.cfg")
-        .write_str(indoc! {r"
+fn install_with_included_local_hooks_path_installs_to_configured_directory() {
+    let context = TestEnv::new_git().with_file(
+        "included-hooks.cfg",
+        indoc! {r"
         [core]
             hooksPath = custom-hooks
-    "})?;
+    "},
+    );
 
     context
         .git()
@@ -427,14 +413,12 @@ fn install_with_included_local_hooks_path_installs_to_configured_directory() -> 
         .work_dir()
         .child("custom-hooks/pre-commit")
         .assert(predicates::path::exists());
-
-    Ok(())
 }
 
 #[test]
 fn install_with_worktree_hooks_path_installs_to_configured_directory() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
-    context.work_dir().child("README.md").write_str("hello\n")?;
+    let context = TestEnv::new_git().with_file("README.md", "hello\n");
+
     context.git().add_all().commit("Initial commit");
 
     context
@@ -651,17 +635,14 @@ fn install_with_legacy_install_hooks_flag_alias() -> anyhow::Result<()> {
 }
 
 #[test]
-fn install_with_existing_legacy_hook() -> anyhow::Result<()> {
+fn install_with_existing_legacy_hook() {
     let context = TestEnv::new_git();
 
     // Install our hook script first.
     context.install().assert().success();
 
     // Simulate an existing migrated legacy hook.
-    context
-        .work_dir()
-        .child(".git/hooks/pre-commit.legacy")
-        .write_str("#!/bin/sh\necho 'legacy'\n")?;
+    context.write_file(".git/hooks/pre-commit.legacy", "#!/bin/sh\necho 'legacy'\n");
 
     // Without --force, we should stay in migration mode.
     cmd_snapshot!(context, context.install(), @r#"
@@ -692,8 +673,6 @@ fn install_with_existing_legacy_hook() -> anyhow::Result<()> {
         .work_dir()
         .child(".git/hooks/pre-commit.legacy")
         .assert(predicates::path::missing());
-
-    Ok(())
 }
 
 /// Run `prek prepare-hooks` to prepare prek hook environments without installing the git hook.
@@ -774,7 +753,7 @@ fn install_with_legacy_install_hooks_subcommand_alias() -> anyhow::Result<()> {
 }
 
 #[test]
-fn uninstall() -> anyhow::Result<()> {
+fn uninstall() {
     let context = TestEnv::new_git();
 
     // Hook does not exist.
@@ -803,10 +782,7 @@ fn uninstall() -> anyhow::Result<()> {
         .assert(predicates::path::missing());
 
     // Hook is not managed by `pre-commit`.
-    context
-        .work_dir()
-        .child(".git/hooks/pre-commit")
-        .write_str("#!/bin/sh\necho 'pre-commit'\n")?;
+    context.write_file(".git/hooks/pre-commit", "#!/bin/sh\necho 'pre-commit'\n");
     cmd_snapshot!(context, context.uninstall(), @r#"
     success: true
     exit_code: 0
@@ -847,8 +823,6 @@ fn uninstall() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
@@ -880,8 +854,8 @@ fn uninstall_with_local_hooks_path_removes_configured_hook() {
 
 #[test]
 fn uninstall_with_worktree_hooks_path_removes_configured_hook() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
-    context.work_dir().child("README.md").write_str("hello\n")?;
+    let context = TestEnv::new_git().with_file("README.md", "hello\n");
+
     context.git().add_all().commit("Initial commit");
 
     context
@@ -1104,16 +1078,14 @@ fn uninstall_with_dot_hooks_path_removes_root_hook() {
 }
 
 #[test]
-fn uninstall_with_included_local_hooks_path_removes_configured_hook() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
-
-    context
-        .work_dir()
-        .child("included-hooks.cfg")
-        .write_str(indoc! {r"
+fn uninstall_with_included_local_hooks_path_removes_configured_hook() {
+    let context = TestEnv::new_git().with_file(
+        "included-hooks.cfg",
+        indoc! {r"
         [core]
             hooksPath = custom-hooks
-    "})?;
+    "},
+    );
 
     context
         .git()
@@ -1129,13 +1101,11 @@ fn uninstall_with_included_local_hooks_path_removes_configured_hook() -> anyhow:
         .work_dir()
         .child("custom-hooks/pre-commit")
         .assert(predicates::path::missing());
-
-    Ok(())
 }
 
 /// `prek uninstall --all` should remove all prek-managed hooks.
 #[test]
-fn uninstall_all_managed_hooks() -> anyhow::Result<()> {
+fn uninstall_all_managed_hooks() {
     let context = TestEnv::new_git();
 
     // Install both pre-commit and pre-push hooks.
@@ -1151,10 +1121,7 @@ fn uninstall_all_managed_hooks() -> anyhow::Result<()> {
     assert!(context.work_dir().join(".git/hooks/pre-push").exists());
 
     let custom_hook = "#!/bin/sh\necho 'custom pre-commit'\n";
-    context
-        .work_dir()
-        .child(".git/hooks/pre-commit")
-        .write_str(custom_hook)?;
+    context.write_file(".git/hooks/pre-commit", custom_hook);
 
     // Uninstall with `--all` should only remove managed hooks.
     cmd_snapshot!(context, context.uninstall().arg("--all"), @r"
@@ -1168,8 +1135,6 @@ fn uninstall_all_managed_hooks() -> anyhow::Result<()> {
 
     assert_eq!(context.read(".git/hooks/pre-commit"), custom_hook);
     assert!(!context.work_dir().join(".git/hooks/pre-push").exists());
-
-    Ok(())
 }
 
 #[test]
@@ -1205,10 +1170,7 @@ fn uninstall_remove_legacy_hook() -> anyhow::Result<()> {
 
     // Create a legacy script that is not ours and ensure it is not removed.
     context.install().assert().success();
-    context
-        .work_dir()
-        .child(".git/hooks/pre-commit.legacy")
-        .write_str("#!/bin/sh\necho 'legacy'\n")?;
+    context.write_file(".git/hooks/pre-commit.legacy", "#!/bin/sh\necho 'legacy'\n");
 
     cmd_snapshot!(context, context.uninstall(), @"
     success: true
@@ -1390,7 +1352,7 @@ fn init_template_dir_non_git_repo() {
 }
 
 #[test]
-fn workspace_install() -> anyhow::Result<()> {
+fn workspace_install() {
     let context = TestEnv::new_git();
 
     let config = indoc! {r#"
@@ -1411,7 +1373,7 @@ fn workspace_install() -> anyhow::Result<()> {
             "project3/project5",
         ],
         config,
-    )?;
+    );
     context.git().add_all();
 
     // Install from root directory.
@@ -1531,8 +1493,6 @@ fn workspace_install() -> anyhow::Result<()> {
 
             exec "$PREK" hook-impl --hook-dir "$HERE" --script-version 4 project3/ --hook-type=pre-commit -- "$@"
             "#);
-
-    Ok(())
 }
 
 #[test]
@@ -1557,7 +1517,7 @@ fn workspace_install_hooks() -> anyhow::Result<()> {
             "project3/project5",
         ],
         config,
-    )?;
+    );
     context.git().add_all();
 
     // Install by selectors
@@ -1586,7 +1546,7 @@ fn workspace_install_hooks() -> anyhow::Result<()> {
 
 /// Only install root config's hook types in a workspace.
 #[test]
-fn workspace_install_only_root_hook_types() -> anyhow::Result<()> {
+fn workspace_install_only_root_hook_types() {
     let context = TestEnv::new_git();
 
     let root_config = indoc! {r#"
@@ -1611,16 +1571,9 @@ fn workspace_install_only_root_hook_types() -> anyhow::Result<()> {
           entry: python -c 'print("nested")'
     "#};
 
-    context
-        .work_dir()
-        .child(PRE_COMMIT_CONFIG_YAML)
-        .write_str(root_config)?;
-    context.work_dir().child("project2").create_dir_all()?;
-    context
-        .work_dir()
-        .child("project2")
-        .child(PRE_COMMIT_CONFIG_YAML)
-        .write_str(nested_config)?;
+    let context = context
+        .with_file(PRE_COMMIT_CONFIG_YAML, root_config)
+        .with_file("project2/.pre-commit-config.yaml", nested_config);
     context.git().add_all();
 
     cmd_snapshot!(context, context.install(), @r#"
@@ -1638,12 +1591,10 @@ fn workspace_install_only_root_hook_types() -> anyhow::Result<()> {
     assert!(context.work_dir().join(".git/hooks/post-commit").exists());
     assert!(!context.work_dir().join(".git/hooks/pre-push").exists());
     assert!(!context.work_dir().join(".git/hooks/post-merge").exists());
-
-    Ok(())
 }
 
 #[test]
-fn workspace_uninstall() -> anyhow::Result<()> {
+fn workspace_uninstall() {
     let context = TestEnv::new_git();
 
     let config = indoc! {r#"
@@ -1664,7 +1615,7 @@ fn workspace_uninstall() -> anyhow::Result<()> {
             "project3/project5",
         ],
         config,
-    )?;
+    );
     context.git().add_all();
 
     // Install first
@@ -1682,8 +1633,6 @@ fn workspace_uninstall() -> anyhow::Result<()> {
 
     // Verify hooks are removed
     assert!(!context.work_dir().join(".git/hooks/pre-commit").exists());
-
-    Ok(())
 }
 
 #[test]
@@ -1708,7 +1657,7 @@ fn workspace_init_template_dir() -> anyhow::Result<()> {
             "project3/project5",
         ],
         config,
-    )?;
+    );
     context.git().add_all();
 
     // Create a template directory

--- a/crates/prek/tests/languages/coursier.rs
+++ b/crates/prek/tests/languages/coursier.rs
@@ -97,14 +97,10 @@ fn pre_commit_channel() -> anyhow::Result<()> {
 }
 
 #[test]
-fn local_pre_commit_channel_is_ignored() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
-
-    let channel_dir = context.work_dir().child(".pre-commit-channel");
-    channel_dir.create_dir_all()?;
-    context.write_file(".pre-commit-channel/scalafmt.json", "{}");
-
-    let context = context.with_config(indoc::indoc! {r"
+fn local_pre_commit_channel_is_ignored() {
+    let context = TestEnv::new_git()
+        .with_file(".pre-commit-channel/scalafmt.json", "{}")
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -127,6 +123,4 @@ fn local_pre_commit_channel_is_ignored() -> anyhow::Result<()> {
     error: Failed to install hook `scalafmt`
       caused by: expected `.pre-commit-channel` directory or `additional_dependencies`
     ");
-
-    Ok(())
 }

--- a/crates/prek/tests/languages/coursier.rs
+++ b/crates/prek/tests/languages/coursier.rs
@@ -102,7 +102,7 @@ fn local_pre_commit_channel_is_ignored() -> anyhow::Result<()> {
 
     let channel_dir = context.work_dir().child(".pre-commit-channel");
     channel_dir.create_dir_all()?;
-    channel_dir.child("scalafmt.json").write_str("{}")?;
+    context.write_file(".pre-commit-channel/scalafmt.json", "{}");
 
     let context = context.with_config(indoc::indoc! {r"
         repos:

--- a/crates/prek/tests/languages/dart.rs
+++ b/crates/prek/tests/languages/dart.rs
@@ -144,11 +144,10 @@ fn with_pubspec_and_dependencies() {
             dependencies:
               ansicolor: ^2.0.1
         "},
-        );
-
-    context.write_file(
-        "bin/hello-world-dart.dart",
-        indoc::indoc! {r#"
+        )
+        .with_file(
+            "bin/hello-world-dart.dart",
+            indoc::indoc! {r#"
             import 'package:ansicolor/ansicolor.dart';
 
             void main() {
@@ -156,7 +155,7 @@ fn with_pubspec_and_dependencies() {
                 print("hello hello " + pen("world"));
             }
         "#},
-    );
+        );
 
     context.git().add_all();
 
@@ -198,16 +197,15 @@ fn with_pubspec() {
             environment:
               sdk: '>=2.17.0 <4.0.0'
         "},
-        );
-
-    context.write_file(
-        "bin/hello.dart",
-        indoc::indoc! {r"
+        )
+        .with_file(
+            "bin/hello.dart",
+            indoc::indoc! {r"
             void main() {
               print('Hello from Dart package!');
             }
         "},
-    );
+        );
 
     context.git().add_all();
 
@@ -255,17 +253,16 @@ fn with_pubspec_and_additional_dependencies() {
             environment:
               sdk: '>=2.17.0 <4.0.0'
         "},
-        );
-
-    context.write_file(
-        "lib/greeting.dart",
-        indoc::indoc! {r"
+        )
+        .with_file(
+            "lib/greeting.dart",
+            indoc::indoc! {r"
             String greet(String subject) => 'Hello $subject!';
         "},
-    );
-    context.write_file(
-        "bin/hello.dart",
-        indoc::indoc! {r"
+        )
+        .with_file(
+            "bin/hello.dart",
+            indoc::indoc! {r"
             import 'package:path/path.dart' as p;
             import 'package:test_package/greeting.dart';
 
@@ -273,7 +270,7 @@ fn with_pubspec_and_additional_dependencies() {
               print(greet(p.posix.join('Dart', 'Hooks')));
             }
         "},
-    );
+        );
 
     context.git().add_all();
 
@@ -298,7 +295,8 @@ fn with_pubspec_and_additional_dependencies() {
 
 #[test]
 fn additional_dependencies() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -310,18 +308,17 @@ fn additional_dependencies() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "#});
-
-    context.write_file(
-        "test_path.dart",
-        indoc::indoc! {r"
+    "#})
+        .with_file(
+            "test_path.dart",
+            indoc::indoc! {r"
             import 'package:path/path.dart' as p;
             void main() {
               var joined = p.join('foo', 'bar', 'baz.txt');
               print('Joined path: $joined');
             }
         "},
-    );
+        );
 
     context.git().add_all();
 
@@ -341,7 +338,8 @@ fn additional_dependencies() {
 
 #[test]
 fn additional_dependencies_with_version() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -353,17 +351,16 @@ fn additional_dependencies_with_version() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "#});
-
-    context.write_file(
-        "test_path.dart",
-        indoc::indoc! {r"
+    "#})
+        .with_file(
+            "test_path.dart",
+            indoc::indoc! {r"
             import 'package:path/path.dart' as p;
             void main() {
               print('Using path package');
             }
         "},
-    );
+        );
 
     context.git().add_all();
 
@@ -406,16 +403,15 @@ fn executable_alias() {
             executables:
               cli: hello
         "},
-        );
-
-    context.write_file(
-        "bin/hello.dart",
-        indoc::indoc! {r"
+        )
+        .with_file(
+            "bin/hello.dart",
+            indoc::indoc! {r"
             void main() {
               print('alias executable works');
             }
         "},
-    );
+        );
 
     context.git().add_all();
 
@@ -435,7 +431,8 @@ fn executable_alias() {
 
 #[test]
 fn dart_environment() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -446,11 +443,10 @@ fn dart_environment() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "});
-
-    context.write_file(
-        "env_test.dart",
-        indoc::indoc! {r"
+    "})
+        .with_file(
+            "env_test.dart",
+            indoc::indoc! {r"
             import 'dart:io';
             void main() {
               var pubCache = Platform.environment['PUB_CACHE'];
@@ -461,7 +457,7 @@ fn dart_environment() {
               }
             }
         "},
-    );
+        );
 
     context.git().add_all();
 

--- a/crates/prek/tests/languages/dart.rs
+++ b/crates/prek/tests/languages/dart.rs
@@ -1,5 +1,3 @@
-use assert_fs::fixture::{FileWriteStr, PathChild};
-
 use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
@@ -33,8 +31,9 @@ fn language_version() {
 }
 
 #[test]
-fn hook_stderr() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn hook_stderr() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -42,18 +41,17 @@ fn hook_stderr() -> anyhow::Result<()> {
                 name: local
                 language: dart
                 entry: dart ./hook.dart
-    "});
-
-    context
-        .work_dir()
-        .child("hook.dart")
-        .write_str(indoc::indoc! {r"
+    "})
+        .with_file(
+            "hook.dart",
+            indoc::indoc! {r"
             import 'dart:io';
             void main() {
               stderr.writeln('Error from Dart hook');
               exit(1);
             }
-        "})?;
+        "},
+        );
 
     context.git().add_all();
 
@@ -69,13 +67,12 @@ fn hook_stderr() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn script_with_files() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn script_with_files() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -84,29 +81,20 @@ fn script_with_files() -> anyhow::Result<()> {
                 language: dart
                 entry: dart ./script.dart
                 verbose: true
-    "});
-
-    context
-        .work_dir()
-        .child("script.dart")
-        .write_str(indoc::indoc! {r"
+    "})
+        .with_file(
+            "script.dart",
+            indoc::indoc! {r"
             import 'dart:io';
             void main(List<String> args) {
               for (var arg in args) {
                 print('Processing file: $arg');
               }
             }
-        "})?;
-
-    context
-        .work_dir()
-        .child("test1.dart")
-        .write_str("void main() { print('test1'); }")?;
-
-    context
-        .work_dir()
-        .child("test2.dart")
-        .write_str("void main() { print('test2'); }")?;
+        "},
+        )
+        .with_file("test1.dart", "void main() { print('test1'); }")
+        .with_file("test2.dart", "void main() { print('test2'); }");
 
     context.git().add_all();
 
@@ -125,13 +113,12 @@ fn script_with_files() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn with_pubspec_and_dependencies() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn with_pubspec_and_dependencies() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -142,12 +129,10 @@ fn with_pubspec_and_dependencies() -> anyhow::Result<()> {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "});
-
-    context
-        .work_dir()
-        .child("pubspec.yaml")
-        .write_str(indoc::indoc! {r"
+    "})
+        .with_file(
+            "pubspec.yaml",
+            indoc::indoc! {r"
             environment:
               sdk: '>=2.17.0 <4.0.0'
 
@@ -158,21 +143,20 @@ fn with_pubspec_and_dependencies() -> anyhow::Result<()> {
 
             dependencies:
               ansicolor: ^2.0.1
-        "})?;
+        "},
+        );
 
-    fs_err::create_dir(context.work_dir().join("bin"))?;
-    context
-        .work_dir()
-        .child("bin")
-        .child("hello-world-dart.dart")
-        .write_str(indoc::indoc! {r#"
+    context.write_file(
+        "bin/hello-world-dart.dart",
+        indoc::indoc! {r#"
             import 'package:ansicolor/ansicolor.dart';
 
             void main() {
                 AnsiPen pen = new AnsiPen()..red();
                 print("hello hello " + pen("world"));
             }
-        "#})?;
+        "#},
+    );
 
     context.git().add_all();
 
@@ -188,13 +172,12 @@ fn with_pubspec_and_dependencies() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn with_pubspec() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn with_pubspec() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -205,29 +188,26 @@ fn with_pubspec() -> anyhow::Result<()> {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "});
-
-    context
-        .work_dir()
-        .child("pubspec.yaml")
-        .write_str(indoc::indoc! {r"
+    "})
+        .with_file(
+            "pubspec.yaml",
+            indoc::indoc! {r"
             name: test_package
             description: A test package
             version: 1.0.0
             environment:
               sdk: '>=2.17.0 <4.0.0'
-        "})?;
+        "},
+        );
 
-    fs_err::create_dir(context.work_dir().join("bin"))?;
-    context
-        .work_dir()
-        .child("bin")
-        .child("hello.dart")
-        .write_str(indoc::indoc! {r"
+    context.write_file(
+        "bin/hello.dart",
+        indoc::indoc! {r"
             void main() {
               print('Hello from Dart package!');
             }
-        "})?;
+        "},
+    );
 
     context.git().add_all();
 
@@ -248,13 +228,12 @@ fn with_pubspec() -> anyhow::Result<()> {
         !context.work_dir().path().join(".dart_tool").exists(),
         "Dart hooks should not mutate the checkout with .dart_tool"
     );
-
-    Ok(())
 }
 
 #[test]
-fn with_pubspec_and_additional_dependencies() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+fn with_pubspec_and_additional_dependencies() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -266,40 +245,35 @@ fn with_pubspec_and_additional_dependencies() -> anyhow::Result<()> {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "#});
-
-    context
-        .work_dir()
-        .child("pubspec.yaml")
-        .write_str(indoc::indoc! {r"
+    "#})
+        .with_file(
+            "pubspec.yaml",
+            indoc::indoc! {r"
             name: test_package
             description: A test package
             version: 1.0.0
             environment:
               sdk: '>=2.17.0 <4.0.0'
-        "})?;
+        "},
+        );
 
-    fs_err::create_dir(context.work_dir().join("bin"))?;
-    fs_err::create_dir(context.work_dir().join("lib"))?;
-    context
-        .work_dir()
-        .child("lib")
-        .child("greeting.dart")
-        .write_str(indoc::indoc! {r"
+    context.write_file(
+        "lib/greeting.dart",
+        indoc::indoc! {r"
             String greet(String subject) => 'Hello $subject!';
-        "})?;
-    context
-        .work_dir()
-        .child("bin")
-        .child("hello.dart")
-        .write_str(indoc::indoc! {r"
+        "},
+    );
+    context.write_file(
+        "bin/hello.dart",
+        indoc::indoc! {r"
             import 'package:path/path.dart' as p;
             import 'package:test_package/greeting.dart';
 
             void main() {
               print(greet(p.posix.join('Dart', 'Hooks')));
             }
-        "})?;
+        "},
+    );
 
     context.git().add_all();
 
@@ -320,8 +294,6 @@ fn with_pubspec_and_additional_dependencies() -> anyhow::Result<()> {
         !context.work_dir().path().join(".dart_tool").exists(),
         "Dart hooks should not mutate the checkout with .dart_tool"
     );
-
-    Ok(())
 }
 
 #[test]
@@ -340,17 +312,16 @@ fn additional_dependencies() {
                 pass_filenames: false
     "#});
 
-    context
-        .work_dir()
-        .child("test_path.dart")
-        .write_str(indoc::indoc! {r"
+    context.write_file(
+        "test_path.dart",
+        indoc::indoc! {r"
             import 'package:path/path.dart' as p;
             void main() {
               var joined = p.join('foo', 'bar', 'baz.txt');
               print('Joined path: $joined');
             }
-        "})
-        .unwrap();
+        "},
+    );
 
     context.git().add_all();
 
@@ -384,16 +355,15 @@ fn additional_dependencies_with_version() {
                 pass_filenames: false
     "#});
 
-    context
-        .work_dir()
-        .child("test_path.dart")
-        .write_str(indoc::indoc! {r"
+    context.write_file(
+        "test_path.dart",
+        indoc::indoc! {r"
             import 'package:path/path.dart' as p;
             void main() {
               print('Using path package');
             }
-        "})
-        .unwrap();
+        "},
+    );
 
     context.git().add_all();
 
@@ -412,8 +382,9 @@ fn additional_dependencies_with_version() {
 }
 
 #[test]
-fn executable_alias() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn executable_alias() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -424,30 +395,27 @@ fn executable_alias() -> anyhow::Result<()> {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "});
-
-    context
-        .work_dir()
-        .child("pubspec.yaml")
-        .write_str(indoc::indoc! {r"
+    "})
+        .with_file(
+            "pubspec.yaml",
+            indoc::indoc! {r"
             name: aliased_dart_tool
             environment:
               sdk: '>=2.17.0 <4.0.0'
 
             executables:
               cli: hello
-        "})?;
+        "},
+        );
 
-    fs_err::create_dir(context.work_dir().join("bin"))?;
-    context
-        .work_dir()
-        .child("bin")
-        .child("hello.dart")
-        .write_str(indoc::indoc! {r"
+    context.write_file(
+        "bin/hello.dart",
+        indoc::indoc! {r"
             void main() {
               print('alias executable works');
             }
-        "})?;
+        "},
+    );
 
     context.git().add_all();
 
@@ -463,8 +431,6 @@ fn executable_alias() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
@@ -482,10 +448,9 @@ fn dart_environment() {
                 pass_filenames: false
     "});
 
-    context
-        .work_dir()
-        .child("env_test.dart")
-        .write_str(indoc::indoc! {r"
+    context.write_file(
+        "env_test.dart",
+        indoc::indoc! {r"
             import 'dart:io';
             void main() {
               var pubCache = Platform.environment['PUB_CACHE'];
@@ -495,8 +460,8 @@ fn dart_environment() {
                 print('PUB_CACHE is not set');
               }
             }
-        "})
-        .unwrap();
+        "},
+    );
 
     context.git().add_all();
 

--- a/crates/prek/tests/languages/deno.rs
+++ b/crates/prek/tests/languages/deno.rs
@@ -39,17 +39,14 @@ fn basic_deno() {
 /// Test running a TypeScript script file with an explicit `deno run` entry.
 #[test]
 fn script_file() {
-    let context = TestEnv::new_git();
-
-    // Create a TypeScript script
-    context.write_file(
-        "check.ts",
-        indoc::indoc! {r#"
+    let context = TestEnv::new_git()
+        .with_file(
+            "check.ts",
+            indoc::indoc! {r#"
             console.log("Script executed successfully!");
         "#},
-    );
-
-    let context = context.with_config(indoc::indoc! {r"
+        )
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -81,18 +78,15 @@ fn script_file() {
 /// Test running Deno built-in subcommands with an explicit `deno` prefix.
 #[test]
 fn builtin_commands() {
-    let context = TestEnv::new_git();
-
-    // Create a TypeScript file for formatting check
-    context.write_file(
-        "example.ts",
-        indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_file(
+            "example.ts",
+            indoc::indoc! {r"
         const x = 1;
         console.log(x);
     "},
-    );
-
-    let context = context.with_config(indoc::indoc! {r"
+        )
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -258,15 +252,13 @@ fn additional_dependencies() {
 /// Test that an absolute file can be installed as an executable additional dependency.
 #[test]
 fn additional_dependencies_absolute_file() {
-    let context = TestEnv::new_git();
-
-    let tool = context.work_dir().child("tool.ts");
-    context.write_file(
+    let context = TestEnv::new_git().with_file(
         "tool.ts",
         indoc::indoc! {r#"
             console.log("Hello from local additional dependency!");
         "#},
     );
+    let tool = context.work_dir().child("tool.ts");
     let dependency = serde_json::to_string(&format!("{}:echo-tool", tool.path().display()))
         .expect("Failed to serialize Deno dependency");
 
@@ -502,19 +494,16 @@ fn version_range() {
 /// Test that hook failure is properly reported.
 #[test]
 fn hook_failure() {
-    let context = TestEnv::new_git();
-
-    // Create a TypeScript file with a lint error
-    context.write_file(
-        "bad.ts",
-        indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_file(
+            "bad.ts",
+            indoc::indoc! {r"
         // This has a lint error: no-explicit-any
         let x: any = 1;
         console.log(x);
     "},
-    );
-
-    let context = context.with_config(indoc::indoc! {r"
+        )
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -537,18 +526,15 @@ fn hook_failure() {
 /// Note: Permissions must come before the script in the entry, so use explicit `deno run`.
 #[test]
 fn script_with_permissions() {
-    let context = TestEnv::new_git();
-
-    // Create a script that reads an environment variable
-    context.write_file(
-        "read_env.ts",
-        indoc::indoc! {r#"
+    // Permissions must be specified before the script path when using deno run.
+    let context = TestEnv::new_git()
+        .with_file(
+            "read_env.ts",
+            indoc::indoc! {r#"
         console.log(Deno.env.get("TEST_VAR") ?? "not set");
     "#},
-    );
-
-    // Permissions must be specified before the script path when using deno run
-    let context = context.with_config(indoc::indoc! {r"
+        )
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:

--- a/crates/prek/tests/languages/deno.rs
+++ b/crates/prek/tests/languages/deno.rs
@@ -1,5 +1,5 @@
 use assert_fs::assert::PathAssert;
-use assert_fs::fixture::{FileWriteStr, PathChild};
+use assert_fs::fixture::PathChild;
 use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 
 use crate::common::{TestEnv, cmd_snapshot};
@@ -42,13 +42,12 @@ fn script_file() {
     let context = TestEnv::new_git();
 
     // Create a TypeScript script
-    context
-        .work_dir()
-        .child("check.ts")
-        .write_str(indoc::indoc! {r#"
+    context.write_file(
+        "check.ts",
+        indoc::indoc! {r#"
             console.log("Script executed successfully!");
-        "#})
-        .expect("Failed to write check.ts");
+        "#},
+    );
 
     let context = context.with_config(indoc::indoc! {r"
         repos:
@@ -85,14 +84,13 @@ fn builtin_commands() {
     let context = TestEnv::new_git();
 
     // Create a TypeScript file for formatting check
-    context
-        .work_dir()
-        .child("example.ts")
-        .write_str(indoc::indoc! {r"
+    context.write_file(
+        "example.ts",
+        indoc::indoc! {r"
         const x = 1;
         console.log(x);
-    "})
-        .expect("Failed to write example.ts");
+    "},
+    );
 
     let context = context.with_config(indoc::indoc! {r"
         repos:
@@ -263,10 +261,12 @@ fn additional_dependencies_absolute_file() {
     let context = TestEnv::new_git();
 
     let tool = context.work_dir().child("tool.ts");
-    tool.write_str(indoc::indoc! {r#"
+    context.write_file(
+        "tool.ts",
+        indoc::indoc! {r#"
             console.log("Hello from local additional dependency!");
-        "#})
-        .expect("Failed to write tool.ts");
+        "#},
+    );
     let dependency = serde_json::to_string(&format!("{}:echo-tool", tool.path().display()))
         .expect("Failed to serialize Deno dependency");
 
@@ -505,15 +505,14 @@ fn hook_failure() {
     let context = TestEnv::new_git();
 
     // Create a TypeScript file with a lint error
-    context
-        .work_dir()
-        .child("bad.ts")
-        .write_str(indoc::indoc! {r"
+    context.write_file(
+        "bad.ts",
+        indoc::indoc! {r"
         // This has a lint error: no-explicit-any
         let x: any = 1;
         console.log(x);
-    "})
-        .expect("Failed to write bad.ts");
+    "},
+    );
 
     let context = context.with_config(indoc::indoc! {r"
         repos:
@@ -541,13 +540,12 @@ fn script_with_permissions() {
     let context = TestEnv::new_git();
 
     // Create a script that reads an environment variable
-    context
-        .work_dir()
-        .child("read_env.ts")
-        .write_str(indoc::indoc! {r#"
+    context.write_file(
+        "read_env.ts",
+        indoc::indoc! {r#"
         console.log(Deno.env.get("TEST_VAR") ?? "not set");
-    "#})
-        .expect("Failed to write read_env.ts");
+    "#},
+    );
 
     // Permissions must be specified before the script path when using deno run
     let context = context.with_config(indoc::indoc! {r"

--- a/crates/prek/tests/languages/docker.rs
+++ b/crates/prek/tests/languages/docker.rs
@@ -36,7 +36,9 @@ fn docker() {
 
 #[test]
 fn workspace_docker() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new_git()
+        .with_file("project1/project1.txt", "")
+        .with_file("project2/project2.txt", "");
     let cwd = context.work_dir();
 
     let config = indoc::indoc! {r"
@@ -50,8 +52,6 @@ fn workspace_docker() {
     "};
 
     context.setup_workspace(&["project1", "project2"], config);
-    context.write_file("project1/project1.txt", "");
-    context.write_file("project2/project2.txt", "");
 
     context.git().add_all();
 

--- a/crates/prek/tests/languages/docker.rs
+++ b/crates/prek/tests/languages/docker.rs
@@ -35,7 +35,7 @@ fn docker() {
 }
 
 #[test]
-fn workspace_docker() -> anyhow::Result<()> {
+fn workspace_docker() {
     let context = TestEnv::new_git();
     let cwd = context.work_dir();
 
@@ -49,9 +49,9 @@ fn workspace_docker() -> anyhow::Result<()> {
                 verbose: true
     "};
 
-    context.setup_workspace(&["project1", "project2"], config)?;
-    cwd.child("project1").child("project1.txt").write_str("")?;
-    cwd.child("project2").child("project2.txt").write_str("")?;
+    context.setup_workspace(&["project1", "project2"], config);
+    context.write_file("project1/project1.txt", "");
+    context.write_file("project2/project2.txt", "");
 
     context.git().add_all();
 
@@ -81,6 +81,4 @@ fn workspace_docker() -> anyhow::Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }

--- a/crates/prek/tests/languages/docker.rs
+++ b/crates/prek/tests/languages/docker.rs
@@ -1,5 +1,3 @@
-use assert_fs::fixture::{FileWriteStr, PathChild};
-
 use crate::common::{TestEnv, cmd_snapshot};
 
 /// GitHub Action only has docker for linux hosted runners.
@@ -39,7 +37,6 @@ fn workspace_docker() {
     let context = TestEnv::new_git()
         .with_file("project1/project1.txt", "")
         .with_file("project2/project2.txt", "");
-    let cwd = context.work_dir();
 
     let config = indoc::indoc! {r"
         repos:

--- a/crates/prek/tests/languages/docker_image.rs
+++ b/crates/prek/tests/languages/docker_image.rs
@@ -7,16 +7,15 @@ use prek_consts::prepend_paths;
 use crate::common::{TestEnv, cmd_snapshot, make_executable};
 
 #[test]
-fn docker_image() -> Result<()> {
-    let context = TestEnv::new_git();
-
-    let cwd = context.work_dir();
+fn docker_image() {
     // Test suite from https://github.com/super-linter/super-linter/tree/main/test/linters/gitleaks/bad
-    cwd.child("gitleaks_bad_01.txt")
-        .write_str(indoc::indoc! {r"
+    let context = TestEnv::new_git().with_file(
+        "gitleaks_bad_01.txt",
+        indoc::indoc! {r"
         aws_access_key_id = AROA47DSWDEZA3RQASWB
         aws_secret_access_key = wQwdsZDiWg4UA5ngO0OSI2TkM4kkYxF6d2S1aYWM
-    "})?;
+    "},
+    );
 
     // Use fully qualified image name for Podman/Docker compatibility
     Command::new("docker")
@@ -64,7 +63,6 @@ fn docker_image() -> Result<()> {
 
     ----- stderr -----
     "#);
-    Ok(())
 }
 
 /// Test that `docker_image` does not try to resolve entry in the host system PATH.
@@ -74,10 +72,9 @@ fn docker_image_does_not_resolve_entry() -> Result<()> {
 
     let cwd = context.work_dir();
     let bin_dir = cwd.child("bin");
-    bin_dir.create_dir_all()?;
 
     let alpine_stub = bin_dir.child("alpine");
-    alpine_stub.write_str("#!/bin/sh\necho host\n")?;
+    context.write_file("bin/alpine", "#!/bin/sh\necho host\n");
 
     make_executable(alpine_stub.path())?;
 

--- a/crates/prek/tests/languages/docker_image.rs
+++ b/crates/prek/tests/languages/docker_image.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use assert_cmd::Command;
-use assert_fs::fixture::{FileWriteStr, PathChild, PathCreateDir};
+use assert_fs::fixture::PathChild;
 use prek_consts::env_vars::EnvVars;
 use prek_consts::prepend_paths;
 

--- a/crates/prek/tests/languages/docker_image.rs
+++ b/crates/prek/tests/languages/docker_image.rs
@@ -68,13 +68,12 @@ fn docker_image() {
 /// Test that `docker_image` does not try to resolve entry in the host system PATH.
 #[test]
 fn docker_image_does_not_resolve_entry() -> Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new_git().with_file("bin/alpine", "#!/bin/sh\necho host\n");
 
     let cwd = context.work_dir();
     let bin_dir = cwd.child("bin");
 
     let alpine_stub = bin_dir.child("alpine");
-    context.write_file("bin/alpine", "#!/bin/sh\necho host\n");
 
     make_executable(alpine_stub.path())?;
 

--- a/crates/prek/tests/languages/dotnet.rs
+++ b/crates/prek/tests/languages/dotnet.rs
@@ -1,4 +1,4 @@
-use assert_fs::fixture::{FileWriteStr, PathChild, PathCreateDir};
+use assert_fs::fixture::{FileWriteStr, PathChild};
 use prek_consts::PRE_COMMIT_HOOKS_YAML;
 use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 
@@ -303,12 +303,13 @@ fn additional_dependencies_in_remote_repo() -> anyhow::Result<()> {
 
 /// Ensure that stderr from hooks is captured and shown to the user.
 #[test]
-fn hook_stderr() -> anyhow::Result<()> {
+fn hook_stderr() {
     if !EnvVars.is_set(EnvVars::CI) {
-        return Ok(());
+        return;
     }
 
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -316,14 +317,10 @@ fn hook_stderr() -> anyhow::Result<()> {
                 name: local
                 language: dotnet
                 entry: dotnet run --project ./hook
-    "});
-
-    // Create a minimal console app that writes to stderr
-    context.work_dir().child("hook").create_dir_all()?;
-    context
-        .work_dir()
-        .child("hook/hook.csproj")
-        .write_str(indoc::indoc! {r#"
+    "})
+        .with_file(
+            "hook/hook.csproj",
+            indoc::indoc! {r#"
         <Project Sdk="Microsoft.NET.Sdk">
           <PropertyGroup>
             <OutputType>Exe</OutputType>
@@ -331,16 +328,17 @@ fn hook_stderr() -> anyhow::Result<()> {
             <ImplicitUsings>disable</ImplicitUsings>
           </PropertyGroup>
         </Project>
-    "#})?;
-    context
-        .work_dir()
-        .child("hook/Program.cs")
-        .write_str(indoc::indoc! {r#"
+    "#},
+        )
+        .with_file(
+            "hook/Program.cs",
+            indoc::indoc! {r#"
         using System;
         Console.Error.WriteLine("Error from hook");
         Console.Error.Flush();
         Environment.Exit(1);
-    "#})?;
+    "#},
+        );
 
     context.git().add_all();
 
@@ -356,6 +354,4 @@ fn hook_stderr() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }

--- a/crates/prek/tests/languages/fail.rs
+++ b/crates/prek/tests/languages/fail.rs
@@ -1,16 +1,9 @@
-use anyhow::Result;
-use assert_fs::prelude::*;
-
 use crate::common::{TestEnv, cmd_snapshot};
 
 /// GitHub Action only has docker for linux hosted runners.
 #[test]
-fn fail() -> Result<()> {
-    let context = TestEnv::new_git();
-
-    let cwd = context.work_dir();
-    cwd.child("changelog").create_dir_all()?;
-    cwd.child("changelog/changelog.md").touch()?;
+fn fail() {
+    let context = TestEnv::new_git().with_file("changelog/changelog.md", "");
 
     let context = context.with_config(indoc::indoc! {r"
         repos:
@@ -39,6 +32,4 @@ fn fail() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }

--- a/crates/prek/tests/languages/golang.rs
+++ b/crates/prek/tests/languages/golang.rs
@@ -276,10 +276,8 @@ fn local_additional_deps() -> anyhow::Result<()> {
     "})?;
     go_hook.git().add_all().commit("Initial commit").tag("v1.0");
 
-    let context = TestEnv::new_git();
-
     let hook_url = go_hook.work_dir().to_str().unwrap();
-    context.write_file(
+    let context = TestEnv::new_git().with_file(
         PRE_COMMIT_CONFIG_YAML,
         indoc::formatdoc! {r"
         repos:

--- a/crates/prek/tests/languages/golang.rs
+++ b/crates/prek/tests/languages/golang.rs
@@ -277,19 +277,19 @@ fn local_additional_deps() -> anyhow::Result<()> {
     go_hook.git().add_all().commit("Initial commit").tag("v1.0");
 
     let context = TestEnv::new_git();
-    let work_dir = context.work_dir();
 
     let hook_url = go_hook.work_dir().to_str().unwrap();
-    work_dir
-        .child(PRE_COMMIT_CONFIG_YAML)
-        .write_str(&indoc::formatdoc! {r"
+    context.write_file(
+        PRE_COMMIT_CONFIG_YAML,
+        indoc::formatdoc! {r"
         repos:
           - repo: {hook_url}
             rev: v1.0
             hooks:
               - id: go-hook
                 verbose: true
-   ", hook_url = hook_url})?;
+   ", hook_url = hook_url},
+    );
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"

--- a/crates/prek/tests/languages/haskell.rs
+++ b/crates/prek/tests/languages/haskell.rs
@@ -1,11 +1,11 @@
-use assert_fs::fixture::{FileWriteStr, PathChild};
 use prek_consts::env_vars::EnvVars;
 
 use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
-fn local_hook() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn local_hook() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -16,12 +16,10 @@ fn local_hook() -> anyhow::Result<()> {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "});
-
-    context
-        .work_dir()
-        .child("hello.cabal")
-        .write_str(indoc::indoc! {r"
+    "})
+        .with_file(
+            "hello.cabal",
+            indoc::indoc! {r"
             cabal-version:       3.0
             name:                hello
             version:             0.1.0.0
@@ -31,16 +29,16 @@ fn local_hook() -> anyhow::Result<()> {
               main-is:             Main.hs
               default-language:    GHC2021
               build-depends:       base >= 4.19 && < 5
-        "})?;
-
-    context
-        .work_dir()
-        .child("Main.hs")
-        .write_str(indoc::indoc! {r#"
+        "},
+        )
+        .with_file(
+            "Main.hs",
+            indoc::indoc! {r#"
             module Main where
             main :: IO ()
             main = putStrLn "Hello Haskell!"
-        "#})?;
+        "#},
+        );
 
     context.git().add_all();
 
@@ -70,8 +68,6 @@ fn local_hook() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]

--- a/crates/prek/tests/languages/julia.rs
+++ b/crates/prek/tests/languages/julia.rs
@@ -78,18 +78,14 @@ fn additional_dependencies() {
 }
 
 #[test]
-fn project_toml() -> anyhow::Result<()> {
-    use assert_fs::fixture::{FileWriteStr, PathChild};
-
-    let context = TestEnv::new_git();
-
-    context
-        .work_dir()
-        .child("Project.toml")
-        .write_str(indoc::indoc! {r#"
+fn project_toml() {
+    let context = TestEnv::new_git().with_file(
+        "Project.toml",
+        indoc::indoc! {r#"
             [deps]
             Example = "7876af07-990d-54b4-ab0e-23690620f79a"
-        "#})?;
+        "#},
+    );
 
     let context = context.with_config(indoc::indoc! {r#"
         repos:
@@ -118,20 +114,12 @@ fn project_toml() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn script_file() -> anyhow::Result<()> {
-    use assert_fs::fixture::{FileWriteStr, PathChild};
-
-    let context = TestEnv::new_git();
-
-    context
-        .work_dir()
-        .child("my_script.jl")
-        .write_str(r#"println("Hello from script file!")"#)?;
+fn script_file() {
+    let context =
+        TestEnv::new_git().with_file("my_script.jl", r#"println("Hello from script file!")"#);
 
     let context = context.with_config(indoc::indoc! {r"
         repos:
@@ -160,8 +148,6 @@ fn script_file() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]

--- a/crates/prek/tests/languages/lua.rs
+++ b/crates/prek/tests/languages/lua.rs
@@ -1,5 +1,3 @@
-use assert_fs::fixture::{FileWriteStr, PathChild};
-
 use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
@@ -80,8 +78,9 @@ fn language_version() {
 
 /// Test that stderr from hooks is captured and shown to the user.
 #[test]
-fn hook_stderr() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn hook_stderr() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -89,12 +88,8 @@ fn hook_stderr() -> anyhow::Result<()> {
                 name: local
                 language: lua
                 entry: lua ./hook.lua
-    "});
-
-    context
-        .work_dir()
-        .child("hook.lua")
-        .write_str("io.stderr:write('How are you\\n'); os.exit(1)")?;
+    "})
+        .with_file("hook.lua", "io.stderr:write('How are you\\n'); os.exit(1)");
 
     context.git().add_all();
 
@@ -110,14 +105,13 @@ fn hook_stderr() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 /// Test Lua script execution with file arguments.
 #[test]
-fn script_with_files() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn script_with_files() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -126,26 +120,17 @@ fn script_with_files() -> anyhow::Result<()> {
                 language: lua
                 entry: lua ./script.lua
                 verbose: true
-    "});
-
-    context
-        .work_dir()
-        .child("script.lua")
-        .write_str(indoc::indoc! {r#"
+    "})
+        .with_file(
+            "script.lua",
+            indoc::indoc! {r#"
         for i, arg in ipairs(arg) do
             print("Processing file:", arg)
         end
-    "#})?;
-
-    context
-        .work_dir()
-        .child("test1.lua")
-        .write_str("print('test1')")?;
-
-    context
-        .work_dir()
-        .child("test2.lua")
-        .write_str("print('test2')")?;
+    "#},
+        )
+        .with_file("test1.lua", "print('test1')")
+        .with_file("test2.lua", "print('test2')");
 
     context.git().add_all();
 
@@ -164,8 +149,6 @@ fn script_with_files() -> anyhow::Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 /// Test Lua environment variables (`LUA_PATH` and `LUA_CPATH`)

--- a/crates/prek/tests/languages/node.rs
+++ b/crates/prek/tests/languages/node.rs
@@ -9,12 +9,10 @@ use crate::common::{TestEnv, cmd_snapshot, make_executable, remove_bin_from_path
 
 #[test]
 fn exec_uses_installed_node_environment() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
-
-    let package = context.work_dir().child("node-env-tool");
-    context.write_file(
-        "node-env-tool/package.json",
-        indoc::indoc! {r#"
+    let context = TestEnv::new_git()
+        .with_file(
+            "node-env-tool/package.json",
+            indoc::indoc! {r#"
         {
           "name": "node-env-tool",
           "version": "1.0.0",
@@ -23,15 +21,16 @@ fn exec_uses_installed_node_environment() -> anyhow::Result<()> {
           }
         }
     "#},
-    );
-    let cli = package.child("cli.js");
-    context.write_file(
-        "node-env-tool/cli.js",
-        indoc::indoc! {r#"
+        )
+        .with_file(
+            "node-env-tool/cli.js",
+            indoc::indoc! {r#"
         #!/usr/bin/env node
         console.log("exec node env ok");
     "#},
-    );
+        );
+    let package = context.work_dir().child("node-env-tool");
+    let cli = package.child("cli.js");
     make_executable(cli.path())?;
 
     let dependency = serde_json::to_string(package.path())?;
@@ -430,12 +429,10 @@ fn remote_prepare_uses_dev_dependencies() -> anyhow::Result<()> {
 /// Test that lowercase npm config inherited from `npm exec` cannot redirect installs.
 #[test]
 fn additional_dependencies_ignore_inherited_npm_config_prefix() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
-
-    let package_dir = context.work_dir().child("prefix-fixture");
-    context.write_file(
-        "prefix-fixture/package.json",
-        indoc::indoc! {r#"
+    let context = TestEnv::new_git()
+        .with_file(
+            "prefix-fixture/package.json",
+            indoc::indoc! {r#"
         {
           "name": "prek-prefix-fixture",
           "version": "1.0.0",
@@ -444,15 +441,16 @@ fn additional_dependencies_ignore_inherited_npm_config_prefix() -> anyhow::Resul
           }
         }
     "#},
-    );
-    let cli = package_dir.child("cli.js");
-    context.write_file(
-        "prefix-fixture/cli.js",
-        indoc::indoc! {r#"
+        )
+        .with_file(
+            "prefix-fixture/cli.js",
+            indoc::indoc! {r#"
         #!/usr/bin/env node
         console.log("prefix fixture ok")
     "#},
-    );
+        );
+    let package_dir = context.work_dir().child("prefix-fixture");
+    let cli = package_dir.child("cli.js");
     make_executable(cli.path())?;
 
     let dependency = serde_json::to_string(package_dir.path())?;

--- a/crates/prek/tests/languages/node.rs
+++ b/crates/prek/tests/languages/node.rs
@@ -12,8 +12,9 @@ fn exec_uses_installed_node_environment() -> anyhow::Result<()> {
     let context = TestEnv::new_git();
 
     let package = context.work_dir().child("node-env-tool");
-    package.create_dir_all()?;
-    package.child("package.json").write_str(indoc::indoc! {r#"
+    context.write_file(
+        "node-env-tool/package.json",
+        indoc::indoc! {r#"
         {
           "name": "node-env-tool",
           "version": "1.0.0",
@@ -21,12 +22,16 @@ fn exec_uses_installed_node_environment() -> anyhow::Result<()> {
             "node-env-tool": "cli.js"
           }
         }
-    "#})?;
+    "#},
+    );
     let cli = package.child("cli.js");
-    cli.write_str(indoc::indoc! {r#"
+    context.write_file(
+        "node-env-tool/cli.js",
+        indoc::indoc! {r#"
         #!/usr/bin/env node
         console.log("exec node env ok");
-    "#})?;
+    "#},
+    );
     make_executable(cli.path())?;
 
     let dependency = serde_json::to_string(package.path())?;
@@ -428,10 +433,9 @@ fn additional_dependencies_ignore_inherited_npm_config_prefix() -> anyhow::Resul
     let context = TestEnv::new_git();
 
     let package_dir = context.work_dir().child("prefix-fixture");
-    package_dir.create_dir_all()?;
-    package_dir
-        .child("package.json")
-        .write_str(indoc::indoc! {r#"
+    context.write_file(
+        "prefix-fixture/package.json",
+        indoc::indoc! {r#"
         {
           "name": "prek-prefix-fixture",
           "version": "1.0.0",
@@ -439,12 +443,16 @@ fn additional_dependencies_ignore_inherited_npm_config_prefix() -> anyhow::Resul
             "prek-prefix-fixture": "cli.js"
           }
         }
-    "#})?;
+    "#},
+    );
     let cli = package_dir.child("cli.js");
-    cli.write_str(indoc::indoc! {r#"
+    context.write_file(
+        "prefix-fixture/cli.js",
+        indoc::indoc! {r#"
         #!/usr/bin/env node
         console.log("prefix fixture ok")
-    "#})?;
+    "#},
+    );
     make_executable(cli.path())?;
 
     let dependency = serde_json::to_string(package_dir.path())?;

--- a/crates/prek/tests/languages/perl.rs
+++ b/crates/prek/tests/languages/perl.rs
@@ -6,8 +6,9 @@ use prek_consts::env_vars::EnvVars;
 use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
-fn local_hook() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn local_hook() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -18,17 +19,16 @@ fn local_hook() -> anyhow::Result<()> {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "});
-
-    context
-        .work_dir()
-        .child("hello.pl")
-        .write_str(indoc::indoc! {r#"
+    "})
+        .with_file(
+            "hello.pl",
+            indoc::indoc! {r#"
             use strict;
             use warnings;
 
             print "Hello from Perl!\n";
-        "#})?;
+        "#},
+        );
 
     context.git().add_all();
 
@@ -44,8 +44,6 @@ fn local_hook() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]

--- a/crates/prek/tests/languages/php.rs
+++ b/crates/prek/tests/languages/php.rs
@@ -4,8 +4,9 @@ use prek_consts::PRE_COMMIT_HOOKS_YAML;
 use crate::common::{TestEnv, cmd_snapshot, make_executable};
 
 #[test]
-fn local_hook() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn local_hook() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -16,11 +17,9 @@ fn local_hook() -> anyhow::Result<()> {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "});
-    context
-        .work_dir()
-        .child("hello.php")
-        .write_str("<?php echo \"Hello from PHP!\\n\";\n")?;
+    "})
+        .with_file("hello.php", "<?php echo \"Hello from PHP!\\n\";\n");
+
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
@@ -49,8 +48,6 @@ fn local_hook() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]

--- a/crates/prek/tests/languages/pygrep.rs
+++ b/crates/prek/tests/languages/pygrep.rs
@@ -1,19 +1,17 @@
-use anyhow::Result;
-
-use assert_fs::prelude::*;
-
 use crate::common::{TestEnv, cmd_snapshot};
 
 /// Test basic pygrep functionality - case-sensitive matching
 #[test]
-fn basic_case_sensitive() -> Result<()> {
-    let context = TestEnv::new_git();
-
-    let cwd = context.work_dir();
-    cwd.child("test.py")
-        .write_str("TODO: implement this\nprint('Hello World')\n# todo: fix later")?;
-    cwd.child("other.py")
-        .write_str("print('No issues here')\n")?;
+fn basic_case_sensitive() {
+    let context = TestEnv::new_git()
+        .with_file(
+            "test.py",
+            indoc::indoc! {r"
+                TODO: implement this
+                print('Hello World')
+                # todo: fix later"},
+        )
+        .with_file("other.py", "print('No issues here')\n");
 
     let context = context.with_config(indoc::indoc! {r#"
         repos:
@@ -53,20 +51,20 @@ fn basic_case_sensitive() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 /// Test case-insensitive matching
 #[test]
-fn case_insensitive() -> Result<()> {
-    let context = TestEnv::new_git();
-
-    let cwd = context.work_dir();
-    cwd.child("test.py")
-        .write_str("TODO: implement this\nprint('Hello World')\n# todo: fix later")?;
-    cwd.child("other.py")
-        .write_str("print('No issues here')\n")?;
+fn case_insensitive() {
+    let context = TestEnv::new_git()
+        .with_file(
+            "test.py",
+            indoc::indoc! {r"
+                TODO: implement this
+                print('Hello World')
+                # todo: fix later"},
+        )
+        .with_file("other.py", "print('No issues here')\n");
 
     let context = context.with_config(indoc::indoc! {r#"
         repos:
@@ -94,19 +92,20 @@ fn case_insensitive() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 /// Test multiline mode
 #[test]
-fn multiline_mode() -> Result<()> {
-    let context = TestEnv::new_git();
-
-    let cwd = context.work_dir();
-    cwd.child("test.py").write_str(
-        "def function():\n    \"\"\"A function\n    with multiline docstring\n    \"\"\"\n    pass",
-    )?;
+fn multiline_mode() {
+    let context = TestEnv::new_git().with_file(
+        "test.py",
+        indoc::indoc! {r#"
+            def function():
+                """A function
+                with multiline docstring
+                """
+                pass"#},
+    );
 
     let context = context.with_config(indoc::indoc! {r#"
         repos:
@@ -135,19 +134,14 @@ fn multiline_mode() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 /// Test negate mode - passes when pattern is NOT found
 #[test]
-fn negate_mode() -> Result<()> {
-    let context = TestEnv::new_git();
-
-    let cwd = context.work_dir();
-    cwd.child("good.py").write_str("print('Hello World')\n")?;
-    cwd.child("bad.py")
-        .write_str("TODO: implement this\nprint('Hello World')\n")?;
+fn negate_mode() {
+    let context = TestEnv::new_git()
+        .with_file("good.py", "print('Hello World')\n")
+        .with_file("bad.py", "TODO: implement this\nprint('Hello World')\n");
 
     let context = context.with_config(indoc::indoc! {r#"
         repos:
@@ -174,21 +168,22 @@ fn negate_mode() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 /// Test negate mode with multiline - should output filename if pattern not found
 #[test]
-fn negate_multiline_mode() -> Result<()> {
-    let context = TestEnv::new_git();
-
-    let cwd = context.work_dir();
-    cwd.child("no_pattern.py")
-        .write_str("print('Hello World')\n")?;
-    cwd.child("has_pattern.py").write_str(
-        "def function():\n    \"\"\"A function\n    with multiline docstring\n    \"\"\"\n    pass",
-    )?;
+fn negate_multiline_mode() {
+    let context = TestEnv::new_git()
+        .with_file("no_pattern.py", "print('Hello World')\n")
+        .with_file(
+            "has_pattern.py",
+            indoc::indoc! {r#"
+                def function():
+                    """A function
+                    with multiline docstring
+                    """
+                    pass"#},
+        );
 
     let context = context.with_config(indoc::indoc! {r#"
         repos:
@@ -215,8 +210,6 @@ fn negate_multiline_mode() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 /// Test invalid regex pattern
@@ -224,10 +217,7 @@ fn negate_multiline_mode() -> Result<()> {
 fn invalid_regex() {
     let context = TestEnv::new_git();
 
-    let cwd = context.work_dir();
-    cwd.child("test.py")
-        .write_str("print('Hello World')\n")
-        .unwrap();
+    context.write_file("test.py", "print('Hello World')\n");
 
     let context = context.with_config(indoc::indoc! {r#"
         repos:
@@ -253,12 +243,15 @@ fn invalid_regex() {
 }
 
 #[test]
-fn python_regex_quirks() -> Result<()> {
-    let context = TestEnv::new_git();
-
-    let cwd = context.work_dir();
-    cwd.child("test.py")
-        .write_str("def function(arg1, arg2):\n    pass\ndef bad_function():\n    pass")?;
+fn python_regex_quirks() {
+    let context = TestEnv::new_git().with_file(
+        "test.py",
+        indoc::indoc! {r"
+            def function(arg1, arg2):
+                pass
+            def bad_function():
+                pass"},
+    );
 
     // Test lookbehind assertion - function with arguments
     let context = context.with_config(indoc::indoc! {r#"
@@ -285,18 +278,19 @@ fn python_regex_quirks() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 /// Test complex regex with word boundaries and character classes
 #[test]
-fn complex_regex_patterns() -> Result<()> {
-    let context = TestEnv::new_git();
-
-    let cwd = context.work_dir();
-    cwd.child("test.py")
-        .write_str("import sys\nfrom os import path\nimport json\nfrom typing import Dict")?;
+fn complex_regex_patterns() {
+    let context = TestEnv::new_git().with_file(
+        "test.py",
+        indoc::indoc! {r"
+            import sys
+            from os import path
+            import json
+            from typing import Dict"},
+    );
 
     // Match import statements but not 'from' imports
     let context = context.with_config(indoc::indoc! {r#"
@@ -324,18 +318,19 @@ fn complex_regex_patterns() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 /// Test combination of case insensitive and multiline
 #[test]
-fn case_insensitive_multiline() -> Result<()> {
-    let context = TestEnv::new_git();
-
-    let cwd = context.work_dir();
-    cwd.child("test.py")
-        .write_str("# TODO: fix this\ndef function():\n    # todo: implement\n    pass")?;
+fn case_insensitive_multiline() {
+    let context = TestEnv::new_git().with_file(
+        "test.py",
+        indoc::indoc! {r"
+            # TODO: fix this
+            def function():
+                # todo: implement
+                pass"},
+    );
 
     let context = context.with_config(indoc::indoc! {r#"
         repos:
@@ -364,18 +359,12 @@ fn case_insensitive_multiline() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 /// Test successful case where pattern is not found
 #[test]
-fn pattern_not_found() -> Result<()> {
-    let context = TestEnv::new_git();
-
-    let cwd = context.work_dir();
-    cwd.child("test.py")
-        .write_str("print('Hello World')\n# All good here")?;
+fn pattern_not_found() {
+    let context = TestEnv::new_git().with_file("test.py", "print('Hello World')\n# All good here");
 
     let context = context.with_config(indoc::indoc! {r#"
         repos:
@@ -397,17 +386,11 @@ fn pattern_not_found() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
-fn invalid_args() -> Result<()> {
-    let context = TestEnv::new_git();
-
-    let cwd = context.work_dir();
-    cwd.child("test.py")
-        .write_str("print('Hello World')\n# All good here")?;
+fn invalid_args() {
+    let context = TestEnv::new_git().with_file("test.py", "print('Hello World')\n# All good here");
 
     let context = context.with_config(indoc::indoc! {r#"
         repos:
@@ -432,6 +415,4 @@ fn invalid_args() -> Result<()> {
       caused by: Failed to parse `args`
       caused by: Unknown argument: --hello
     ");
-
-    Ok(())
 }

--- a/crates/prek/tests/languages/pygrep.rs
+++ b/crates/prek/tests/languages/pygrep.rs
@@ -215,11 +215,9 @@ fn negate_multiline_mode() {
 /// Test invalid regex pattern
 #[test]
 fn invalid_regex() {
-    let context = TestEnv::new_git();
-
-    context.write_file("test.py", "print('Hello World')\n");
-
-    let context = context.with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git()
+        .with_file("test.py", "print('Hello World')\n")
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:

--- a/crates/prek/tests/languages/python.rs
+++ b/crates/prek/tests/languages/python.rs
@@ -313,8 +313,9 @@ fn additional_dependencies_in_remote_repo() -> anyhow::Result<()> {
 
 /// Ensure that stderr from hooks is captured and shown to the user.
 #[test]
-fn hook_stderr() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn hook_stderr() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -322,12 +323,11 @@ fn hook_stderr() -> anyhow::Result<()> {
                 name: local
                 language: python
                 entry: python ./hook.py
-    "});
-
-    context
-        .work_dir()
-        .child("hook.py")
-        .write_str("import sys; print('How are you', file=sys.stderr); sys.exit(1)")?;
+    "})
+        .with_file(
+            "hook.py",
+            "import sys; print('How are you', file=sys.stderr); sys.exit(1)",
+        );
 
     context.git().add_all();
 
@@ -343,15 +343,14 @@ fn hook_stderr() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 /// Test that pep723 script for local hook is installed correctly.
 /// Only if no additional dependencies are specified.
 #[test]
-fn pep723_script() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+fn pep723_script() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -367,13 +366,10 @@ fn pep723_script() -> anyhow::Result<()> {
                 entry: ./script.py hello world
                 verbose: true
                 pass_filenames: false
-    "#});
-    // On Windows, uv venv does not create `python3.exe`, `python3.12.exe` symlink,
-    // be sure to use `python` as the interpreter name.
-    context
-        .work_dir()
-        .child("script.py")
-        .write_str(indoc::indoc! {r#"
+    "#})
+        .with_file(
+            "script.py",
+            indoc::indoc! {r#"
         #!/usr/bin/env python
         # /// script
         # requires-python = ">=3.10"
@@ -381,7 +377,10 @@ fn pep723_script() -> anyhow::Result<()> {
         # ///
         from pyecho import main
         main()
-    "#})?;
+    "#},
+        );
+    // On Windows, uv venv does not create `python3.exe`, `python3.12.exe` symlink,
+    // be sure to use `python` as the interpreter name.
 
     context.git().add_all();
 
@@ -402,8 +401,6 @@ fn pep723_script() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 /// Test that GIT environment variables do not leak into uv pip install subprocess.
@@ -413,19 +410,16 @@ fn pep723_script() -> anyhow::Result<()> {
 /// Regression test for <https://github.com/j178/prek/issues/1354>
 #[test]
 fn git_env_vars_not_leaked_to_pip_install() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
-
-    // setup.py that fails if GIT_DIR leaks into pip install
-    context
-        .work_dir()
-        .child("setup.py")
-        .write_str(indoc::indoc! {r#"
+    let context = TestEnv::new_git().with_file(
+        "setup.py",
+        indoc::indoc! {r#"
         import os, sys
         from setuptools import setup
         if os.environ.get("GIT_DIR"):
             sys.exit("ERROR: GIT_DIR should not leak into pip install")
         setup(name="test", version="0.1.0", extras_require={"test": []})
-    "#})?;
+    "#},
+    );
 
     let dependency = serde_json::to_string(&format!(
         "{}[test]",
@@ -461,16 +455,15 @@ fn git_env_vars_not_leaked_to_pip_install() -> anyhow::Result<()> {
 
 /// Regression test for <https://github.com/j178/prek/issues/1603>.
 #[test]
-fn local_relative_additional_dependency_is_not_resolved_from_worktree() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
-    context
-        .work_dir()
-        .child("pyproject.toml")
-        .write_str(indoc::indoc! {r#"
+fn local_relative_additional_dependency_is_not_resolved_from_worktree() {
+    let context = TestEnv::new_git().with_file(
+        "pyproject.toml",
+        indoc::indoc! {r#"
             [project]
             name = "local-project"
             version = "0.1.0"
-        "#})?;
+        "#},
+    );
 
     let context = context
         .with_config(indoc::indoc! {r#"
@@ -515,8 +508,6 @@ fn local_relative_additional_dependency_is_not_resolved_from_worktree() -> anyho
     Using Python [VERSION] environment at: [HOME]/hooks/python-[HASH]
     error: [INSTALL_CWD] does not appear to be a Python project, as neither `pyproject.toml` nor `setup.py` are present in the directory
     "#);
-
-    Ok(())
 }
 
 /// Test that health check passes when Python toolchain path involves symlinks.

--- a/crates/prek/tests/languages/r.rs
+++ b/crates/prek/tests/languages/r.rs
@@ -4,12 +4,11 @@ use prek_consts::PRE_COMMIT_HOOKS_YAML;
 use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
-fn local_hook() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
-    context
-        .work_dir()
-        .child(".Rprofile")
-        .write_str(r#"stop("project .Rprofile should not be loaded")"#)?;
+fn local_hook() {
+    let context = TestEnv::new_git().with_file(
+        ".Rprofile",
+        r#"stop("project .Rprofile should not be loaded")"#,
+    );
 
     let context = context.with_config(indoc::indoc! {r#"
         repos:
@@ -52,8 +51,6 @@ fn local_hook() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]

--- a/crates/prek/tests/languages/ruby.rs
+++ b/crates/prek/tests/languages/ruby.rs
@@ -216,18 +216,15 @@ fn specific_ruby_unavailable() {
 
 /// Test Ruby hook with `additional_dependencies` and `require` statement
 #[test]
-fn additional_gem_dependencies() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
-
-    // Create a Ruby script that uses a gem from additional_dependencies
-    // Use 'rspec' - a gem that's NOT bundled with Ruby
-    context
-        .work_dir()
-        .child("test_script.rb")
-        .write_str(indoc::indoc! {r"
+fn additional_gem_dependencies() {
+    // Use a gem that is not bundled with Ruby.
+    let context = TestEnv::new_git().with_file(
+        "test_script.rb",
+        indoc::indoc! {r"
             require 'rspec'
             puts RSpec::Version::STRING
-        "})?;
+        "},
+    );
 
     let context = context.with_config(indoc::indoc! {r#"
         repos:
@@ -299,20 +296,15 @@ fn additional_gem_dependencies() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 /// Test Ruby hook with gemspec
 #[test]
 fn gemspec_workflow() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
-
-    // Create a simple gemspec
-    context
-        .work_dir()
-        .child("test_gem.gemspec")
-        .write_str(indoc::indoc! {r#"
+    let context = TestEnv::new_git()
+        .with_file(
+            "test_gem.gemspec",
+            indoc::indoc! {r#"
             Gem::Specification.new do |spec|
               spec.name          = "test_gem"
               spec.version       = "0.1.0"
@@ -322,29 +314,25 @@ fn gemspec_workflow() -> anyhow::Result<()> {
               spec.files         = ["lib/test_gem.rb"]
               spec.require_paths = ["lib"]
             end
-        "#})?;
-
-    // Create lib directory and file
-    context.work_dir().child("lib").create_dir_all()?;
-    context
-        .work_dir()
-        .child("lib/test_gem.rb")
-        .write_str(indoc::indoc! {r#"
+        "#},
+        )
+        .with_file(
+            "lib/test_gem.rb",
+            indoc::indoc! {r#"
             module TestGem
               def self.hello
                 "Hello from TestGem"
               end
             end
-        "#})?;
-
-    // Create test script
-    context
-        .work_dir()
-        .child("test_script.rb")
-        .write_str(indoc::indoc! {r"
+        "#},
+        )
+        .with_file(
+            "test_script.rb",
+            indoc::indoc! {r"
             require 'test_gem'
             puts TestGem.hello
-        "})?;
+        "},
+        );
 
     let context = context.with_config(indoc::indoc! {r"
         repos:
@@ -633,14 +621,11 @@ fn local_hook_with_gemspec() -> anyhow::Result<()> {
 
 /// Test Ruby hook with native gem (C extension)
 #[test]
-fn native_gem_dependency() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
-
-    // Create a Ruby script that uses msgpack (small native gem that compiles quickly)
-    context
-        .work_dir()
-        .child("check_msgpack.rb")
-        .write_str(indoc::indoc! {r#"
+fn native_gem_dependency() {
+    // msgpack is a small native gem that compiles quickly.
+    let context = TestEnv::new_git().with_file(
+        "check_msgpack.rb",
+        indoc::indoc! {r#"
             #!/usr/bin/env ruby
             require 'msgpack'
 
@@ -651,7 +636,8 @@ fn native_gem_dependency() -> anyhow::Result<()> {
 
             puts "MessagePack native extension working!"
             puts "Packed size: #{packed.bytesize} bytes"
-        "#})?;
+        "#},
+    );
 
     let context = context.with_config(indoc::indoc! {r"
         repos:
@@ -680,20 +666,14 @@ fn native_gem_dependency() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 /// Test Ruby hook that processes files
 #[test]
-fn process_files() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
-
-    // Create a Ruby script that validates file extensions
-    context
-        .work_dir()
-        .child("check_ruby.rb")
-        .write_str(indoc::indoc! {r#"
+fn process_files() {
+    let context = TestEnv::new_git().with_file(
+        "check_ruby.rb",
+        indoc::indoc! {r#"
             ARGV.sort.each do |file|
               unless file.end_with?('.rb')
                 puts "Error: #{file} is not a Ruby file"
@@ -701,9 +681,11 @@ fn process_files() -> anyhow::Result<()> {
               end
               puts "OK: #{file}"
             end
-        "#})?;
+        "#},
+    );
 
-    let context = context.with_config(indoc::indoc! {r"
+    let context = context
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -714,15 +696,9 @@ fn process_files() -> anyhow::Result<()> {
                 language_version: system
                 files: \.rb$
                 verbose: true
-    "});
-
-    // Create a Ruby file
-    context
-        .work_dir()
-        .child("test.rb")
-        .write_str("puts 'hello'")?;
-    // Create a text file
-    context.work_dir().child("test.txt").write_str("hello")?;
+    "})
+        .with_file("test.rb", "puts 'hello'")
+        .with_file("test.txt", "hello");
 
     context.git().add_all();
 
@@ -739,8 +715,6 @@ fn process_files() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 /// Test that Ruby is auto-downloaded from rv-ruby when a specific version

--- a/crates/prek/tests/languages/script.rs
+++ b/crates/prek/tests/languages/script.rs
@@ -50,8 +50,6 @@ mod unix {
 
     #[test]
     fn workspace_script_run() -> Result<()> {
-        let context = TestEnv::new_git();
-
         let config = indoc::indoc! {r#"
         repos:
           - repo: local
@@ -64,23 +62,24 @@ mod unix {
                   MESSAGE: "Hello, World"
                 verbose: true
         "#};
-        let context = context.with_config(config).with_file(
-            "script.sh",
-            indoc::indoc! {r#"
+        let context = TestEnv::new_git()
+            .with_config(config)
+            .with_file(
+                "script.sh",
+                indoc::indoc! {r#"
             #!/usr/bin/env bash
             echo "$MESSAGE!"
         "#},
-        );
-
-        let child = context.work_dir().child("child");
-        context.write_file("child/.pre-commit-config.yaml", config);
-        context.write_file(
-            "child/script.sh",
-            indoc::indoc! {r#"
+            )
+            .with_file("child/.pre-commit-config.yaml", config)
+            .with_file(
+                "child/script.sh",
+                indoc::indoc! {r#"
             #!/usr/bin/env bash
             echo "$MESSAGE from child!"
         "#},
-        );
+            );
+        let child = context.work_dir().child("child");
 
         make_executable(context.work_dir().child("script.sh"))?;
         make_executable(child.child("script.sh"))?;
@@ -124,7 +123,8 @@ mod unix {
 
     #[test]
     fn local_repo_bash_shebang() -> Result<()> {
-        let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+        let context = TestEnv::new_git()
+            .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -133,16 +133,15 @@ mod unix {
                 language: script
                 entry: ./echo.sh
                 verbose: true
-        "});
-
-        let script = context.work_dir().child("echo.sh");
-        context.write_file(
-            "echo.sh",
-            indoc::indoc! {r#"
+        "})
+            .with_file(
+                "echo.sh",
+                indoc::indoc! {r#"
             #!/usr/bin/env bash
             echo "Hello, World!"
         "#},
-        );
+            );
+        let script = context.work_dir().child("echo.sh");
         make_executable(&script)?;
 
         context.git().add_all();
@@ -207,7 +206,8 @@ mod unix {
 /// The interpreter must exist in the PATH, the script is not needed to be executable.
 #[test]
 fn windows_script_run() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
     repos:
       - repo: local
         hooks:
@@ -216,16 +216,15 @@ fn windows_script_run() -> Result<()> {
             language: script
             entry: ./echo.sh
             verbose: true
-    "});
-
-    let script = context.work_dir().child("echo.sh");
-    context.write_file(
-        "echo.sh",
-        indoc::indoc! {r#"
+    "})
+        .with_file(
+            "echo.sh",
+            indoc::indoc! {r#"
         #!/usr/bin/env python3
         print("Hello, World!")
     "#},
-    );
+        );
+    let script = context.work_dir().child("echo.sh");
     make_executable(&script)?;
 
     context.git().add_all();

--- a/crates/prek/tests/languages/script.rs
+++ b/crates/prek/tests/languages/script.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use assert_fs::fixture::{FileWriteStr, PathChild};
+use assert_fs::fixture::PathChild;
 
 use crate::common::make_executable;
 use crate::common::{TestEnv, cmd_snapshot};
@@ -8,8 +8,7 @@ use crate::common::{TestEnv, cmd_snapshot};
 mod unix {
     use super::*;
 
-    use assert_fs::fixture::{FileWriteStr, PathChild, PathCreateDir};
-    use prek_consts::PRE_COMMIT_CONFIG_YAML;
+    use assert_fs::fixture::PathChild;
 
     #[test]
     fn script_run() {
@@ -65,22 +64,23 @@ mod unix {
                   MESSAGE: "Hello, World"
                 verbose: true
         "#};
-        let context = context.with_config(config);
-        context
-            .work_dir()
-            .child("script.sh")
-            .write_str(indoc::indoc! {r#"
+        let context = context.with_config(config).with_file(
+            "script.sh",
+            indoc::indoc! {r#"
             #!/usr/bin/env bash
             echo "$MESSAGE!"
-        "#})?;
+        "#},
+        );
 
         let child = context.work_dir().child("child");
-        child.create_dir_all()?;
-        child.child(PRE_COMMIT_CONFIG_YAML).write_str(config)?;
-        child.child("script.sh").write_str(indoc::indoc! {r#"
+        context.write_file("child/.pre-commit-config.yaml", config);
+        context.write_file(
+            "child/script.sh",
+            indoc::indoc! {r#"
             #!/usr/bin/env bash
             echo "$MESSAGE from child!"
-        "#})?;
+        "#},
+        );
 
         make_executable(context.work_dir().child("script.sh"))?;
         make_executable(child.child("script.sh"))?;
@@ -136,10 +136,13 @@ mod unix {
         "});
 
         let script = context.work_dir().child("echo.sh");
-        script.write_str(indoc::indoc! {r#"
+        context.write_file(
+            "echo.sh",
+            indoc::indoc! {r#"
             #!/usr/bin/env bash
             echo "Hello, World!"
-        "#})?;
+        "#},
+        );
         make_executable(&script)?;
 
         context.git().add_all();
@@ -161,8 +164,9 @@ mod unix {
     }
 
     #[test]
-    fn script_shell_runs_entry_as_shell_source() -> Result<()> {
-        let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    fn script_shell_runs_entry_as_shell_source() {
+        let context = TestEnv::new_git()
+            .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -179,8 +183,9 @@ mod unix {
                 shell: sh
                 args: [configured]
                 verbose: true
-        "#});
-        context.work_dir().child("a.txt").write_str("a")?;
+        "#})
+            .with_file("a.txt", "a");
+
         context.git().add_all();
 
         cmd_snapshot!(context, context.run(), @r"
@@ -195,8 +200,6 @@ mod unix {
 
         ----- stderr -----
         ");
-
-        Ok(())
     }
 }
 
@@ -216,10 +219,13 @@ fn windows_script_run() -> Result<()> {
     "});
 
     let script = context.work_dir().child("echo.sh");
-    script.write_str(indoc::indoc! {r#"
+    context.write_file(
+        "echo.sh",
+        indoc::indoc! {r#"
         #!/usr/bin/env python3
         print("Hello, World!")
-    "#})?;
+    "#},
+    );
     make_executable(&script)?;
 
     context.git().add_all();

--- a/crates/prek/tests/languages/shell.rs
+++ b/crates/prek/tests/languages/shell.rs
@@ -1,11 +1,10 @@
-use assert_fs::fixture::{FileWriteStr, PathChild};
-
 use crate::common::{TestEnv, cmd_snapshot};
 
 #[cfg(unix)]
 #[test]
-fn bash_shell_adapter_runs_entry() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+fn bash_shell_adapter_runs_entry() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -19,8 +18,9 @@ fn bash_shell_adapter_runs_entry() -> anyhow::Result<()> {
                   printf 'bash:%s:%s\n' "${items[0]}" "${items[1]}"
                 args: [configured]
                 verbose: true
-    "#});
-    context.work_dir().child("input.txt").write_str("input")?;
+    "#})
+        .with_file("input.txt", "input");
+
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
@@ -35,17 +35,16 @@ fn bash_shell_adapter_runs_entry() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn pwsh_shell_adapter_runs_entry() -> anyhow::Result<()> {
+fn pwsh_shell_adapter_runs_entry() {
     if which::which("pwsh").is_err() {
-        return Ok(());
+        return;
     }
 
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -58,8 +57,9 @@ fn pwsh_shell_adapter_runs_entry() -> anyhow::Result<()> {
                   Write-Output "pwsh:$($args[0]):$($args[1])"
                 args: [configured]
                 verbose: true
-    "#});
-    context.work_dir().child("input.txt").write_str("input")?;
+    "#})
+        .with_file("input.txt", "input");
+
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
@@ -74,14 +74,13 @@ fn pwsh_shell_adapter_runs_entry() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[cfg(windows)]
 #[test]
-fn powershell_shell_adapter_runs_entry() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+fn powershell_shell_adapter_runs_entry() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -94,8 +93,9 @@ fn powershell_shell_adapter_runs_entry() -> anyhow::Result<()> {
                   Write-Output "powershell:$($args[0]):$($args[1])"
                 args: [configured]
                 verbose: true
-    "#});
-    context.work_dir().child("input.txt").write_str("input")?;
+    "#})
+        .with_file("input.txt", "input");
+
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
@@ -110,14 +110,13 @@ fn powershell_shell_adapter_runs_entry() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[cfg(windows)]
 #[test]
-fn cmd_shell_adapter_runs_entry() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn cmd_shell_adapter_runs_entry() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -131,8 +130,9 @@ fn cmd_shell_adapter_runs_entry() -> anyhow::Result<()> {
                   echo cmd:%1:%2
                 args: [configured]
                 verbose: true
-    "});
-    context.work_dir().child("input.txt").write_str("input")?;
+    "})
+        .with_file("input.txt", "input");
+
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
@@ -147,8 +147,6 @@ fn cmd_shell_adapter_runs_entry() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]

--- a/crates/prek/tests/languages/system.rs
+++ b/crates/prek/tests/languages/system.rs
@@ -1,8 +1,6 @@
 #[cfg(unix)]
 use crate::common::{TestEnv, cmd_snapshot};
 #[cfg(unix)]
-use assert_fs::fixture::{FileWriteStr, PathChild};
-
 #[cfg(unix)]
 #[test]
 fn multiline_entry_without_shell_uses_argv_semantics() {
@@ -71,8 +69,9 @@ fn shell_runs_multiline_entry_as_one_script() {
 
 #[cfg(unix)]
 #[test]
-fn shell_entry_receives_hook_args_before_filenames() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+fn shell_entry_receives_hook_args_before_filenames() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
     repos:
       - repo: local
         hooks:
@@ -89,8 +88,9 @@ fn shell_entry_receives_hook_args_before_filenames() -> anyhow::Result<()> {
             shell: sh
             args: [configured]
             verbose: true
-    "#});
-    context.work_dir().child("a.txt").write_str("a")?;
+    "#})
+        .with_file("a.txt", "a");
+
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
@@ -105,6 +105,4 @@ fn shell_entry_receives_hook_args_before_filenames() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }

--- a/crates/prek/tests/languages/unsupported.rs
+++ b/crates/prek/tests/languages/unsupported.rs
@@ -1,11 +1,11 @@
 /// Test `language: unsupported` and `language: unsupported_script` works.
 #[cfg(unix)]
 #[test]
-fn unsupported_language() -> anyhow::Result<()> {
+fn unsupported_language() {
     use crate::common::{TestEnv, cmd_snapshot};
-    use assert_fs::fixture::{FileWriteStr, PathChild};
 
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -19,14 +19,15 @@ fn unsupported_language() -> anyhow::Result<()> {
                 language: unsupported_script
                 entry: ./script.sh
                 verbose: true
-    "});
-    context
-        .work_dir()
-        .child("script.sh")
-        .write_str(indoc::indoc! {r#"
+    "})
+        .with_file(
+            "script.sh",
+            indoc::indoc! {r#"
             #!/usr/bin/env bash
             echo "Hello, World!"
-        "#})?;
+        "#},
+        );
+
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
@@ -46,6 +47,4 @@ fn unsupported_language() -> anyhow::Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }

--- a/crates/prek/tests/list.rs
+++ b/crates/prek/tests/list.rs
@@ -583,7 +583,7 @@ fn list_json_output() {
 }
 
 #[test]
-fn workspace_list() -> anyhow::Result<()> {
+fn workspace_list() {
     let context = TestEnv::new_git();
     let cwd = context.work_dir().to_path_buf();
 
@@ -606,7 +606,7 @@ fn workspace_list() -> anyhow::Result<()> {
             "project3/project5",
         ],
         config,
-    )?;
+    );
     context.git().add_all();
 
     cmd_snapshot!(context, context.list(), @r"
@@ -767,12 +767,10 @@ fn workspace_list() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn list_with_selectors() -> anyhow::Result<()> {
+fn list_with_selectors() {
     let context = TestEnv::new_git();
 
     let config = indoc! {r"
@@ -794,7 +792,7 @@ fn list_with_selectors() -> anyhow::Result<()> {
             "project3/project5",
         ],
         config,
-    )?;
+    );
     context.git().add_all();
 
     cmd_snapshot!(context, context.list().arg("project2/"), @r"
@@ -913,6 +911,4 @@ fn list_with_selectors() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }

--- a/crates/prek/tests/meta_hooks.rs
+++ b/crates/prek/tests/meta_hooks.rs
@@ -90,8 +90,6 @@ fn meta_hooks_unknown_hook() {
 
 #[test]
 fn check_useless_excludes_remote() {
-    let context = TestEnv::new_git();
-
     // When checking useless excludes, remote hooks are not actually cloned,
     // so hook options defined from HookManifest are not used.
     // If applied, "types_or: [python, pyi]" from black-pre-commit-mirror
@@ -114,9 +112,9 @@ fn check_useless_excludes_remote() {
         hooks:
             - id: check-useless-excludes
     "};
-    context.write_file("html/file1.html", "<!DOCTYPE html>");
-
-    let context = context.with_config(&pre_commit_config);
+    let context = TestEnv::new_git()
+        .with_file("html/file1.html", "<!DOCTYPE html>")
+        .with_config(&pre_commit_config);
     context.git().add_all();
     cmd_snapshot!(context, context.run().arg("check-useless-excludes"), @r"
     success: false
@@ -134,11 +132,10 @@ fn check_useless_excludes_remote() {
 
 #[test]
 fn meta_hooks_workspace() {
-    let context = TestEnv::new_git();
-
-    context.write_file(
-        "app/.pre-commit-config.yaml",
-        indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_file(
+            "app/.pre-commit-config.yaml",
+            indoc::indoc! {r"
         repos:
           - repo: meta
             hooks:
@@ -158,14 +155,12 @@ fn meta_hooks_workspace() {
                 entry: python3 -c 'import sys; sys.exit(0)'
                 exclude: $nonexistent^
     "},
-    );
-
-    context.write_file("app/file.txt", "Hello, world!\n");
-    context.write_file("app/valid.json", "{}");
-    context.write_file("app/invalid.json", "{x}");
-    context.write_file("app/main.py", r#"print "abc"  "#);
-
-    let context = context.with_config("repos: []");
+        )
+        .with_file("app/file.txt", "Hello, world!\n")
+        .with_file("app/valid.json", "{}")
+        .with_file("app/invalid.json", "{x}")
+        .with_file("app/main.py", r#"print "abc"  "#)
+        .with_config("repos: []");
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
@@ -201,17 +196,17 @@ fn meta_hooks_workspace() {
 
 #[test]
 fn check_useless_excludes_workspace_paths_are_project_relative() {
-    let context = TestEnv::new_git();
-
     // Workspace layout:
     // - Root project has no hooks.
     // - Nested project `app/` runs `check-useless-excludes`.
     //
     // Regression: in workspace mode, `files`/`exclude` matching must use paths *relative to the
     // nested project root* (so anchored patterns like `^...$` work as expected).
-    context.write_file(
-        "app/.pre-commit-config.yaml",
-        indoc::indoc! {r"
+    // The two sentinel files keep the anchored excludes from being reported as useless.
+    let context = TestEnv::new_git()
+        .with_file(
+            "app/.pre-commit-config.yaml",
+            indoc::indoc! {r"
         exclude: '^global_excluded$'
         repos:
           - repo: meta
@@ -225,14 +220,10 @@ fn check_useless_excludes_workspace_paths_are_project_relative() {
                 entry: python3 -c 'import sys; sys.exit(0)'
                 exclude: '^hook_excluded$'
         "},
-    );
-
-    // These files exist specifically so the anchored patterns above are NOT useless.
-    // If the meta hook mistakenly matches against `app/<name>` instead of `<name>`, it will fail.
-    context.write_file("app/global_excluded", "ignored\n");
-    context.write_file("app/hook_excluded", "ignored\n");
-
-    let context = context.with_config("repos: []");
+        )
+        .with_file("app/global_excluded", "ignored\n")
+        .with_file("app/hook_excluded", "ignored\n")
+        .with_config("repos: []");
     context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("check-useless-excludes"), @r#"

--- a/crates/prek/tests/meta_hooks.rs
+++ b/crates/prek/tests/meta_hooks.rs
@@ -2,9 +2,6 @@ mod common;
 
 use crate::common::{TestEnv, cmd_snapshot};
 
-use assert_fs::fixture::{FileWriteStr, PathChild, PathCreateDir};
-use prek_consts::PRE_COMMIT_CONFIG_YAML;
-
 #[test]
 fn meta_hooks() {
     let context = TestEnv::new_git()
@@ -92,7 +89,7 @@ fn meta_hooks_unknown_hook() {
 }
 
 #[test]
-fn check_useless_excludes_remote() -> anyhow::Result<()> {
+fn check_useless_excludes_remote() {
     let context = TestEnv::new_git();
 
     // When checking useless excludes, remote hooks are not actually cloned,
@@ -117,12 +114,7 @@ fn check_useless_excludes_remote() -> anyhow::Result<()> {
         hooks:
             - id: check-useless-excludes
     "};
-    context.work_dir().child("html").create_dir_all()?;
-    context
-        .work_dir()
-        .child("html")
-        .child("file1.html")
-        .write_str("<!DOCTYPE html>")?;
+    context.write_file("html/file1.html", "<!DOCTYPE html>");
 
     let context = context.with_config(&pre_commit_config);
     context.git().add_all();
@@ -138,18 +130,15 @@ fn check_useless_excludes_remote() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn meta_hooks_workspace() -> anyhow::Result<()> {
+fn meta_hooks_workspace() {
     let context = TestEnv::new_git();
 
-    let app = context.work_dir().child("app");
-    app.create_dir_all()?;
-    app.child(PRE_COMMIT_CONFIG_YAML)
-        .write_str(indoc::indoc! {r"
+    context.write_file(
+        "app/.pre-commit-config.yaml",
+        indoc::indoc! {r"
         repos:
           - repo: meta
             hooks:
@@ -168,12 +157,13 @@ fn meta_hooks_workspace() -> anyhow::Result<()> {
                 language: system
                 entry: python3 -c 'import sys; sys.exit(0)'
                 exclude: $nonexistent^
-    "})?;
+    "},
+    );
 
-    app.child("file.txt").write_str("Hello, world!\n")?;
-    app.child("valid.json").write_str("{}")?;
-    app.child("invalid.json").write_str("{x}")?;
-    app.child("main.py").write_str(r#"print "abc"  "#)?;
+    context.write_file("app/file.txt", "Hello, world!\n");
+    context.write_file("app/valid.json", "{}");
+    context.write_file("app/invalid.json", "{x}");
+    context.write_file("app/main.py", r#"print "abc"  "#);
 
     let context = context.with_config("repos: []");
     context.git().add_all();
@@ -207,12 +197,10 @@ fn meta_hooks_workspace() -> anyhow::Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
-fn check_useless_excludes_workspace_paths_are_project_relative() -> anyhow::Result<()> {
+fn check_useless_excludes_workspace_paths_are_project_relative() {
     let context = TestEnv::new_git();
 
     // Workspace layout:
@@ -221,10 +209,9 @@ fn check_useless_excludes_workspace_paths_are_project_relative() -> anyhow::Resu
     //
     // Regression: in workspace mode, `files`/`exclude` matching must use paths *relative to the
     // nested project root* (so anchored patterns like `^...$` work as expected).
-    let app = context.work_dir().child("app");
-    app.create_dir_all()?;
-    app.child(PRE_COMMIT_CONFIG_YAML)
-        .write_str(indoc::indoc! {r"
+    context.write_file(
+        "app/.pre-commit-config.yaml",
+        indoc::indoc! {r"
         exclude: '^global_excluded$'
         repos:
           - repo: meta
@@ -237,12 +224,13 @@ fn check_useless_excludes_workspace_paths_are_project_relative() -> anyhow::Resu
                 language: system
                 entry: python3 -c 'import sys; sys.exit(0)'
                 exclude: '^hook_excluded$'
-        "})?;
+        "},
+    );
 
     // These files exist specifically so the anchored patterns above are NOT useless.
     // If the meta hook mistakenly matches against `app/<name>` instead of `<name>`, it will fail.
-    app.child("global_excluded").write_str("ignored\n")?;
-    app.child("hook_excluded").write_str("ignored\n")?;
+    context.write_file("app/global_excluded", "ignored\n");
+    context.write_file("app/hook_excluded", "ignored\n");
 
     let context = context.with_config("repos: []");
     context.git().add_all();
@@ -256,6 +244,4 @@ fn check_useless_excludes_workspace_paths_are_project_relative() -> anyhow::Resu
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -29,8 +29,9 @@ fn with_remote_fetch_error_filters(context: TestEnv) -> TestEnv {
 }
 
 #[test]
-fn run_basic() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn run_basic() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/pre-commit/pre-commit-hooks
             rev: v5.0.0
@@ -40,13 +41,10 @@ fn run_basic() -> Result<()> {
               - id: requirements-txt-fixer
                 files: ^file\.txt$
               - id: check-json
-    "});
-
-    let cwd = context.work_dir();
-
-    cwd.child("file.txt").write_str("z-project\na-project\n")?;
-    cwd.child("valid.json").write_str("{}")?;
-    cwd.child("main.py").write_str(r#"print "abc"  "#)?;
+    "})
+        .with_file("file.txt", "z-project\na-project\n")
+        .with_file("valid.json", "{}")
+        .with_file("main.py", r#"print "abc"  "#);
 
     context.git().add_all();
 
@@ -92,13 +90,12 @@ fn run_basic() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
-fn fast_path_checks_filenames_from_entry_and_args() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn fast_path_checks_filenames_from_entry_and_args() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/pre-commit/pre-commit-hooks
             rev: v5.0.0
@@ -107,12 +104,11 @@ fn fast_path_checks_filenames_from_entry_and_args() -> Result<()> {
                 entry: check-json from-entry.json
                 args: [from-args.json]
                 files: ^selected\.json$
-    "});
+    "})
+        .with_file("from-entry.json", "invalid")
+        .with_file("from-args.json", "invalid")
+        .with_file("selected.json", "{}");
 
-    let cwd = context.work_dir();
-    cwd.child("from-entry.json").write_str("invalid")?;
-    cwd.child("from-args.json").write_str("invalid")?;
-    cwd.child("selected.json").write_str("{}")?;
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
@@ -129,25 +125,22 @@ fn fast_path_checks_filenames_from_entry_and_args() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn run_preserves_stdout_stderr_order() -> Result<()> {
-    let context = TestEnv::new_git();
-
-    context
-        .work_dir()
-        .child("output.py")
-        .write_str(indoc::indoc! {r#"
+fn run_preserves_stdout_stderr_order() {
+    let context = TestEnv::new_git().with_file(
+        "output.py",
+        indoc::indoc! {r#"
             import os
 
             os.write(2, b"__PREK_STDERR_1__\n")
             os.write(1, b"__PREK_STDOUT_1__\n")
             os.write(2, b"__PREK_STDERR_2__\n")
             os.write(1, b"__PREK_STDOUT_2__\n")
-        "#})?;
+        "#},
+    );
+
     let context = context.with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -177,8 +170,6 @@ fn run_preserves_stdout_stderr_order() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
@@ -306,8 +297,9 @@ fn run_tracks_relative_config_as_absolute_path() -> Result<()> {
 }
 
 #[test]
-fn run_glob_patterns_with_multiple_hooks() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+fn run_glob_patterns_with_multiple_hooks() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -325,16 +317,10 @@ fn run_glob_patterns_with_multiple_hooks() -> Result<()> {
                 files:
                   glob: "**/*.md"
                 verbose: true
-    "#});
-
-    let cwd = context.work_dir();
-
-    let src_dir = cwd.child("src");
-    src_dir.create_dir_all()?;
-    src_dir.child("main.py").write_str("print('hi')")?;
-    cwd.child("docs").create_dir_all()?;
-    cwd.child("docs/readme.md").write_str("# Docs")?;
-    cwd.child("notes.txt").write_str("note")?;
+    "#})
+        .with_file("src/main.py", "print('hi')")
+        .with_file("docs/readme.md", "# Docs")
+        .with_file("notes.txt", "note");
 
     context.git().add_all();
 
@@ -355,8 +341,6 @@ fn run_glob_patterns_with_multiple_hooks() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
@@ -496,8 +480,9 @@ fn invalid_config() {
 
 /// Use same repo multiple times, with same or different revisions.
 #[test]
-fn same_repo() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn same_repo() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/pre-commit/pre-commit-hooks
             rev: v5.0.0
@@ -511,14 +496,12 @@ fn same_repo() -> Result<()> {
             rev: v4.6.0
             hooks:
               - id: trailing-whitespace
-    "});
+    "})
+        .with_file("file.txt", "Hello, world!\n")
+        .with_file("valid.json", "{}")
+        .with_file("invalid.json", "{}")
+        .with_file("main.py", r#"print "abc"  "#);
 
-    let cwd = context.work_dir();
-
-    cwd.child("file.txt").write_str("Hello, world!\n")?;
-    cwd.child("valid.json").write_str("{}")?;
-    cwd.child("invalid.json").write_str("{}")?;
-    cwd.child("main.py").write_str(r#"print "abc"  "#)?;
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
@@ -537,8 +520,6 @@ fn same_repo() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
@@ -567,8 +548,9 @@ fn local() {
 }
 
 #[test]
-fn hook_repo_placeholder_expands_to_local_project() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+fn hook_repo_placeholder_expands_to_local_project() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -578,8 +560,9 @@ fn hook_repo_placeholder_expands_to_local_project() -> Result<()> {
                 entry: git -C "{hook_repo}" cat-file -e HEAD:hook-repo-marker
                 always_run: true
                 pass_filenames: false
-    "#});
-    context.work_dir().child("hook-repo-marker").write_str("")?;
+    "#})
+        .with_file("hook-repo-marker", "");
+
     context.git().add_all().commit("Add local hook");
 
     cmd_snapshot!(context, context.run(), @r#"
@@ -590,8 +573,6 @@ fn hook_repo_placeholder_expands_to_local_project() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
@@ -1367,9 +1348,8 @@ fn priority_fail_fast_stops_later_groups() {
 }
 
 #[test]
-fn explicitly_skipped_hook_does_not_affect_priority_group_outcome() -> Result<()> {
-    let context = TestEnv::new_git();
-    context.work_dir().child("file.txt").write_str("hello\n")?;
+fn explicitly_skipped_hook_does_not_affect_priority_group_outcome() {
+    let context = TestEnv::new_git().with_file("file.txt", "hello\n");
 
     let context = context.with_config(indoc::indoc! {r#"
         repos:
@@ -1411,7 +1391,7 @@ fn explicitly_skipped_hook_does_not_affect_priority_group_outcome() -> Result<()
     ----- stderr -----
     "#);
 
-    context.work_dir().child("file.txt").write_str("hello\n")?;
+    context.write_file("file.txt", "hello\n");
     cmd_snapshot!(context, context.run().arg("--skip").arg("skipped").arg("--hide-status").arg("failed"), @r#"
     success: false
     exit_code: 1
@@ -1421,16 +1401,11 @@ fn explicitly_skipped_hook_does_not_affect_priority_group_outcome() -> Result<()
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
-fn priority_group_modified_files_is_group_failure_and_output_is_indented() -> Result<()> {
-    let context = TestEnv::new_git();
-
-    let cwd = context.work_dir();
-    cwd.child("file.txt").write_str("hello\n")?;
+fn priority_group_modified_files_is_group_failure_and_output_is_indented() {
+    let context = TestEnv::new_git().with_file("file.txt", "hello\n");
 
     let context = context.with_config(indoc::indoc! {r#"
         repos:
@@ -1497,7 +1472,7 @@ fn priority_group_modified_files_is_group_failure_and_output_is_indented() -> Re
     ----- stderr -----
     ");
 
-    context.work_dir().child("file.txt").write_str("hello\n")?;
+    context.write_file("file.txt", "hello\n");
     cmd_snapshot!(context, context.run().arg("--skip").arg("skipped").arg("--hide-status").arg("passed"), @r#"
     success: false
     exit_code: 1
@@ -1507,16 +1482,13 @@ fn priority_group_modified_files_is_group_failure_and_output_is_indented() -> Re
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 /// `.pre-commit-config.yaml` is not staged.
 #[test]
-fn config_not_staged() -> Result<()> {
-    let context = TestEnv::new_git();
+fn config_not_staged() {
+    let context = TestEnv::new_git().with_file(PRE_COMMIT_CONFIG_YAML, "");
 
-    context.work_dir().child(PRE_COMMIT_CONFIG_YAML).touch()?;
     context.git().add_all();
 
     let context = context.with_config(indoc::indoc! {r"
@@ -1537,8 +1509,6 @@ fn config_not_staged() -> Result<()> {
     ----- stderr -----
     error: Configuration file `.pre-commit-config.yaml` is not staged. Stage it with `git add` and try again
     "#);
-
-    Ok(())
 }
 
 /// `.pre-commit-config.yaml` outside the repository should not be checked.
@@ -1552,10 +1522,9 @@ fn config_outside_repo() -> Result<()> {
     context.git_at(&root).init();
 
     // Create a configuration file in . (outside the repository).
-    context
-        .work_dir()
-        .child("c.yaml")
-        .write_str(indoc::indoc! {r#"
+    let context = context.with_file(
+        "c.yaml",
+        indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -1563,7 +1532,8 @@ fn config_outside_repo() -> Result<()> {
                 name: trailing-whitespace
                 language: system
                 entry: python3 -c 'print("Hello world")'
-    "#})?;
+    "#},
+    );
 
     cmd_snapshot!(context, context.run().current_dir(&root).arg("-c").arg("../c.yaml"), @r#"
     success: true
@@ -1712,9 +1682,9 @@ fn hide_status_filters_hook_reports() {
 }
 
 #[test]
-fn hide_status_uses_final_display_status() -> Result<()> {
-    let context = TestEnv::new_git();
-    context.work_dir().child("file.txt").write_str("hello\n")?;
+fn hide_status_uses_final_display_status() {
+    let context = TestEnv::new_git().with_file("file.txt", "hello\n");
+
     let context = context.with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -1737,8 +1707,6 @@ fn hide_status_uses_final_display_status() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
@@ -1917,14 +1885,12 @@ fn fallback_to_manual_stage() {
 
 /// Test global `files`, `exclude`, and hook level `files`, `exclude`.
 #[test]
-fn files_and_exclude() -> Result<()> {
-    let context = TestEnv::new_git();
-
-    let cwd = context.work_dir();
-    cwd.child("file.txt").write_str("Hello, world!  \n")?;
-    cwd.child("valid.json").write_str("{}\n  ")?;
-    cwd.child("invalid.json").write_str("{}")?;
-    cwd.child("main.py").write_str(r#"print "abc"  "#)?;
+fn files_and_exclude() {
+    let context = TestEnv::new_git()
+        .with_file("file.txt", "Hello, world!  \n")
+        .with_file("valid.json", "{}\n  ")
+        .with_file("invalid.json", "{}")
+        .with_file("main.py", r#"print "abc"  "#);
 
     // Global files and exclude.
     let context = context.with_config(indoc::indoc! {r"
@@ -2010,19 +1976,15 @@ fn files_and_exclude() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 /// Test selecting files by type, `types`, `types_or`, and `exclude_types`.
 #[test]
-fn file_types() -> Result<()> {
-    let context = TestEnv::new_git();
-
-    let cwd = context.work_dir();
-    cwd.child("file.txt").write_str("Hello, world!  ")?;
-    cwd.child("json.json").write_str("{}\n  ")?;
-    cwd.child("main.py").write_str(r#"print "abc"  "#)?;
+fn file_types() {
+    let context = TestEnv::new_git()
+        .with_file("file.txt", "Hello, world!  ")
+        .with_file("json.json", "{}\n  ")
+        .with_file("main.py", r#"print "abc"  "#);
 
     let context = context.with_config(indoc::indoc! {r#"
         repos:
@@ -2081,8 +2043,6 @@ fn file_types() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 /// Abort the run if a hook fails.
@@ -2235,13 +2195,12 @@ fn no_fail_fast_cli_flag() {
 
 /// Run from a subdirectory. File arguments should be fixed to be relative to the root.
 #[test]
-fn subdirectory() -> Result<()> {
+fn subdirectory() {
     let context = TestEnv::new_git();
 
     let cwd = context.work_dir();
     let child = cwd.child("foo/bar/baz");
-    child.create_dir_all()?;
-    child.child("file.txt").write_str("Hello, world!\n")?;
+    context.write_file("foo/bar/baz/file.txt", "Hello, world!\n");
 
     let context = context.with_config(indoc::indoc! {r"
         repos:
@@ -2281,8 +2240,6 @@ fn subdirectory() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
@@ -2318,9 +2275,10 @@ fn log_file() -> Result<()> {
     let context = TestEnv::new_git();
 
     let config_dir = context.work_dir().child("config");
-    config_dir.create_dir_all()?;
     let config_file = config_dir.child(PRE_COMMIT_CONFIG_YAML);
-    config_file.write_str(indoc::indoc! {r#"
+    context.write_file(
+        "config/.pre-commit-config.yaml",
+        indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -2330,7 +2288,8 @@ fn log_file() -> Result<()> {
                 entry: python3 -c 'import sys; sys.stdout.buffer.write(b"\x1b[2Kraw\xff"); exit(1)'
                 always_run: true
                 log_file: log.txt
-    "#})?;
+    "#},
+    );
     context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("-c").arg(config_file.path()), @r#"
@@ -2379,8 +2338,9 @@ fn pass_env_vars() {
 }
 
 #[test]
-fn staged_files_only() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+fn staged_files_only() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -2390,19 +2350,13 @@ fn staged_files_only() -> Result<()> {
                 entry: python3 -c 'print(open("file.txt", "rt").read())'
                 verbose: true
                 types: [text]
-   "#});
+   "#})
+        .with_file("file.txt", "Hello, world!");
 
-    context
-        .work_dir()
-        .child("file.txt")
-        .write_str("Hello, world!")?;
     context.git().add_all();
 
     // Non-staged files should be stashed and restored.
-    context
-        .work_dir()
-        .child("file.txt")
-        .write_str("Hello world again!")?;
+    context.write_file("file.txt", "Hello world again!");
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -2421,8 +2375,6 @@ fn staged_files_only() -> Result<()> {
 
     let content = context.read("file.txt");
     assert_snapshot!(content, @"Hello world again!");
-
-    Ok(())
 }
 
 #[test]
@@ -2441,7 +2393,7 @@ fn intent_to_add_file_survives_conflicted_stash_restore() -> Result<()> {
     let cwd = context.work_dir();
     context.git().add(PRE_COMMIT_CONFIG_YAML);
 
-    cwd.child("intent.txt").write_str("preserve me\n")?;
+    context.write_file("intent.txt", "preserve me\n");
     context
         .git_at(cwd)
         .command()
@@ -2451,9 +2403,9 @@ fn intent_to_add_file_survives_conflicted_stash_restore() -> Result<()> {
         .assert()
         .success();
 
-    cwd.child("test.py").write_str("a=1\n")?;
+    context.write_file("test.py", "a=1\n");
     context.git().add("test.py");
-    cwd.child("test.py").write_str("a=1\nb = 2\n")?;
+    context.write_file("test.py", "a=1\nb = 2\n");
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -2502,19 +2454,12 @@ fn restore_on_interrupt() -> Result<()> {
                 entry: python3 -c 'import time; open("out.txt", "wt").write(open("file.txt", "rt").read()); time.sleep(10)'
                 verbose: true
                 types: [text]
-   "#});
+   "#}).with_file("file.txt", "Hello, world!");
 
-    context
-        .work_dir()
-        .child("file.txt")
-        .write_str("Hello, world!")?;
     context.git().add_all();
 
     // Non-staged files should be stashed and restored.
-    context
-        .work_dir()
-        .child("file.txt")
-        .write_str("Hello world again!")?;
+    context.write_file("file.txt", "Hello world again!");
 
     let mut child = context.run().spawn()?;
     let child_id = child.id();
@@ -2542,21 +2487,20 @@ fn restore_on_interrupt() -> Result<()> {
 
 /// When in merge conflict, runs on files that have conflicts fixed.
 #[test]
-fn merge_conflicts() -> Result<()> {
-    let context = TestEnv::new_git();
+fn merge_conflicts() {
+    let context = TestEnv::new_git().with_file("file.txt", "Hello, world!");
 
     // Create a merge conflict.
     let cwd = context.work_dir();
-    cwd.child("file.txt").write_str("Hello, world!")?;
+
     context.git().add_all().commit("Initial commit");
 
     context.git().branch("feature").checkout("feature");
-    cwd.child("file.txt").write_str("Hello, world again!")?;
+    context.write_file("file.txt", "Hello, world again!");
     context.git().add_all().commit("Feature commit");
 
     context.git().checkout("master");
-    cwd.child("file.txt")
-        .write_str("Hello, world from master!")?;
+    context.write_file("file.txt", "Hello, world from master!");
     context.git().add_all().commit("Master commit");
 
     context
@@ -2602,8 +2546,6 @@ fn merge_conflicts() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 /// Local python hook with no additional dependencies.
@@ -2847,8 +2789,9 @@ fn unmatched_skip_does_not_suppress_remote_clone() {
 
 /// Test hooks that specifies `types: [directory]`.
 #[test]
-fn types_directory() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn types_directory() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -2857,12 +2800,9 @@ fn types_directory() -> Result<()> {
                 language: system
                 entry: echo
                 types: [directory]
-        "});
-    context.work_dir().child("dir").create_dir_all()?;
-    context
-        .work_dir()
-        .child("dir/file.txt")
-        .write_str("Hello, world!")?;
+        "})
+        .with_file("dir/file.txt", "Hello, world!");
+
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
@@ -2901,31 +2841,28 @@ fn types_directory() -> Result<()> {
     ----- stderr -----
     warning: This file does not exist and will be ignored: `non-exist-files`
     ");
-    Ok(())
 }
 
 #[test]
-fn run_last_commit() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn run_last_commit() {
+    // file2 starts with issues but is intentionally absent from the last commit.
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/pre-commit/pre-commit-hooks
             rev: v5.0.0
             hooks:
               - id: trailing-whitespace
               - id: end-of-file-fixer
-    "});
+    "})
+        .with_file("file1.txt", "Hello, world!\n")
+        .with_file("file2.txt", "Initial content with trailing spaces   \n");
 
-    let cwd = context.work_dir();
-
-    // Create initial files and make first commit
-    cwd.child("file1.txt").write_str("Hello, world!\n")?;
-    cwd.child("file2.txt")
-        .write_str("Initial content with trailing spaces   \n")?; // This has issues but won't be in last commit
     context.git().add_all().commit("Initial commit");
 
     // Modify files and make second commit with trailing whitespace
-    cwd.child("file1.txt").write_str("Hello, world!   \n")?; // trailing whitespace
-    cwd.child("file3.txt").write_str("New file")?; // missing newline
+    context.write_file("file1.txt", "Hello, world!   \n"); // trailing whitespace
+    context.write_file("file3.txt", "New file"); // missing newline
     // Note: file2.txt is NOT modified in this commit, so it should be filtered out by --last-commit
     context.git().add_all().commit("Second commit with issues");
 
@@ -2954,8 +2891,8 @@ fn run_last_commit() -> Result<()> {
     ");
 
     // Now reset the files to their problematic state for comparison
-    cwd.child("file1.txt").write_str("Hello, world!   \n")?; // trailing whitespace
-    cwd.child("file3.txt").write_str("New file")?; // missing newline
+    context.write_file("file1.txt", "Hello, world!   \n"); // trailing whitespace
+    context.write_file("file3.txt", "New file"); // missing newline
 
     // Run with --all-files should check ALL files including file2.txt
     // This demonstrates that file2.txt was indeed filtered out in the previous test
@@ -2981,14 +2918,13 @@ fn run_last_commit() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 /// Test `prek run --files` with multiple files.
 #[test]
-fn run_multiple_files() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn run_multiple_files() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -2998,10 +2934,10 @@ fn run_multiple_files() -> Result<()> {
                 entry: echo
                 verbose: true
                 types: [text]
-    "});
-    let cwd = context.work_dir();
-    cwd.child("file1.txt").write_str("Hello, world!")?;
-    cwd.child("file2.txt").write_str("Hello, world!")?;
+    "})
+        .with_file("file1.txt", "Hello, world!")
+        .with_file("file2.txt", "Hello, world!");
+
     context.git().add_all();
     // `--files` with multiple files
     cmd_snapshot!(context, context.run().arg("--files").arg("file1.txt").arg("file2.txt"), @r#"
@@ -3016,13 +2952,13 @@ fn run_multiple_files() -> Result<()> {
 
     ----- stderr -----
     "#);
-    Ok(())
 }
 
 /// Test `prek run --glob` and its interaction with other explicit file selectors.
 #[test]
-fn run_glob() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn run_glob() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -3032,18 +2968,15 @@ fn run_glob() -> Result<()> {
                 entry: echo
                 verbose: true
                 types: [text]
-    "});
+    "})
+        .with_file("root.rs", "fn main() {}")
+        .with_file("src/lib.rs", "pub fn lib() {}")
+        .with_file("src/lib.py", "print('hello')")
+        .with_file("src/nested/mod.rs", "pub mod nested;")
+        .with_file("docs/readme.md", "# Readme");
 
-    let cwd = context.work_dir();
-    cwd.child("root.rs").write_str("fn main() {}")?;
-    cwd.child("src/lib.rs").write_str("pub fn lib() {}")?;
-    cwd.child("src/lib.py").write_str("print('hello')")?;
-    cwd.child("src/nested/mod.rs")
-        .write_str("pub mod nested;")?;
-    cwd.child("docs/readme.md").write_str("# Readme")?;
     context.git().add_all();
-    cwd.child("src/untracked.rs")
-        .write_str("pub fn untracked() {}")?;
+    context.write_file("src/untracked.rs", "pub fn untracked() {}");
 
     cmd_snapshot!(context, context.run().arg("--glob").arg("src/**/*.rs"), @r#"
     success: true
@@ -3088,8 +3021,6 @@ fn run_glob() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 /// Test `prek run --files` with no files.
@@ -3123,8 +3054,9 @@ fn run_no_files() {
 
 /// Test `prek run --directory` flags.
 #[test]
-fn run_directory() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn run_directory() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -3133,13 +3065,12 @@ fn run_directory() -> Result<()> {
                 language: system
                 entry: echo
                 verbose: true
-    "});
+    "})
+        .with_file("dir1/file.txt", "Hello, world!")
+        .with_file("dir2/file.txt", "Hello, world!");
 
     let cwd = context.work_dir();
-    cwd.child("dir1").create_dir_all()?;
-    cwd.child("dir1/file.txt").write_str("Hello, world!")?;
-    cwd.child("dir2").create_dir_all()?;
-    cwd.child("dir2/file.txt").write_str("Hello, world!")?;
+
     context.git().add_all();
 
     // one `--directory`
@@ -3246,8 +3177,6 @@ fn run_directory() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 /// Test `minimum_prek_version` option.
@@ -3292,7 +3221,7 @@ fn minimum_prek_version() {
 /// Run hooks that would echo color.
 #[test]
 #[cfg(not(windows))]
-fn color() -> Result<()> {
+fn color() {
     let context = TestEnv::new_git().with_config(indoc::indoc! {r"
       repos:
         - repo: local
@@ -3313,7 +3242,7 @@ fn color() -> Result<()> {
           print('Hello, world!')
       sys.stdout.flush()
   "};
-    context.work_dir().child("color.py").write_str(script)?;
+    let context = context.with_file("color.py", script);
 
     context.git().add_all();
 
@@ -3345,13 +3274,11 @@ fn color() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
 #[cfg(not(windows))]
-fn tty_output_preserves_color_without_replaying_terminal_controls() -> Result<()> {
+fn tty_output_preserves_color_without_replaying_terminal_controls() {
     let context = TestEnv::new_git().with_config(indoc::indoc! {r"
       repos:
         - repo: local
@@ -3374,10 +3301,7 @@ fn tty_output_preserves_color_without_replaying_terminal_controls() -> Result<()
       sys.stdout.write('\033]0;title\007plain\n')
       sys.stdout.flush()
   "};
-    context
-        .work_dir()
-        .child("terminal_output.py")
-        .write_str(script)?;
+    let context = context.with_file("terminal_output.py", script);
 
     context.git().add_all();
 
@@ -3397,13 +3321,11 @@ fn tty_output_preserves_color_without_replaying_terminal_controls() -> Result<()
     ----- stderr -----
     "#
     );
-
-    Ok(())
 }
 
 /// Test running hook whose `entry` is script with shebang on Windows.
 #[test]
-fn shebang_script() -> Result<()> {
+fn shebang_script() {
     let context = TestEnv::new_git();
 
     // Create a script with shebang.
@@ -3413,9 +3335,9 @@ fn shebang_script() -> Result<()> {
         print('Hello, world!')
         sys.exit(0)
     "};
-    context.work_dir().child("script.py").write_str(script)?;
-
-    let context = context.with_config(indoc::indoc! {r"
+    let context = context
+        .with_file("script.py", script)
+        .with_config(indoc::indoc! {r"
       repos:
         - repo: local
           hooks:
@@ -3441,13 +3363,11 @@ fn shebang_script() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 /// Test `git commit -a` works without `.git/index.lock exists` error.
 #[test]
-fn git_commit_a() -> Result<()> {
+fn git_commit_a() {
     let context =
         TestEnv::new_git().with_filter("7c8398204bbc95c33a6d2543f86a27621647cf78", "[HASH]");
 
@@ -3463,9 +3383,7 @@ fn git_commit_a() -> Result<()> {
     "});
 
     // Create a file and commit it.
-    let cwd = context.work_dir();
-    let file = cwd.child("file.txt");
-    file.write_str("Hello, world!\n")?;
+    context.write_file("file.txt", "Hello, world!\n");
 
     cmd_snapshot!(context, context.install(), @r#"
     success: true
@@ -3479,9 +3397,9 @@ fn git_commit_a() -> Result<()> {
     context.git().add_all().commit("Initial commit");
 
     // Edit the file
-    file.write_str("Hello, world again!\n")?;
+    context.write_file("file.txt", "Hello, world again!\n");
 
-    let mut commit = context.git_at(cwd).command();
+    let mut commit = context.git().command();
     commit.arg("commit").arg("-a").arg("-m").arg("Update file");
 
     cmd_snapshot!(context, commit, @r"
@@ -3498,17 +3416,28 @@ fn git_commit_a() -> Result<()> {
 
       file.txt
     ");
-
-    Ok(())
 }
 
 #[cfg(unix)]
 #[test]
-fn git_commit_a_currently_fails_when_hook_writes_to_temp_git_index() -> Result<()> {
-    let context = TestEnv::new_git().with_filter(
-        r"invalid object 100644 [0-9a-f]{40}",
-        "invalid object 100644 [HASH]",
-    );
+fn git_commit_a_currently_fails_when_hook_writes_to_temp_git_index() {
+    let context = TestEnv::new_git()
+        .with_filter(
+            r"invalid object 100644 [0-9a-f]{40}",
+            "invalid object 100644 [HASH]",
+        )
+        .with_file(
+            "hook.sh",
+            indoc::indoc! {r#"
+        set -eu
+        tmpdir="$(mktemp -d)"
+        trap 'rm -rf "$tmpdir"' EXIT
+        cd "$tmpdir"
+        git init >/dev/null 2>&1
+        printf 'hook version\n' > file.txt
+        git add file.txt
+    "#},
+        );
 
     // Repro for #1786 documenting the current behavior. `git commit -a`
     // exports `GIT_INDEX_FILE=.git/index.lock` to the hook process. If the
@@ -3520,18 +3449,6 @@ fn git_commit_a_currently_fails_when_hook_writes_to_temp_git_index() -> Result<(
     // path in the parent repo. `prek` treats the post-hook diff as a best-effort
     // snapshot, so the commit continues until Git tries to build trees from the
     // corrupted temporary index and fails with `invalid object ... for 'file.txt'`.
-    context
-        .work_dir()
-        .child("hook.sh")
-        .write_str(indoc::indoc! {r#"
-        set -eu
-        tmpdir="$(mktemp -d)"
-        trap 'rm -rf "$tmpdir"' EXIT
-        cd "$tmpdir"
-        git init >/dev/null 2>&1
-        printf 'hook version\n' > file.txt
-        git add file.txt
-    "#})?;
 
     let context = context.with_config(indoc::indoc! {r"
         repos:
@@ -3546,9 +3463,7 @@ fn git_commit_a_currently_fails_when_hook_writes_to_temp_git_index() -> Result<(
                 verbose: true
     "});
 
-    let cwd = context.work_dir();
-    let file = cwd.child("file.txt");
-    file.write_str("Hello, world!\n")?;
+    context.write_file("file.txt", "Hello, world!\n");
 
     cmd_snapshot!(context, context.install(), @r#"
     success: true
@@ -3563,9 +3478,9 @@ fn git_commit_a_currently_fails_when_hook_writes_to_temp_git_index() -> Result<(
 
     // `git commit` does not set `GIT_INDEX_FILE`; `git commit -a` does.
     // The repro only triggers on the `-a` path.
-    file.write_str("Hello again!\n")?;
+    context.write_file("file.txt", "Hello again!\n");
 
-    let mut commit = context.git_at(cwd).command();
+    let mut commit = context.git().command();
     commit.arg("commit").arg("-a").arg("-m").arg("Update file");
 
     cmd_snapshot!(context, commit, @r"
@@ -3581,8 +3496,6 @@ fn git_commit_a_currently_fails_when_hook_writes_to_temp_git_index() -> Result<(
     error: Error building trees
     "
     );
-
-    Ok(())
 }
 
 fn write_project_config(path: &Path, hooks: &[(&str, &str)]) -> Result<()> {
@@ -3791,8 +3704,9 @@ fn reuse_env() -> Result<()> {
     let context = TestEnv::new_git();
 
     let pkg_dir = context.work_dir().child("local_pkg");
-    pkg_dir.create_dir_all()?;
-    pkg_dir.child("setup.py").write_str(indoc::indoc! {r#"
+    context.write_file(
+        "local_pkg/setup.py",
+        indoc::indoc! {r#"
         from setuptools import setup
 
         setup(
@@ -3800,10 +3714,12 @@ fn reuse_env() -> Result<()> {
             version="0.1.0",
             py_modules=["local_pkg"],
         )
-    "#})?;
-    pkg_dir
-        .child("local_pkg.py")
-        .write_str("def hello():\n     print('hello')\n")?;
+    "#},
+    );
+    context.write_file(
+        "local_pkg/local_pkg.py",
+        "def hello():\n     print('hello')\n",
+    );
 
     let dependency = serde_json::to_string(&std::path::absolute(pkg_dir.path())?)?;
     let context = context.with_config(indoc::formatdoc! {r#"
@@ -3897,13 +3813,10 @@ fn dry_run() {
 
 /// Supports reading `pre-commit-config.yml` as well.
 #[test]
-fn alternate_config_file() -> Result<()> {
-    let context = TestEnv::new_git();
-
-    context
-        .work_dir()
-        .child(PRE_COMMIT_CONFIG_YML)
-        .write_str(indoc::indoc! {r#"
+fn alternate_config_file() {
+    let context = TestEnv::new_git().with_file(
+        PRE_COMMIT_CONFIG_YML,
+        indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -3911,7 +3824,9 @@ fn alternate_config_file() -> Result<()> {
                 name: local-python-hook
                 language: python
                 entry: python3 -c 'import sys; print("Hello, world!")'
-    "#})?;
+    "#},
+    );
+
     context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("-v"), @r"
@@ -3927,10 +3842,9 @@ fn alternate_config_file() -> Result<()> {
     ----- stderr -----
     ");
 
-    context
-        .work_dir()
-        .child(PRE_COMMIT_CONFIG_YAML)
-        .write_str(indoc::indoc! {r#"
+    context.write_file(
+        PRE_COMMIT_CONFIG_YAML,
+        indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -3938,7 +3852,8 @@ fn alternate_config_file() -> Result<()> {
                 name: local-python-hook
                 language: python
                 entry: python3 -c 'import sys; print("Hello, world!")'
-    "#})?;
+    "#},
+    );
     context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--refresh").arg("-v"), @r"
@@ -3955,10 +3870,9 @@ fn alternate_config_file() -> Result<()> {
     warning: Multiple configuration files found (`.pre-commit-config.yaml`, `.pre-commit-config.yml`); using `[TEMP_DIR]/.pre-commit-config.yaml`
     ");
 
-    context
-        .work_dir()
-        .child(PREK_TOML)
-        .write_str(indoc::indoc! {r#"
+    context.write_file(
+        PREK_TOML,
+        indoc::indoc! {r#"
         [[repos]]
         repo = "local"
         hooks = [
@@ -3969,7 +3883,8 @@ fn alternate_config_file() -> Result<()> {
             entry = "python3 -c 'import sys; print(\"Hello, world!\")'"
           }
         ]
-    "#})?;
+    "#},
+    );
     context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--refresh").arg("-v"), @r"
@@ -3985,19 +3900,14 @@ fn alternate_config_file() -> Result<()> {
     ----- stderr -----
     warning: Multiple configuration files found (`prek.toml`, `.pre-commit-config.yaml`, `.pre-commit-config.yml`); using `[TEMP_DIR]/prek.toml`
     ");
-
-    Ok(())
 }
 
 /// Supports `prek.toml` as configuration file.
 #[test]
-fn prek_toml() -> Result<()> {
-    let context = TestEnv::new_git();
-
-    context
-        .work_dir()
-        .child(PREK_TOML)
-        .write_str(indoc::indoc! {r#"
+fn prek_toml() {
+    let context = TestEnv::new_git().with_file(
+        PREK_TOML,
+        indoc::indoc! {r#"
         [[repos]]
         repo = "local"
         hooks = [
@@ -4008,7 +3918,9 @@ fn prek_toml() -> Result<()> {
             entry = "python3 -c 'import sys; print(\"Hello, world!\")'"
           }
         ]
-    "#})?;
+    "#},
+    );
+
     context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("-v"), @r"
@@ -4023,18 +3935,13 @@ fn prek_toml() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn prek_toml_resolves_priority_aliases() -> Result<()> {
-    let context = TestEnv::new_git();
-
-    context
-        .work_dir()
-        .child(PREK_TOML)
-        .write_str(indoc::indoc! {r#"
+fn prek_toml_resolves_priority_aliases() {
+    let context = TestEnv::new_git().with_file(
+        PREK_TOML,
+        indoc::indoc! {r#"
         [priorities]
         early = 0
         late = 10
@@ -4059,7 +3966,9 @@ fn prek_toml_resolves_priority_aliases() -> Result<()> {
             priority = "early",
           },
         ]
-    "#})?;
+    "#},
+    );
+
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r"
@@ -4071,12 +3980,10 @@ fn prek_toml_resolves_priority_aliases() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn show_diff_on_failure() -> Result<()> {
+fn show_diff_on_failure() {
     let context =
         TestEnv::new_git().with_filter(r"index \w{7}\.\.\w{7} \d{6}", "index [OLD]..[NEW] 100644");
 
@@ -4090,11 +3997,10 @@ fn show_diff_on_failure() -> Result<()> {
                 entry: python -c "import sys; open('file.txt', 'a').write('Added line\n')"
                 pass_filenames: false
     "#};
-    let context = context.with_config(config);
-    context
-        .work_dir()
-        .child("file.txt")
-        .write_str("Original line\n")?;
+    let context = context
+        .with_config(config)
+        .with_file("file.txt", "Original line\n");
+
     context.git().add_all();
 
     // When failed in CI environment
@@ -4123,10 +4029,7 @@ fn show_diff_on_failure() -> Result<()> {
     ----- stderr -----
     ");
 
-    context
-        .work_dir()
-        .child("file.txt")
-        .write_str("Original line\n")?;
+    context.write_file("file.txt", "Original line\n");
     context.git().add_all();
     // When failed in non-CI environment
     cmd_snapshot!(context, context.run().env_remove(EnvVars::CI).arg("--show-diff-on-failure").arg("-v"), @r"
@@ -4151,9 +4054,8 @@ fn show_diff_on_failure() -> Result<()> {
 
     // Run in the `app` subproject.
     let app = context.work_dir().child("app");
-    app.create_dir_all()?;
-    app.child("file.txt").write_str("Original line\n")?;
-    app.child(PRE_COMMIT_CONFIG_YAML).write_str(config)?;
+    context.write_file("app/file.txt", "Original line\n");
+    context.write_file("app/.pre-commit-config.yaml", config);
 
     context.git_at(&app).add(".");
 
@@ -4212,8 +4114,6 @@ fn show_diff_on_failure() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
@@ -4592,8 +4492,9 @@ fn expands_tilde_in_prek_home() -> Result<()> {
 }
 
 #[test]
-fn run_with_tree_object_as_ref() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+fn run_with_tree_object_as_ref() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -4602,16 +4503,15 @@ fn run_with_tree_object_as_ref() -> Result<()> {
                 entry: echo
                 language: system
                 pass_filenames: true
-    "});
+    "})
+        .with_file("file1.txt", "hello");
 
     let cwd = context.work_dir();
 
-    // Create initial commit
-    cwd.child("file1.txt").write_str("hello")?;
     context.git().add_all().commit("Initial commit");
 
     // Create some changes and stage them
-    cwd.child("file2.txt").write_str("world")?;
+    context.write_file("file2.txt", "world");
     context.git().add("file2.txt");
 
     // Get the tree object from the staged changes
@@ -4636,14 +4536,12 @@ fn run_with_tree_object_as_ref() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 /// `pass_filenames: n` limits each invocation to at most n files.
 /// With n=1, each matched file gets its own invocation.
 #[test]
-fn pass_filenames_1_limits_batch_size() -> Result<()> {
+fn pass_filenames_1_limits_batch_size() {
     let context = TestEnv::new_git();
 
     // Use a script that errors if it receives more than one filename argument.
@@ -4658,13 +4556,8 @@ fn pass_filenames_1_limits_batch_size() -> Result<()> {
                 pass_filenames: 1
                 require_serial: true
                 verbose: true
-    "#});
+    "#}).with_file("a.txt", "a").with_file("b.txt", "b").with_file("c.txt", "c");
 
-    let cwd = context.work_dir();
-
-    cwd.child("a.txt").write_str("a")?;
-    cwd.child("b.txt").write_str("b")?;
-    cwd.child("c.txt").write_str("c")?;
     context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--all-files"), @r"
@@ -4677,37 +4570,34 @@ fn pass_filenames_1_limits_batch_size() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 /// `pass_filenames: n` limits each invocation to at most n files.
 /// With n=2 and more than 2 matching files, multiple batches are spawned.
 #[test]
-fn pass_filenames_2_limits_batch_size() -> Result<()> {
+fn pass_filenames_2_limits_batch_size() {
     let context = TestEnv::new_git();
 
     // Use a script that errors if it receives more than two filename arguments.
-    let context = context.with_config(indoc::indoc! {r#"
-        repos:
-          - repo: local
-            hooks:
-              - id: two-at-a-time
-                name: two at a time
-                entry: python -c "import sys; args = sys.argv[1:]; sys.exit(0 if len(args) <= 2 else 1)"
-                language: system
-                pass_filenames: 2
-                require_serial: true
-                verbose: true
-    "#});
+    let context = context
+        .with_config(indoc::indoc! {r#"
+            repos:
+              - repo: local
+                hooks:
+                  - id: two-at-a-time
+                    name: two at a time
+                    entry: python -c "import sys; args = sys.argv[1:]; sys.exit(0 if len(args) <= 2 else 1)"
+                    language: system
+                    pass_filenames: 2
+                    require_serial: true
+                    verbose: true
+        "#})
+        .with_file("a.txt", "a")
+        .with_file("b.txt", "b")
+        .with_file("c.txt", "c")
+        .with_file("d.txt", "d")
+        .with_file("e.txt", "e");
 
-    let cwd = context.work_dir();
-
-    cwd.child("a.txt").write_str("a")?;
-    cwd.child("b.txt").write_str("b")?;
-    cwd.child("c.txt").write_str("c")?;
-    cwd.child("d.txt").write_str("d")?;
-    cwd.child("e.txt").write_str("e")?;
     context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--all-files"), @r"
@@ -4720,6 +4610,4 @@ fn pass_filenames_2_limits_batch_size() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -1351,7 +1351,8 @@ fn priority_fail_fast_stops_later_groups() {
 fn explicitly_skipped_hook_does_not_affect_priority_group_outcome() {
     let context = TestEnv::new_git().with_file("file.txt", "hello\n");
 
-    let context = context.with_config(indoc::indoc! {r#"
+    let context = context
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -2196,13 +2197,9 @@ fn no_fail_fast_cli_flag() {
 /// Run from a subdirectory. File arguments should be fixed to be relative to the root.
 #[test]
 fn subdirectory() {
-    let context = TestEnv::new_git();
-
-    let cwd = context.work_dir();
-    let child = cwd.child("foo/bar/baz");
-    context.write_file("foo/bar/baz/file.txt", "Hello, world!\n");
-
-    let context = context.with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_file("foo/bar/baz/file.txt", "Hello, world!\n")
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -2212,6 +2209,8 @@ fn subdirectory() {
                 entry: python3 -c 'import sys; print(sys.argv[1]); exit(1)'
                 always_run: true
     "});
+    let cwd = context.work_dir();
+    let child = cwd.child("foo/bar/baz");
 
     context.git().add_all();
 
@@ -2272,11 +2271,7 @@ fn global_path_options_expand_tilde() -> Result<()> {
 /// Test hook `log_file` option.
 #[test]
 fn log_file() -> Result<()> {
-    let context = TestEnv::new_git();
-
-    let config_dir = context.work_dir().child("config");
-    let config_file = config_dir.child(PRE_COMMIT_CONFIG_YAML);
-    context.write_file(
+    let context = TestEnv::new_git().with_file(
         "config/.pre-commit-config.yaml",
         indoc::indoc! {r#"
         repos:
@@ -2288,8 +2283,10 @@ fn log_file() -> Result<()> {
                 entry: python3 -c 'import sys; sys.stdout.buffer.write(b"\x1b[2Kraw\xff"); exit(1)'
                 always_run: true
                 log_file: log.txt
-    "#},
+        "#},
     );
+    let config_dir = context.work_dir().child("config");
+    let config_file = config_dir.child(PRE_COMMIT_CONFIG_YAML);
     context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("-c").arg(config_file.path()), @r#"
@@ -2454,7 +2451,8 @@ fn restore_on_interrupt() -> Result<()> {
                 entry: python3 -c 'import time; open("out.txt", "wt").write(open("file.txt", "rt").read()); time.sleep(10)'
                 verbose: true
                 types: [text]
-   "#}).with_file("file.txt", "Hello, world!");
+   "#})
+        .with_file("file.txt", "Hello, world!");
 
     context.git().add_all();
 
@@ -3368,10 +3366,9 @@ fn shebang_script() {
 /// Test `git commit -a` works without `.git/index.lock exists` error.
 #[test]
 fn git_commit_a() {
-    let context =
-        TestEnv::new_git().with_filter("7c8398204bbc95c33a6d2543f86a27621647cf78", "[HASH]");
-
-    let context = context.with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_filter("7c8398204bbc95c33a6d2543f86a27621647cf78", "[HASH]")
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -3380,10 +3377,8 @@ fn git_commit_a() {
                 language: system
                 entry: echo
                 verbose: true
-    "});
-
-    // Create a file and commit it.
-    context.write_file("file.txt", "Hello, world!\n");
+    "})
+        .with_file("file.txt", "Hello, world!\n");
 
     cmd_snapshot!(context, context.install(), @r#"
     success: true
@@ -3421,6 +3416,16 @@ fn git_commit_a() {
 #[cfg(unix)]
 #[test]
 fn git_commit_a_currently_fails_when_hook_writes_to_temp_git_index() {
+    // Repro for #1786 documenting the current behavior. `git commit -a`
+    // exports `GIT_INDEX_FILE=.git/index.lock` to the hook process. If the
+    // hook inherits that env var and then runs a git command that writes to an
+    // index in a different repository, Git writes those entries into the
+    // parent repo's temporary index instead.
+    //
+    // The important detail is that the temp repo stages `file.txt`, matching a tracked
+    // path in the parent repo. `prek` treats the post-hook diff as a best-effort
+    // snapshot, so the commit continues until Git tries to build trees from the
+    // corrupted temporary index and fails with `invalid object ... for 'file.txt'`.
     let context = TestEnv::new_git()
         .with_filter(
             r"invalid object 100644 [0-9a-f]{40}",
@@ -3437,20 +3442,8 @@ fn git_commit_a_currently_fails_when_hook_writes_to_temp_git_index() {
         printf 'hook version\n' > file.txt
         git add file.txt
     "#},
-        );
-
-    // Repro for #1786 documenting the current behavior. `git commit -a`
-    // exports `GIT_INDEX_FILE=.git/index.lock` to the hook process. If the
-    // hook inherits that env var and then runs a git command that writes to an
-    // index in a different repository, Git writes those entries into the
-    // parent repo's temporary index instead.
-    //
-    // The important detail is that the temp repo stages `file.txt`, matching a tracked
-    // path in the parent repo. `prek` treats the post-hook diff as a best-effort
-    // snapshot, so the commit continues until Git tries to build trees from the
-    // corrupted temporary index and fails with `invalid object ... for 'file.txt'`.
-
-    let context = context.with_config(indoc::indoc! {r"
+        )
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -3461,9 +3454,8 @@ fn git_commit_a_currently_fails_when_hook_writes_to_temp_git_index() {
                 pass_filenames: false
                 always_run: true
                 verbose: true
-    "});
-
-    context.write_file("file.txt", "Hello, world!\n");
+    "})
+        .with_file("file.txt", "Hello, world!\n");
 
     cmd_snapshot!(context, context.install(), @r#"
     success: true
@@ -3701,12 +3693,10 @@ fn selectors_completion() -> Result<()> {
 /// Test reusing hook environments only when dependencies are exactly same. (ignore order)
 #[test]
 fn reuse_env() -> Result<()> {
-    let context = TestEnv::new_git();
-
-    let pkg_dir = context.work_dir().child("local_pkg");
-    context.write_file(
-        "local_pkg/setup.py",
-        indoc::indoc! {r#"
+    let context = TestEnv::new_git()
+        .with_file(
+            "local_pkg/setup.py",
+            indoc::indoc! {r#"
         from setuptools import setup
 
         setup(
@@ -3715,11 +3705,12 @@ fn reuse_env() -> Result<()> {
             py_modules=["local_pkg"],
         )
     "#},
-    );
-    context.write_file(
-        "local_pkg/local_pkg.py",
-        "def hello():\n     print('hello')\n",
-    );
+        )
+        .with_file(
+            "local_pkg/local_pkg.py",
+            "def hello():\n     print('hello')\n",
+        );
+    let pkg_dir = context.work_dir().child("local_pkg");
 
     let dependency = serde_json::to_string(&std::path::absolute(pkg_dir.path())?)?;
     let context = context.with_config(indoc::formatdoc! {r#"
@@ -4545,7 +4536,8 @@ fn pass_filenames_1_limits_batch_size() {
     let context = TestEnv::new_git();
 
     // Use a script that errors if it receives more than one filename argument.
-    let context = context.with_config(indoc::indoc! {r#"
+    let context = context
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -4556,7 +4548,10 @@ fn pass_filenames_1_limits_batch_size() {
                 pass_filenames: 1
                 require_serial: true
                 verbose: true
-    "#}).with_file("a.txt", "a").with_file("b.txt", "b").with_file("c.txt", "c");
+    "#})
+        .with_file("a.txt", "a")
+        .with_file("b.txt", "b")
+        .with_file("c.txt", "c");
 
     context.git().add_all();
 

--- a/crates/prek/tests/skipped_hooks.rs
+++ b/crates/prek/tests/skipped_hooks.rs
@@ -46,8 +46,9 @@ fn remove_loose_blob(context: &TestEnv, filename: &str) -> Result<()> {
 
 /// All hooks skip when no staged files match their file patterns.
 #[test]
-fn all_hooks_skipped_no_matching_files() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+fn all_hooks_skipped_no_matching_files() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -66,13 +67,10 @@ fn all_hooks_skipped_no_matching_files() -> Result<()> {
                 language: system
                 entry: echo "checking go"
                 files: \.go$
-    "#});
-
-    let cwd = context.work_dir();
-
-    cwd.child("readme.txt").write_str("Hello")?;
-    cwd.child("data.json").write_str("{}")?;
-    cwd.child("config.yaml").write_str("key: value")?;
+    "#})
+        .with_file("readme.txt", "Hello")
+        .with_file("data.json", "{}")
+        .with_file("config.yaml", "key: value");
 
     context.git().add_all();
 
@@ -86,14 +84,13 @@ fn all_hooks_skipped_no_matching_files() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 /// Installable hooks with no matching files should not create environments.
 #[test]
 fn skipped_installable_hook_does_not_install_env() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -102,11 +99,9 @@ fn skipped_installable_hook_does_not_install_env() -> Result<()> {
                 language: python
                 entry: python -c "print('checking python')"
                 files: \.py$
-    "#});
+    "#})
+        .with_file("README.md", "Hello");
 
-    let cwd = context.work_dir();
-
-    cwd.child("README.md").write_str("Hello")?;
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
@@ -163,7 +158,8 @@ fn group_excluded_installable_hook_does_not_install_env() -> Result<()> {
 /// `always_run` installable hooks still install and run without matching files.
 #[test]
 fn always_run_installable_hook_installs_without_matching_files() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -174,11 +170,9 @@ fn always_run_installable_hook_installs_without_matching_files() -> Result<()> {
                 files: \.py$
                 always_run: true
                 pass_filenames: false
-    "#});
+    "#})
+        .with_file("README.md", "Hello");
 
-    let cwd = context.work_dir();
-
-    cwd.child("README.md").write_str("Hello")?;
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
@@ -197,8 +191,9 @@ fn always_run_installable_hook_installs_without_matching_files() -> Result<()> {
 
 /// `--dry-run` skips hooks without executing them.
 #[test]
-fn dry_run_skips_all_hooks() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+fn dry_run_skips_all_hooks() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -212,11 +207,9 @@ fn dry_run_skips_all_hooks() -> Result<()> {
                 language: system
                 entry: echo "linting"
                 files: \.txt$
-    "#});
+    "#})
+        .with_file("file.txt", "content");
 
-    let cwd = context.work_dir();
-
-    cwd.child("file.txt").write_str("content")?;
     context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--dry-run"), @r#"
@@ -230,14 +223,13 @@ fn dry_run_skips_all_hooks() -> Result<()> {
     "#);
 
     assert_eq!(context.read("file.txt"), "content");
-
-    Ok(())
 }
 
 /// Hooks that match staged files run; others are skipped.
 #[test]
-fn mixed_skipped_and_executed_hooks() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+fn mixed_skipped_and_executed_hooks() {
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -256,11 +248,9 @@ fn mixed_skipped_and_executed_hooks() -> Result<()> {
                 language: system
                 entry: echo "checking rs"
                 files: \.rs$
-    "#});
+    "#})
+        .with_file("readme.txt", "Hello");
 
-    let cwd = context.work_dir();
-
-    cwd.child("readme.txt").write_str("Hello")?;
     context.git().add_all();
 
     cmd_snapshot!(context, context.run(), @r#"
@@ -273,20 +263,12 @@ fn mixed_skipped_and_executed_hooks() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 /// Skipped hooks in untouched workspace projects should not install environments.
 #[test]
 fn skipped_workspace_project_installable_hook_does_not_install_env() -> Result<()> {
     let context = TestEnv::new_git();
-
-    let cwd = context.work_dir();
-    let proj_a = cwd.child("proj-a");
-    let proj_b = cwd.child("proj-b");
-    proj_a.create_dir_all()?;
-    proj_b.create_dir_all()?;
 
     let context = context.with_config(indoc::indoc! {r"
         repos:
@@ -298,9 +280,9 @@ fn skipped_workspace_project_installable_hook_does_not_install_env() -> Result<(
                 entry: echo root
                 files: \.root$
     "});
-    proj_a
-        .child(".pre-commit-config.yaml")
-        .write_str(indoc::indoc! {r"
+    context.write_file(
+        "proj-a/.pre-commit-config.yaml",
+        indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -309,10 +291,11 @@ fn skipped_workspace_project_installable_hook_does_not_install_env() -> Result<(
                 language: system
                 entry: echo proj-a
                 files: \.txt$
-    "})?;
-    proj_b
-        .child(".pre-commit-config.yaml")
-        .write_str(indoc::indoc! {r#"
+    "},
+    );
+    context.write_file(
+        "proj-b/.pre-commit-config.yaml",
+        indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -321,9 +304,10 @@ fn skipped_workspace_project_installable_hook_does_not_install_env() -> Result<(
                 language: python
                 entry: python -c "print('proj-b')"
                 files: \.py$
-    "#})?;
+    "#},
+    );
 
-    proj_a.child("README.txt").write_str("Hello")?;
+    context.write_file("proj-a/README.txt", "Hello");
     context.git().add_all();
 
     let output = context.run().output()?;
@@ -341,10 +325,6 @@ fn skipped_workspace_project_installable_hook_does_not_install_env() -> Result<(
 fn orphan_project_early_match_still_hides_child_files_from_parent_install() -> Result<()> {
     let context = TestEnv::new_git();
 
-    let cwd = context.work_dir();
-    let child = cwd.child("child");
-    child.create_dir_all()?;
-
     let context = context.with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -355,9 +335,9 @@ fn orphan_project_early_match_still_hides_child_files_from_parent_install() -> R
                 entry: ROOT_SHOULD_NOT_RUN
                 files: \.py$
     "});
-    child
-        .child(".pre-commit-config.yaml")
-        .write_str(indoc::indoc! {r#"
+    context.write_file(
+        "child/.pre-commit-config.yaml",
+        indoc::indoc! {r#"
         orphan: true
         repos:
           - repo: local
@@ -368,9 +348,10 @@ fn orphan_project_early_match_still_hides_child_files_from_parent_install() -> R
                 entry: python -c "print('child')"
                 always_run: true
                 pass_filenames: false
-    "#})?;
+    "#},
+    );
 
-    child.child("child.py").write_str("print('child')\n")?;
+    context.write_file("child/child.py", "print('child')\n");
     context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--all-files"), @r#"
@@ -401,7 +382,8 @@ fn orphan_project_early_match_still_hides_child_files_from_parent_install() -> R
 /// contains non-deterministic timestamps and timing data unsuitable for snapshots.
 #[test]
 fn all_hooks_skipped_multiple_priority_groups() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -423,11 +405,9 @@ fn all_hooks_skipped_multiple_priority_groups() -> Result<()> {
                 entry: echo "priority 30"
                 files: \.go$
                 priority: 30
-    "#});
+    "#})
+        .with_file("data.json", "{}");
 
-    let cwd = context.work_dir();
-
-    cwd.child("data.json").write_str("{}")?;
     context.git().add_all();
 
     // Run with trace logging to verify #1335 fix
@@ -455,7 +435,8 @@ fn all_hooks_skipped_multiple_priority_groups() -> Result<()> {
 
 #[test]
 fn external_hook_without_changes_uses_quiet_diff_check() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -464,11 +445,9 @@ fn external_hook_without_changes_uses_quiet_diff_check() -> Result<()> {
                 language: system
                 entry: python3 -c "pass"
                 pass_filenames: false
-    "#});
+    "#})
+        .with_file("file.txt", "original\n");
 
-    let cwd = context.work_dir();
-
-    cwd.child("file.txt").write_str("original\n")?;
     context.git().add_all();
 
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
@@ -495,7 +474,8 @@ fn external_hook_without_changes_uses_quiet_diff_check() -> Result<()> {
 #[test]
 #[cfg(unix)]
 fn identical_rewrite_with_stat_change_is_not_modified() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -504,10 +484,10 @@ fn identical_rewrite_with_stat_change_is_not_modified() -> Result<()> {
                 language: system
                 entry: python3 rewrite.py
                 files: \.txt$
-    "});
-
-    let cwd = context.work_dir();
-    cwd.child("rewrite.py").write_str(indoc::indoc! {r"
+    "})
+        .with_file(
+            "rewrite.py",
+            indoc::indoc! {r"
         from pathlib import Path
         import os
         import sys
@@ -518,9 +498,10 @@ fn identical_rewrite_with_stat_change_is_not_modified() -> Result<()> {
             path.write_text(path.read_text())
             timestamp = time.time() + 10
             os.utime(path, (timestamp, timestamp))
-    "})?;
+    "},
+        )
+        .with_file("file.txt", "original\n");
 
-    cwd.child("file.txt").write_str("original\n")?;
     context.git().add_all();
 
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
@@ -563,11 +544,8 @@ fn modifying_hook_uses_clean_baseline_diff_detection() -> Result<()> {
                 language: system
                 entry: python3 -c "from pathlib import Path; Path('file.txt').write_text('changed\n')"
                 pass_filenames: false
-    "#});
+    "#}).with_file("file.txt", "original\n");
 
-    let cwd = context.work_dir();
-
-    cwd.child("file.txt").write_str("original\n")?;
     context.git().add_all();
 
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
@@ -628,15 +606,13 @@ fn binary_diff_snapshots_use_full_object_ids() -> Result<()> {
                 entry: python3 -c "from pathlib import Path; Path('binary.dat').write_bytes(b'variant-30375\n')"
                 pass_filenames: false
                 priority: 1
-    "#});
+    "#}).with_file(".gitattributes", "binary.dat -diff\n").with_file("binary.dat", "original\n");
 
     let cwd = context.work_dir();
 
     // The two replacement blobs have distinct SHA-1s whose first seven
     // hexadecimal digits are both `4b8e34c`.
-    cwd.child(".gitattributes")
-        .write_str("binary.dat -diff\n")?;
-    cwd.child("binary.dat").write_str("original\n")?;
+
     context.git().add_all();
 
     let status = context
@@ -674,14 +650,10 @@ fn all_files_with_existing_unstaged_changes_uses_snapshot_baseline() -> Result<(
                 language: system
                 entry: python3 -c "from pathlib import Path; Path('hook.txt').write_text('changed\n')"
                 pass_filenames: false
-    "#});
+    "#}).with_file("file.txt", "original\n").with_file("hook.txt", "original\n");
 
-    let cwd = context.work_dir();
-
-    cwd.child("file.txt").write_str("original\n")?;
-    cwd.child("hook.txt").write_str("original\n")?;
     context.git().add_all();
-    cwd.child("file.txt").write_str("unstaged\n")?;
+    context.write_file("file.txt", "unstaged\n");
 
     let output = context
         .run()
@@ -717,7 +689,8 @@ fn all_files_with_existing_unstaged_changes_uses_snapshot_baseline() -> Result<(
 
 #[test]
 fn all_files_clean_missing_blob_ignores_diff_snapshot_errors() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -726,11 +699,11 @@ fn all_files_clean_missing_blob_ignores_diff_snapshot_errors() -> Result<()> {
                 language: system
                 entry: python3 -c "pass"
                 pass_filenames: false
-    "#});
+    "#})
+        .with_file("file.txt", "original\n");
 
     let cwd = context.work_dir();
 
-    cwd.child("file.txt").write_str("original\n")?;
     context.git().add_all().commit("init");
 
     remove_loose_blob(&context, "file.txt")?;
@@ -780,10 +753,6 @@ fn all_files_clean_missing_blob_ignores_diff_snapshot_errors() -> Result<()> {
 fn later_project_snapshots_diff_left_by_previous_project() -> Result<()> {
     let context = TestEnv::new_git();
 
-    let cwd = context.work_dir();
-    let child = cwd.child("child");
-    child.create_dir_all()?;
-
     let context = context.with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -795,9 +764,7 @@ fn later_project_snapshots_diff_left_by_previous_project() -> Result<()> {
                 always_run: true
                 pass_filenames: false
     "#});
-    child
-        .child(".pre-commit-config.yaml")
-        .write_str(indoc::indoc! {r#"
+    context.write_file("child/.pre-commit-config.yaml", indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -807,9 +774,9 @@ fn later_project_snapshots_diff_left_by_previous_project() -> Result<()> {
                 entry: python3 -c "from pathlib import Path; Path('child.txt').write_text('changed\n')"
                 always_run: true
                 pass_filenames: false
-    "#})?;
+    "#});
 
-    child.child("child.txt").write_str("original\n")?;
+    context.write_file("child/child.txt", "original\n");
     context.git().add_all();
 
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
@@ -840,17 +807,15 @@ fn later_project_snapshots_diff_left_by_previous_project() -> Result<()> {
 
 #[test]
 fn read_only_builtin_hook_does_not_run_diff_detection() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-toml
-    "});
+    "})
+        .with_file("pyproject.toml", "[project]\nname = \"demo\"\n");
 
-    let cwd = context.work_dir();
-
-    cwd.child("pyproject.toml")
-        .write_str("[project]\nname = \"demo\"\n")?;
     context.git().add_all();
 
     let output = context
@@ -874,7 +839,8 @@ fn read_only_builtin_hook_does_not_run_diff_detection() -> Result<()> {
 
 #[test]
 fn read_only_languages_do_not_run_diff_detection() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -888,11 +854,9 @@ fn read_only_languages_do_not_run_diff_detection() -> Result<()> {
                 language: pygrep
                 entry: not-present
                 files: \.txt$
-    "});
+    "})
+        .with_file("file.txt", "original\n");
 
-    let cwd = context.work_dir();
-
-    cwd.child("file.txt").write_str("original\n")?;
     context.git().add_all();
 
     let output = context
@@ -927,7 +891,8 @@ fn read_only_languages_do_not_run_diff_detection() -> Result<()> {
 
 #[test]
 fn same_group_known_modification_skips_diff_detection() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: builtin
             hooks:
@@ -941,11 +906,9 @@ fn same_group_known_modification_skips_diff_detection() -> Result<()> {
                 entry: python3 -c "pass"
                 pass_filenames: false
                 priority: 0
-    "#});
+    "#})
+        .with_file("file.txt", "missing newline");
 
-    let cwd = context.work_dir();
-
-    cwd.child("file.txt").write_str("missing newline")?;
     context.git().add_all();
 
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
@@ -982,7 +945,8 @@ fn same_group_known_modification_skips_diff_detection() -> Result<()> {
 
 #[test]
 fn same_group_known_modification_rebaselines_later_external_hook() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: builtin
             hooks:
@@ -1002,11 +966,9 @@ fn same_group_known_modification_rebaselines_later_external_hook() -> Result<()>
                 entry: python3 -c "pass"
                 pass_filenames: false
                 priority: 1
-    "#});
+    "#})
+        .with_file("file.txt", "missing newline");
 
-    let cwd = context.work_dir();
-
-    cwd.child("file.txt").write_str("missing newline")?;
     context.git().add_all();
 
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
@@ -1043,7 +1005,8 @@ fn same_group_known_modification_rebaselines_later_external_hook() -> Result<()>
 
 #[test]
 fn modifying_builtin_invalidates_baseline_for_later_external_hook() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: builtin
             hooks:
@@ -1057,11 +1020,9 @@ fn modifying_builtin_invalidates_baseline_for_later_external_hook() -> Result<()
                 entry: python3 -c "pass"
                 pass_filenames: false
                 priority: 1
-    "#});
+    "#})
+        .with_file("file.txt", "missing newline");
 
-    let cwd = context.work_dir();
-
-    cwd.child("file.txt").write_str("missing newline")?;
     context.git().add_all();
 
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
@@ -1097,17 +1058,16 @@ fn modifying_builtin_invalidates_baseline_for_later_external_hook() -> Result<()
 
 #[test]
 fn failed_non_modifying_builtin_skips_diff_detection() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: mixed-line-ending
                 args: ['--fix=no']
-    "});
+    "})
+        .with_file("mixed.txt", "first\r\nsecond\n");
 
-    let cwd = context.work_dir();
-
-    cwd.child("mixed.txt").write_str("first\r\nsecond\n")?;
     context.git().add_all();
 
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;

--- a/crates/prek/tests/skipped_hooks.rs
+++ b/crates/prek/tests/skipped_hooks.rs
@@ -268,9 +268,8 @@ fn mixed_skipped_and_executed_hooks() {
 /// Skipped hooks in untouched workspace projects should not install environments.
 #[test]
 fn skipped_workspace_project_installable_hook_does_not_install_env() -> Result<()> {
-    let context = TestEnv::new_git();
-
-    let context = context.with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -279,10 +278,10 @@ fn skipped_workspace_project_installable_hook_does_not_install_env() -> Result<(
                 language: system
                 entry: echo root
                 files: \.root$
-    "});
-    context.write_file(
-        "proj-a/.pre-commit-config.yaml",
-        indoc::indoc! {r"
+    "})
+        .with_file(
+            "proj-a/.pre-commit-config.yaml",
+            indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -292,10 +291,10 @@ fn skipped_workspace_project_installable_hook_does_not_install_env() -> Result<(
                 entry: echo proj-a
                 files: \.txt$
     "},
-    );
-    context.write_file(
-        "proj-b/.pre-commit-config.yaml",
-        indoc::indoc! {r#"
+        )
+        .with_file(
+            "proj-b/.pre-commit-config.yaml",
+            indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -305,9 +304,8 @@ fn skipped_workspace_project_installable_hook_does_not_install_env() -> Result<(
                 entry: python -c "print('proj-b')"
                 files: \.py$
     "#},
-    );
-
-    context.write_file("proj-a/README.txt", "Hello");
+        )
+        .with_file("proj-a/README.txt", "Hello");
     context.git().add_all();
 
     let output = context.run().output()?;
@@ -323,9 +321,8 @@ fn skipped_workspace_project_installable_hook_does_not_install_env() -> Result<(
 
 #[test]
 fn orphan_project_early_match_still_hides_child_files_from_parent_install() -> Result<()> {
-    let context = TestEnv::new_git();
-
-    let context = context.with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -334,10 +331,10 @@ fn orphan_project_early_match_still_hides_child_files_from_parent_install() -> R
                 language: pygrep
                 entry: ROOT_SHOULD_NOT_RUN
                 files: \.py$
-    "});
-    context.write_file(
-        "child/.pre-commit-config.yaml",
-        indoc::indoc! {r#"
+    "})
+        .with_file(
+            "child/.pre-commit-config.yaml",
+            indoc::indoc! {r#"
         orphan: true
         repos:
           - repo: local
@@ -349,9 +346,8 @@ fn orphan_project_early_match_still_hides_child_files_from_parent_install() -> R
                 always_run: true
                 pass_filenames: false
     "#},
-    );
-
-    context.write_file("child/child.py", "print('child')\n");
+        )
+        .with_file("child/child.py", "print('child')\n");
     context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--all-files"), @r#"
@@ -535,7 +531,8 @@ fn identical_rewrite_with_stat_change_is_not_modified() -> Result<()> {
 
 #[test]
 fn modifying_hook_uses_clean_baseline_diff_detection() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -544,7 +541,8 @@ fn modifying_hook_uses_clean_baseline_diff_detection() -> Result<()> {
                 language: system
                 entry: python3 -c "from pathlib import Path; Path('file.txt').write_text('changed\n')"
                 pass_filenames: false
-    "#}).with_file("file.txt", "original\n");
+    "#})
+        .with_file("file.txt", "original\n");
 
     context.git().add_all();
 
@@ -590,7 +588,8 @@ fn binary_diff_snapshots_use_full_object_ids() -> Result<()> {
         "initializing SHA-1 repository should succeed"
     );
 
-    let context = context.with_config(indoc::indoc! {r#"
+    let context = context
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -606,7 +605,9 @@ fn binary_diff_snapshots_use_full_object_ids() -> Result<()> {
                 entry: python3 -c "from pathlib import Path; Path('binary.dat').write_bytes(b'variant-30375\n')"
                 pass_filenames: false
                 priority: 1
-    "#}).with_file(".gitattributes", "binary.dat -diff\n").with_file("binary.dat", "original\n");
+    "#})
+        .with_file(".gitattributes", "binary.dat -diff\n")
+        .with_file("binary.dat", "original\n");
 
     let cwd = context.work_dir();
 
@@ -641,7 +642,8 @@ fn binary_diff_snapshots_use_full_object_ids() -> Result<()> {
 
 #[test]
 fn all_files_with_existing_unstaged_changes_uses_snapshot_baseline() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -650,7 +652,9 @@ fn all_files_with_existing_unstaged_changes_uses_snapshot_baseline() -> Result<(
                 language: system
                 entry: python3 -c "from pathlib import Path; Path('hook.txt').write_text('changed\n')"
                 pass_filenames: false
-    "#}).with_file("file.txt", "original\n").with_file("hook.txt", "original\n");
+    "#})
+        .with_file("file.txt", "original\n")
+        .with_file("hook.txt", "original\n");
 
     context.git().add_all();
     context.write_file("file.txt", "unstaged\n");
@@ -751,9 +755,8 @@ fn all_files_clean_missing_blob_ignores_diff_snapshot_errors() -> Result<()> {
 
 #[test]
 fn later_project_snapshots_diff_left_by_previous_project() -> Result<()> {
-    let context = TestEnv::new_git();
-
-    let context = context.with_config(indoc::indoc! {r#"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -763,8 +766,10 @@ fn later_project_snapshots_diff_left_by_previous_project() -> Result<()> {
                 entry: python3 -c "pass"
                 always_run: true
                 pass_filenames: false
-    "#});
-    context.write_file("child/.pre-commit-config.yaml", indoc::indoc! {r#"
+    "#})
+        .with_file(
+            "child/.pre-commit-config.yaml",
+            indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -774,9 +779,9 @@ fn later_project_snapshots_diff_left_by_previous_project() -> Result<()> {
                 entry: python3 -c "from pathlib import Path; Path('child.txt').write_text('changed\n')"
                 always_run: true
                 pass_filenames: false
-    "#});
-
-    context.write_file("child/child.txt", "original\n");
+    "#},
+        )
+        .with_file("child/child.txt", "original\n");
     context.git().add_all();
 
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;

--- a/crates/prek/tests/update.rs
+++ b/crates/prek/tests/update.rs
@@ -584,11 +584,11 @@ fn update_warns_when_repo_override_matches_another_project() -> Result<()> {
     let repo1_path = create_local_git_repo(&context, "project-repo-1", &["v1.0.0", "v1.1.0"])?;
     let repo2_path = create_local_git_repo(&context, "project-repo-2", &["v1.0.0", "v1.1.0"])?;
 
-    context.setup_workspace(&["project-a", "project-b"], "repos: []")?;
-    context
-        .work_dir()
-        .child("project-a/.pre-commit-config.yaml")
-        .write_str(&indoc::formatdoc! {r#"
+    context.setup_workspace(&["project-a", "project-b"], "repos: []");
+    let context = context
+        .with_file(
+            "project-a/.pre-commit-config.yaml",
+            indoc::formatdoc! {r#"
         update:
           repos:
             "{}":
@@ -598,11 +598,11 @@ fn update_warns_when_repo_override_matches_another_project() -> Result<()> {
             rev: v1.0.0
             hooks:
               - id: test-hook
-    "#, repo2_path, repo1_path})?;
-    context
-        .work_dir()
-        .child("project-b/.pre-commit-config.yaml")
-        .write_str(&indoc::formatdoc! {r#"
+    "#, repo2_path, repo1_path},
+        )
+        .with_file(
+            "project-b/.pre-commit-config.yaml",
+            indoc::formatdoc! {r#"
         update:
           repos:
             "{}":
@@ -612,7 +612,9 @@ fn update_warns_when_repo_override_matches_another_project() -> Result<()> {
             rev: v1.0.0
             hooks:
               - id: test-hook
-    "#, repo1_path, repo2_path})?;
+    "#, repo1_path, repo2_path},
+        );
+
     context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--jobs").arg("1"), @"
@@ -1822,17 +1824,17 @@ fn update_updates_mismatched_frozen_comment_toml() -> Result<()> {
 
     let commit_sha = context.git_at(&repo_path).rev_parse("v1.1.0^{}")?;
 
-    context
-        .work_dir()
-        .child(PREK_TOML)
-        .write_str(&indoc::formatdoc! {r#"
+    let context = context.with_file(
+        PREK_TOML,
+        indoc::formatdoc! {r#"
         [[repos]]
         repo = "{}"
         rev = "{}" # frozen: v1.0.0
         hooks = [
           {{ id = "test-hook" }},
         ]
-        "#, repo_path, commit_sha})?;
+        "#, repo_path, commit_sha},
+    );
 
     context.git().add_all();
 
@@ -1972,12 +1974,12 @@ fn update_workspace() -> Result<()> {
     context.setup_workspace(
         &["project-a", "project-b"],
         "repos: []", // Minimal valid config for root
-    )?;
+    );
 
-    context
-        .work_dir()
-        .child("project-a/.pre-commit-config.yaml")
-        .write_str(&indoc::formatdoc! {r"
+    let context = context
+        .with_file(
+            "project-a/.pre-commit-config.yaml",
+            indoc::formatdoc! {r"
         repos:
           - repo: {}
             rev: v1.0.0
@@ -1987,12 +1989,11 @@ fn update_workspace() -> Result<()> {
             rev: v1.0.0
             hooks:
               - id: another-hook
-    ", repo1_path, repo2_path})?;
-
-    context
-        .work_dir()
-        .child("project-b/.pre-commit-config.yaml")
-        .write_str(&indoc::formatdoc! {r"
+    ", repo1_path, repo2_path},
+        )
+        .with_file(
+            "project-b/.pre-commit-config.yaml",
+            indoc::formatdoc! {r"
         repos:
           - repo: {}
             rev: v1.0.0
@@ -2002,7 +2003,8 @@ fn update_workspace() -> Result<()> {
             rev: v2.0.0
             hooks:
               - id: test-hook
-    ", repo2_path, repo3_path})?;
+    ", repo2_path, repo3_path},
+        );
 
     context.git().add_all();
 
@@ -2075,12 +2077,12 @@ fn update_workspace_same_repo_uses_project_cooldown() -> Result<()> {
     context.setup_workspace(
         &["project-a", "project-b"],
         "repos: []", // Minimal valid config for root
-    )?;
+    );
 
-    context
-        .work_dir()
-        .child("project-a/.pre-commit-config.yaml")
-        .write_str(&indoc::formatdoc! {r"
+    let context = context
+        .with_file(
+            "project-a/.pre-commit-config.yaml",
+            indoc::formatdoc! {r"
         update:
           cooldown_days: 0
         repos:
@@ -2088,18 +2090,18 @@ fn update_workspace_same_repo_uses_project_cooldown() -> Result<()> {
             rev: v1.0.0
             hooks:
               - id: test-hook
-    ", repo_path})?;
-
-    context
-        .work_dir()
-        .child("project-b/.pre-commit-config.yaml")
-        .write_str(&indoc::formatdoc! {r"
+    ", repo_path},
+        )
+        .with_file(
+            "project-b/.pre-commit-config.yaml",
+            indoc::formatdoc! {r"
         repos:
           - repo: {}
             rev: v1.0.0
             hooks:
               - id: test-hook
-    ", repo_path})?;
+    ", repo_path},
+        );
 
     context.git().add_all();
 
@@ -2484,14 +2486,9 @@ fn quoting_float_like_version_number_without_existing_quotes() -> Result<()> {
 }
 
 #[test]
-fn update_with_invalid_config_file() -> Result<()> {
-    let context = TestEnv::new_git();
-
-    // Write an invalid config file
-    context
-        .work_dir()
-        .child(PRE_COMMIT_CONFIG_YAML)
-        .write_str("invalid_yaml: [unclosed_list")?;
+fn update_with_invalid_config_file() {
+    let context =
+        TestEnv::new_git().with_file(PRE_COMMIT_CONFIG_YAML, "invalid_yaml: [unclosed_list");
 
     cmd_snapshot!(context, context.update(), @"
     success: false
@@ -2506,8 +2503,6 @@ fn update_with_invalid_config_file() -> Result<()> {
     1 | invalid_yaml: [unclosed_list
       |               ^ unclosed bracket '['
     ");
-
-    Ok(())
 }
 
 #[test]
@@ -2517,17 +2512,17 @@ fn update_toml() -> Result<()> {
     let repo_path =
         create_local_git_repo(&context, "test-repo-toml", &["v1.0.0", "v1.1.0", "v2.0.0"])?;
 
-    context
-        .work_dir()
-        .child(PREK_TOML)
-        .write_str(&indoc::formatdoc! {r#"
+    let context = context.with_file(
+        PREK_TOML,
+        indoc::formatdoc! {r#"
         [[repos]]
         repo = "{}"
         rev = "v1.0.0"
         hooks = [
           {{ id = "test-hook" }},
         ]
-      "#, repo_path})?;
+      "#, repo_path},
+    );
     context.git().add_all();
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
@@ -2559,17 +2554,17 @@ fn update_toml_with_comment() -> Result<()> {
     let repo_path =
         create_local_git_repo(&context, "test-repo-toml", &["v1.0.0", "v1.1.0", "v2.0.0"])?;
 
-    context
-        .work_dir()
-        .child(PREK_TOML)
-        .write_str(&indoc::formatdoc! {r#"
+    let context = context.with_file(
+        PREK_TOML,
+        indoc::formatdoc! {r#"
         [[repos]]
         repo = "{}"
         rev = "v1.0.0" # This is a comment
         hooks = [
           {{ id = "test-hook" }},
         ]
-      "#, repo_path})?;
+      "#, repo_path},
+    );
 
     context.git().add_all();
 
@@ -2593,17 +2588,17 @@ fn update_toml_with_comment() -> Result<()> {
         "#);
 
     // "frozen: xx" comment should be removed
-    context
-        .work_dir()
-        .child(PREK_TOML)
-        .write_str(&indoc::formatdoc! {r#"
+    context.write_file(
+        PREK_TOML,
+        indoc::formatdoc! {r#"
         [[repos]]
         repo = "{}"
         rev = "v1.0.0" # frozen: v1.0.0
         hooks = [
           {{ id = "test-hook" }},
         ]
-      "#, repo_path})?;
+      "#, repo_path},
+    );
 
     context.git().add_all();
 
@@ -2650,17 +2645,17 @@ fn update_freeze_toml() -> Result<()> {
         .assert()
         .success();
 
-    context
-        .work_dir()
-        .child(PREK_TOML)
-        .write_str(&indoc::formatdoc! {r#"
+    let context = context.with_file(
+        PREK_TOML,
+        indoc::formatdoc! {r#"
         [[repos]]
         repo = "{}"
         rev = "v1.0.0"
         hooks = [
           {{ id = "test-hook" }},
         ]
-    "#, repo_path})?;
+    "#, repo_path},
+    );
 
     context.git().add_all();
 
@@ -2856,10 +2851,9 @@ fn update_freeze_toml_with_comment() -> Result<()> {
         .assert()
         .success();
 
-    context
-        .work_dir()
-        .child(PREK_TOML)
-        .write_str(&indoc::formatdoc! {r#"
+    let context = context.with_file(
+        PREK_TOML,
+        indoc::formatdoc! {r#"
         [[repos]]
         repo = "{}"
         # A comment above
@@ -2868,7 +2862,8 @@ fn update_freeze_toml_with_comment() -> Result<()> {
         hooks = [
           {{ id = "test-hook" }},
         ]
-    "#, repo_path})?;
+    "#, repo_path},
+    );
 
     context.git().add_all();
 

--- a/crates/prek/tests/validate.rs
+++ b/crates/prek/tests/validate.rs
@@ -1,4 +1,3 @@
-use assert_fs::fixture::{FileWriteStr, PathChild};
 use prek_consts::PRE_COMMIT_CONFIG_YAML;
 
 use crate::common::{TestEnv, cmd_snapshot};
@@ -6,7 +5,7 @@ use crate::common::{TestEnv, cmd_snapshot};
 mod common;
 
 #[test]
-fn validate_config() -> anyhow::Result<()> {
+fn validate_config() {
     let context = TestEnv::new();
 
     // No files to validate.
@@ -38,13 +37,13 @@ fn validate_config() -> anyhow::Result<()> {
     success: All configs are valid
     ");
 
-    context
-        .work_dir()
-        .child("config-1.yaml")
-        .write_str(indoc::indoc! {r"
+    context.write_file(
+        "config-1.yaml",
+        indoc::indoc! {r"
             repos:
               - repo: https://github.com/pre-commit/pre-commit-hooks
-        "})?;
+        "},
+    );
 
     // Validate multiple files.
     cmd_snapshot!(context, context.validate_config().arg(PRE_COMMIT_CONFIG_YAML).arg("config-1.yaml"), @"
@@ -61,8 +60,6 @@ fn validate_config() -> anyhow::Result<()> {
     2 |   - repo: https://github.com/pre-commit/pre-commit-hooks
       |     ^ missing field `rev`
     ");
-
-    Ok(())
 }
 
 #[test]
@@ -223,7 +220,7 @@ fn duplicate_and_unused_priority_aliases_are_valid() {
 }
 
 #[test]
-fn validate_manifest() -> anyhow::Result<()> {
+fn validate_manifest() {
     let context = TestEnv::new();
 
     // No files to validate.
@@ -236,10 +233,9 @@ fn validate_manifest() -> anyhow::Result<()> {
     warning: No manifests to check
     ");
 
-    context
-        .work_dir()
-        .child(".pre-commit-hooks.yaml")
-        .write_str(indoc::indoc! {r"
+    context.write_file(
+        ".pre-commit-hooks.yaml",
+        indoc::indoc! {r"
             -   id: check-added-large-files
                 name: check for added large files
                 description: prevents giant files from being committed.
@@ -247,7 +243,8 @@ fn validate_manifest() -> anyhow::Result<()> {
                 language: python
                 stages: [pre-commit, pre-push, manual]
                 minimum_pre_commit_version: 3.2.0
-        "})?;
+        "},
+    );
     // Validate one file.
     cmd_snapshot!(context, context.validate_manifest().arg(".pre-commit-hooks.yaml"), @r"
     success: true
@@ -258,17 +255,17 @@ fn validate_manifest() -> anyhow::Result<()> {
     success: All manifests are valid
     ");
 
-    context
-        .work_dir()
-        .child("hooks-1.yaml")
-        .write_str(indoc::indoc! {r"
+    context.write_file(
+        "hooks-1.yaml",
+        indoc::indoc! {r"
             -   id: check-added-large-files
                 name: check for added large files
                 description: prevents giant files from being committed.
                 language: python
                 stages: [pre-commit, pre-push, manual]
                 minimum_pre_commit_version: 3.2.0
-        "})?;
+        "},
+    );
 
     // Validate multiple files.
     cmd_snapshot!(context, context.validate_manifest().arg(".pre-commit-hooks.yaml").arg("hooks-1.yaml"), @"
@@ -287,8 +284,6 @@ fn validate_manifest() -> anyhow::Result<()> {
     3 |     description: prevents giant files from being committed.
       |
     ");
-
-    Ok(())
 }
 
 #[test]

--- a/crates/prek/tests/workspace.rs
+++ b/crates/prek/tests/workspace.rs
@@ -253,7 +253,7 @@ fn same_depth_project_concurrency_has_stable_output() {
 
 #[test]
 fn fail_fast_stops_after_current_project_level() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let root_config = indoc::indoc! {r#"
     repos:
       - repo: local
         hooks:
@@ -262,7 +262,7 @@ fn fail_fast_stops_after_current_project_level() {
           language: system
           entry: python3 -c "print('root ran')"
           always_run: true
-    "#});
+    "#};
 
     let failing_config = indoc! {r#"
     repos:
@@ -286,9 +286,10 @@ fn fail_fast_stops_after_current_project_level() {
           always_run: true
     "#};
 
-    context.write_file("a/.pre-commit-config.yaml", failing_config);
-
-    context.write_file("b/.pre-commit-config.yaml", passing_config);
+    let context = TestEnv::new_git()
+        .with_config(root_config)
+        .with_file("a/.pre-commit-config.yaml", failing_config)
+        .with_file("b/.pre-commit-config.yaml", passing_config);
 
     context.git().add_all();
 
@@ -714,7 +715,8 @@ fn run_with_selectors() {
 
 #[test]
 fn run_with_mixed_project_and_hook_selectors() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new_git()
+        .with_config(indoc::indoc! {r"
     repos:
       - repo: local
         hooks:
@@ -723,11 +725,10 @@ fn run_with_mixed_project_and_hook_selectors() {
           entry: echo root
           language: system
           pass_filenames: false
-    "});
-
-    context.write_file(
-        "sub/.pre-commit-config.yaml",
-        indoc! {r"
+    "})
+        .with_file(
+            "sub/.pre-commit-config.yaml",
+            indoc! {r"
     repos:
       - repo: local
         hooks:
@@ -737,12 +738,10 @@ fn run_with_mixed_project_and_hook_selectors() {
           language: system
           pass_filenames: false
     "},
-    );
-    context.write_file("sub/file.txt", "");
-
-    context.write_file("empty/.pre-commit-config.yaml", "repos: []\n");
-
-    context.write_file("unselected/.pre-commit-config.yaml", "invalid: config\n");
+        )
+        .with_file("sub/file.txt", "")
+        .with_file("empty/.pre-commit-config.yaml", "repos: []\n")
+        .with_file("unselected/.pre-commit-config.yaml", "invalid: config\n");
 
     context.git().add_all();
 
@@ -1457,12 +1456,8 @@ fn orphan_projects() {
 }
 
 fn setup_relative_repo_path_project() -> Result<TestEnv> {
-    let context = TestEnv::new_git();
-
     // Create a local hook repository at the root level
-    let hook_repo = context.work_dir().child("hook-repo");
-
-    context.write_file(
+    let context = TestEnv::new_git().with_file(
         "hook-repo/.pre-commit-hooks.yaml",
         indoc! {r"
         - id: test-hook
@@ -1470,8 +1465,9 @@ fn setup_relative_repo_path_project() -> Result<TestEnv> {
           entry: echo test
           language: system
           always_run: true
-    "},
+        "},
     );
+    let hook_repo = context.work_dir().child("hook-repo");
 
     let git = context.git_at(&hook_repo);
     git.init().add(".").commit("Initial commit");
@@ -1481,9 +1477,10 @@ fn setup_relative_repo_path_project() -> Result<TestEnv> {
 
     // Create a subproject that references the hook repo with a relative path
     // From subproject/, ../hook-repo should resolve to the hook-repo at root
-    context.write_file(
-        "subproject/.pre-commit-config.yaml",
-        indoc::formatdoc! {r"
+    let context = context
+        .with_file(
+            "subproject/.pre-commit-config.yaml",
+            indoc::formatdoc! {r"
         repos:
           - repo: ../hook-repo
             rev: {commit_sha}
@@ -1491,12 +1488,9 @@ fn setup_relative_repo_path_project() -> Result<TestEnv> {
               - id: test-hook
                 always_run: true
     "},
-    );
-
-    context.write_file("subproject/test.txt", "test content");
-
-    // Root config so workspace discovery works
-    let context = context.with_config(indoc::indoc! {r"
+        )
+        .with_file("subproject/test.txt", "test content")
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:

--- a/crates/prek/tests/workspace.rs
+++ b/crates/prek/tests/workspace.rs
@@ -2,15 +2,15 @@ mod common;
 
 use anyhow::Result;
 use assert_cmd::assert::OutputAssertExt;
-use assert_fs::fixture::{FileWriteStr, PathChild, PathCreateDir};
+use assert_fs::fixture::PathChild;
 use indoc::indoc;
+use prek_consts::PRE_COMMIT_CONFIG_YAML;
 use prek_consts::env_vars::EnvVars;
-use prek_consts::{PRE_COMMIT_CONFIG_YAML, PRE_COMMIT_HOOKS_YAML};
 
 use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
-fn basic_discovery() -> Result<()> {
+fn basic_discovery() {
     let context = TestEnv::new_git();
     let cwd = context.work_dir();
 
@@ -33,7 +33,7 @@ fn basic_discovery() -> Result<()> {
             "project3/project5",
         ],
         config,
-    )?;
+    );
     context.git().add_all();
 
     // Run from the root directory
@@ -156,10 +156,7 @@ fn basic_discovery() -> Result<()> {
     "#);
 
     // Ignore `project5` in `project3`
-    context
-        .work_dir()
-        .child("project3/.prekignore")
-        .write_str("project5/\n")?;
+    context.write_file("project3/.prekignore", "project5/\n");
     context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--refresh").arg("--cd").arg(cwd.join("project3")), @r#"
@@ -177,10 +174,7 @@ fn basic_discovery() -> Result<()> {
     "#);
 
     // Ignoring everything under project3, but when runs from project3, it’s still getting picked up.
-    context
-        .work_dir()
-        .child("project3/.prekignore")
-        .write_str("*\n")?;
+    context.write_file("project3/.prekignore", "*\n");
     context.git().add_all();
     cmd_snapshot!(context, context.run().arg("--refresh").arg("--cd").arg(cwd.join("project3")), @r#"
     success: true
@@ -195,17 +189,13 @@ fn basic_discovery() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
-fn same_depth_project_concurrency_has_stable_output() -> Result<()> {
-    let context = TestEnv::new_git().with_config("repos: []");
-    context
-        .work_dir()
-        .child("concurrent_hook.py")
-        .write_str(indoc! {r#"
+fn same_depth_project_concurrency_has_stable_output() {
+    let context = TestEnv::new_git().with_config("repos: []").with_file(
+        "concurrent_hook.py",
+        indoc! {r#"
             from pathlib import Path
             import time
 
@@ -224,7 +214,8 @@ fn same_depth_project_concurrency_has_stable_output() -> Result<()> {
             # Make b finish first so output order cannot follow completion order.
             if project == "a":
                 time.sleep(0.5)
-        "#})?;
+        "#},
+    );
 
     let config = indoc! {r"
     repos:
@@ -239,12 +230,8 @@ fn same_depth_project_concurrency_has_stable_output() -> Result<()> {
     "};
 
     for project in ["a", "b"] {
-        let project_dir = context.work_dir().child(project);
-        project_dir.create_dir_all()?;
-        project_dir
-            .child(".pre-commit-config.yaml")
-            .write_str(config)?;
-        project_dir.child("file.txt").write_str("")?;
+        context.write_file(format!("{project}/{PRE_COMMIT_CONFIG_YAML}"), config);
+        context.write_file(format!("{project}/file.txt"), "");
     }
     context.git().add_all();
 
@@ -262,12 +249,10 @@ fn same_depth_project_concurrency_has_stable_output() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
-fn fail_fast_stops_after_current_project_level() -> Result<()> {
+fn fail_fast_stops_after_current_project_level() {
     let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
     repos:
       - repo: local
@@ -301,17 +286,9 @@ fn fail_fast_stops_after_current_project_level() -> Result<()> {
           always_run: true
     "#};
 
-    let project_a = context.work_dir().child("a");
-    project_a.create_dir_all()?;
-    project_a
-        .child(".pre-commit-config.yaml")
-        .write_str(failing_config)?;
+    context.write_file("a/.pre-commit-config.yaml", failing_config);
 
-    let project_b = context.work_dir().child("b");
-    project_b.create_dir_all()?;
-    project_b
-        .child(".pre-commit-config.yaml")
-        .write_str(passing_config)?;
+    context.write_file("b/.pre-commit-config.yaml", passing_config);
 
     context.git().add_all();
 
@@ -331,12 +308,10 @@ fn fail_fast_stops_after_current_project_level() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
-fn config_not_staged() -> Result<()> {
+fn config_not_staged() {
     let context = TestEnv::new_git();
     let cwd = context.work_dir();
 
@@ -358,7 +333,7 @@ fn config_not_staged() -> Result<()> {
             "project3/project5",
         ],
         config,
-    )?;
+    );
     context.git().add_all();
 
     let config = indoc! {r"
@@ -380,7 +355,7 @@ fn config_not_staged() -> Result<()> {
             "project3/project5",
         ],
         config,
-    )?;
+    );
 
     // Run from the root directory
     cmd_snapshot!(context, context.run(), @r"
@@ -417,12 +392,10 @@ fn config_not_staged() -> Result<()> {
     ----- stderr -----
     error: Configuration file `.pre-commit-config.yaml` is not staged. Stage it with `git add` and try again
     ");
-
-    Ok(())
 }
 
 #[test]
-fn run_with_selectors() -> Result<()> {
+fn run_with_selectors() {
     let context = TestEnv::new_git();
 
     let config = indoc! {r"
@@ -444,7 +417,7 @@ fn run_with_selectors() -> Result<()> {
             "project3/project5",
         ],
         config,
-    )?;
+    );
     context.git().add_all();
 
     cmd_snapshot!(context, context.run().arg("--hide-status").arg("passed"), @r#"
@@ -737,12 +710,10 @@ fn run_with_selectors() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn run_with_mixed_project_and_hook_selectors() -> Result<()> {
+fn run_with_mixed_project_and_hook_selectors() {
     let context = TestEnv::new_git().with_config(indoc::indoc! {r"
     repos:
       - repo: local
@@ -754,9 +725,9 @@ fn run_with_mixed_project_and_hook_selectors() -> Result<()> {
           pass_filenames: false
     "});
 
-    let sub = context.work_dir().child("sub");
-    sub.create_dir_all()?;
-    sub.child(".pre-commit-config.yaml").write_str(indoc! {r"
+    context.write_file(
+        "sub/.pre-commit-config.yaml",
+        indoc! {r"
     repos:
       - repo: local
         hooks:
@@ -765,20 +736,13 @@ fn run_with_mixed_project_and_hook_selectors() -> Result<()> {
           entry: echo sub
           language: system
           pass_filenames: false
-    "})?;
-    sub.child("file.txt").write_str("")?;
+    "},
+    );
+    context.write_file("sub/file.txt", "");
 
-    let empty = context.work_dir().child("empty");
-    empty.create_dir_all()?;
-    empty
-        .child(".pre-commit-config.yaml")
-        .write_str("repos: []\n")?;
+    context.write_file("empty/.pre-commit-config.yaml", "repos: []\n");
 
-    let unselected = context.work_dir().child("unselected");
-    unselected.create_dir_all()?;
-    unselected
-        .child(".pre-commit-config.yaml")
-        .write_str("invalid: config\n")?;
+    context.write_file("unselected/.pre-commit-config.yaml", "invalid: config\n");
 
     context.git().add_all();
 
@@ -814,12 +778,10 @@ fn run_with_mixed_project_and_hook_selectors() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 #[test]
-fn skips() -> Result<()> {
+fn skips() {
     let context = TestEnv::new_git();
 
     let config = indoc! {r"
@@ -833,7 +795,7 @@ fn skips() -> Result<()> {
           verbose: true
     "};
 
-    context.setup_workspace(&["project2", "project3", "project3/project4"], config)?;
+    context.setup_workspace(&["project2", "project3", "project3/project4"], config);
     context.git().add_all();
 
     // Test CLI skip
@@ -1003,10 +965,7 @@ fn skips() -> Result<()> {
     ");
 
     // Add an invalid config
-    context
-        .work_dir()
-        .child("project3/.pre-commit-config.yaml")
-        .write_str("invalid_yaml: [")?;
+    context.write_file("project3/.pre-commit-config.yaml", "invalid_yaml: [");
     context.git().add_all();
 
     // Should error out because of the invalid config
@@ -1046,8 +1005,6 @@ fn skips() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
@@ -1068,7 +1025,7 @@ fn workspace_no_projects() {
 }
 
 #[test]
-fn gitignore_respected() -> Result<()> {
+fn gitignore_respected() {
     let context = TestEnv::new_git();
 
     let config = indoc! {r"
@@ -1090,13 +1047,9 @@ fn gitignore_respected() -> Result<()> {
             "target/ignored",       // Should be ignored by .gitignore
         ],
         config,
-    )?;
+    );
 
-    // Create .gitignore that ignores node_modules and target
-    context
-        .work_dir()
-        .child(".gitignore")
-        .write_str("node_modules/\ntarget/\n")?;
+    let context = context.with_file(".gitignore", "node_modules/\ntarget/\n");
 
     context.git().add_all();
 
@@ -1122,12 +1075,10 @@ fn gitignore_respected() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
-fn nested_project_exclude_is_relative() -> Result<()> {
+fn nested_project_exclude_is_relative() {
     let context = TestEnv::new_git();
 
     // Regression test for nested workspaces:
@@ -1150,22 +1101,15 @@ fn nested_project_exclude_is_relative() -> Result<()> {
     "#};
 
     // Workspace with a nested project.
-    context.setup_workspace(&["nested"], config)?;
+    context.setup_workspace(&["nested"], config);
 
     // A root-level file which should be excluded by the root project (path is `excluded_by_project`).
     // This keeps the snapshot focused on the nested files, while proving the regex is not
     // accidentally matching `nested/excluded_by_project`.
-    context
-        .work_dir()
-        .child("excluded_by_project")
-        .write_str("")?;
-
-    // Files inside the nested project: one that should be included and one excluded.
-    context.work_dir().child("nested/include").write_str("")?;
-    context
-        .work_dir()
-        .child("nested/excluded_by_project")
-        .write_str("")?;
+    let context = context
+        .with_file("excluded_by_project", "")
+        .with_file("nested/include", "")
+        .with_file("nested/excluded_by_project", "");
 
     context.git().add_all();
 
@@ -1194,13 +1138,11 @@ fn nested_project_exclude_is_relative() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 /// Tests that `--files` arguments references files in other projects, should be filtered out properly.
 #[test]
-fn reference_files_across_projects() -> Result<()> {
+fn reference_files_across_projects() {
     let context = TestEnv::new_git();
 
     let config = indoc! {r"
@@ -1215,11 +1157,10 @@ fn reference_files_across_projects() -> Result<()> {
     "};
 
     // Create a project structure with directories that should be ignored
-    context.setup_workspace(&["frontend", "backend"], config)?;
+    context.setup_workspace(&["frontend", "backend"], config);
 
+    let context = context.with_file("backend/app.py", "print('Hello from backend')");
     let cwd = context.work_dir();
-    cwd.child("backend/app.py")
-        .write_str("print('Hello from backend')")?;
     context.git().add_all();
     // Run with --files referencing a file in another project
     cmd_snapshot!(context, context.run().current_dir(cwd.child("frontend")).arg("--files").arg("../backend/app.py").arg("../backend/non-exist.py"), @r"
@@ -1231,8 +1172,6 @@ fn reference_files_across_projects() -> Result<()> {
     ----- stderr -----
     warning: This file does not exist and will be ignored: `../backend/non-exist.py`
     ");
-
-    Ok(())
 }
 
 #[test]
@@ -1251,7 +1190,7 @@ fn submodule_discovery() -> Result<()> {
           verbose: true
     "};
 
-    context.setup_workspace(&["project2"], config)?;
+    context.setup_workspace(&["project2"], config);
 
     // Create a submodule
     let submodule_path = cwd.child("submodule");
@@ -1325,7 +1264,7 @@ fn submodule_discovery() -> Result<()> {
 }
 
 #[test]
-fn cookiecutter_template_directories_are_skipped() -> Result<()> {
+fn cookiecutter_template_directories_are_skipped() {
     let context = TestEnv::new_git();
 
     let config = indoc! {r"
@@ -1339,7 +1278,7 @@ fn cookiecutter_template_directories_are_skipped() -> Result<()> {
           verbose: true
     "};
 
-    context.setup_workspace(&["project2", "{{cookiecutter.project_slug}}"], config)?;
+    context.setup_workspace(&["project2", "{{cookiecutter.project_slug}}"], config);
 
     // Stage only the configs that should participate in discovery.
     context
@@ -1369,12 +1308,10 @@ fn cookiecutter_template_directories_are_skipped() -> Result<()> {
 
     ----- stderr -----
     "#);
-
-    Ok(())
 }
 
 #[test]
-fn orphan_projects() -> Result<()> {
+fn orphan_projects() {
     let context = TestEnv::new_git();
 
     // Create a hook that shows which files it processes
@@ -1391,27 +1328,13 @@ fn orphan_projects() -> Result<()> {
           verbose: true
     "#};
 
-    // Setup workspace with nested projects
-    context
-        .work_dir()
-        .child("src/backend/.pre-commit-config.yaml")
-        .write_str(config)?;
-    context
-        .work_dir()
-        .child("src/.pre-commit-config.yaml")
-        .write_str(config)?;
-    context
-        .work_dir()
-        .child(".pre-commit-config.yaml")
-        .write_str(config)?;
-
-    // Create test files
-    context
-        .work_dir()
-        .child("src/backend/test.py")
-        .write_str("")?;
-    context.work_dir().child("src/test.py").write_str("")?;
-    context.work_dir().child("test.py").write_str("")?;
+    let context = context
+        .with_file("src/backend/.pre-commit-config.yaml", config)
+        .with_file("src/.pre-commit-config.yaml", config)
+        .with_file(".pre-commit-config.yaml", config)
+        .with_file("src/backend/test.py", "")
+        .with_file("src/test.py", "")
+        .with_file("test.py", "");
     context.git().add_all();
 
     // Without `orphan`: files in subprojects are processed multiple times
@@ -1448,10 +1371,7 @@ fn orphan_projects() -> Result<()> {
     "#);
 
     // Enable `orphan`
-    context
-        .work_dir()
-        .child("src/backend/.pre-commit-config.yaml")
-        .write_str(indoc! {r#"
+    context.write_file("src/backend/.pre-commit-config.yaml", indoc! {r#"
         orphan: true
         exclude: \.pre-commit-config\.yaml$
         repos:
@@ -1463,13 +1383,10 @@ fn orphan_projects() -> Result<()> {
               entry: python -c 'import sys; print("Processing {} files".format(len(sys.argv[1:]))); [print("  - {}".format(f)) for f in sys.argv[1:]]'
               pass_filenames: true
               verbose: true
-    "#})?;
+    "#});
 
     // `files` match nothing, but files are still "consumed"
-    context
-        .work_dir()
-        .child("src/.pre-commit-config.yaml")
-        .write_str(indoc! {r#"
+    context.write_file("src/.pre-commit-config.yaml", indoc! {r#"
         orphan: true
         files: ^$
         exclude: \.pre-commit-config\.yaml$
@@ -1482,12 +1399,9 @@ fn orphan_projects() -> Result<()> {
               entry: python -c 'import sys; print("Processing {} files".format(len(sys.argv[1:]))); [print("  - {}".format(f)) for f in sys.argv[1:]]'
               pass_filenames: true
               verbose: true
-    "#})?;
+    "#});
 
-    context
-        .work_dir()
-        .child(".pre-commit-config.yaml")
-        .write_str(indoc! {r#"
+    context.write_file(".pre-commit-config.yaml", indoc! {r#"
         orphan: false
         exclude: \.pre-commit-config\.yaml$
         repos:
@@ -1499,7 +1413,7 @@ fn orphan_projects() -> Result<()> {
               entry: python -c 'import sys; print("Processing {} files".format(len(sys.argv[1:]))); [print("  - {}".format(f)) for f in sys.argv[1:]]'
               pass_filenames: true
               verbose: true
-    "#})?;
+    "#});
 
     // In orphan project, files are "consumed" and not processed again in parent projects
     cmd_snapshot!(context, context.run().arg("--all-files"), @r#"
@@ -1540,8 +1454,6 @@ fn orphan_projects() -> Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 fn setup_relative_repo_path_project() -> Result<TestEnv> {
@@ -1549,15 +1461,17 @@ fn setup_relative_repo_path_project() -> Result<TestEnv> {
 
     // Create a local hook repository at the root level
     let hook_repo = context.work_dir().child("hook-repo");
-    hook_repo.create_dir_all()?;
 
-    hook_repo.child(PRE_COMMIT_HOOKS_YAML).write_str(indoc! {r"
+    context.write_file(
+        "hook-repo/.pre-commit-hooks.yaml",
+        indoc! {r"
         - id: test-hook
           name: Test Hook
           entry: echo test
           language: system
           always_run: true
-    "})?;
+    "},
+    );
 
     let git = context.git_at(&hook_repo);
     git.init().add(".").commit("Initial commit");
@@ -1566,22 +1480,20 @@ fn setup_relative_repo_path_project() -> Result<TestEnv> {
     let commit_sha = git.rev_parse("HEAD")?;
 
     // Create a subproject that references the hook repo with a relative path
-    let subproject = context.work_dir().child("subproject");
-    subproject.create_dir_all()?;
-
     // From subproject/, ../hook-repo should resolve to the hook-repo at root
-    subproject
-        .child(PRE_COMMIT_CONFIG_YAML)
-        .write_str(&indoc::formatdoc! {r"
+    context.write_file(
+        "subproject/.pre-commit-config.yaml",
+        indoc::formatdoc! {r"
         repos:
           - repo: ../hook-repo
             rev: {commit_sha}
             hooks:
               - id: test-hook
                 always_run: true
-    "})?;
+    "},
+    );
 
-    subproject.child("test.txt").write_str("test content")?;
+    context.write_file("subproject/test.txt", "test content");
 
     // Root config so workspace discovery works
     let context = context.with_config(indoc::indoc! {r"

--- a/crates/prek/tests/yaml_to_toml.rs
+++ b/crates/prek/tests/yaml_to_toml.rs
@@ -1,5 +1,5 @@
 use assert_fs::assert::PathAssert;
-use assert_fs::fixture::{FileWriteStr, PathChild};
+use assert_fs::fixture::PathChild;
 use prek_consts::{PRE_COMMIT_CONFIG_YAML, PRE_COMMIT_CONFIG_YML, PREK_TOML};
 
 use crate::common::{TestEnv, cmd_snapshot};
@@ -57,13 +57,8 @@ repos:
 "#;
 
 #[test]
-fn yaml_to_toml_writes_default_output() -> anyhow::Result<()> {
-    let context = TestEnv::new();
-
-    context
-        .work_dir()
-        .child("config.yaml")
-        .write_str(YAML_CONFIG)?;
+fn yaml_to_toml_writes_default_output() {
+    let context = TestEnv::new().with_file("config.yaml", YAML_CONFIG);
 
     cmd_snapshot!(context,
         context
@@ -148,19 +143,13 @@ fn yaml_to_toml_writes_default_output() -> anyhow::Result<()> {
       }
     ]
     "#);
-
-    Ok(())
 }
 
 #[test]
-fn yaml_to_toml_force_overwrite() -> anyhow::Result<()> {
-    let context = TestEnv::new();
-
-    context
-        .work_dir()
-        .child("config.yaml")
-        .write_str(YAML_CONFIG)?;
-    context.work_dir().child(PREK_TOML).write_str("existing")?;
+fn yaml_to_toml_force_overwrite() {
+    let context = TestEnv::new()
+        .with_file("config.yaml", YAML_CONFIG)
+        .with_file(PREK_TOML, "existing");
 
     cmd_snapshot!(context,
         context
@@ -189,18 +178,11 @@ fn yaml_to_toml_force_overwrite() -> anyhow::Result<()> {
     ----- stderr -----
     "
     );
-
-    Ok(())
 }
 
 #[test]
-fn yaml_to_toml_rejects_invalid_config() -> anyhow::Result<()> {
-    let context = TestEnv::new();
-
-    context
-        .work_dir()
-        .child("config.yaml")
-        .write_str("repos: 123")?;
+fn yaml_to_toml_rejects_invalid_config() {
+    let context = TestEnv::new().with_file("config.yaml", "repos: 123");
 
     cmd_snapshot!(context,
       context
@@ -220,18 +202,11 @@ fn yaml_to_toml_rejects_invalid_config() -> anyhow::Result<()> {
       |        ^ expected sequence start
     "#
     );
-
-    Ok(())
 }
 
 #[test]
-fn yaml_to_toml_same_output() -> anyhow::Result<()> {
-    let context = TestEnv::new();
-
-    context
-        .work_dir()
-        .child("config.yaml")
-        .write_str(YAML_CONFIG)?;
+fn yaml_to_toml_same_output() {
+    let context = TestEnv::new().with_file("config.yaml", YAML_CONFIG);
 
     cmd_snapshot!(context,
         context
@@ -251,18 +226,11 @@ fn yaml_to_toml_same_output() -> anyhow::Result<()> {
         .work_dir()
         .child(PREK_TOML)
         .assert(predicates::path::missing());
-
-    Ok(())
 }
 
 #[test]
-fn yaml_to_toml_discovers_pre_commit_config_yaml() -> anyhow::Result<()> {
-    let context = TestEnv::new();
-
-    context
-        .work_dir()
-        .child(PRE_COMMIT_CONFIG_YAML)
-        .write_str(YAML_CONFIG)?;
+fn yaml_to_toml_discovers_pre_commit_config_yaml() {
+    let context = TestEnv::new().with_file(PRE_COMMIT_CONFIG_YAML, YAML_CONFIG);
 
     cmd_snapshot!(context,
         context.command().args(["util", "yaml-to-toml"]),
@@ -280,18 +248,11 @@ fn yaml_to_toml_discovers_pre_commit_config_yaml() -> anyhow::Result<()> {
         .work_dir()
         .child(PREK_TOML)
         .assert(predicates::path::exists());
-
-    Ok(())
 }
 
 #[test]
-fn yaml_to_toml_discovers_pre_commit_config_yml() -> anyhow::Result<()> {
-    let context = TestEnv::new();
-
-    context
-        .work_dir()
-        .child(PRE_COMMIT_CONFIG_YML)
-        .write_str(YAML_CONFIG)?;
+fn yaml_to_toml_discovers_pre_commit_config_yml() {
+    let context = TestEnv::new().with_file(PRE_COMMIT_CONFIG_YML, YAML_CONFIG);
 
     cmd_snapshot!(context,
         context.command().args(["util", "yaml-to-toml"]),
@@ -309,12 +270,10 @@ fn yaml_to_toml_discovers_pre_commit_config_yml() -> anyhow::Result<()> {
         .work_dir()
         .child(PREK_TOML)
         .assert(predicates::path::exists());
-
-    Ok(())
 }
 
 #[test]
-fn yaml_to_toml_prefers_yaml_over_yml() -> anyhow::Result<()> {
+fn yaml_to_toml_prefers_yaml_over_yml() {
     let context = TestEnv::new();
 
     // Write different content to each file so we can verify which was used.
@@ -331,14 +290,9 @@ fn yaml_to_toml_prefers_yaml_over_yml() -> anyhow::Result<()> {
               - id: end-of-file-fixer
     "};
 
-    context
-        .work_dir()
-        .child(PRE_COMMIT_CONFIG_YAML)
-        .write_str(yaml_only)?;
-    context
-        .work_dir()
-        .child(PRE_COMMIT_CONFIG_YML)
-        .write_str(yml_only)?;
+    let context = context
+        .with_file(PRE_COMMIT_CONFIG_YAML, yaml_only)
+        .with_file(PRE_COMMIT_CONFIG_YML, yml_only);
 
     cmd_snapshot!(context,
         context.command().args(["util", "yaml-to-toml"]),
@@ -358,8 +312,6 @@ fn yaml_to_toml_prefers_yaml_over_yml() -> anyhow::Result<()> {
         output.contains("trailing-whitespace"),
         "Expected .yaml to be preferred over .yml"
     );
-
-    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
Use TestEnv file helpers throughout integration tests so fixture setup focuses on paths and contents.

Remove redundant filesystem plumbing and Result propagation from workspace fixture setup.
