### PR TITLE
Drop low-usage release targets

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -51,8 +51,6 @@ jobs:
         platform:
           - target: x86_64-pc-windows-msvc
             arch: x64
-          - target: i686-pc-windows-msvc
-            arch: x86
           - target: aarch64-pc-windows-msvc
             arch: x64 # not relevant here
     steps:
@@ -60,10 +58,10 @@ jobs:
         with:
           persist-credentials: false
       - name: "Install NASM"
-        # NASM is required for x86/x86-64 Windows targets by aws-lc-sys.
+        # NASM is required for the x86-64 Windows target by aws-lc-sys.
         # On aarch64-pc-windows-msvc, it uses clang-cl instead.
         # See: https://aws.github.io/aws-lc-rs/requirements/windows.html#build-requirements
-        if: contains(matrix.platform.target, 'x86') || contains(matrix.platform.target, 'i686')
+        if: contains(matrix.platform.target, 'x86')
         run: |
           winget install NASM.NASM --accept-source-agreements --accept-package-agreements
           echo "C:\Program Files\NASM" | Out-File -FilePath $env:GITHUB_PATH -Append
@@ -141,11 +139,8 @@ jobs:
 
   linux:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - { target: "i686-unknown-linux-gnu", cc: "gcc -m32" }
-          - { target: "x86_64-unknown-linux-gnu", cc: "gcc" }
+    env:
+      TARGET: x86_64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -154,58 +149,42 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           maturin-version: ${{ env.MATURIN_VERSION }}
-          target: ${{ matrix.target }}
-          # Generally, we try to build in a target docker container. In this case however, a
-          # 32-bit compiler runs out of memory (4GB memory limit for 32-bit), so we cross compile
-          # from 64-bit version of the container, breaking the pattern from other builds.
+          target: ${{ env.TARGET }}
           container: quay.io/pypa/manylinux2014
           args: --release --locked --out dist --features self-update
           # See: https://github.com/sfackler/rust-openssl/issues/2036#issuecomment-1724324145
           before-script-linux: |
-            # Install the 32-bit cross target on 64-bit (noop if we're already on 64-bit)
-            rustup target add ${{ matrix.target }}
+            rustup target add ${{ env.TARGET }}
             # If we're running on rhel centos, install needed packages.
             if command -v yum &> /dev/null; then
                 yum update -y && yum install -y perl-core openssl openssl-devel pkgconfig libatomic
-
-                # If we're running on i686 we need to symlink libatomic
-                # in order to build openssl with -latomic flag.
-                if [[ ! -d "/usr/lib64" ]]; then
-                    ln -s /usr/lib/libatomic.so.1 /usr/lib/libatomic.so
-                else
-                    # Support cross-compiling from 64-bit to 32-bit
-                    yum install -y glibc-devel.i686 libstdc++-devel.i686
-                fi
             else
                 # If we're running on debian-based system.
                 apt update -y && apt-get install -y libssl-dev openssl pkg-config
             fi
           sccache: 'true'
           manylinux: auto
-        env:
-          CC: ${{ matrix.cc }}
       - name: "Upload wheels"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: wheels-linux-${{ matrix.target }}
+          name: wheels-linux-${{ env.TARGET }}
           path: dist
       - name: "Archive binary"
         shell: bash
         run: |
           set -euo pipefail
 
-          TARGET=${{ matrix.target }}
-          ARCHIVE_NAME=prek-$TARGET
-          ARCHIVE_FILE=$ARCHIVE_NAME.tar.gz
+          ARCHIVE_NAME="prek-$TARGET"
+          ARCHIVE_FILE="$ARCHIVE_NAME.tar.gz"
 
-          mkdir -p $ARCHIVE_NAME
-          cp target/$TARGET/release/prek $ARCHIVE_NAME/prek
-          tar czvf $ARCHIVE_FILE $ARCHIVE_NAME
-          shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
+          mkdir -p "$ARCHIVE_NAME"
+          cp "target/$TARGET/release/prek" "$ARCHIVE_NAME/prek"
+          tar czvf "$ARCHIVE_FILE" "$ARCHIVE_NAME"
+          shasum -a 256 "$ARCHIVE_FILE" > "$ARCHIVE_FILE.sha256"
       - name: "Upload binary"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: artifacts-${{ matrix.target }}
+          name: artifacts-${{ env.TARGET }}
           path: |
             *.tar.gz
             *.sha256
@@ -213,18 +192,8 @@ jobs:
   linux-arm:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    strategy:
-      matrix:
-        platform:
-          - target: aarch64-unknown-linux-gnu
-            arch: aarch64
-            # see https://github.com/astral-sh/ruff/issues/3791
-            # and https://github.com/gnzlbg/jemallocator/issues/170#issuecomment-1503228963
-            maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
-          - target: armv7-unknown-linux-gnueabihf
-            arch: armv7
-          - target: arm-unknown-linux-musleabihf
-            arch: arm
+    env:
+      TARGET: aarch64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -233,138 +202,41 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           maturin-version: ${{ env.MATURIN_VERSION }}
-          target: ${{ matrix.platform.target }}
-          # On `aarch64`, use `manylinux: 2_28`; otherwise, use `manylinux: auto`.
-          manylinux: ${{ matrix.platform.arch == 'aarch64' && '2_28' || 'auto' }}
-          docker-options: ${{ matrix.platform.maturin_docker_options }}
+          target: ${{ env.TARGET }}
+          manylinux: 2_28
+          # See https://github.com/astral-sh/ruff/issues/3791
+          # and https://github.com/gnzlbg/jemallocator/issues/170#issuecomment-1503228963.
+          docker-options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
           args: --release --locked --out dist --features self-update
       - name: "Upload wheels"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: wheels-linux-${{ matrix.platform.target }}
+          name: wheels-linux-${{ env.TARGET }}
           path: dist
       - name: "Archive binary"
         shell: bash
         run: |
           set -euo pipefail
 
-          TARGET=${{ matrix.platform.target }}
-          ARCHIVE_NAME=prek-$TARGET
-          ARCHIVE_FILE=$ARCHIVE_NAME.tar.gz
+          ARCHIVE_NAME="prek-$TARGET"
+          ARCHIVE_FILE="$ARCHIVE_NAME.tar.gz"
 
-          mkdir -p $ARCHIVE_NAME
-          cp target/$TARGET/release/prek $ARCHIVE_NAME/prek
-          tar czvf $ARCHIVE_FILE $ARCHIVE_NAME
-          shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
+          mkdir -p "$ARCHIVE_NAME"
+          cp "target/$TARGET/release/prek" "$ARCHIVE_NAME/prek"
+          tar czvf "$ARCHIVE_FILE" "$ARCHIVE_NAME"
+          shasum -a 256 "$ARCHIVE_FILE" > "$ARCHIVE_FILE.sha256"
       - name: "Upload binary"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: artifacts-${{ matrix.platform.target }}
+          name: artifacts-${{ env.TARGET }}
           path: |
             *.tar.gz
             *.sha256
-
-  linux-s390x:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        platform:
-          - target: s390x-unknown-linux-gnu
-            arch: s390x
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - name: "Build wheels"
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
-        with:
-          maturin-version: ${{ env.MATURIN_VERSION }}
-          target: ${{ matrix.platform.target }}
-          manylinux: auto
-          args: --release --locked --out dist --features self-update
-          rust-toolchain: ${{ matrix.platform.toolchain || null }}
-        env:
-          CFLAGS_s390x_unknown_linux_gnu: -march=z10
-      - name: "Upload wheels"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: wheels-linux-${{ matrix.platform.target }}
-          path: dist
-      - name: "Archive binary"
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          TARGET=${{ matrix.platform.target }}
-          ARCHIVE_NAME=prek-$TARGET
-          ARCHIVE_FILE=$ARCHIVE_NAME.tar.gz
-
-          mkdir -p $ARCHIVE_NAME
-          cp target/$TARGET/release/prek $ARCHIVE_NAME/prek
-          tar czvf $ARCHIVE_FILE $ARCHIVE_NAME
-          shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
-      - name: "Upload binary"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: artifacts-${{ matrix.platform.target }}
-          path: |
-            *.tar.gz
-            *.sha256
-
-  linux-riscv64:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        platform:
-          - target: riscv64gc-unknown-linux-gnu
-            arch: riscv64
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - name: "Build wheels"
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
-        with:
-          maturin-version: ${{ env.MATURIN_VERSION }}
-          target: ${{ matrix.platform.target }}
-          manylinux: auto
-          args: --release --locked --out dist --features self-update
-      - name: "Upload wheels"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: wheels-linux-${{ matrix.platform.target }}
-          path: dist
-      - name: "Archive binary"
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          TARGET=${{ matrix.platform.target }}
-          ARCHIVE_NAME=prek-$TARGET
-          ARCHIVE_FILE=$ARCHIVE_NAME.tar.gz
-
-          mkdir -p $ARCHIVE_NAME
-          cp target/$TARGET/release/prek $ARCHIVE_NAME/prek
-          tar czvf $ARCHIVE_FILE $ARCHIVE_NAME
-          shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
-      - name: "Upload binary"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: artifacts-${{ matrix.platform.target }}
-          path: |
-            *.tar.gz
-            *.sha256
-
 
   musllinux:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target:
-          - x86_64-unknown-linux-musl
-          - i686-unknown-linux-musl
+    env:
+      TARGET: x86_64-unknown-linux-musl
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -373,46 +245,38 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           maturin-version: ${{ env.MATURIN_VERSION }}
-          target: ${{ matrix.target }}
+          target: ${{ env.TARGET }}
           manylinux: musllinux_1_1
           args: --release --locked --out dist --features self-update
       - name: "Upload wheels"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: wheels-linux-${{ matrix.target }}
+          name: wheels-linux-${{ env.TARGET }}
           path: dist
       - name: "Archive binary"
         shell: bash
         run: |
           set -euo pipefail
 
-          TARGET=${{ matrix.target }}
-          ARCHIVE_NAME=prek-$TARGET
-          ARCHIVE_FILE=$ARCHIVE_NAME.tar.gz
+          ARCHIVE_NAME="prek-$TARGET"
+          ARCHIVE_FILE="$ARCHIVE_NAME.tar.gz"
 
-          mkdir -p $ARCHIVE_NAME
-          cp target/$TARGET/release/prek $ARCHIVE_NAME/prek
-          tar czvf $ARCHIVE_FILE $ARCHIVE_NAME
-          shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
+          mkdir -p "$ARCHIVE_NAME"
+          cp "target/$TARGET/release/prek" "$ARCHIVE_NAME/prek"
+          tar czvf "$ARCHIVE_FILE" "$ARCHIVE_NAME"
+          shasum -a 256 "$ARCHIVE_FILE" > "$ARCHIVE_FILE.sha256"
       - name: "Upload binary"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: artifacts-${{ matrix.target }}
+          name: artifacts-${{ env.TARGET }}
           path: |
             *.tar.gz
             *.sha256
 
   musllinux-cross:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform:
-          - target: aarch64-unknown-linux-musl
-            arch: aarch64
-            maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
-          - target: armv7-unknown-linux-musleabihf
-            arch: armv7
-      fail-fast: false
+    env:
+      TARGET: aarch64-unknown-linux-musl
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -421,33 +285,31 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           maturin-version: ${{ env.MATURIN_VERSION }}
-          target: ${{ matrix.platform.target }}
+          target: ${{ env.TARGET }}
           manylinux: musllinux_1_1
-          args: --release --locked --out dist --features self-update ${{ matrix.platform.arch == 'aarch64' && '--compatibility 2_17' || ''}}
-          docker-options: ${{ matrix.platform.maturin_docker_options }}
-          rust-toolchain: ${{ matrix.platform.toolchain || null }}
+          args: --release --locked --out dist --features self-update --compatibility 2_17
+          docker-options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
       - name: "Upload wheels"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: wheels-linux-${{ matrix.platform.target }}
+          name: wheels-linux-${{ env.TARGET }}
           path: dist
       - name: "Archive binary"
         shell: bash
         run: |
           set -euo pipefail
 
-          TARGET=${{ matrix.platform.target }}
-          ARCHIVE_NAME=prek-$TARGET
-          ARCHIVE_FILE=$ARCHIVE_NAME.tar.gz
+          ARCHIVE_NAME="prek-$TARGET"
+          ARCHIVE_FILE="$ARCHIVE_NAME.tar.gz"
 
-          mkdir -p $ARCHIVE_NAME
-          cp target/$TARGET/release/prek $ARCHIVE_NAME/prek
-          tar czvf $ARCHIVE_FILE $ARCHIVE_NAME
-          shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
+          mkdir -p "$ARCHIVE_NAME"
+          cp "target/$TARGET/release/prek" "$ARCHIVE_NAME/prek"
+          tar czvf "$ARCHIVE_FILE" "$ARCHIVE_NAME"
+          shasum -a 256 "$ARCHIVE_FILE" > "$ARCHIVE_FILE.sha256"
       - name: "Upload binary"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: artifacts-${{ matrix.platform.target }}
+          name: artifacts-${{ env.TARGET }}
           path: |
             *.tar.gz
             *.sha256

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -31,18 +31,10 @@ targets = [
   "aarch64-unknown-linux-gnu",
   "aarch64-unknown-linux-musl",
   "aarch64-pc-windows-msvc",
-  "arm-unknown-linux-musleabihf",
-  "armv7-unknown-linux-gnueabihf",
-  "armv7-unknown-linux-musleabihf",
   "x86_64-apple-darwin",
-  "riscv64gc-unknown-linux-gnu",
-  "s390x-unknown-linux-gnu",
   "x86_64-unknown-linux-gnu",
   "x86_64-unknown-linux-musl",
   "x86_64-pc-windows-msvc",
-  "i686-unknown-linux-gnu",
-  "i686-unknown-linux-musl",
-  "i686-pc-windows-msvc",
 ]
 # Local artifacts jobs to run in CI
 local-artifacts-jobs = ["./build-release-binaries", "./build-docker"]

--- a/npm/bin/prek.js
+++ b/npm/bin/prek.js
@@ -76,22 +76,6 @@ function isMusl() {
   return false;
 }
 
-function armVersion() {
-  const version = Number(process.config.variables.arm_version ?? 0);
-  return Number.isFinite(version) ? version : 0;
-}
-
-function matchesArmVersion(spec) {
-  const version = armVersion();
-  if (spec.armVersionMin != null && version < spec.armVersionMin) {
-    return false;
-  }
-  if (spec.armVersionMax != null && version > spec.armVersionMax) {
-    return false;
-  }
-  return true;
-}
-
 function currentLibc() {
   if (process.platform !== "linux") {
     return null;
@@ -102,11 +86,10 @@ function currentLibc() {
 function pickPlatformPackage() {
   const libc = currentLibc();
   debug(
-    `selecting package for platform=${process.platform} arch=${process.arch}` +
-      `${libc ? ` libc=${libc}` : ""} armVersion=${armVersion()}`,
+    `selecting package for platform=${process.platform} arch=${process.arch}${libc ? ` libc=${libc}` : ""}`,
   );
 
-  const candidates = PLATFORMS.filter((spec) => {
+  const candidate = PLATFORMS.find((spec) => {
     if (!spec.os.includes(process.platform)) {
       return false;
     }
@@ -116,24 +99,17 @@ function pickPlatformPackage() {
     if (spec.libc && spec.libc !== libc) {
       return false;
     }
-    if (!matchesArmVersion(spec)) {
-      return false;
-    }
     return true;
-  }).sort((left, right) => {
-    const leftSpecificity = left.armVersionMin ?? 0;
-    const rightSpecificity = right.armVersionMin ?? 0;
-    return rightSpecificity - leftSpecificity;
   });
 
-  if (candidates.length === 0) {
+  if (candidate == null) {
     const libcSuffix = libc ? ` (${libc})` : "";
     throw new Error(
       `Unsupported platform: ${process.platform} ${process.arch}${libcSuffix}`,
     );
   }
 
-  return candidates[0];
+  return candidate;
 }
 
 function resolvePackageJson(packageName) {

--- a/scripts/build-npm-packages.py
+++ b/scripts/build-npm-packages.py
@@ -26,8 +26,6 @@ class PlatformSpec:
     os: list[str]
     cpu: list[str]
     libc: str | None = None
-    arm_version_min: int | None = None
-    arm_version_max: int | None = None
 
     def output_dir(self, base_dir: Path) -> Path:
         return base_dir.joinpath(*self.package_name.split("/"))
@@ -42,10 +40,6 @@ class PlatformSpec:
         }
         if self.libc is not None:
             config["libc"] = self.libc
-        if self.arm_version_min is not None:
-            config["armVersionMin"] = self.arm_version_min
-        if self.arm_version_max is not None:
-            config["armVersionMax"] = self.arm_version_max
         return config
 
     def package_json(self, version: str) -> dict[str, object]:
@@ -129,71 +123,6 @@ PLATFORMS = (
         cpu=["arm64"],
     ),
     PlatformSpec(
-        rust_target="armv7-unknown-linux-gnueabihf",
-        package_name="@j178/prek-linux-arm-gnueabihf",
-        archive_file="prek-armv7-unknown-linux-gnueabihf.tar.gz",
-        binary_name="prek",
-        os=["linux"],
-        cpu=["arm"],
-        libc="glibc",
-        arm_version_min=7,
-    ),
-    PlatformSpec(
-        rust_target="arm-unknown-linux-musleabihf",
-        package_name="@j178/prek-linux-arm-musleabihf",
-        archive_file="prek-arm-unknown-linux-musleabihf.tar.gz",
-        binary_name="prek",
-        os=["linux"],
-        cpu=["arm"],
-        libc="musl",
-    ),
-    PlatformSpec(
-        rust_target="armv7-unknown-linux-musleabihf",
-        package_name="@j178/prek-linux-armv7-musleabihf",
-        archive_file="prek-armv7-unknown-linux-musleabihf.tar.gz",
-        binary_name="prek",
-        os=["linux"],
-        cpu=["arm"],
-        libc="musl",
-        arm_version_min=7,
-    ),
-    PlatformSpec(
-        rust_target="i686-unknown-linux-gnu",
-        package_name="@j178/prek-linux-ia32-gnu",
-        archive_file="prek-i686-unknown-linux-gnu.tar.gz",
-        binary_name="prek",
-        os=["linux"],
-        cpu=["ia32"],
-        libc="glibc",
-    ),
-    PlatformSpec(
-        rust_target="i686-unknown-linux-musl",
-        package_name="@j178/prek-linux-ia32-musl",
-        archive_file="prek-i686-unknown-linux-musl.tar.gz",
-        binary_name="prek",
-        os=["linux"],
-        cpu=["ia32"],
-        libc="musl",
-    ),
-    PlatformSpec(
-        rust_target="riscv64gc-unknown-linux-gnu",
-        package_name="@j178/prek-linux-riscv64-gnu",
-        archive_file="prek-riscv64gc-unknown-linux-gnu.tar.gz",
-        binary_name="prek",
-        os=["linux"],
-        cpu=["riscv64"],
-        libc="glibc",
-    ),
-    PlatformSpec(
-        rust_target="s390x-unknown-linux-gnu",
-        package_name="@j178/prek-linux-s390x-gnu",
-        archive_file="prek-s390x-unknown-linux-gnu.tar.gz",
-        binary_name="prek",
-        os=["linux"],
-        cpu=["s390x"],
-        libc="glibc",
-    ),
-    PlatformSpec(
         rust_target="x86_64-unknown-linux-gnu",
         package_name="@j178/prek-linux-x64-gnu",
         archive_file="prek-x86_64-unknown-linux-gnu.tar.gz",
@@ -218,14 +147,6 @@ PLATFORMS = (
         binary_name="prek.exe",
         os=["win32"],
         cpu=["arm64"],
-    ),
-    PlatformSpec(
-        rust_target="i686-pc-windows-msvc",
-        package_name="@j178/prek-win32-ia32-msvc",
-        archive_file="prek-i686-pc-windows-msvc.zip",
-        binary_name="prek.exe",
-        os=["win32"],
-        cpu=["ia32"],
     ),
     PlatformSpec(
         rust_target="x86_64-pc-windows-msvc",


### PR DESCRIPTION
## Summary

Drop eight low-usage targets from cargo-dist, PyPI wheels, and GitHub release archives.

## Usage data

PyPI counts come from `bigquery-public-data.pypi.file_downloads` for the 90 days ending 2026-08-28. GitHub counts are current archive-only download totals, excluding checksums, across 68 releases as of 2026-08-29.

| Target | PyPI wheel downloads, 90d | GitHub archive downloads |
| --- | ---: | ---: |
| `arm-unknown-linux-musleabihf` | 7,474,041* | 582 |
| `armv7-unknown-linux-gnueabihf` | 5,600 | 1,043 |
| `armv7-unknown-linux-musleabihf` | 5,586 | 572 |
| `i686-unknown-linux-gnu` | 6,043 | 715 |
| `i686-unknown-linux-musl` | 5,937 | 1,585 |
| `riscv64gc-unknown-linux-gnu` | 5,761 | 11,317 |
| `s390x-unknown-linux-gnu` | 5,519 | 11,308 |
| `i686-pc-windows-msvc` | 4,879 | 4,376 |

*The armv6 wheel is an automation outlier: 6,817,761 downloads were marked as CI and 7,394,198 were attributed to uv, while only 2 requests in the same window reported an `armv6l` CPU. For the other seven targets, 95–100% of downloads had unknown CI status and only 77–335 downloads per target were attributed to pip or uv.

The least-downloaded retained GitHub archive has 17,990 downloads. The eight removed build jobs also consumed 46.85 runner-minutes in the [v0.5.0 release run](https://github.com/j178/prek/actions/runs/33036763810).
