### PR TITLE
Build local hook repository fixtures from manifests

### DIFF
--- a/crates/prek/tests/common/mod.rs
+++ b/crates/prek/tests/common/mod.rs
@@ -10,8 +10,8 @@ use assert_fs::fixture::{ChildPath, FileWriteBin, PathChild, PathCreateDir};
 use etcetera::BaseStrategy;
 use rustc_hash::FxHashSet;
 
-use prek_consts::PRE_COMMIT_CONFIG_YAML;
 use prek_consts::env_vars::{EnvVars, EnvVarsRead};
+use prek_consts::{PRE_COMMIT_CONFIG_YAML, PRE_COMMIT_HOOKS_YAML};
 
 #[cfg(unix)]
 pub(crate) fn make_executable(path: impl AsRef<Path>) -> std::io::Result<()> {
@@ -169,6 +169,12 @@ impl TestRepo {
 
     pub(crate) fn git(&self) -> TestGit<'_> {
         TestGit::new(&self.path, &self.home_dir)
+    }
+
+    /// Commit the fixture at `v1.0.0` and return its config-ready path.
+    pub(crate) fn build(self) -> String {
+        self.git().add(".").commit("Initial commit").tag("v1.0.0");
+        self.path().to_string_lossy().replace('\\', "/")
     }
 }
 
@@ -478,7 +484,17 @@ impl TestEnv {
         &self.home_dir
     }
 
-    /// Create a Git repository that can be used as a local remote.
+    /// Create a local hook repository from its manifest definition.
+    pub(crate) fn create_hook_repo(
+        &self,
+        name: impl AsRef<Path>,
+        manifest: impl AsRef<str>,
+    ) -> TestRepo {
+        self.create_repo(name)
+            .with_file(PRE_COMMIT_HOOKS_YAML, manifest.as_ref())
+    }
+
+    /// Create an uncommitted Git repository for non-hook fixtures or custom history.
     pub(crate) fn create_repo(&self, name: impl AsRef<Path>) -> TestRepo {
         TestRepo::new(
             self.home_dir.child("test-repos").child(name),

--- a/crates/prek/tests/languages/conda.rs
+++ b/crates/prek/tests/languages/conda.rs
@@ -1,5 +1,3 @@
-use prek_consts::PRE_COMMIT_HOOKS_YAML;
-
 use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
@@ -70,9 +68,8 @@ fn local_hook_with_additional_dependencies() {
 fn remote_repo_install() {
     let context = TestEnv::new().init_git();
     let hook_repo = context
-        .create_repo("conda-hook")
-        .with_file(
-            PRE_COMMIT_HOOKS_YAML,
+        .create_hook_repo(
+            "conda-hook",
             indoc::indoc! {r"
             - id: conda-remote
               name: conda-remote
@@ -88,13 +85,8 @@ fn remote_repo_install() {
             dependencies:
               - openssl
         "},
-        );
-
-    hook_repo
-        .git()
-        .add(".")
-        .commit("Add conda hook")
-        .tag("v1.0.0");
+        )
+        .build();
 
     context.write_config(indoc::formatdoc! {r"
         repos:
@@ -105,7 +97,7 @@ fn remote_repo_install() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    ", hook_repo.path().display()});
+    ", hook_repo});
 
     context.git().add(".");
 

--- a/crates/prek/tests/languages/coursier.rs
+++ b/crates/prek/tests/languages/coursier.rs
@@ -1,5 +1,3 @@
-use prek_consts::PRE_COMMIT_HOOKS_YAML;
-
 use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
@@ -38,9 +36,8 @@ fn additional_dependencies() {
 fn pre_commit_channel() {
     let context = TestEnv::new().init_git();
     let hook_repo = context
-        .create_repo("coursier-hook")
-        .with_file(
-            PRE_COMMIT_HOOKS_YAML,
+        .create_hook_repo(
+            "coursier-hook",
             indoc::indoc! {r"
             - id: echo-java
               name: echo-java
@@ -56,13 +53,8 @@ fn pre_commit_channel() {
               "dependencies": ["io.get-coursier:echo:latest.stable"]
             }
         "#},
-        );
-
-    hook_repo
-        .git()
-        .add(".")
-        .commit("Add coursier hook")
-        .tag("v1.0.0");
+        )
+        .build();
 
     context.write_config(indoc::formatdoc! {r"
         repos:
@@ -73,7 +65,7 @@ fn pre_commit_channel() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    ", hook_repo.path().display()});
+    ", hook_repo});
 
     context.git().add(".");
 

--- a/crates/prek/tests/languages/dotnet.rs
+++ b/crates/prek/tests/languages/dotnet.rs
@@ -1,7 +1,5 @@
 #[cfg(feature = "ci")]
 use assert_fs::fixture::PathChild;
-#[cfg(feature = "ci")]
-use prek_consts::PRE_COMMIT_HOOKS_YAML;
 
 use crate::common::{TestEnv, cmd_snapshot};
 
@@ -248,28 +246,28 @@ fn additional_dependencies_with_version() {
 #[test]
 fn additional_dependencies_in_remote_repo() {
     let context = TestEnv::new().init_git();
-    let repo = context.create_repo("dotnet-hook").with_file(
-        PRE_COMMIT_HOOKS_YAML,
-        indoc::indoc! {r#"
+    let hook_repo = context
+        .create_hook_repo(
+            "dotnet-hook",
+            indoc::indoc! {r#"
             - id: dotnet-outdated
               name: dotnet-outdated
               language: dotnet
               entry: dotnet-outdated --version
               additional_dependencies: ["dotnet-outdated-tool:4.7.1"]
         "#},
-    );
-    let repo_path = repo.path();
-    repo.git().add(".").commit("Add manifest").tag("v0.1.0");
+        )
+        .build();
 
     context.write_config(indoc::formatdoc! {r"
         repos:
           - repo: {}
-            rev: v0.1.0
+            rev: v1.0.0
             hooks:
               - id: dotnet-outdated
                 verbose: true
                 pass_filenames: false
-    ", repo_path.display()});
+    ", hook_repo});
 
     context.git().add(".");
 

--- a/crates/prek/tests/languages/golang.rs
+++ b/crates/prek/tests/languages/golang.rs
@@ -2,7 +2,6 @@
 use assert_fs::assert::PathAssert;
 #[cfg(feature = "ci")]
 use assert_fs::fixture::PathChild;
-use prek_consts::{PRE_COMMIT_CONFIG_YAML, PRE_COMMIT_HOOKS_YAML};
 
 use crate::common::{TestEnv, cmd_snapshot};
 
@@ -232,8 +231,18 @@ fn remote_hook() {
 /// Fix <https://github.com/j178/prek/issues/901>
 #[test]
 fn local_additional_deps() {
-    // Create a local go hook with additional_dependencies.
-    let go_hook = TestEnv::new()
+    let context = TestEnv::new().init_git();
+    let hook_repo = context
+        .create_hook_repo(
+            "go-hook",
+            indoc::indoc! {r"
+                - id: go-hook
+                  name: go-hook
+                  entry: cmd
+                  language: golang
+                  additional_dependencies: [ ./cmd ]
+            "},
+        )
         .with_file(
             "go.mod",
             indoc::indoc! {r"
@@ -260,33 +269,17 @@ fn local_additional_deps() {
                 }
             "#},
         )
-        .with_file(
-            PRE_COMMIT_HOOKS_YAML,
-            indoc::indoc! {r"
-                - id: go-hook
-                  name: go-hook
-                  entry: cmd
-                  language: golang
-                  additional_dependencies: [ ./cmd ]
-            "},
-        )
-        .init_git();
-    go_hook.git().commit("Initial commit").tag("v1.0");
+        .build();
 
-    let hook_url = go_hook.work_dir().to_str().unwrap();
-    let context = TestEnv::new()
-        .with_file(
-            PRE_COMMIT_CONFIG_YAML,
-            indoc::formatdoc! {r"
+    context.write_config(indoc::formatdoc! {r"
         repos:
-          - repo: {hook_url}
-            rev: v1.0
+          - repo: {hook_repo}
+            rev: v1.0.0
             hooks:
               - id: go-hook
                 verbose: true
-       ", hook_url = hook_url},
-        )
-        .init_git();
+   "});
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -306,18 +299,10 @@ fn local_additional_deps() {
 /// the Go version for remote hooks.
 #[test]
 fn remote_go_mod_metadata_sets_language_version() {
-    // Create a remote repo containing a golang hook.
-    let go_hook = TestEnv::new()
-        .with_file(
-            "go.mod",
-            indoc::indoc! {r"
-                module example.com/go-hook
-
-                go 2.100 // unrealistic version to ensure the downloading fails
-            "},
-        )
-        .with_file(
-            PRE_COMMIT_HOOKS_YAML,
+    let context = TestEnv::new().init_git();
+    let hook_repo = context
+        .create_hook_repo(
+            "go-hook",
             indoc::indoc! {r"
                 - id: echo
                   name: echo
@@ -326,22 +311,23 @@ fn remote_go_mod_metadata_sets_language_version() {
                   verbose: true
             "},
         )
-        .init_git();
+        .with_file(
+            "go.mod",
+            indoc::indoc! {r"
+                module example.com/go-hook
 
-    go_hook.git().commit("Initial commit").tag("v1.0");
-
-    // Use it as a remote repo in a separate project.
-    let context = TestEnv::new().init_git();
-
-    let hook_url = go_hook.work_dir().to_str().unwrap();
+                go 2.100 // unrealistic version to ensure the downloading fails
+            "},
+        )
+        .build();
     context.write_config(indoc::formatdoc! {r"
       repos:
-        - repo: {hook_url}
-          rev: v1.0
+        - repo: {hook_repo}
+          rev: v1.0.0
           hooks:
             - id: echo
               verbose: true
-      ", hook_url = hook_url});
+      "});
     context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @"

--- a/crates/prek/tests/languages/mise.rs
+++ b/crates/prek/tests/languages/mise.rs
@@ -84,9 +84,8 @@ fn system_mise_installs_and_activates_dependencies() -> Result<()> {
         .init_git();
 
     let hook_repo = context
-        .create_repo("mise-system-hook")
-        .with_file(
-            ".pre-commit-hooks.yaml",
+        .create_hook_repo(
+            "mise-system-hook",
             indoc::indoc! {r#"
             - id: mise-system
               name: mise system
@@ -100,9 +99,8 @@ fn system_mise_installs_and_activates_dependencies() -> Result<()> {
         "#},
         )
         // Provisioning must not read configuration from the hook repository.
-        .with_file("mise.toml", "not valid = [");
-    hook_repo.git().add(".").commit("Add mise hook");
-    let rev = hook_repo.git().rev_parse("HEAD")?;
+        .with_file("mise.toml", "not valid = [")
+        .build();
 
     // Keep a conflicting executable beside the real system mise. Activating the private tool must
     // not move this whole directory ahead of the PATH returned by `mise env`.
@@ -123,10 +121,10 @@ fn system_mise_installs_and_activates_dependencies() -> Result<()> {
     context.write_config(indoc::formatdoc! {r"
         repos:
           - repo: '{}'
-            rev: {}
+            rev: v1.0.0
             hooks:
               - id: mise-system
-    ", hook_repo.path().display(), rev});
+    ", hook_repo});
     context.git().add(".");
 
     let ambient_data = context.work_dir().join("ambient-mise-data");

--- a/crates/prek/tests/languages/node.rs
+++ b/crates/prek/tests/languages/node.rs
@@ -1,7 +1,6 @@
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::assert::PathAssert;
 use assert_fs::fixture::{FileWriteStr, PathChild, PathCreateDir};
-use prek_consts::PRE_COMMIT_HOOKS_YAML;
 use prek_consts::env_vars::EnvVars;
 use url::Url;
 
@@ -251,9 +250,8 @@ fn additional_dependencies() {
 fn remote_package_is_installed_from_git() {
     let context = TestEnv::new().init_git();
     let hook_repo = context
-        .create_repo("remote-node-hook")
-        .with_file(
-            PRE_COMMIT_HOOKS_YAML,
+        .create_hook_repo(
+            "remote-node-hook",
             indoc::indoc! {r"
                 - id: remote-node-hook
                   name: remote-node-hook
@@ -286,13 +284,8 @@ fn remote_package_is_installed_from_git() {
         if (!isNumber(42)) process.exit(1);
         console.log("remote hook ok");
     "#},
-        );
-
-    hook_repo
-        .git()
-        .add(".")
-        .commit("Add remote Node hook")
-        .tag("v1.0.0");
+        )
+        .build();
 
     context.write_config(indoc::formatdoc! {r"
         repos:
@@ -301,7 +294,7 @@ fn remote_package_is_installed_from_git() {
             hooks:
               - id: remote-node-hook
                 verbose: true
-    ", hook_repo.path().display()});
+    ", hook_repo});
     context.git().add(".");
 
     cmd_snapshot!(context, context.run().env(EnvVars::PREK_HOME, ".prek-cache"), @r"
@@ -329,9 +322,8 @@ fn remote_package_is_installed_from_git() {
 fn remote_prepare_uses_dev_dependencies() {
     let context = TestEnv::new().init_git();
     let hook_repo = context
-        .create_repo("prepared-node-hook")
-        .with_file(
-            PRE_COMMIT_HOOKS_YAML,
+        .create_hook_repo(
+            "prepared-node-hook",
             indoc::indoc! {r"
                 - id: prepared-node-hook
                   name: prepared-node-hook
@@ -383,14 +375,9 @@ fn remote_prepare_uses_dev_dependencies() {
             indoc::indoc! {r#"
                 #!/usr/bin/env node
                 console.log("prepared hook ok");
-            "#},
-        );
-
-    hook_repo
-        .git()
-        .add(".")
-        .commit("Add source-built Node hook")
-        .tag("v1.0.0");
+        "#},
+        )
+        .build();
 
     context.write_config(indoc::formatdoc! {r"
         repos:
@@ -399,7 +386,7 @@ fn remote_prepare_uses_dev_dependencies() {
             hooks:
               - id: prepared-node-hook
                 verbose: true
-    ", hook_repo.path().display()});
+    ", hook_repo});
     context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
@@ -584,7 +571,17 @@ fn node_install_preserves_global_git_config_and_isolates_repository() -> anyhow:
         .commit("Add sentinel Node dependency");
 
     let hook_repo = context
-        .create_repo("sentinel-node-hook")
+        .create_hook_repo(
+            "sentinel-node-hook",
+            indoc::indoc! {r"
+        - id: sentinel-node
+          name: sentinel-node
+          entry: sentinel-node-tool
+          language: node
+          always_run: true
+          pass_filenames: false
+    "},
+        )
         .with_file(
             "package.json",
             indoc::indoc! {r#"
@@ -604,23 +601,7 @@ fn node_install_preserves_global_git_config_and_isolates_repository() -> anyhow:
         console.log("sentinel node ok");
     "#},
         )
-        .with_file(
-            PRE_COMMIT_HOOKS_YAML,
-            indoc::indoc! {r"
-        - id: sentinel-node
-          name: sentinel-node
-          entry: sentinel-node-tool
-          language: node
-          always_run: true
-          pass_filenames: false
-    "},
-        );
-
-    hook_repo
-        .git()
-        .add(".")
-        .commit("Add sentinel Node hook")
-        .tag("v1.0.0");
+        .build();
 
     context.write_config(indoc::formatdoc! {r"
         repos:
@@ -630,7 +611,7 @@ fn node_install_preserves_global_git_config_and_isolates_repository() -> anyhow:
               - id: sentinel-node
                 additional_dependencies:
                   - git+file:///prek-node-git-dependency
-    ", repo = hook_repo.path().display()});
+    ", repo = hook_repo});
     context.git().add(".");
 
     // The regression corrupts the calling repository's index, so capture it before npm runs.

--- a/crates/prek/tests/languages/perl.rs
+++ b/crates/prek/tests/languages/perl.rs
@@ -1,5 +1,4 @@
 use assert_cmd::assert::OutputAssertExt;
-use prek_consts::PRE_COMMIT_HOOKS_YAML;
 use prek_consts::env_vars::EnvVars;
 
 use crate::common::{TestEnv, cmd_snapshot};
@@ -48,9 +47,8 @@ fn local_hook() {
 fn remote_repo_install() {
     let context = TestEnv::new().init_git();
     let hook_repo = context
-        .create_repo("perl-hook")
-        .with_file(
-            PRE_COMMIT_HOOKS_YAML,
+        .create_hook_repo(
+            "perl-hook",
             indoc::indoc! {r"
             - id: hello
               name: hello
@@ -87,13 +85,8 @@ fn remote_repo_install() {
 
             1;
         "#},
-        );
-
-    hook_repo
-        .git()
-        .add(".")
-        .commit("Add perl hook")
-        .tag("v1.0.0");
+        )
+        .build();
 
     context.write_config(indoc::formatdoc! {r"
         repos:
@@ -104,7 +97,7 @@ fn remote_repo_install() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    ", hook_repo.path().display()});
+    ", hook_repo});
 
     context.git().add(".");
 

--- a/crates/prek/tests/languages/php.rs
+++ b/crates/prek/tests/languages/php.rs
@@ -1,5 +1,4 @@
 use assert_fs::fixture::{FileWriteStr, PathChild, PathCreateDir};
-use prek_consts::PRE_COMMIT_HOOKS_YAML;
 
 use crate::common::{TestEnv, cmd_snapshot};
 
@@ -53,7 +52,15 @@ fn local_hook() {
 fn remote_repo_install() -> anyhow::Result<()> {
     let context = TestEnv::new().init_git();
     let hook_repo = context
-        .create_repo("php-hook")
+        .create_hook_repo(
+            "php-hook",
+            indoc::indoc! {r"
+                - id: php-hook
+                  name: php-hook
+                  language: php
+                  entry: php-hook
+            "},
+        )
         .with_file(
             COMPOSER_JSON,
             indoc::indoc! {r#"
@@ -63,28 +70,14 @@ fn remote_repo_install() -> anyhow::Result<()> {
                 }
             "#},
         )
-        .with_file(
-            PRE_COMMIT_HOOKS_YAML,
-            indoc::indoc! {r"
-                - id: php-hook
-                  name: php-hook
-                  language: php
-                  entry: php-hook
-            "},
-        )
         .with_executable_file(
             "bin/php-hook",
             indoc::indoc! {r#"
         #!/usr/bin/env php
         <?php echo "Hello from remote PHP!\n";
     "#},
-        );
-
-    hook_repo
-        .git()
-        .add(".")
-        .commit("Add PHP hook")
-        .tag("v1.0.0");
+        )
+        .build();
 
     context.write_config(indoc::formatdoc! {r"
         repos:
@@ -95,7 +88,7 @@ fn remote_repo_install() -> anyhow::Result<()> {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    ", hook_repo.path().display()});
+    ", hook_repo});
     context.git().add(".");
 
     let composer_home = context.home_dir().child("composer");

--- a/crates/prek/tests/languages/python.rs
+++ b/crates/prek/tests/languages/python.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "ci")]
 use assert_fs::assert::PathAssert;
 use assert_fs::fixture::PathChild;
-use prek_consts::PRE_COMMIT_HOOKS_YAML;
 use prek_consts::env_vars::EnvVars;
 
 use crate::common::{TestEnv, cmd_snapshot};
@@ -254,10 +253,9 @@ fn additional_dependencies() {
 #[test]
 fn additional_dependencies_in_remote_repo() {
     let context = TestEnv::new().init_git();
-    let repo = context
-        .create_repo("python-hook")
-        .with_file(
-            PRE_COMMIT_HOOKS_YAML,
+    let hook_repo = context
+        .create_hook_repo(
+            "python-hook",
             indoc::indoc! {r#"
             - id: hello
               name: hello
@@ -287,19 +285,18 @@ fn additional_dependencies_in_remote_repo() {
                 }
             )
         "#},
-        );
-    let repo_path = repo.path();
-    repo.git().add(".").commit("Add manifest").tag("v0.1.0");
+        )
+        .build();
 
     context.write_config(indoc::formatdoc! {r"
         repos:
           - repo: {}
-            rev: v0.1.0
+            rev: v1.0.0
             hooks:
               - id: hello
                 name: hello
                 verbose: true
-    ", repo_path.display()});
+    ", hook_repo});
 
     context.git().add(".");
     cmd_snapshot!(context, context.run(), @r"

--- a/crates/prek/tests/languages/r.rs
+++ b/crates/prek/tests/languages/r.rs
@@ -1,5 +1,4 @@
 use assert_fs::fixture::{ChildPath, FileWriteStr, PathChild, PathCreateDir};
-use prek_consts::PRE_COMMIT_HOOKS_YAML;
 
 use crate::common::{TestEnv, cmd_snapshot};
 
@@ -99,9 +98,8 @@ fn local_hook_with_absolute_additional_dependency() -> anyhow::Result<()> {
 fn remote_repo_install() -> anyhow::Result<()> {
     let context = TestEnv::new().init_git();
     let hook_repo = context
-        .create_repo("r-hook")
-        .with_file(
-            PRE_COMMIT_HOOKS_YAML,
+        .create_hook_repo(
+            "r-hook",
             indoc::indoc! {r"
             - id: r-remote
               name: r-remote
@@ -113,7 +111,7 @@ fn remote_repo_install() -> anyhow::Result<()> {
     write_local_r_package(hook_repo.path(), "localdep")?;
     write_renv_project(hook_repo.path())?;
 
-    hook_repo.git().add(".").commit("Add R hook").tag("v1.0.0");
+    let hook_repo = hook_repo.build();
 
     context.write_config(indoc::formatdoc! {r"
         repos:
@@ -125,7 +123,7 @@ fn remote_repo_install() -> anyhow::Result<()> {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    ", hook_repo.path().display()});
+    ", hook_repo});
 
     context.git().add(".");
 

--- a/crates/prek/tests/languages/ruby.rs
+++ b/crates/prek/tests/languages/ruby.rs
@@ -2,7 +2,6 @@ use std::env::consts::EXE_EXTENSION;
 
 #[cfg(all(feature = "ci", not(target_os = "windows")))]
 use assert_fs::fixture::PathChild;
-use prek_consts::PRE_COMMIT_HOOKS_YAML;
 
 use crate::common::{TestEnv, cmd_snapshot};
 
@@ -547,10 +546,19 @@ fn environment_isolation() -> anyhow::Result<()> {
 
 /// Test local Ruby hook repository with gemspec build and install
 #[test]
-fn local_hook_with_gemspec() -> anyhow::Result<()> {
+fn local_hook_with_gemspec() {
     let context = TestEnv::new().init_git();
     let hook_repo = context
-        .create_repo("ruby-hook")
+        .create_hook_repo(
+            "ruby-hook",
+            indoc::indoc! {r"
+            - id: my-hook
+              name: My Hook
+              entry: my-hook
+              language: ruby
+              pass_filenames: false
+        "},
+        )
         .with_file(
             "my_hook.gemspec",
             indoc::indoc! {r#"
@@ -573,25 +581,13 @@ fn local_hook_with_gemspec() -> anyhow::Result<()> {
         puts "Hook executed from gem!"
     "#},
         )
-        .with_file(
-            PRE_COMMIT_HOOKS_YAML,
-            indoc::indoc! {r"
-            - id: my-hook
-              name: My Hook
-              entry: my-hook
-              language: ruby
-              pass_filenames: false
-        "},
-        );
-
-    hook_repo.git().add(".").commit("Initial commit");
-    let rev = hook_repo.git().rev_parse("HEAD")?;
+        .build();
 
     // Configure prek to use this local repo
     context.write_config(indoc::formatdoc! {r"
             repos:
               - repo: {}
-                rev: {}
+                rev: v1.0.0
                 hooks:
                   - id: my-hook
                     name: my-hook
@@ -600,8 +596,7 @@ fn local_hook_with_gemspec() -> anyhow::Result<()> {
                     pass_filenames: false
                     always_run: true
         ",
-        hook_repo.path().display(),
-        rev
+        hook_repo
     });
     context.git().add(".pre-commit-config.yaml");
 
@@ -617,8 +612,6 @@ fn local_hook_with_gemspec() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
-
-    Ok(())
 }
 
 /// Test Ruby hook with native gem (C extension)

--- a/crates/prek/tests/languages/swift.rs
+++ b/crates/prek/tests/languages/swift.rs
@@ -1,5 +1,3 @@
-use prek_consts::PRE_COMMIT_HOOKS_YAML;
-
 use crate::common::{TestEnv, cmd_snapshot};
 
 /// Test that a local Swift hook with a system command works.
@@ -114,8 +112,17 @@ fn health_check() {
 /// Test that a Swift Package.swift is built and the executable is available.
 #[test]
 fn local_package_build() {
-    // Create a minimal Swift package
-    let swift_hook = TestEnv::new()
+    let context = TestEnv::new().init_git();
+    let hook_repo = context
+        .create_hook_repo(
+            "swift-hook",
+            indoc::indoc! {r"
+                - id: swift-package-test
+                  name: swift-package-test
+                  entry: prek-swift-test
+                  language: swift
+            "},
+        )
         .with_file(
             "Package.swift",
             indoc::indoc! {r#"
@@ -136,31 +143,17 @@ fn local_package_build() {
                 print("Hello from Swift package!")
             "#},
         )
-        .with_file(
-            PRE_COMMIT_HOOKS_YAML,
-            indoc::indoc! {r"
-                - id: swift-package-test
-                  name: swift-package-test
-                  entry: prek-swift-test
-                  language: swift
-            "},
-        )
-        .init_git();
-    swift_hook.git().commit("Initial commit").tag("v1.0");
-
-    let context = TestEnv::new().init_git();
-
-    let hook_url = swift_hook.work_dir().to_str().unwrap();
+        .build();
     context.write_config(indoc::formatdoc! {r"
         repos:
-          - repo: {hook_url}
-            rev: v1.0
+          - repo: {hook_repo}
+            rev: v1.0.0
             hooks:
               - id: swift-package-test
                 verbose: true
                 always_run: true
                 pass_filenames: false
-    ", hook_url = hook_url});
+    "});
     context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -7,9 +7,7 @@ use assert_fs::prelude::*;
 use insta::assert_snapshot;
 use predicates::prelude::predicate;
 use prek_consts::env_vars::EnvVars;
-use prek_consts::{
-    PRE_COMMIT_CONFIG_YAML, PRE_COMMIT_CONFIG_YML, PRE_COMMIT_HOOKS_YAML, PREK_TOML,
-};
+use prek_consts::{PRE_COMMIT_CONFIG_YAML, PRE_COMMIT_CONFIG_YML, PREK_TOML};
 
 use crate::common::{TestEnv, cmd_snapshot};
 
@@ -582,9 +580,8 @@ fn hook_repo_placeholder_expands_to_local_project() {
 fn hook_repo_placeholder_expands_to_remote_checkout() {
     let context = TestEnv::new().init_git();
     let hook_repo = context
-        .create_repo("hook-repo-placeholder")
-        .with_file(
-            PRE_COMMIT_HOOKS_YAML,
+        .create_hook_repo(
+            "hook-repo-placeholder",
             indoc::indoc! {r#"
             - id: hook-repo-remote
               name: remote
@@ -594,12 +591,8 @@ fn hook_repo_placeholder_expands_to_remote_checkout() {
               pass_filenames: false
         "#},
         )
-        .with_file("hook-repo-marker", "");
-    hook_repo
-        .git()
-        .add(".")
-        .commit("Add remote hook")
-        .tag("v1.0.0");
+        .with_file("hook-repo-marker", "")
+        .build();
 
     context.write_config(indoc::formatdoc! {r"
         repos:
@@ -607,7 +600,7 @@ fn hook_repo_placeholder_expands_to_remote_checkout() {
             rev: v1.0.0
             hooks:
               - id: hook-repo-remote
-    ", hook_repo.path().display()});
+    ", hook_repo});
     context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r#"
@@ -2683,22 +2676,18 @@ fn skipped_remote_repo_is_not_cloned() {
 #[test]
 fn skipped_same_key_remote_repo_entry_is_not_initialized() {
     let context = TestEnv::new().init_git();
-    let hook_repo = context.create_repo("duplicate-key-hook").with_file(
-        PRE_COMMIT_HOOKS_YAML,
-        indoc::indoc! {r"
+    let hook_repo = context
+        .create_hook_repo(
+            "duplicate-key-hook",
+            indoc::indoc! {r"
         - id: test-hook
           name: Test Hook
           entry: echo ok
           language: system
           always_run: true
     "},
-    );
-
-    hook_repo
-        .git()
-        .add(".")
-        .commit("Initial commit")
-        .tag("v1.0.0");
+        )
+        .build();
 
     context.write_config(indoc::formatdoc! {r"
         repos:
@@ -2711,7 +2700,7 @@ fn skipped_same_key_remote_repo_entry_is_not_initialized() {
             rev: v1.0.0
             hooks:
               - id: test-hook
-    ", repo = hook_repo.path().display()});
+    ", repo = hook_repo});
     context.git().add(".");
 
     context

--- a/crates/prek/tests/try_repo.rs
+++ b/crates/prek/tests/try_repo.rs
@@ -1,22 +1,20 @@
 mod common;
 
 use anyhow::Result;
+use assert_fs::fixture::ChildPath;
 use assert_fs::prelude::*;
-use std::path::PathBuf;
+use prek_consts::PRE_COMMIT_HOOKS_YAML;
 
 use crate::common::{TestEnv, cmd_snapshot};
-use assert_fs::fixture::ChildPath;
-use prek_consts::PRE_COMMIT_HOOKS_YAML;
 
 fn with_try_repo_filters(context: TestEnv) -> TestEnv {
     context.with_filters([(r"[a-f0-9]{40}", "[COMMIT_SHA]"), ("'", "\"")])
 }
 
-fn create_hook_repo(context: &TestEnv, repo_name: &str) -> PathBuf {
-    let repo = context
-        .create_repo(repo_name)
-        .with_file(
-            PRE_COMMIT_HOOKS_YAML,
+fn create_hook_repo(context: &TestEnv, repo_name: &str) -> String {
+    context
+        .create_hook_repo(
+            repo_name,
             indoc::indoc! {r#"
         - id: test-hook
           name: Test Hook
@@ -33,28 +31,23 @@ fn create_hook_repo(context: &TestEnv, repo_name: &str) -> PathBuf {
         .with_file(
             "setup.py",
             "from setuptools import setup; setup(name='dummy-pkg', version='0.0.1')",
-        );
-
-    repo.git().add(".").commit("Initial commit");
-
-    repo.path().to_path_buf()
+        )
+        .build()
 }
 
 // Helper for a repo with a hook that is designed to fail
-fn create_failing_hook_repo(context: &TestEnv, repo_name: &str) -> PathBuf {
-    let repo = context.create_repo(repo_name).with_file(
-        PRE_COMMIT_HOOKS_YAML,
-        indoc::indoc! {r#"
+fn create_failing_hook_repo(context: &TestEnv, repo_name: &str) -> String {
+    context
+        .create_hook_repo(
+            repo_name,
+            indoc::indoc! {r#"
         - id: failing-hook
           name: Always Fail
           entry: "false"
           language: system
         "#},
-    );
-
-    repo.git().add(".").commit("Initial commit");
-
-    repo.path().to_path_buf()
+        )
+        .build()
 }
 
 #[test]


### PR DESCRIPTION
Centralize local hook repository fixture setup around manifest definitions and return config-ready paths after creating a standard tagged commit.

Keep custom Git history available through the lower-level repository fixture API.
