### PR TITLE
Initialize Git test fixtures after file setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,9 @@ In integration tests, you can use `cmd_snapshot!` macro to simplify creating sna
 ```rust
 #[test]
 fn test_run() {
-    let env = TestEnv::new_git();
+    let env = TestEnv::new()
+        .with_config("repos: []")
+        .init_git();
 
     cmd_snapshot!(env, env.run(), @"");
 }

--- a/crates/prek/tests/builtin_hooks.rs
+++ b/crates/prek/tests/builtin_hooks.rs
@@ -16,13 +16,14 @@ mod common;
 /// Tests that `repo: builtin` hooks doesn't create hook env.
 #[test]
 fn builtin_hooks_not_create_env() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: end-of-file-fixer
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -46,13 +47,14 @@ fn builtin_hooks_not_create_env() {
 
 #[test]
 fn builtin_hooks_unknown_hook() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: this-hook-does-not-exist
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @"
     success: false
@@ -73,7 +75,7 @@ fn builtin_hooks_unknown_hook() {
 
 #[test]
 fn deny_filename_pattern_hook_matches_only_basename() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -86,9 +88,8 @@ fn deny_filename_pattern_hook_matches_only_basename() {
             ("docs/README.md", ""),
             ("README/guide.md", ""),
             ("docs/guide.md", ""),
-        ]);
-
-    context.git().add_all();
+        ])
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -107,7 +108,7 @@ fn deny_filename_pattern_hook_matches_only_basename() {
 
 #[test]
 fn deny_pattern_hook_reports_matching_lines() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -128,9 +129,8 @@ fn deny_pattern_hook_reports_matching_lines() {
         #import package: *
     "},
         )
-        .with_file("ignored.txt", "TODO: ignored by files filter\n");
-
-    context.git().add_all();
+        .with_file("ignored.txt", "TODO: ignored by files filter\n")
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -150,7 +150,7 @@ fn deny_pattern_hook_reports_matching_lines() {
 
 #[test]
 fn deny_pattern_hook_rejects_invalid_regex() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -158,9 +158,8 @@ fn deny_pattern_hook_rejects_invalid_regex() {
               - id: deny-pattern
                 args: ['*invalid-pattern*']
     "})
-        .with_file("file.txt", "content\n");
-
-    context.git().add_all();
+        .with_file("file.txt", "content\n")
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -180,7 +179,7 @@ fn deny_pattern_hook_rejects_invalid_regex() {
 
 #[test]
 fn deny_pattern_hook_reports_earliest_multiline_match() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     // `END` is listed first, but `BEGIN.*END` starts earlier in the file.
     // Multiline matching should report the earliest match, not the first pattern.
@@ -204,7 +203,7 @@ fn deny_pattern_hook_reports_earliest_multiline_match() {
     "},
         );
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -225,7 +224,7 @@ fn deny_pattern_hook_reports_earliest_multiline_match() {
 
 #[test]
 fn require_filename_pattern_hook_accepts_any_pattern_for_basename() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -243,9 +242,8 @@ fn require_filename_pattern_hook_accepts_any_pattern_for_basename() {
             ("tests/unit/__init__.py", ""),
             ("tests/unit/conftest.py", ""),
             ("tests/test_unit/parser.py", ""),
-        ]);
-
-    context.git().add_all();
+        ])
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -265,7 +263,7 @@ fn require_filename_pattern_hook_accepts_any_pattern_for_basename() {
 
 #[test]
 fn require_pattern_hook_reports_files_without_any_match() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -276,9 +274,8 @@ fn require_pattern_hook_reports_files_without_any_match() {
     "})
         .with_file("block.txt", "BEGIN\nmiddle\nEND\n")
         .with_file("copyright.txt", "Copyright 2026\n")
-        .with_file("missing.txt", "No required marker\n");
-
-    context.git().add_all();
+        .with_file("missing.txt", "No required marker\n")
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -297,7 +294,7 @@ fn require_pattern_hook_reports_files_without_any_match() {
 
 #[test]
 fn end_of_file_fixer_hook() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -313,9 +310,8 @@ fn end_of_file_fixer_hook() {
             ("empty.txt", ""),
             ("only_newlines.txt", "\n\n"),
             ("only_win_newlines.txt", "\r\n\r\n"),
-        ]);
-
-    context.git().add_all();
+        ])
+        .init_git();
 
     // First run: hooks should fail and fix the files
     cmd_snapshot!(context, context.run(), @r#"
@@ -347,7 +343,7 @@ fn end_of_file_fixer_hook() {
     assert_snapshot!(context.read("only_newlines.txt"), @"");
     assert_snapshot!(context.read("only_win_newlines.txt"), @"");
 
-    context.git().add_all();
+    context.git().add(".");
 
     // Second run: hooks should now pass. The output will be stable.
     cmd_snapshot!(context, context.run(), @r"
@@ -362,7 +358,7 @@ fn end_of_file_fixer_hook() {
 
 #[test]
 fn file_contents_sorter_hook() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -372,9 +368,8 @@ fn file_contents_sorter_hook() {
                 args: [--ignore-case]
     "})
         .with_file("allowlist.txt", "Banana\n\napple\nApricot\n")
-        .with_file("ignored.txt", "zebra\nant\n");
-
-    context.git().add_all();
+        .with_file("ignored.txt", "zebra\nant\n")
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -401,7 +396,7 @@ fn file_contents_sorter_hook() {
     ant
     ");
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -415,7 +410,7 @@ fn file_contents_sorter_hook() {
 
 #[test]
 fn builtin_hook_checks_filename_from_args_after_options() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -425,9 +420,8 @@ fn builtin_hook_checks_filename_from_args_after_options() {
                 files: ^selected\.txt$
     "})
         .with_file("configured.txt", "beta\nAlpha\n")
-        .with_file("selected.txt", "Beta\nalpha\n");
-
-    context.git().add_all();
+        .with_file("selected.txt", "Beta\nalpha\n")
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -451,7 +445,7 @@ fn builtin_hook_checks_filename_from_args_after_options() {
 
 #[test]
 fn requirements_txt_fixer_hook() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -468,9 +462,8 @@ fn requirements_txt_fixer_hook() {
         pkg-resources==0.0.0
     "},
         )
-        .with_file("requirements.in", "z-project\na-project\n");
-
-    context.git().add_all();
+        .with_file("requirements.in", "z-project\na-project\n")
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -497,7 +490,7 @@ fn requirements_txt_fixer_hook() {
     );
     assert_eq!(context.read("requirements.in"), "z-project\na-project\n");
 
-    context.git().add_all();
+    context.git().add(".");
     cmd_snapshot!(context, context.run(), @r"
     success: true
     exit_code: 0
@@ -517,7 +510,7 @@ fn requirements_txt_fixer_hook() {
 
     context.write_file("requirements.txt", "flask\n  requests==2\n");
     context.write_file("valid.json", "{}\n");
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -539,17 +532,20 @@ fn requirements_txt_fixer_hook() {
 
 #[test]
 fn forbid_new_submodules_hook_in_workspace_project() {
-    let context = TestEnv::new_git().with_config("repos: []\n").with_file(
-        "project2/.pre-commit-config.yaml",
-        indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config("repos: []\n")
+        .with_file(
+            "project2/.pre-commit-config.yaml",
+            indoc::indoc! {r"
             repos:
               - repo: builtin
                 hooks:
                   - id: forbid-new-submodules
         "},
-    );
+        )
+        .init_git();
 
-    context.git().add_all().commit("Initial commit");
+    context.git().commit("Initial commit");
 
     let context = context.with_file("project2/sub module/README.md", "submodule\n");
     let submodule_path = context.child("project2/sub module");
@@ -589,7 +585,7 @@ fn forbid_new_submodules_hook_in_workspace_project() {
 
 #[test]
 fn check_yaml_hook() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -599,9 +595,8 @@ fn check_yaml_hook() {
         .with_file("valid.yaml", "a: 1")
         .with_file("invalid.yaml", "a: b: c")
         .with_file("duplicate.yaml", "a: 1\na: 2")
-        .with_file("empty.yaml", "");
-
-    context.git().add_all();
+        .with_file("empty.yaml", "")
+        .init_git();
 
     // First run: hooks should fail
     cmd_snapshot!(context, context.run(), @"
@@ -632,7 +627,7 @@ fn check_yaml_hook() {
     context.write_file("invalid.yaml", "a:\n  b: c");
     context.write_file("duplicate.yaml", "a: 1\nb: 2");
 
-    context.git().add_all();
+    context.git().add(".");
 
     // Second run: hooks should now pass
     cmd_snapshot!(context, context.run(), @r"
@@ -647,7 +642,7 @@ fn check_yaml_hook() {
 
 #[test]
 fn check_yaml_multiple_document() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -667,9 +662,8 @@ fn check_yaml_multiple_document() {
         b: 2
         "
             },
-        );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @"
     success: false
@@ -695,7 +689,7 @@ fn check_yaml_multiple_document() {
 
 #[test]
 fn check_vcs_permalinks_builtin() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -706,9 +700,7 @@ fn check_vcs_permalinks_builtin() {
         .with_file("links.md", indoc::indoc! {r"
         See https://github.com/owner/repo/blob/main/file.py#L10 and https://github.example.com/owner/repo/blob/master/src/lib.rs#L5 for context.
         https://github.com/owner/repo/blob/abcdef1234567890abcdef1234567890abcdef12/file.py#L10
-    "});
-
-    context.git().add_all();
+    "}).init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -728,7 +720,7 @@ fn check_vcs_permalinks_builtin() {
 
 #[test]
 fn check_json_hook() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -738,9 +730,8 @@ fn check_json_hook() {
         .with_file("valid.json", r#"{"a": 1}"#)
         .with_file("invalid.json", r#"{"a": 1,}"#)
         .with_file("duplicate.json", r#"{"a": 1, "a": 2}"#)
-        .with_file("empty.json", "");
-
-    context.git().add_all();
+        .with_file("empty.json", "")
+        .init_git();
 
     // First run: hooks should fail
     cmd_snapshot!(context, context.run(), @r"
@@ -762,7 +753,7 @@ fn check_json_hook() {
     context.write_file("invalid.json", r#"{"a": 1}"#);
     context.write_file("duplicate.json", r#"{"a": 1, "b": 2}"#);
 
-    context.git().add_all();
+    context.git().add(".");
 
     // Second run: hooks should now pass
     cmd_snapshot!(context, context.run(), @r"
@@ -777,7 +768,7 @@ fn check_json_hook() {
 
 #[test]
 fn mixed_line_ending_hook() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -788,9 +779,8 @@ fn mixed_line_ending_hook() {
         .with_file("only_lf.txt", "line1\nline2\n")
         .with_file("only_crlf.txt", "line1\r\nline2\r\n")
         .with_file("no_endings.txt", "hello world")
-        .with_file("empty.txt", "");
-
-    context.git().add_all();
+        .with_file("empty.txt", "")
+        .init_git();
 
     // First run: hooks should fail and fix the files
     cmd_snapshot!(context, context.run(), @r"
@@ -823,7 +813,7 @@ fn mixed_line_ending_hook() {
     line2
     ");
 
-    context.git().add_all();
+    context.git().add(".");
 
     // Second run: hooks should now pass.
     cmd_snapshot!(context, context.run(), @r"
@@ -844,7 +834,7 @@ fn mixed_line_ending_hook() {
                 args: ['--fix=no']
     "});
     context.write_file("mixed.txt", "line1\nline2\r\n");
-    context.git().add_all();
+    context.git().add(".");
     cmd_snapshot!(context, context.run(), @r"
     success: false
     exit_code: 1
@@ -872,7 +862,7 @@ fn mixed_line_ending_hook() {
                 args: ['--fix', 'crlf']
     "});
     context.write_file("mixed.txt", "line1\nline2\r\n");
-    context.git().add_all();
+    context.git().add(".");
     cmd_snapshot!(context, context.run(), @r#"
     success: false
     exit_code: 1
@@ -903,7 +893,7 @@ fn mixed_line_ending_hook() {
                 args: ['--fix']
     "});
     context.write_file("mixed.txt", "line1\nline2\r\nline3\n");
-    context.git().add_all();
+    context.git().add(".");
     cmd_snapshot!(context, context.run(), @r"
     success: false
     exit_code: 2
@@ -919,8 +909,10 @@ fn mixed_line_ending_hook() {
 #[test]
 fn check_added_large_files_hook() {
     // Create an initial commit
-    let context = TestEnv::new_git().with_file("README.md", "Initial commit");
-    context.git().add_all().commit("Initial commit");
+    let context = TestEnv::new()
+        .with_file("README.md", "Initial commit")
+        .init_git();
+    context.git().commit("Initial commit");
 
     let context = context
         .with_config(indoc::indoc! {r"
@@ -933,7 +925,7 @@ fn check_added_large_files_hook() {
         .with_file("small_file.txt", "Hello World\n")
         .with_file("large_file.txt", [0_u8; 2048]);
 
-    context.git().add_all();
+    context.git().add(".");
 
     // First run: hook should fail because of the large file
     cmd_snapshot!(context, context.run(), @r"
@@ -951,7 +943,7 @@ fn check_added_large_files_hook() {
     ");
 
     // Commit the files
-    context.git().add_all().commit("Add large file");
+    context.git().add(".").commit("Add large file");
 
     // Create a new unstaged large file
     context.write_file("unstaged_large_file.txt", [0_u8; 2048]);
@@ -981,7 +973,10 @@ fn check_added_large_files_hook() {
     ----- stderr -----
     "#);
 
-    context.git().rm("unstaged_large_file.txt").clean();
+    context
+        .git()
+        .rm("unstaged_large_file.txt")
+        .run(["clean", "-fdx"]);
 
     // Test git-lfs integration
     context.write_config(indoc::indoc! {r"
@@ -998,7 +993,7 @@ fn check_added_large_files_hook() {
     );
     context.git().add(".gitattributes");
     context.write_file("lfs_file.dat", [0_u8; 2048]);
-    context.git().add_all();
+    context.git().add(".");
 
     // Third run: hook should pass because the large file is tracked by git-lfs
     cmd_snapshot!(context, context.run(), @r"
@@ -1018,7 +1013,7 @@ fn check_added_large_files_workspace_mode_respects_project_relative_lfs_paths() 
     // nested project root, not the workspace root.
     // Use `--enforce-all` so this regression isolates git-lfs attribute lookup in workspace
     // mode instead of depending on the separate staged-file path filtering behavior.
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config("repos: []\n")
         .with_project_config(
             "app",
@@ -1034,9 +1029,8 @@ fn check_added_large_files_workspace_mode_respects_project_relative_lfs_paths() 
             "app/.gitattributes",
             "*.dat filter=lfs diff=lfs merge=lfs -text",
         )
-        .with_file("app/large.dat", [0; 2048]);
-
-    context.git().add_all();
+        .with_file("app/large.dat", [0; 2048])
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -1051,7 +1045,7 @@ fn check_added_large_files_workspace_mode_respects_project_relative_lfs_paths() 
 
 #[test]
 fn check_added_large_files_workspace_mode_respects_project_relative_added_files() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config("repos: []\n")
         .with_file(
             "app/.pre-commit-config.yaml",
@@ -1063,9 +1057,8 @@ fn check_added_large_files_workspace_mode_respects_project_relative_added_files(
                 args: ['--maxkb', '1']
     "},
         )
-        .with_file("app/large.bin", [0; 2048]);
-
-    context.git().add_all();
+        .with_file("app/large.bin", [0; 2048])
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -1085,7 +1078,7 @@ fn check_added_large_files_workspace_mode_respects_project_relative_added_files(
 
 #[test]
 fn tracked_file_exceeds_large_file_limit() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -1093,11 +1086,12 @@ fn tracked_file_exceeds_large_file_limit() {
               - id: check-added-large-files
                 args: ['--maxkb', '1']
     "})
-        .with_file("large_file.txt", [0; 2048]); // 2KB file
-    context.git().add_all().commit("Add large file");
+        .with_file("large_file.txt", [0; 2048])
+        .init_git(); // 2KB file
+    context.git().add(".").commit("Add large file");
     // Modify the large file
     context.write_file("large_file.txt", [0; 4096]); // 4KB file
-    context.git().add_all();
+    context.git().add(".");
 
     // Run the hook: it should pass because the file is already tracked
     cmd_snapshot!(context, context.run(), @r"
@@ -1112,7 +1106,7 @@ fn tracked_file_exceeds_large_file_limit() {
 
 #[test]
 fn builtin_hooks_workspace_mode() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: meta
@@ -1150,9 +1144,8 @@ fn builtin_hooks_workspace_mode() {
             ("app/duplicate.json", r#"{"a": 1, "a": 2}"#),
             ("app/empty.json", ""),
         ])
-        .with_file("app/large.bin", [0u8; 2048]);
-
-    context.git().add_all();
+        .with_file("app/large.bin", [0u8; 2048])
+        .init_git();
 
     // First run: expect failures and auto-fixes where applicable.
     cmd_snapshot!(context, context.run(), @r#"
@@ -1261,7 +1254,7 @@ fn builtin_hooks_workspace_mode() {
     context.write_file("app/invalid.json", concat!(r#"{"a": 1}"#, "\n"));
     context.write_file("app/duplicate.json", concat!(r#"{"a": 1, "b": 2}"#, "\n"));
     context.write_file("app/large.bin", [0u8; 100]);
-    context.git().add_all();
+    context.git().add(".");
 
     // Second run: all hooks should now pass.
     cmd_snapshot!(context, context.run(), @r#"
@@ -1318,7 +1311,7 @@ fn builtin_hooks_workspace_mode() {
 
 #[test]
 fn fix_byte_order_marker_hook() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -1334,9 +1327,8 @@ fn fix_byte_order_marker_hook() {
             ],
         )
         .with_file("bom_only.txt", [0xef, 0xbb, 0xbf])
-        .with_file("empty.txt", "");
-
-    context.git().add_all();
+        .with_file("empty.txt", "")
+        .init_git();
 
     // First run: hooks should fix files with BOM
     cmd_snapshot!(context, context.run(), @r"
@@ -1361,7 +1353,7 @@ fn fix_byte_order_marker_hook() {
     assert_eq!(context.read("without_bom.txt"), "Hello, World!");
     assert_eq!(context.read("empty.txt"), "");
 
-    context.git().add_all();
+    context.git().add(".");
 
     // Second run: all should pass now
     cmd_snapshot!(context, context.run(), @r"
@@ -1376,7 +1368,7 @@ fn fix_byte_order_marker_hook() {
 
 #[test]
 fn pretty_format_json_hook() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -1418,9 +1410,8 @@ fn pretty_format_json_hook() {
 "#,
         )
         .with_file("invalid.json", r#"{"a": 1,}"#)
-        .with_file("empty.json", "");
-
-    context.git().add_all();
+        .with_file("empty.json", "")
+        .init_git();
 
     // First run: hooks should fail and fix the files
     cmd_snapshot!(context, context.run(), @r#"
@@ -1498,7 +1489,7 @@ fn pretty_format_json_hook() {
 "#,
     );
 
-    context.git().add_all();
+    context.git().add(".");
 
     // Second run: hooks should now pass
     cmd_snapshot!(context, context.run(), @r#"
@@ -1513,7 +1504,7 @@ fn pretty_format_json_hook() {
 
 #[test]
 fn pretty_format_json_with_options() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -1521,9 +1512,8 @@ fn pretty_format_json_with_options() {
               - id: pretty-format-json
                 args: ['--autofix', '--indent=4', '--no-sort-keys']
     "})
-        .with_file("test.json", r#"{"z":1,"a":2,"m":3}"#);
-
-    context.git().add_all();
+        .with_file("test.json", r#"{"z":1,"a":2,"m":3}"#)
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -1549,7 +1539,7 @@ fn pretty_format_json_with_options() {
     }
     "#);
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -1563,7 +1553,7 @@ fn pretty_format_json_with_options() {
 
 #[test]
 fn pretty_format_json_with_top_keys() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -1574,9 +1564,8 @@ fn pretty_format_json_with_top_keys() {
         .with_file(
             "package.json",
             r#"{"description":"test","name":"my-package","author":"me","version":"1.0.0"}"#,
-        );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -1602,7 +1591,7 @@ fn pretty_format_json_with_top_keys() {
     }
     "#);
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -1616,7 +1605,7 @@ fn pretty_format_json_with_top_keys() {
 
 #[test]
 fn pretty_format_json_no_ensure_ascii() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -1627,9 +1616,8 @@ fn pretty_format_json_no_ensure_ascii() {
         .with_file(
             "unicode.json",
             r#"{"text":"\u4E2D\u6587\u306B\u307B\u3093\u3054"}"#,
-        );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -1653,7 +1641,7 @@ fn pretty_format_json_no_ensure_ascii() {
     }
     "#);
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -1667,7 +1655,7 @@ fn pretty_format_json_no_ensure_ascii() {
 
 #[test]
 fn pretty_format_json_custom_space_indent() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -1675,9 +1663,8 @@ fn pretty_format_json_custom_space_indent() {
               - id: pretty-format-json
                 args: ['--autofix', '--indent=  ']
     "})
-        .with_file("test.json", r#"{"a":1,"b":2}"#);
-
-    context.git().add_all();
+        .with_file("test.json", r#"{"a":1,"b":2}"#)
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -1701,7 +1688,7 @@ fn pretty_format_json_custom_space_indent() {
     }
     "#);
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -1716,7 +1703,7 @@ fn pretty_format_json_custom_space_indent() {
 #[test]
 #[cfg(unix)]
 fn check_symlinks_hook_unix() -> Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -1724,7 +1711,8 @@ fn check_symlinks_hook_unix() -> Result<()> {
               - id: check-symlinks
     "})
         .with_file("regular.txt", "regular file")
-        .with_file("target.txt", "target content");
+        .with_file("target.txt", "target content")
+        .init_git();
 
     // Create valid symlink
     fs_err::os::unix::fs::symlink(
@@ -1738,7 +1726,7 @@ fn check_symlinks_hook_unix() -> Result<()> {
         context.child("broken_link.txt").path(),
     )?;
 
-    context.git().add_all();
+    context.git().add(".");
 
     // First run: should fail due to broken symlink
     cmd_snapshot!(context, context.run(), @r"
@@ -1757,7 +1745,7 @@ fn check_symlinks_hook_unix() -> Result<()> {
 
     // Remove broken symlink
     fs_err::remove_file(context.child("broken_link.txt").path())?;
-    context.git().add_all();
+    context.git().add(".");
 
     // Second run: should pass
     cmd_snapshot!(context, context.run(), @r"
@@ -1775,7 +1763,7 @@ fn check_symlinks_hook_unix() -> Result<()> {
 #[test]
 #[cfg(windows)]
 fn check_symlinks_hook_windows() -> Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -1783,7 +1771,8 @@ fn check_symlinks_hook_windows() -> Result<()> {
               - id: check-symlinks
     "})
         .with_file("regular.txt", "regular file")
-        .with_file("target.txt", "target content");
+        .with_file("target.txt", "target content")
+        .init_git();
 
     // Try to create valid symlink (may fail without admin/developer mode)
     let valid_link_result = fs_err::os::windows::fs::symlink_file(
@@ -1803,7 +1792,7 @@ fn check_symlinks_hook_windows() -> Result<()> {
         return Ok(());
     }
 
-    context.git().add_all();
+    context.git().add(".");
 
     // First run: should fail due to broken symlink
     cmd_snapshot!(context, context.run(), @r#"
@@ -1822,7 +1811,7 @@ fn check_symlinks_hook_windows() -> Result<()> {
 
     // Remove broken symlink
     fs_err::remove_file(context.child("broken_link.txt").path())?;
-    context.git().add_all();
+    context.git().add(".");
 
     // Second run: should pass
     cmd_snapshot!(context, context.run(), @r#"
@@ -1845,10 +1834,12 @@ fn destroyed_symlinks_hook() -> Result<()> {
     const TEST_FILE: &str = "test_file";
     const TEST_FILE_RENAMED: &str = "test_file_renamed";
 
-    let source = TestEnv::new_git().with_file(TEST_FILE, "some random content\n");
+    let source = TestEnv::new()
+        .with_file(TEST_FILE, "some random content\n")
+        .init_git();
 
     fs_err::os::unix::fs::symlink(TEST_SYMLINK_TARGET, source.child(TEST_SYMLINK).path())?;
-    source.git().add_all().commit("initial");
+    source.git().add(".").commit("initial");
 
     let tree = source
         .git()
@@ -1964,7 +1955,7 @@ fn destroyed_symlinks_hook() -> Result<()> {
 
 #[test]
 fn detect_private_key_hook() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -2011,9 +2002,8 @@ fn detect_private_key_hook() {
             "safe2.txt",
             "This is just a regular file\nwith some content\n",
         )
-        .with_file("empty.txt", "");
-
-    context.git().add_all();
+        .with_file("empty.txt", "")
+        .init_git();
 
     // First run: hooks should fail due to private keys
     cmd_snapshot!(context, context.run(), @r#"
@@ -2048,8 +2038,8 @@ fn detect_private_key_hook() {
         .rm("private.asc")
         .rm("ta.key")
         .rm("doc.txt")
-        .clean()
-        .add_all();
+        .run(["clean", "-fdx"])
+        .add(".");
 
     // Second run: hooks should now pass
     cmd_snapshot!(context, context.run(), @r"
@@ -2064,7 +2054,7 @@ fn detect_private_key_hook() {
 
 #[test]
 fn check_merge_conflict_hook() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -2101,9 +2091,8 @@ fn check_merge_conflict_hook() {
         Conflicting line
         =======
     "},
-        );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     // First run: hooks should fail due to conflict markers
     cmd_snapshot!(context, context.run(), @r#"
@@ -2142,7 +2131,7 @@ fn check_merge_conflict_hook() {
         "Some content\nResolved line\n",
     );
 
-    context.git().add_all();
+    context.git().add(".");
 
     // Second run: hooks should now pass
     cmd_snapshot!(context, context.run(), @r"
@@ -2157,7 +2146,7 @@ fn check_merge_conflict_hook() {
 
 #[test]
 fn check_merge_conflict_ignores_rst_headings() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -2171,9 +2160,8 @@ fn check_merge_conflict_ignores_rst_headings() {
         Depends
         =======
     "},
-        );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -2187,7 +2175,7 @@ fn check_merge_conflict_ignores_rst_headings() {
 
 #[test]
 fn check_merge_conflict_diff3_hook() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -2208,9 +2196,8 @@ fn check_merge_conflict_diff3_hook() {
         >>>>>>> branch
         After conflict
     "},
-        );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -2232,7 +2219,7 @@ fn check_merge_conflict_diff3_hook() {
 
 #[test]
 fn check_merge_conflict_without_assume_flag() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     // Without --assume-in-merge, hook should pass even with conflict markers
     // if we're not actually in a merge state
@@ -2254,7 +2241,7 @@ fn check_merge_conflict_without_assume_flag() {
     "},
         );
 
-    context.git().add_all();
+    context.git().add(".");
 
     // Should pass because we're not in a merge state and no --assume-in-merge flag
     cmd_snapshot!(context, context.run(), @r"
@@ -2269,7 +2256,7 @@ fn check_merge_conflict_without_assume_flag() {
 
 #[test]
 fn check_xml_hook() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -2303,9 +2290,8 @@ fn check_xml_hook() {
 <element>value</element>
 <another>value</another>"#,
         )
-        .with_file("empty.xml", "");
-
-    context.git().add_all();
+        .with_file("empty.xml", "")
+        .init_git();
 
     // First run: hooks should fail
     cmd_snapshot!(context, context.run(), @r#"
@@ -2349,7 +2335,7 @@ fn check_xml_hook() {
 </root>"#,
     );
 
-    context.git().add_all();
+    context.git().add(".");
 
     // Second run: hooks should now pass
     cmd_snapshot!(context, context.run(), @r"
@@ -2369,7 +2355,7 @@ fn check_xml_hook() {
 
 #[test]
 fn check_xml_with_features() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -2379,35 +2365,34 @@ fn check_xml_with_features() {
         .with_file(
             "with_attributes.xml",
             r#"<?xml version="1.0" encoding="UTF-8"?>
-<root xmlns="http://example.com">
+    <root xmlns="http://example.com">
     <element id="1" type="test">value</element>
-</root>"#,
+    </root>"#,
         )
         .with_file(
             "with_cdata.xml",
             r#"<?xml version="1.0" encoding="UTF-8"?>
-<root>
+    <root>
     <element><![CDATA[Some <special> characters & symbols]]></element>
-</root>"#,
+    </root>"#,
         )
         .with_file(
             "with_comments.xml",
             r#"<?xml version="1.0" encoding="UTF-8"?>
-<root>
+    <root>
     <!-- This is a comment -->
     <element>value</element>
-</root>"#,
+    </root>"#,
         )
         .with_file(
             "with_doctype.xml",
             r#"<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE root SYSTEM "root.dtd">
-<root>
+    <!DOCTYPE root SYSTEM "root.dtd">
+    <root>
     <element>value</element>
-</root>"#,
-        );
-
-    context.git().add_all();
+    </root>"#,
+        )
+        .init_git();
 
     // All should pass
     cmd_snapshot!(context, context.run(), @r"
@@ -2422,16 +2407,17 @@ fn check_xml_with_features() {
 
 #[test]
 fn no_commit_to_branch_hook() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: no-commit-to-branch
     "})
-        .with_file("test.txt", "Hello World");
+        .with_file("test.txt", "Hello World")
+        .init_git();
 
-    context.git().add_all().commit("Initial commit");
+    context.git().commit("Initial commit");
 
     // Test 1: Try to commit to master branch (should fail)
     cmd_snapshot!(context, context.run(), @r"
@@ -2455,7 +2441,7 @@ fn no_commit_to_branch_hook() {
         .checkout("feature/new-feature");
 
     context.write_file("feature.txt", "Feature content");
-    context.git().add_all().commit("Add feature");
+    context.git().add(".").commit("Add feature");
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -2470,7 +2456,7 @@ fn no_commit_to_branch_hook() {
     context.git().branch("main").checkout("main");
 
     context.write_file("main.txt", "Main content");
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -2489,7 +2475,7 @@ fn no_commit_to_branch_hook() {
 
 #[test]
 fn no_commit_to_branch_hook_with_custom_branches() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -2497,9 +2483,10 @@ fn no_commit_to_branch_hook_with_custom_branches() {
               - id: no-commit-to-branch
                 args: ['--branch', 'develop', '--branch', 'production']
     "})
-        .with_file("test.txt", "Hello World");
+        .with_file("test.txt", "Hello World")
+        .init_git();
 
-    context.git().add_all().commit("Initial commit");
+    context.git().commit("Initial commit");
 
     // Test 1: Try to commit to master branch (should pass - not in custom list)
     cmd_snapshot!(context, context.run(), @r"
@@ -2515,7 +2502,7 @@ fn no_commit_to_branch_hook_with_custom_branches() {
     context.git().branch("develop").checkout("develop");
 
     context.write_file("develop.txt", "Develop content");
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -2535,7 +2522,7 @@ fn no_commit_to_branch_hook_with_custom_branches() {
     context.git().branch("production").checkout("production");
 
     context.write_file("production.txt", "Production content");
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -2554,7 +2541,7 @@ fn no_commit_to_branch_hook_with_custom_branches() {
 
 #[test]
 fn no_commit_to_branch_hook_with_patterns() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -2562,9 +2549,10 @@ fn no_commit_to_branch_hook_with_patterns() {
               - id: no-commit-to-branch
                 args: ['--pattern', '^feature/.*', '--pattern', '.*-wip$']
     "})
-        .with_file("test.txt", "Hello World");
+        .with_file("test.txt", "Hello World")
+        .init_git();
 
-    context.git().add_all().commit("Initial commit");
+    context.git().commit("Initial commit");
 
     // Test 1: Try to commit to master branch (should fail - If branch is not specified, branch defaults to master and main)
     cmd_snapshot!(context, context.run(), @r"
@@ -2588,7 +2576,7 @@ fn no_commit_to_branch_hook_with_patterns() {
         .checkout("feature/new-feature");
 
     context.write_file("feature.txt", "Feature content");
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -2611,7 +2599,7 @@ fn no_commit_to_branch_hook_with_patterns() {
         .checkout("my-branch-wip");
 
     context.write_file("wip.txt", "WIP content");
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -2634,7 +2622,7 @@ fn no_commit_to_branch_hook_with_patterns() {
         .checkout("normal-branch");
 
     context.write_file("normal.txt", "Normal content");
-    context.git().add_all().commit("Add normal content");
+    context.git().add(".").commit("Add normal content");
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -2671,7 +2659,7 @@ fn no_commit_to_branch_hook_with_patterns() {
         .checkout("invalid-branch");
 
     context.write_file("invalid.txt", "Invalid content");
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -2688,7 +2676,7 @@ fn no_commit_to_branch_hook_with_patterns() {
 #[cfg(unix)]
 #[test]
 fn check_executables_have_shebangs_hook() -> Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -2698,9 +2686,8 @@ fn check_executables_have_shebangs_hook() -> Result<()> {
         .with_executable_file("script_with_shebang.sh", "#!/bin/bash\necho ok\n")
         .with_executable_file("script_without_shebang.sh", "echo missing shebang\n")
         .with_file("not_executable.txt", "not executable\n")
-        .with_executable_file("empty.sh", "");
-
-    context.git().add_all();
+        .with_executable_file("empty.sh", "")
+        .init_git();
 
     // First run: should fail for script_without_shebang.sh and empty.sh
     cmd_snapshot!(context, context.run(), @r"
@@ -2731,7 +2718,7 @@ fn check_executables_have_shebangs_hook() -> Result<()> {
         std::fs::Permissions::from_mode(0o644),
     )?;
 
-    context.git().add_all();
+    context.git().add(".");
 
     // Second run: should now pass
     cmd_snapshot!(context, context.run(), @r"
@@ -2749,7 +2736,7 @@ fn check_executables_have_shebangs_hook() -> Result<()> {
 #[cfg(windows)]
 #[test]
 fn check_executables_have_shebangs_win() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -2757,9 +2744,8 @@ fn check_executables_have_shebangs_win() {
               - id: check-executables-have-shebangs
     "})
         .with_file("win_script_with_shebang.sh", "#!/bin/bash\necho ok\n")
-        .with_file("win_script_without_shebang.sh", "missing shebang\n");
-
-    context.git().add_all();
+        .with_file("win_script_without_shebang.sh", "missing shebang\n")
+        .init_git();
 
     context
         .git()
@@ -2791,7 +2777,7 @@ fn check_executables_have_shebangs_win() {
 #[cfg(unix)]
 #[test]
 fn check_executables_have_shebangs_various_cases() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -2802,9 +2788,8 @@ fn check_executables_have_shebangs_various_cases() {
         .with_executable_file("shebang_with_space.sh", "#! /bin/bash\necho ok\n")
         .with_file("non_executable.txt", "not executable\n")
         .with_executable_file("whitespace.sh", "   \n")
-        .with_executable_file("invalid_shebang.sh", "##!/bin/bash\necho bad\n");
-
-    context.git().add_all();
+        .with_executable_file("invalid_shebang.sh", "##!/bin/bash\necho bad\n")
+        .init_git();
 
     // Run: should fail for partial_shebang.sh, whitespace.sh, invalid_shebang.sh
     cmd_snapshot!(context, context.run(), @r#"
@@ -2837,7 +2822,7 @@ fn check_executables_have_shebangs_various_cases() {
     context.write_file("whitespace.sh", "#!/bin/sh\n");
     context.write_file("invalid_shebang.sh", "#!/bin/bash\necho fixed\n");
 
-    context.git().add_all();
+    context.git().add(".");
 
     // Second run: should now pass
     cmd_snapshot!(context, context.run(), @r"
@@ -2853,7 +2838,7 @@ fn check_executables_have_shebangs_various_cases() {
 #[cfg(windows)]
 #[test]
 fn check_executables_have_shebangs_various_cases_win() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -2866,9 +2851,8 @@ fn check_executables_have_shebangs_various_cases_win() {
             ("non_executable.txt", "not executable\n"),
             ("whitespace.sh", "   \n"),
             ("invalid_shebang.sh", "##!/bin/bash\necho bad\n"),
-        ]);
-
-    context.git().add_all();
+        ])
+        .init_git();
 
     let executable_files = [
         "partial_shebang.sh",
@@ -2910,7 +2894,7 @@ fn check_executables_have_shebangs_various_cases_win() {
 
 #[test]
 fn check_shebang_scripts_are_executable() -> Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -2919,9 +2903,9 @@ fn check_shebang_scripts_are_executable() -> Result<()> {
     "})
         .with_file("plain.txt", "plain text\n")
         .with_file("script.sh", "#!/bin/sh\necho hi\n")
-        .with_executable_file("script_exec.sh", "#!/bin/sh\necho hi\n");
+        .with_executable_file("script_exec.sh", "#!/bin/sh\necho hi\n")
+        .init_git();
 
-    context.git().add_all();
     context
         .git()
         .run(["update-index", "--chmod=+x", "script_exec.sh"]);
@@ -2972,7 +2956,7 @@ fn is_case_sensitive_filesystem(context: &TestEnv) -> Result<bool> {
 
 #[test]
 fn check_case_conflict_hook() -> Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     if !is_case_sensitive_filesystem(&context)? {
         // Skipping test on case-insensitive filesystem
@@ -2983,7 +2967,7 @@ fn check_case_conflict_hook() -> Result<()> {
     let context = context
         .with_file("README.md", "Initial commit")
         .with_file("src/foo.txt", "existing file");
-    context.git().add_all().commit("Initial commit");
+    context.git().add(".").commit("Initial commit");
 
     let context = context
         .with_config(indoc::indoc! {r"
@@ -2994,7 +2978,7 @@ fn check_case_conflict_hook() -> Result<()> {
     "})
         .with_file("src/FOO.txt", "conflicting case");
 
-    context.git().add_all();
+    context.git().add(".");
 
     // First run: should fail due to case conflict
     cmd_snapshot!(context, context.run(), @r#"
@@ -3017,7 +3001,7 @@ fn check_case_conflict_hook() -> Result<()> {
 
     // Add a non-conflicting file
     context.write_file("src/bar.txt", "no conflict");
-    context.git().add_all();
+    context.git().add(".");
 
     // Second run: should pass
     cmd_snapshot!(context, context.run(), @r#"
@@ -3034,7 +3018,7 @@ fn check_case_conflict_hook() -> Result<()> {
 
 #[test]
 fn check_case_conflict_directory() -> Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new();
 
     if !is_case_sensitive_filesystem(&context)? {
         // Skipping test on case-insensitive filesystem
@@ -3042,8 +3026,10 @@ fn check_case_conflict_directory() -> Result<()> {
     }
 
     // Create directory with file
-    let context = context.with_file("src/utils/helper.py", "helper");
-    context.git().add_all().commit("Initial commit");
+    let context = context
+        .with_file("src/utils/helper.py", "helper")
+        .init_git();
+    context.git().commit("Initial commit");
 
     let context = context
         .with_config(indoc::indoc! {r"
@@ -3054,7 +3040,7 @@ fn check_case_conflict_directory() -> Result<()> {
     "})
         .with_file("src/UTILS/other.py", "conflict");
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -3076,15 +3062,15 @@ fn check_case_conflict_directory() -> Result<()> {
 
 #[test]
 fn check_case_conflict_among_new_files() -> Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new();
 
     if !is_case_sensitive_filesystem(&context)? {
         // Skipping test on case-insensitive filesystem
         return Ok(());
     }
 
-    let context = context.with_file("README.md", "Initial");
-    context.git().add_all().commit("Initial commit");
+    let context = context.with_file("README.md", "Initial").init_git();
+    context.git().commit("Initial commit");
 
     let context = context
         .with_config(indoc::indoc! {r"
@@ -3097,7 +3083,7 @@ fn check_case_conflict_among_new_files() -> Result<()> {
         .with_file("newfile.txt", "file 2")
         .with_file("NEWFILE.TXT", "file 3");
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -3120,7 +3106,7 @@ fn check_case_conflict_among_new_files() -> Result<()> {
 
 #[test]
 fn check_case_conflict_workspace_mode_includes_added_files() -> Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     if !is_case_sensitive_filesystem(&context)? {
         return Ok(());
@@ -3130,7 +3116,7 @@ fn check_case_conflict_workspace_mode_includes_added_files() -> Result<()> {
         .with_config("repos: []\n")
         .with_file("app/foo.txt", "existing file")
         .with_file("app/trigger.txt", "tracked trigger");
-    context.git().add_all().commit("Initial commit");
+    context.git().add(".").commit("Initial commit");
 
     context.write_file(
         "app/.pre-commit-config.yaml",
@@ -3176,7 +3162,7 @@ fn check_case_conflict_workspace_mode_includes_added_files() -> Result<()> {
 
 #[test]
 fn check_json5() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -3201,9 +3187,8 @@ fn check_json5() {
             key2: 'value2', // Missing comma between key-value pairs
         }
     "},
-        );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     // First run: hooks should fail
     cmd_snapshot!(context, context.run(), @r"
@@ -3230,7 +3215,7 @@ fn check_json5() {
         }
     "},
     );
-    context.git().add_all();
+    context.git().add(".");
 
     // Second run: hooks should now pass
     cmd_snapshot!(context, context.run(), @r"
@@ -3246,7 +3231,7 @@ fn check_json5() {
 #[cfg(unix)]
 #[test]
 fn check_illegal_windows_names() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -3254,9 +3239,8 @@ fn check_illegal_windows_names() {
               - id: check-illegal-windows-names
     "})
         .with_file("normal.txt", "ok")
-        .with_file("CON.txt", "bad");
-
-    context.git().add_all();
+        .with_file("CON.txt", "bad")
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @"
     success: false
@@ -3283,7 +3267,7 @@ fn check_illegal_windows_names() {
 #[test]
 #[cfg(unix)]
 fn builtin_hooks_ignore_system_path_binaries() -> Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     // Create a fake "trailing-whitespace-fixer" binary with a shebang in a temp dir.
     // This simulates `pip install pre-commit-hooks` which places such binaries in PATH.
@@ -3303,7 +3287,7 @@ fn builtin_hooks_ignore_system_path_binaries() -> Result<()> {
     "})
         .with_file("test.txt", "hello world   \n");
 
-    context.git().add_all();
+    context.git().add(".");
 
     // Prepend the fake bin directory to PATH so the fake binary is found first.
     let original_path = EnvVars.var_os(EnvVars::PATH).unwrap_or_default();

--- a/crates/prek/tests/cache.rs
+++ b/crates/prek/tests/cache.rs
@@ -181,7 +181,7 @@ fn cache_size_output_formats() {
 
 #[test]
 fn cache_size_with_populated_cache() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_filter(r"(?m)^\d+\n", "[BYTES]\n")
         .with_config(indoc::indoc! {r"
         repos:
@@ -190,9 +190,8 @@ fn cache_size_with_populated_cache() {
             hooks:
               - id: end-of-file-fixer
     "})
-        .with_file("file.txt", "Hello, world!\n");
-
-    context.git().add_all();
+        .with_file("file.txt", "Hello, world!\n")
+        .init_git();
 
     context.run();
 
@@ -217,7 +216,7 @@ fn cache_size_with_populated_cache() {
 
 #[test]
 fn cache_gc_removes_unreferenced_entries() -> anyhow::Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -231,9 +230,8 @@ fn cache_gc_removes_unreferenced_entries() -> anyhow::Result<()> {
                 entry: python -c "print('Hello from Python')"
                 language: python
     "#})
-        .with_file("valid.yaml", "a: 1\n");
-
-    context.git().add_all();
+        .with_file("valid.yaml", "a: 1\n")
+        .init_git();
 
     let home = context.home_dir();
     // Populate store + config tracking.
@@ -288,16 +286,18 @@ fn cache_gc_removes_unreferenced_entries() -> anyhow::Result<()> {
 
 #[test]
 fn cache_gc_keeps_relative_remote_repo() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_file(
-        "hook-repo/.pre-commit-hooks.yaml",
-        indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_file(
+            "hook-repo/.pre-commit-hooks.yaml",
+            indoc::indoc! {r"
         - id: test-hook
           name: Test Hook
           entry: echo test
           language: system
           always_run: true
     "},
-    );
+        )
+        .init_git();
     let hook_repo = context.child("hook-repo");
     let git = context.git_at(&hook_repo);
     let revision = git
@@ -316,7 +316,7 @@ fn cache_gc_keeps_relative_remote_repo() -> anyhow::Result<()> {
                   - id: test-hook
         "},
     );
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run()
         .arg("--config")
@@ -583,7 +583,7 @@ fn cache_gc_prunes_tool_versions_without_positive_identification() -> anyhow::Re
 
 #[test]
 fn cache_gc_keeps_local_hook_env() -> anyhow::Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -593,9 +593,8 @@ fn cache_gc_keeps_local_hook_env() -> anyhow::Result<()> {
                 entry: python -c "print('hello')"
                 language: python
     "#})
-        .with_file("file.txt", "Hello\n");
-
-    context.git().add_all();
+        .with_file("file.txt", "Hello\n")
+        .init_git();
 
     // Install + run the local hook so it creates a hook env under PREK_HOME/hooks.
     cmd_snapshot!(context, context.run(), @r"
@@ -730,9 +729,7 @@ fn write_patch_file(path: &ChildPath, content: &str, modified: SystemTime) -> an
 
 #[test]
 fn cache_gc_drops_missing_tracked_config() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config("repos: []\n");
-
-    context.git().add_all();
+    let context = TestEnv::new().with_config("repos: []\n").init_git();
 
     let home = context.home_dir();
     let config_path = context.child(PRE_COMMIT_CONFIG_YAML);
@@ -778,9 +775,9 @@ fn cache_gc_drops_missing_tracked_config() -> anyhow::Result<()> {
 #[test]
 fn cache_gc_keeps_tracked_config_on_parse_error() -> anyhow::Result<()> {
     // Keep the tracked config intentionally invalid while exercising GC.
-    let context = TestEnv::new_git().with_file(PRE_COMMIT_CONFIG_YAML, "repos: [\n");
-
-    context.git().add_all();
+    let context = TestEnv::new()
+        .with_file(PRE_COMMIT_CONFIG_YAML, "repos: [\n")
+        .init_git();
 
     let home = context.home_dir();
     let config_path = context.child(PRE_COMMIT_CONFIG_YAML);
@@ -816,9 +813,7 @@ fn cache_gc_keeps_tracked_config_on_parse_error() -> anyhow::Result<()> {
 
 #[test]
 fn cache_gc_dry_run_does_not_remove_entries() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config("repos: []\n");
-
-    context.git().add_all();
+    let context = TestEnv::new().with_config("repos: []\n").init_git();
 
     let home = context.home_dir();
     // Seed tracking with a missing config to force sweeping everything.

--- a/crates/prek/tests/common/mod.rs
+++ b/crates/prek/tests/common/mod.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code, unreachable_pub)]
+#![allow(dead_code)]
 
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::OnceLock;
 
 use assert_cmd::assert::OutputAssertExt;
-use assert_fs::fixture::{ChildPath, FileWriteBin, FileWriteStr, PathChild, PathCreateDir};
+use assert_fs::fixture::{ChildPath, FileWriteBin, PathChild, PathCreateDir};
 use etcetera::BaseStrategy;
 use rustc_hash::FxHashSet;
 
@@ -14,7 +14,7 @@ use prek_consts::PRE_COMMIT_CONFIG_YAML;
 use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 
 #[cfg(unix)]
-pub fn make_executable(path: impl AsRef<Path>) -> std::io::Result<()> {
+pub(crate) fn make_executable(path: impl AsRef<Path>) -> std::io::Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
     let path = path.as_ref();
@@ -28,20 +28,8 @@ pub fn make_executable(path: impl AsRef<Path>) -> std::io::Result<()> {
     clippy::unnecessary_wraps,
     reason = "Keep the cross-platform test helper API consistent"
 )]
-pub fn make_executable(_path: impl AsRef<Path>) -> std::io::Result<()> {
+pub(crate) fn make_executable(_path: impl AsRef<Path>) -> std::io::Result<()> {
     Ok(())
-}
-
-fn git_cmd(dir: impl AsRef<Path>, home_dir: impl AsRef<Path>) -> Command {
-    let mut cmd = Command::new("git");
-    cmd.current_dir(dir)
-        .env(EnvVars::PREK_HOME, home_dir.as_ref())
-        .args(["-c", "commit.gpgsign=false"])
-        .args(["-c", "tag.gpgsign=false"])
-        .args(["-c", "core.autocrlf=false"])
-        .args(["-c", "user.name=Prek Test"])
-        .args(["-c", "user.email=test@prek.dev"]);
-    cmd
 }
 
 fn write_test_file(root: &ChildPath, file: &Path, content: &[u8]) {
@@ -60,17 +48,8 @@ fn write_executable_test_file(root: &ChildPath, file: &Path, content: &[u8]) {
     });
 }
 
-fn init_repo(path: impl AsRef<Path>, home_dir: impl AsRef<Path>) {
-    git_cmd(path, home_dir)
-        .arg("-c")
-        .arg("init.defaultBranch=master")
-        .arg("init")
-        .assert()
-        .success();
-}
-
 /// Git operations for an integration-test repository.
-pub struct TestGit<'a> {
+pub(crate) struct TestGit<'a> {
     path: PathBuf,
     home_dir: &'a Path,
 }
@@ -84,12 +63,21 @@ impl<'a> TestGit<'a> {
     }
 
     /// Create a raw Git command for operations not covered by this wrapper.
-    pub fn command(&self) -> Command {
-        git_cmd(&self.path, self.home_dir)
+    pub(crate) fn command(&self) -> Command {
+        let mut command = Command::new("git");
+        command
+            .current_dir(&self.path)
+            .env(EnvVars::PREK_HOME, self.home_dir)
+            .args(["-c", "commit.gpgsign=false"])
+            .args(["-c", "tag.gpgsign=false"])
+            .args(["-c", "core.autocrlf=false"])
+            .args(["-c", "user.name=Prek Test"])
+            .args(["-c", "user.email=test@prek.dev"]);
+        command
     }
 
     /// Run a Git command that is expected to succeed.
-    pub fn run<S>(&self, args: impl IntoIterator<Item = S>) -> &Self
+    pub(crate) fn run<S>(&self, args: impl IntoIterator<Item = S>) -> &Self
     where
         S: AsRef<OsStr>,
     {
@@ -97,25 +85,20 @@ impl<'a> TestGit<'a> {
         self
     }
 
-    pub fn init(&self) -> &Self {
-        init_repo(&self.path, self.home_dir);
-        self
+    pub(crate) fn init(&self) -> &Self {
+        self.run(["-c", "init.defaultBranch=master", "init"])
     }
 
-    pub fn add(&self, path: impl AsRef<OsStr>) -> &Self {
+    pub(crate) fn add(&self, path: impl AsRef<OsStr>) -> &Self {
         self.command().arg("add").arg(path).assert().success();
         self
     }
 
-    pub fn add_all(&self) -> &Self {
-        self.add(".")
-    }
-
-    pub fn commit(&self, message: &str) -> &Self {
+    pub(crate) fn commit(&self, message: &str) -> &Self {
         self.run(["commit", "-m", message])
     }
 
-    pub fn tag(&self, tag: &str) -> &Self {
+    pub(crate) fn tag(&self, tag: &str) -> &Self {
         self.command()
             .args(["tag", tag, "-m"])
             .arg(format!("Tag {tag}"))
@@ -124,7 +107,7 @@ impl<'a> TestGit<'a> {
         self
     }
 
-    pub fn rev_parse(&self, rev: &str) -> anyhow::Result<String> {
+    pub(crate) fn rev_parse(&self, rev: &str) -> anyhow::Result<String> {
         let output = self.command().args(["rev-parse", rev]).output()?;
         let output = output.assert().success();
         Ok(std::str::from_utf8(&output.get_output().stdout)?
@@ -132,7 +115,7 @@ impl<'a> TestGit<'a> {
             .to_owned())
     }
 
-    pub fn rm(&self, path: &str) -> &Self {
+    pub(crate) fn rm(&self, path: &str) -> &Self {
         self.run(["rm", "--cached", path]);
         let file_path = self.path.join(path);
         if file_path.exists() {
@@ -141,20 +124,16 @@ impl<'a> TestGit<'a> {
         self
     }
 
-    pub fn clean(&self) -> &Self {
-        self.run(["clean", "-fdx"])
-    }
-
-    pub fn branch(&self, branch_name: &str) -> &Self {
+    pub(crate) fn branch(&self, branch_name: &str) -> &Self {
         self.run(["branch", branch_name])
     }
 
-    pub fn checkout(&self, branch_name: &str) -> &Self {
+    pub(crate) fn checkout(&self, branch_name: &str) -> &Self {
         self.run(["checkout", branch_name])
     }
 }
 
-pub struct TestRepo {
+pub(crate) struct TestRepo {
     path: ChildPath,
     home_dir: PathBuf,
 }
@@ -163,32 +142,37 @@ impl TestRepo {
     fn new(path: ChildPath, home_dir: PathBuf) -> Self {
         path.create_dir_all()
             .expect("Failed to create test repository directory");
-        init_repo(&path, &home_dir);
-        Self { path, home_dir }
+        let repo = Self { path, home_dir };
+        repo.git().init();
+        repo
     }
 
-    pub fn path(&self) -> &ChildPath {
+    pub(crate) fn path(&self) -> &ChildPath {
         &self.path
     }
 
     #[must_use]
-    pub fn with_file(self, file: impl AsRef<Path>, content: impl AsRef<[u8]>) -> Self {
+    pub(crate) fn with_file(self, file: impl AsRef<Path>, content: impl AsRef<[u8]>) -> Self {
         write_test_file(&self.path, file.as_ref(), content.as_ref());
         self
     }
 
     #[must_use]
-    pub fn with_executable_file(self, file: impl AsRef<Path>, content: impl AsRef<[u8]>) -> Self {
+    pub(crate) fn with_executable_file(
+        self,
+        file: impl AsRef<Path>,
+        content: impl AsRef<[u8]>,
+    ) -> Self {
         write_executable_test_file(&self.path, file.as_ref(), content.as_ref());
         self
     }
 
-    pub fn git(&self) -> TestGit<'_> {
+    pub(crate) fn git(&self) -> TestGit<'_> {
         TestGit::new(&self.path, &self.home_dir)
     }
 }
 
-pub struct TestEnv {
+pub(crate) struct TestEnv {
     work_dir: ChildPath,
     home_dir: ChildPath,
 
@@ -201,7 +185,7 @@ pub struct TestEnv {
 
 impl TestEnv {
     /// Create an isolated test environment without a Git repository.
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         let bucket = Self::test_bucket_dir();
         fs_err::create_dir_all(&bucket).expect("Failed to create test bucket");
 
@@ -210,36 +194,6 @@ impl TestEnv {
         let work_dir = ChildPath::new(root.path()).child("temp");
         fs_err::create_dir_all(&work_dir).expect("Failed to create test working directory");
 
-        Self::from_root(root, work_dir)
-    }
-
-    /// Create an isolated test environment with a Git repository.
-    pub fn new_git() -> Self {
-        let env = Self::new();
-        init_repo(&env.work_dir, &env.home_dir);
-        env
-    }
-
-    /// Create a Git test environment at the given working directory.
-    pub fn new_git_at(path: impl AsRef<Path>) -> Self {
-        let env = Self::new_at(path);
-        init_repo(&env.work_dir, &env.home_dir);
-        env
-    }
-
-    fn new_at(path: impl AsRef<Path>) -> Self {
-        let bucket = Self::test_bucket_dir();
-        fs_err::create_dir_all(&bucket).expect("Failed to create test bucket");
-
-        let root = tempfile::TempDir::new_in(bucket).expect("Failed to create test root directory");
-
-        let work_dir = ChildPath::new(path.as_ref().to_path_buf());
-        fs_err::create_dir_all(&work_dir).expect("Failed to create test working directory");
-
-        Self::from_root(root, work_dir)
-    }
-
-    fn from_root(root: tempfile::TempDir, work_dir: ChildPath) -> Self {
         let home_dir = ChildPath::new(root.path()).child("home");
         fs_err::create_dir_all(&home_dir).expect("Failed to create test home directory");
 
@@ -250,6 +204,13 @@ impl TestEnv {
             filters: Vec::new(),
             _root: root,
         }
+    }
+
+    /// Initialize a Git repository, stage all existing files, and return this environment.
+    #[must_use]
+    pub(crate) fn init_git(self) -> Self {
+        self.git().init().add(".");
+        self
     }
 
     fn build_default_filters(&self) -> Vec<(String, String)> {
@@ -328,26 +289,26 @@ impl TestEnv {
     }
 
     /// Read a file in the temporary directory
-    pub fn read(&self, file: impl AsRef<Path>) -> String {
+    pub(crate) fn read(&self, file: impl AsRef<Path>) -> String {
         fs_err::read_to_string(self.work_dir.join(&file))
             .unwrap_or_else(|_| panic!("Missing file: `{}`", file.as_ref().display()))
     }
 
     /// Write or replace a file in the working directory.
-    pub fn write_file(&self, file: impl AsRef<Path>, content: impl AsRef<[u8]>) {
+    pub(crate) fn write_file(&self, file: impl AsRef<Path>, content: impl AsRef<[u8]>) {
         write_test_file(&self.work_dir, file.as_ref(), content.as_ref());
     }
 
     /// Write a file in the working directory and return this environment.
     #[must_use]
-    pub fn with_file(self, file: impl AsRef<Path>, content: impl AsRef<[u8]>) -> Self {
+    pub(crate) fn with_file(self, file: impl AsRef<Path>, content: impl AsRef<[u8]>) -> Self {
         self.write_file(file, content);
         self
     }
 
     /// Write files in the working directory and return this environment.
     #[must_use]
-    pub fn with_files<P, C>(self, files: impl IntoIterator<Item = (P, C)>) -> Self
+    pub(crate) fn with_files<P, C>(self, files: impl IntoIterator<Item = (P, C)>) -> Self
     where
         P: AsRef<Path>,
         C: AsRef<[u8]>,
@@ -359,23 +320,27 @@ impl TestEnv {
     }
 
     /// Write or replace an executable file in the working directory.
-    pub fn write_executable_file(&self, file: impl AsRef<Path>, content: impl AsRef<[u8]>) {
+    pub(crate) fn write_executable_file(&self, file: impl AsRef<Path>, content: impl AsRef<[u8]>) {
         write_executable_test_file(&self.work_dir, file.as_ref(), content.as_ref());
     }
 
     /// Write an executable file in the working directory and return this environment.
     #[must_use]
-    pub fn with_executable_file(self, file: impl AsRef<Path>, content: impl AsRef<[u8]>) -> Self {
+    pub(crate) fn with_executable_file(
+        self,
+        file: impl AsRef<Path>,
+        content: impl AsRef<[u8]>,
+    ) -> Self {
         self.write_executable_file(file, content);
         self
     }
 
-    pub fn command(&self) -> Command {
+    pub(crate) fn command(&self) -> Command {
         let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("prek"));
         cmd.current_dir(self.work_dir())
             .env(EnvVars::PREK_HOME, &**self.home_dir())
             .env(EnvVars::PREK_INTERNAL__SORT_FILENAMES, "1")
-            // Git commands spawned by prek do not inherit `git_cmd`'s `-c` arguments.
+            // Git commands spawned by prek do not inherit `TestGit::command`'s `-c` arguments.
             .envs([
                 ("GIT_CONFIG_COUNT", "1"),
                 ("GIT_CONFIG_KEY_0", "core.autocrlf"),
@@ -390,11 +355,11 @@ impl TestEnv {
         cmd
     }
 
-    pub fn git(&self) -> TestGit<'_> {
+    pub(crate) fn git(&self) -> TestGit<'_> {
         self.git_at(&self.work_dir)
     }
 
-    pub fn git_at(&self, dir: impl AsRef<Path>) -> TestGit<'_> {
+    pub(crate) fn git_at(&self, dir: impl AsRef<Path>) -> TestGit<'_> {
         TestGit::new(dir, self.home_dir.as_ref())
     }
 
@@ -405,57 +370,53 @@ impl TestEnv {
             .child("prek.toml")
     }
 
-    pub fn write_user_config(&self, content: &str) {
-        let config_dir = self.home_dir.child("config").child("prek");
-        config_dir
-            .create_dir_all()
-            .expect("Failed to create user config directory");
+    pub(crate) fn write_user_config(&self, content: &str) {
         self.user_config_path()
-            .write_str(content)
+            .write_binary(content.as_bytes())
             .expect("Failed to write user config");
     }
 
-    pub fn run(&self) -> Command {
+    pub(crate) fn run(&self) -> Command {
         self.subcommand("run")
     }
 
-    pub fn exec(&self) -> Command {
+    pub(crate) fn exec(&self) -> Command {
         self.subcommand("exec")
     }
 
-    pub fn validate_config(&self) -> Command {
+    pub(crate) fn validate_config(&self) -> Command {
         self.subcommand("validate-config")
     }
 
-    pub fn validate_manifest(&self) -> Command {
+    pub(crate) fn validate_manifest(&self) -> Command {
         self.subcommand("validate-manifest")
     }
 
-    pub fn install(&self) -> Command {
+    pub(crate) fn install(&self) -> Command {
         self.subcommand("install")
     }
 
-    pub fn prepare_hooks(&self) -> Command {
+    pub(crate) fn prepare_hooks(&self) -> Command {
         self.subcommand("prepare-hooks")
     }
 
-    pub fn uninstall(&self) -> Command {
+    pub(crate) fn uninstall(&self) -> Command {
         self.subcommand("uninstall")
     }
 
-    pub fn sample_config(&self) -> Command {
+    pub(crate) fn sample_config(&self) -> Command {
         self.subcommand("sample-config")
     }
 
-    pub fn list(&self) -> Command {
+    pub(crate) fn list(&self) -> Command {
         self.subcommand("list")
     }
 
-    pub fn update(&self) -> Command {
+    pub(crate) fn update(&self) -> Command {
         self.subcommand("update")
     }
 
-    pub fn try_repo(&self) -> Command {
+    pub(crate) fn try_repo(&self) -> Command {
         self.subcommand("try-repo")
     }
 
@@ -466,7 +427,7 @@ impl TestEnv {
     }
 
     #[must_use]
-    pub fn with_filter(
+    pub(crate) fn with_filter(
         mut self,
         matcher: impl Into<String>,
         replacement: impl Into<String>,
@@ -476,7 +437,7 @@ impl TestEnv {
     }
 
     #[must_use]
-    pub fn with_filters<M, R>(mut self, filters: impl IntoIterator<Item = (M, R)>) -> Self
+    pub(crate) fn with_filters<M, R>(mut self, filters: impl IntoIterator<Item = (M, R)>) -> Self
     where
         M: Into<String>,
         R: Into<String>,
@@ -489,7 +450,7 @@ impl TestEnv {
         self
     }
 
-    pub fn with_snapshot_settings<T>(&self, f: impl FnOnce() -> T) -> T {
+    pub(crate) fn with_snapshot_settings<T>(&self, f: impl FnOnce() -> T) -> T {
         let default_filters = self
             .default_filters
             .get_or_init(|| self.build_default_filters());
@@ -503,22 +464,22 @@ impl TestEnv {
     }
 
     /// Get the working directory for the test environment.
-    pub fn work_dir(&self) -> &ChildPath {
+    pub(crate) fn work_dir(&self) -> &ChildPath {
         &self.work_dir
     }
 
     /// Get a path relative to the working directory.
-    pub fn child(&self, path: impl AsRef<Path>) -> ChildPath {
+    pub(crate) fn child(&self, path: impl AsRef<Path>) -> ChildPath {
         self.work_dir.child(path)
     }
 
     /// Get the home directory for the test environment.
-    pub fn home_dir(&self) -> &ChildPath {
+    pub(crate) fn home_dir(&self) -> &ChildPath {
         &self.home_dir
     }
 
     /// Create a Git repository that can be used as a local remote.
-    pub fn create_repo(&self, name: impl AsRef<Path>) -> TestRepo {
+    pub(crate) fn create_repo(&self, name: impl AsRef<Path>) -> TestRepo {
         TestRepo::new(
             self.home_dir.child("test-repos").child(name),
             self.home_dir.to_path_buf(),
@@ -527,17 +488,14 @@ impl TestEnv {
 
     /// Write a `.pre-commit-config.yaml` file and return this environment.
     #[must_use]
-    pub fn with_config(self, content: impl AsRef<str>) -> Self {
+    pub(crate) fn with_config(self, content: impl AsRef<str>) -> Self {
         self.write_config(content);
         self
     }
 
     /// Write or replace the `.pre-commit-config.yaml` file in the working directory.
-    pub fn write_config(&self, content: impl AsRef<str>) {
-        self.work_dir
-            .child(PRE_COMMIT_CONFIG_YAML)
-            .write_str(content.as_ref())
-            .expect("Failed to write pre-commit config");
+    pub(crate) fn write_config(&self, content: impl AsRef<str>) {
+        self.write_file(PRE_COMMIT_CONFIG_YAML, content.as_ref());
     }
 
     /// Write a `.pre-commit-config.yaml` file for a nested project.
@@ -550,13 +508,17 @@ impl TestEnv {
 
     /// Write a nested project config and return this environment.
     #[must_use]
-    pub fn with_project_config(self, project: impl AsRef<Path>, content: impl AsRef<str>) -> Self {
+    pub(crate) fn with_project_config(
+        self,
+        project: impl AsRef<Path>,
+        content: impl AsRef<str>,
+    ) -> Self {
         self.write_project_config(project, content);
         self
     }
 
     /// Write the same config for the workspace root and each nested project.
-    pub fn write_workspace<P>(
+    pub(crate) fn write_workspace<P>(
         &self,
         project_paths: impl IntoIterator<Item = P>,
         config: impl AsRef<str>,
@@ -573,7 +535,7 @@ impl TestEnv {
 
     /// Write workspace configs and return this environment.
     #[must_use]
-    pub fn with_workspace<P>(
+    pub(crate) fn with_workspace<P>(
         self,
         project_paths: impl IntoIterator<Item = P>,
         config: impl AsRef<str>,
@@ -586,8 +548,7 @@ impl TestEnv {
     }
 }
 
-#[doc(hidden)]
-pub fn bind_filters<'a, T>(
+pub(crate) fn bind_filters<'a, T>(
     filters: impl IntoIterator<Item = (&'a str, &'a str)>,
     f: impl FnOnce() -> T,
 ) -> T {
@@ -598,8 +559,7 @@ pub fn bind_filters<'a, T>(
     settings.bind(f)
 }
 
-#[doc(hidden)] // Macro and test environment only, don't use directly.
-pub const INSTA_FILTERS: &[(&str, &str)] = &[
+pub(crate) const INSTA_FILTERS: &[(&str, &str)] = &[
     // File sizes
     (r"(\s|\()(\d+\.)?\d+\s?([KMGTPE]i)?B", "$1[SIZE]"),
     // Rewrite Windows output to Unix output

--- a/crates/prek/tests/exec.rs
+++ b/crates/prek/tests/exec.rs
@@ -22,7 +22,7 @@ fn config() -> &'static str {
 }
 
 fn context_with_config() -> TestEnv {
-    TestEnv::new_git().with_config(config())
+    TestEnv::new().with_config(config()).init_git()
 }
 
 #[test]
@@ -105,7 +105,9 @@ fn exec_propagates_child_exit_status() {
 
 #[test]
 fn exec_rejects_ambiguous_hook_selector() {
-    let context = TestEnv::new_git().with_workspace(["frontend"], config());
+    let context = TestEnv::new()
+        .with_workspace(["frontend"], config())
+        .init_git();
 
     cmd_snapshot!(context, context.exec().args([
         "exec-test",
@@ -128,7 +130,9 @@ fn exec_rejects_ambiguous_hook_selector() {
 
 #[test]
 fn exec_keeps_current_working_directory() {
-    let context = TestEnv::new_git().with_workspace(["frontend"], config());
+    let context = TestEnv::new()
+        .with_workspace(["frontend"], config())
+        .init_git();
 
     cmd_snapshot!(context, context.exec().args([
             "frontend:exec-test",
@@ -149,9 +153,10 @@ fn exec_keeps_current_working_directory() {
 #[cfg(unix)]
 #[test]
 fn exec_resolves_relative_command_from_current_working_directory() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_workspace(["frontend"], config())
-        .with_executable_file("exec-tool", "#!/bin/sh\necho relative command ok\n");
+        .with_executable_file("exec-tool", "#!/bin/sh\necho relative command ok\n")
+        .init_git();
 
     cmd_snapshot!(context, context.exec().args([
         "frontend:exec-test",
@@ -169,7 +174,8 @@ fn exec_resolves_relative_command_from_current_working_directory() {
 
 #[test]
 fn exec_rejects_unsupported_language_before_install() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -177,7 +183,8 @@ fn exec_rejects_unsupported_language_before_install() {
                 name: Julia hook
                 entry: hook.jl
                 language: julia
-    "});
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.exec().args([
         "julia-hook",

--- a/crates/prek/tests/global_config.rs
+++ b/crates/prek/tests/global_config.rs
@@ -4,7 +4,7 @@ mod common;
 
 #[test]
 fn global_config_missing_file_is_optional() {
-    let context = TestEnv::new_git().with_config("repos: []");
+    let context = TestEnv::new().with_config("repos: []").init_git();
 
     cmd_snapshot!(context, context.update(), @"
     success: true
@@ -17,7 +17,7 @@ fn global_config_missing_file_is_optional() {
 
 #[test]
 fn global_config_ignores_unknown_options() {
-    let context = TestEnv::new_git().with_config("repos: []");
+    let context = TestEnv::new().with_config("repos: []").init_git();
     context.write_user_config(indoc::indoc! {r#"
         future_option = true
 
@@ -37,7 +37,7 @@ fn global_config_ignores_unknown_options() {
 
 #[test]
 fn update_command_accepts_upstream_alias() {
-    let context = TestEnv::new_git().with_config("repos: []");
+    let context = TestEnv::new().with_config("repos: []").init_git();
 
     cmd_snapshot!(context, context.command().arg("autoupdate"), @"
     success: true
@@ -50,7 +50,7 @@ fn update_command_accepts_upstream_alias() {
 
 #[test]
 fn global_config_invalid_file_reports_parse_error() {
-    let context = TestEnv::new_git().with_config("repos: []");
+    let context = TestEnv::new().with_config("repos: []").init_git();
     context.write_user_config(indoc::indoc! {r#"
         [update]
         cooldown_days = "soon"

--- a/crates/prek/tests/hook_impl.rs
+++ b/crates/prek/tests/hook_impl.rs
@@ -9,7 +9,8 @@ mod common;
 
 #[test]
 fn hook_impl() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
         - repo: local
           hooks:
@@ -18,9 +19,8 @@ fn hook_impl() {
              language: fail
              entry: always fail
              always_run: true
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     let mut commit = context.git().command();
     commit.arg("commit").arg("-m").arg("Initial commit");
@@ -52,7 +52,7 @@ fn hook_impl() {
 
 #[test]
 fn hook_impl_allows_missing_hook_dir() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
         - repo: local
@@ -70,7 +70,8 @@ fn hook_impl_allows_missing_hook_dir() {
         python3 -c 'print("legacy pre-commit ran")'
         exit 1
         "#},
-        );
+        )
+        .init_git();
 
     // Git 2.54+ config-based hooks can invoke `hook-impl` without
     // `--hook-dir`; without a hook script directory, legacy hooks are skipped.
@@ -94,7 +95,7 @@ fn hook_impl_allows_missing_hook_dir() {
 
 #[test]
 fn hook_impl_pre_push() -> anyhow::Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_filter(r"\b[0-9a-f]{7}\b", "[SHA1]")
         .with_config(indoc::indoc! {r#"
         repos:
@@ -105,8 +106,8 @@ fn hook_impl_pre_push() -> anyhow::Result<()> {
              language: system
              entry: echo "hook ran successfully"
              always_run: true
-    "#});
-    context.git().add_all();
+    "#})
+        .init_git();
 
     let mut commit = context.git().command();
     commit.arg("commit").arg("-m").arg("Initial commit");
@@ -198,7 +199,7 @@ fn hook_impl_pre_push() -> anyhow::Result<()> {
 
 #[test]
 fn hook_impl_pre_push_force_push_after_rebase() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     // Regression test for https://github.com/j178/prek/issues/2088.
     // The hook fails after printing its filenames so the assertion can inspect
@@ -226,7 +227,7 @@ fn hook_impl_pre_push_force_push_after_rebase() -> anyhow::Result<()> {
         "},
         );
 
-    context.git().add_all().commit("Initial commit");
+    context.git().add(".").commit("Initial commit");
 
     let remote_repo_path = context.home_dir().join("remote.git");
     fs_err::create_dir_all(&remote_repo_path)?;
@@ -251,7 +252,7 @@ fn hook_impl_pre_push_force_push_after_rebase() -> anyhow::Result<()> {
     context.git().run(["checkout", "-b", "feature"]);
 
     context.write_file("feature.txt", "feature");
-    context.git().add_all().commit("Add feature file");
+    context.git().add(".").commit("Add feature file");
 
     context.git().run(["push", "origin", "feature"]);
 
@@ -260,7 +261,7 @@ fn hook_impl_pre_push_force_push_after_rebase() -> anyhow::Result<()> {
     // list because it is default-branch churn, not a feature-branch change.
     context.git().checkout("master");
     context.write_file("main.txt", "main");
-    context.git().add_all().commit("Update master");
+    context.git().add(".").commit("Update master");
 
     context
         .git()
@@ -312,7 +313,7 @@ fn hook_impl_pre_push_force_push_after_rebase() -> anyhow::Result<()> {
 
 #[test]
 fn hook_impl_runs_legacy_hook() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_file(
             PRE_COMMIT_CONFIG_YAML,
             indoc! {r"
@@ -324,11 +325,10 @@ fn hook_impl_runs_legacy_hook() {
                 language: system
                 entry: echo manual-only
                 stages: [ manual ]
-  "},
+      "},
         )
-        .with_file("file.txt", "x");
-
-    context.git().add_all();
+        .with_file("file.txt", "x")
+        .init_git();
 
     cmd_snapshot!(context, context.install(), @r#"
     success: true
@@ -362,7 +362,8 @@ fn hook_impl_runs_legacy_hook() {
 
 #[test]
 fn hook_impl_pre_push_runs_legacy_and_prek() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
     repos:
     - repo: local
       hooks:
@@ -371,8 +372,9 @@ fn hook_impl_pre_push_runs_legacy_and_prek() -> anyhow::Result<()> {
             language: system
             entry: echo "hook ran successfully"
             always_run: true
-  "#});
-    context.git().add_all().commit("Initial commit");
+      "#})
+        .init_git();
+    context.git().commit("Initial commit");
 
     cmd_snapshot!(context, context.install().arg("--hook-type").arg("pre-push"), @r#"
     success: true
@@ -411,7 +413,7 @@ fn hook_impl_pre_push_runs_legacy_and_prek() -> anyhow::Result<()> {
     add_remote.output()?.assert().success();
 
     context.write_file("file.txt", "x");
-    context.git().add_all().commit("Second commit");
+    context.git().add(".").commit("Second commit");
 
     let mut push_cmd = context.git().command();
     push_cmd.arg("push").arg("origin").arg("master");
@@ -433,7 +435,8 @@ fn hook_impl_pre_push_runs_legacy_and_prek() -> anyhow::Result<()> {
 /// Test prek hook runs in the correct worktree.
 #[test]
 fn run_worktree() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
         - repo: local
           hooks:
@@ -442,8 +445,9 @@ fn run_worktree() {
              language: fail
              entry: always fail
              always_run: true
-    "});
-    context.git().add_all().commit("Initial commit");
+    "})
+        .init_git();
+    context.git().commit("Initial commit");
 
     cmd_snapshot!(context, context.install(), @r#"
     success: true
@@ -484,7 +488,7 @@ fn run_worktree() {
 /// Test prek hooks runs with `GIT_DIR` respected.
 #[test]
 fn git_dir_respected() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new().with_config(indoc::indoc! {r#"
         repos:
         - repo: local
           hooks:
@@ -493,8 +497,8 @@ fn git_dir_respected() {
              language: python
              entry: python -c 'import os, sys; print("GIT_DIR:", os.environ.get("GIT_DIR")); print("GIT_WORK_TREE:", os.environ.get("GIT_WORK_TREE")); sys.exit(1)'
              pass_filenames: false
-    "#});
-    context.git().add_all();
+    "#}).init_git();
+
     let cwd = context.work_dir();
 
     cmd_snapshot!(context, context.install(), @r#"
@@ -533,7 +537,7 @@ fn git_dir_respected() {
 
 #[test]
 fn git_dir_synthesized_git_work_tree_not_leaked_to_hook() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new().with_config(indoc::indoc! {r#"
         repos:
         - repo: local
           hooks:
@@ -543,8 +547,7 @@ fn git_dir_synthesized_git_work_tree_not_leaked_to_hook() {
              entry: python3 -c 'import os, sys; print("GIT_DIR:", os.environ.get("GIT_DIR")); print("GIT_WORK_TREE:", os.environ.get("GIT_WORK_TREE")); sys.exit(1)'
              pass_filenames: false
              always_run: true
-    "#});
-    context.git().add_all();
+    "#}).init_git();
 
     let mut run = context.run();
     run.env(EnvVars::GIT_DIR, context.work_dir().join(".git"));
@@ -570,7 +573,7 @@ fn git_dir_synthesized_git_work_tree_not_leaked_to_hook() {
 /// it runs must still resolve the repository root, not the project directory.
 #[test]
 fn workspace_hook_in_linked_worktree_keeps_git_index() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_filter("[a-f0-9]{7}", "abc1234")
         .with_config(indoc::indoc! {r"
         repos:
@@ -600,9 +603,10 @@ fn workspace_hook_in_linked_worktree_keeps_git_index() {
         .with_file("README.md", "root\n")
         .with_file("tracked.txt", "b\n")
         .with_file("sub/README.md", "sub\n")
-        .with_file("deep/nested/a.txt", "a\n");
+        .with_file("deep/nested/a.txt", "a\n")
+        .init_git();
 
-    context.git().add_all().commit("Initial commit");
+    context.git().commit("Initial commit");
 
     cmd_snapshot!(context, context.install(), @r#"
     success: true
@@ -669,7 +673,9 @@ fn workspace_hook_in_linked_worktree_keeps_git_index() {
 
 #[test]
 fn workspace_hook_impl_root() {
-    let context = TestEnv::new_git().with_filter("[a-f0-9]{7}", "abc1234");
+    let context = TestEnv::new()
+        .with_filter("[a-f0-9]{7}", "abc1234")
+        .init_git();
 
     let config = indoc! {r#"
     repos:
@@ -683,7 +689,7 @@ fn workspace_hook_impl_root() {
     "#};
 
     context.write_workspace(["project2", "project3"], config);
-    context.git().add_all();
+    context.git().add(".");
 
     // Install from root
     cmd_snapshot!(context, context.install(), @r#"
@@ -735,7 +741,9 @@ fn workspace_hook_impl_root() {
 
 #[test]
 fn workspace_commit_msg_hook_receives_message_file_for_each_project() {
-    let context = TestEnv::new_git().with_filter("[a-f0-9]{7}", "abc1234");
+    let context = TestEnv::new()
+        .with_filter("[a-f0-9]{7}", "abc1234")
+        .init_git();
 
     let config = indoc! {r#"
     default_install_hook_types:
@@ -753,7 +761,7 @@ fn workspace_commit_msg_hook_receives_message_file_for_each_project() {
     "#};
 
     context.write_workspace(["template"], config);
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.install(), @r#"
     success: true
@@ -796,7 +804,7 @@ fn workspace_commit_msg_hook_receives_message_file_for_each_project() {
 
 #[test]
 fn commit_msg_builtin_hook_respects_message_file_filters() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_filter("[a-f0-9]{7}", "abc1234")
         .with_config(indoc::indoc! {r"
     default_install_hook_types:
@@ -805,8 +813,8 @@ fn commit_msg_builtin_hook_respects_message_file_filters() {
       - repo: builtin
         hooks:
         - id: check-json
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.install(), @r#"
     success: true
@@ -835,7 +843,9 @@ fn commit_msg_builtin_hook_respects_message_file_filters() {
 
 #[test]
 fn workspace_hook_impl_subdirectory() {
-    let context = TestEnv::new_git().with_filter("[a-f0-9]{7}", "abc1234");
+    let context = TestEnv::new()
+        .with_filter("[a-f0-9]{7}", "abc1234")
+        .init_git();
     let cwd = context.work_dir();
 
     let config = indoc! {r#"
@@ -850,7 +860,7 @@ fn workspace_hook_impl_subdirectory() {
     "#};
 
     context.write_workspace(["project2", "project3"], config);
-    context.git().add_all();
+    context.git().add(".");
 
     // Install from a subdirectory
     cmd_snapshot!(context, context.install().current_dir(cwd.join("project2")), @r#"
@@ -893,7 +903,9 @@ fn workspace_hook_impl_subdirectory() {
 /// Install from a subdirectory, and run commit in another worktree.
 #[test]
 fn workspace_hook_impl_worktree_subdirectory() {
-    let context = TestEnv::new_git().with_filter("[a-f0-9]{7}", "abc1234");
+    let context = TestEnv::new()
+        .with_filter("[a-f0-9]{7}", "abc1234")
+        .init_git();
     let cwd = context.work_dir();
 
     let config = indoc! {r#"
@@ -908,7 +920,7 @@ fn workspace_hook_impl_worktree_subdirectory() {
     "#};
 
     context.write_workspace(["project2", "project3"], config);
-    context.git().add_all().commit("Initial commit");
+    context.git().add(".").commit("Initial commit");
 
     // Install from a subdirectory
     cmd_snapshot!(context, context.install().current_dir(cwd.join("project2")), @r#"
@@ -949,13 +961,14 @@ fn workspace_hook_impl_worktree_subdirectory() {
 
 #[test]
 fn workspace_hook_impl_no_project_found() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_filter("[a-f0-9]{7}", "1d5e501")
-        .with_file("empty/file.txt", "Some content");
+        .with_file("empty/file.txt", "Some content")
+        .init_git();
 
     // Create a directory without .pre-commit-config.yaml
     let empty_dir = context.child("empty");
-    context.git().add_all();
+    context.git().add(".");
 
     // Install hook that allows missing config
     cmd_snapshot!(context, context.install(), @r#"
@@ -1018,7 +1031,7 @@ fn workspace_hook_impl_no_project_found() {
                 language: fail
     "},
     );
-    context.git().add_all();
+    context.git().add(".");
 
     // Commit with `PREK_ALLOW_NO_CONFIG=1` again, the hooks should run (and fail)
     let mut commit = context.git_at(&empty_dir).command();
@@ -1046,7 +1059,7 @@ fn workspace_hook_impl_no_project_found() {
 
 #[test]
 fn hook_impl_does_not_fail_when_no_hooks_match_stage() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_filter("[a-f0-9]{7}", "abc1234")
         .with_file(
             PRE_COMMIT_CONFIG_YAML,
@@ -1061,11 +1074,12 @@ fn hook_impl_does_not_fail_when_no_hooks_match_stage() {
                 stages: [ manual ]
     "},
         )
-        .with_file("file.txt", "x");
+        .with_file("file.txt", "x")
+        .init_git();
 
     // Only a manual-stage hook; a pre-commit hook run should find nothing for the stage.
 
-    context.git().add_all();
+    context.git().add(".");
 
     // Install the git hook (which invokes `prek hook-impl`).
     cmd_snapshot!(context, context.install(), @r#"
@@ -1096,7 +1110,9 @@ fn hook_impl_does_not_fail_when_no_hooks_match_stage() {
 
 #[test]
 fn workspace_hook_impl_with_selectors() {
-    let context = TestEnv::new_git().with_filter("[a-f0-9]{7}", "abc1234");
+    let context = TestEnv::new()
+        .with_filter("[a-f0-9]{7}", "abc1234")
+        .init_git();
     let config = indoc! {r#"
     repos:
       - repo: local
@@ -1109,7 +1125,7 @@ fn workspace_hook_impl_with_selectors() {
     "#};
 
     context.write_workspace(["project2", "project3"], config);
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.install().arg("project2/"), @r#"
     success: true

--- a/crates/prek/tests/init.rs
+++ b/crates/prek/tests/init.rs
@@ -8,7 +8,7 @@ mod common;
 
 #[test]
 fn init_defaults_to_git_root() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
     let child = context.child("child");
     child.create_dir_all()?;
 
@@ -30,7 +30,7 @@ fn init_defaults_to_git_root() -> anyhow::Result<()> {
 
 #[test]
 fn init_child_project_refreshes_parent_workspace() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config("repos: []\n");
+    let context = TestEnv::new().with_config("repos: []\n").init_git();
     context.list().assert().success();
 
     let child = context.child("child");
@@ -64,7 +64,7 @@ fn init_child_project_refreshes_parent_workspace() -> anyhow::Result<()> {
 #[test]
 fn init_preserves_existing_config() {
     let config = "repos: []\n";
-    let context = TestEnv::new_git().with_config(config);
+    let context = TestEnv::new().with_config(config).init_git();
 
     cmd_snapshot!(context, context.command().arg("init"), @r#"
     success: true
@@ -82,7 +82,7 @@ fn init_preserves_existing_config() {
 
 #[test]
 fn init_can_create_yaml_config() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     cmd_snapshot!(context, context.command().args(["init", "--format", "yaml"]), @r#"
     success: true
@@ -100,7 +100,7 @@ fn init_can_create_yaml_config() {
 
 #[test]
 fn init_can_skip_hook_installation() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     cmd_snapshot!(context, context.command().args(["init", "--no-install"]), @r#"
     success: true

--- a/crates/prek/tests/install.rs
+++ b/crates/prek/tests/install.rs
@@ -11,7 +11,7 @@ mod common;
 
 #[test]
 fn install() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     // Install `prek` hook.
     cmd_snapshot!(context, context.install(), @r#"
@@ -137,7 +137,7 @@ fn install() {
 
 #[test]
 fn install_with_git_dir() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     cmd_snapshot!(context, context.install().arg("--git-dir").arg("custom-git-dir"), @r#"
     success: true
@@ -174,7 +174,7 @@ fn install_with_git_dir() {
 
 #[test]
 fn install_with_local_hooks_path_installs_to_configured_directory() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     context
         .git()
@@ -215,7 +215,7 @@ fn install_with_local_hooks_path_installs_to_configured_directory() {
 
 #[test]
 fn install_with_git_dir_allows_external_hooks_path_set() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let global_gitconfig = context.work_dir().join("global.gitconfig");
     context
@@ -264,8 +264,9 @@ fn install_with_git_dir_allows_external_hooks_path_set() {
 
 #[test]
 fn install_force_uses_repository_hooks_with_external_hooks_path_set() {
-    let context =
-        TestEnv::new_git().with_file("custom-hooks/pre-commit", "#!/bin/sh\necho global hook\n");
+    let context = TestEnv::new()
+        .with_file("custom-hooks/pre-commit", "#!/bin/sh\necho global hook\n")
+        .init_git();
 
     let global_gitconfig = context.work_dir().join("global.gitconfig");
     context
@@ -301,7 +302,7 @@ fn install_force_uses_repository_hooks_with_external_hooks_path_set() {
 
 #[test]
 fn install_refuses_empty_external_hooks_path_set() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let global_gitconfig = context.work_dir().join("global.gitconfig");
     context
@@ -336,7 +337,7 @@ fn install_refuses_empty_external_hooks_path_set() {
 
 #[test]
 fn install_refuses_empty_local_hooks_path_set() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     context.git().run(["config", "core.hooksPath", ""]);
 
@@ -352,7 +353,7 @@ fn install_refuses_empty_local_hooks_path_set() {
 
 #[test]
 fn install_with_dot_hooks_path_installs_to_repo_root() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     context.git().run(["config", "core.hooksPath", "."]);
 
@@ -368,13 +369,15 @@ fn install_with_dot_hooks_path_installs_to_repo_root() {
 
 #[test]
 fn install_with_included_local_hooks_path_installs_to_configured_directory() {
-    let context = TestEnv::new_git().with_file(
-        "included-hooks.cfg",
-        indoc! {r"
+    let context = TestEnv::new()
+        .with_file(
+            "included-hooks.cfg",
+            indoc! {r"
         [core]
             hooksPath = custom-hooks
     "},
-    );
+        )
+        .init_git();
 
     context
         .git()
@@ -392,9 +395,9 @@ fn install_with_included_local_hooks_path_installs_to_configured_directory() {
 
 #[test]
 fn install_with_worktree_hooks_path_installs_to_configured_directory() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_file("README.md", "hello\n");
+    let context = TestEnv::new().with_file("README.md", "hello\n").init_git();
 
-    context.git().add_all().commit("Initial commit");
+    context.git().commit("Initial commit");
 
     context
         .git()
@@ -445,7 +448,7 @@ fn install_with_worktree_hooks_path_installs_to_configured_directory() -> anyhow
 fn install_uses_standard_permissions_by_default() {
     use std::os::unix::fs::PermissionsExt;
 
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     context.install().assert().success();
 
@@ -465,7 +468,7 @@ fn install_uses_standard_permissions_by_default() {
 fn install_uses_group_permissions_for_shared_repository() {
     use std::os::unix::fs::PermissionsExt;
 
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     // Set core.sharedRepository = group
     context
@@ -490,7 +493,7 @@ fn install_uses_group_permissions_for_shared_repository() {
 fn install_uses_explicit_shared_repository_mode() {
     use std::os::unix::fs::PermissionsExt;
 
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     context
         .git()
@@ -510,7 +513,8 @@ fn install_uses_explicit_shared_repository_mode() {
 /// Run `prek install --prepare-hooks` to install the git hook and prepare prek hook environments.
 #[test]
 fn install_with_hooks() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/pre-commit/pre-commit-hooks
             rev: v5.0.0
@@ -520,7 +524,8 @@ fn install_with_hooks() -> anyhow::Result<()> {
             rev: v5.0.0
             hooks:
               - id: trailing-whitespace
-    "});
+    "})
+        .init_git();
 
     context
         .home_dir()
@@ -565,7 +570,8 @@ fn install_with_hooks() -> anyhow::Result<()> {
 
 #[test]
 fn install_with_legacy_install_hooks_flag_alias() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -573,7 +579,8 @@ fn install_with_legacy_install_hooks_flag_alias() -> anyhow::Result<()> {
                 name: Test Hook
                 language: python
                 entry: python -c 'print("test")'
-    "#});
+    "#})
+        .init_git();
 
     context
         .home_dir()
@@ -596,7 +603,7 @@ fn install_with_legacy_install_hooks_flag_alias() -> anyhow::Result<()> {
 
 #[test]
 fn install_with_existing_legacy_hook() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     // Install our hook script first.
     context.install().assert().success();
@@ -636,7 +643,8 @@ fn install_with_existing_legacy_hook() {
 /// Run `prek prepare-hooks` to prepare prek hook environments without installing the git hook.
 #[test]
 fn install_hooks_only() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/pre-commit/pre-commit-hooks
             rev: v5.0.0
@@ -646,7 +654,8 @@ fn install_hooks_only() -> anyhow::Result<()> {
             rev: v5.0.0
             hooks:
               - id: trailing-whitespace
-    "});
+    "})
+        .init_git();
 
     context
         .home_dir()
@@ -679,7 +688,8 @@ fn install_hooks_only() -> anyhow::Result<()> {
 
 #[test]
 fn install_with_legacy_install_hooks_subcommand_alias() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -687,7 +697,8 @@ fn install_with_legacy_install_hooks_subcommand_alias() -> anyhow::Result<()> {
                 name: Test Hook
                 language: python
                 entry: python -c 'print("test")'
-        "#});
+        "#})
+        .init_git();
 
     context
         .home_dir()
@@ -711,7 +722,7 @@ fn install_with_legacy_install_hooks_subcommand_alias() -> anyhow::Result<()> {
 
 #[test]
 fn uninstall() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     // Hook does not exist.
     cmd_snapshot!(context, context.uninstall(), @r#"
@@ -783,7 +794,7 @@ fn uninstall() {
 
 #[test]
 fn uninstall_with_local_hooks_path_removes_configured_hook() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     context
         .git()
@@ -806,9 +817,9 @@ fn uninstall_with_local_hooks_path_removes_configured_hook() {
 
 #[test]
 fn uninstall_with_worktree_hooks_path_removes_configured_hook() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_file("README.md", "hello\n");
+    let context = TestEnv::new().with_file("README.md", "hello\n").init_git();
 
-    context.git().add_all().commit("Initial commit");
+    context.git().commit("Initial commit");
 
     context
         .git()
@@ -877,7 +888,7 @@ fn uninstall_with_worktree_hooks_path_removes_configured_hook() -> anyhow::Resul
 
 #[test]
 fn uninstall_refuses_external_hooks_path_set() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let global_gitconfig = context.work_dir().join("global.gitconfig");
     context
@@ -909,7 +920,7 @@ fn uninstall_refuses_external_hooks_path_set() {
 
 #[test]
 fn uninstall_with_git_dir_allows_external_hooks_path_set() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let global_gitconfig = context.work_dir().join("global.gitconfig");
     context
@@ -948,7 +959,7 @@ fn uninstall_with_git_dir_allows_external_hooks_path_set() {
 
 #[test]
 fn uninstall_refuses_empty_external_hooks_path_set() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let global_gitconfig = context.work_dir().join("global.gitconfig");
     context
@@ -980,7 +991,7 @@ fn uninstall_refuses_empty_external_hooks_path_set() {
 
 #[test]
 fn uninstall_refuses_empty_local_hooks_path_set() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     context.git().run(["config", "core.hooksPath", ""]);
 
@@ -996,7 +1007,7 @@ fn uninstall_refuses_empty_local_hooks_path_set() {
 
 #[test]
 fn uninstall_with_dot_hooks_path_removes_root_hook() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     context.git().run(["config", "core.hooksPath", "."]);
 
@@ -1010,13 +1021,15 @@ fn uninstall_with_dot_hooks_path_removes_root_hook() {
 
 #[test]
 fn uninstall_with_included_local_hooks_path_removes_configured_hook() {
-    let context = TestEnv::new_git().with_file(
-        "included-hooks.cfg",
-        indoc! {r"
+    let context = TestEnv::new()
+        .with_file(
+            "included-hooks.cfg",
+            indoc! {r"
         [core]
             hooksPath = custom-hooks
     "},
-    );
+        )
+        .init_git();
 
     context
         .git()
@@ -1033,7 +1046,7 @@ fn uninstall_with_included_local_hooks_path_removes_configured_hook() {
 /// `prek uninstall --all` should remove all prek-managed hooks.
 #[test]
 fn uninstall_all_managed_hooks() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     // Install both pre-commit and pre-push hooks.
     context
@@ -1066,7 +1079,7 @@ fn uninstall_all_managed_hooks() {
 
 #[test]
 fn uninstall_remove_legacy_hook() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     // Create the `pre-commit` hook.
     context.install().assert().success();
@@ -1118,7 +1131,7 @@ fn uninstall_remove_legacy_hook() -> anyhow::Result<()> {
 
 #[test]
 fn init_templatedir() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     cmd_snapshot!(context, context.command().arg("init-templatedir").arg(".git"), @r#"
     success: true
@@ -1207,7 +1220,7 @@ fn init_templatedir() -> anyhow::Result<()> {
 /// Tests `prek util init-template-dir` works.
 #[test]
 fn util_init_template_dir() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     cmd_snapshot!(context, context.command().arg("util").arg("init-template-dir").arg(".git"), @r#"
     success: true
@@ -1276,7 +1289,7 @@ fn init_template_dir_non_git_repo() {
 
 #[test]
 fn workspace_install() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let config = indoc! {r#"
     repos:
@@ -1297,7 +1310,7 @@ fn workspace_install() {
         ],
         config,
     );
-    context.git().add_all();
+    context.git().add(".");
 
     // Install from root directory.
     cmd_snapshot!(context, context.install(), @r#"
@@ -1420,7 +1433,7 @@ fn workspace_install() {
 
 #[test]
 fn workspace_install_hooks() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let config = indoc! {r#"
     repos:
@@ -1441,7 +1454,7 @@ fn workspace_install_hooks() -> anyhow::Result<()> {
         ],
         config,
     );
-    context.git().add_all();
+    context.git().add(".");
 
     // Install by selectors
     cmd_snapshot!(context, context.prepare_hooks().arg("project3").arg("--skip").arg("project3/project5/"), @r"
@@ -1470,7 +1483,7 @@ fn workspace_install_hooks() -> anyhow::Result<()> {
 /// Only install root config's hook types in a workspace.
 #[test]
 fn workspace_install_only_root_hook_types() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let root_config = indoc! {r#"
     default_install_hook_types: [pre-commit, post-commit]
@@ -1497,7 +1510,7 @@ fn workspace_install_only_root_hook_types() {
     let context = context
         .with_file(PRE_COMMIT_CONFIG_YAML, root_config)
         .with_file("project2/.pre-commit-config.yaml", nested_config);
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.install(), @r#"
     success: true
@@ -1518,7 +1531,7 @@ fn workspace_install_only_root_hook_types() {
 
 #[test]
 fn workspace_uninstall() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let config = indoc! {r#"
     repos:
@@ -1539,7 +1552,7 @@ fn workspace_uninstall() {
         ],
         config,
     );
-    context.git().add_all();
+    context.git().add(".");
 
     // Install first
     context.install().assert().success();
@@ -1560,7 +1573,7 @@ fn workspace_uninstall() {
 
 #[test]
 fn workspace_init_template_dir() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let config = indoc! {r#"
     repos:
@@ -1581,7 +1594,7 @@ fn workspace_init_template_dir() -> anyhow::Result<()> {
         ],
         config,
     );
-    context.git().add_all();
+    context.git().add(".");
 
     // Create a template directory
     let template_dir = context.child("template");
@@ -1622,7 +1635,7 @@ fn workspace_init_template_dir() -> anyhow::Result<()> {
 /// Test that a warning is shown when the config file exists but is invalid.
 #[test]
 fn install_invalid_config_warning() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     // Write an invalid config (missing required `rev` field).
     context.write_config(indoc::indoc! {r"

--- a/crates/prek/tests/languages/bun.rs
+++ b/crates/prek/tests/languages/bun.rs
@@ -9,7 +9,8 @@ use assert_fs::fixture::PathChild;
 /// Test basic Bun hook execution.
 #[test]
 fn basic_bun() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -20,9 +21,8 @@ fn basic_bun() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -41,7 +41,8 @@ fn basic_bun() {
 /// Test that `additional_dependencies` are installed correctly.
 #[test]
 fn additional_dependencies() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -53,9 +54,8 @@ fn additional_dependencies() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -104,7 +104,8 @@ fn additional_dependencies() {
 #[cfg(feature = "ci")]
 #[test]
 fn language_version() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -141,9 +142,8 @@ fn language_version() -> Result<()> {
                 verbose: true
                 pass_filenames: false
                 additional_dependencies: ["cowsay"] # different dep to force create separate env
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     let bun_dir = context.home_dir().child("tools").child("bun");
     bun_dir.assert(predicates::path::missing());

--- a/crates/prek/tests/languages/conda.rs
+++ b/crates/prek/tests/languages/conda.rs
@@ -4,7 +4,8 @@ use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
 fn language_version() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -16,9 +17,8 @@ fn language_version() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -34,7 +34,8 @@ fn language_version() {
 
 #[test]
 fn local_hook_with_additional_dependencies() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -46,9 +47,8 @@ fn local_hook_with_additional_dependencies() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     let context = context.with_filter(r"OpenSSL [^\n]+", "OpenSSL [VERSION]");
 
@@ -68,7 +68,7 @@ fn local_hook_with_additional_dependencies() {
 
 #[test]
 fn remote_repo_install() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
     let hook_repo = context
         .create_repo("conda-hook")
         .with_file(
@@ -92,7 +92,7 @@ fn remote_repo_install() {
 
     hook_repo
         .git()
-        .add_all()
+        .add(".")
         .commit("Add conda hook")
         .tag("v1.0.0");
 
@@ -107,7 +107,7 @@ fn remote_repo_install() {
                 pass_filenames: false
     ", hook_repo.path().display()});
 
-    context.git().add_all();
+    context.git().add(".");
 
     let context = context.with_filter(r"OpenSSL [^\n]+", "OpenSSL [VERSION]");
 

--- a/crates/prek/tests/languages/coursier.rs
+++ b/crates/prek/tests/languages/coursier.rs
@@ -4,7 +4,8 @@ use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
 fn additional_dependencies() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -16,9 +17,8 @@ fn additional_dependencies() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @"
     success: true
@@ -36,7 +36,7 @@ fn additional_dependencies() {
 
 #[test]
 fn pre_commit_channel() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
     let hook_repo = context
         .create_repo("coursier-hook")
         .with_file(
@@ -60,7 +60,7 @@ fn pre_commit_channel() {
 
     hook_repo
         .git()
-        .add_all()
+        .add(".")
         .commit("Add coursier hook")
         .tag("v1.0.0");
 
@@ -75,7 +75,7 @@ fn pre_commit_channel() {
                 pass_filenames: false
     ", hook_repo.path().display()});
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @"
     success: true
@@ -93,7 +93,7 @@ fn pre_commit_channel() {
 
 #[test]
 fn local_pre_commit_channel_is_ignored() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_file(".pre-commit-channel/scalafmt.json", "{}")
         .with_config(indoc::indoc! {r"
         repos:
@@ -105,9 +105,8 @@ fn local_pre_commit_channel_is_ignored() {
                 entry: scalafmt --version
                 always_run: true
                 pass_filenames: false
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @"
     success: false

--- a/crates/prek/tests/languages/dart.rs
+++ b/crates/prek/tests/languages/dart.rs
@@ -2,7 +2,8 @@ use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
 fn language_version() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -14,9 +15,8 @@ fn language_version() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -32,7 +32,7 @@ fn language_version() {
 
 #[test]
 fn hook_stderr() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -51,9 +51,8 @@ fn hook_stderr() {
               exit(1);
             }
         "},
-        );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -71,7 +70,7 @@ fn hook_stderr() {
 
 #[test]
 fn script_with_files() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -94,9 +93,8 @@ fn script_with_files() {
         "},
         )
         .with_file("test1.dart", "void main() { print('test1'); }")
-        .with_file("test2.dart", "void main() { print('test2'); }");
-
-    context.git().add_all();
+        .with_file("test2.dart", "void main() { print('test2'); }")
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -117,7 +115,7 @@ fn script_with_files() {
 
 #[test]
 fn with_pubspec_and_dependencies() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -155,9 +153,8 @@ fn with_pubspec_and_dependencies() {
                 print("hello hello " + pen("world"));
             }
         "#},
-        );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -175,7 +172,7 @@ fn with_pubspec_and_dependencies() {
 
 #[test]
 fn with_pubspec() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -205,9 +202,8 @@ fn with_pubspec() {
               print('Hello from Dart package!');
             }
         "},
-        );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -230,7 +226,7 @@ fn with_pubspec() {
 
 #[test]
 fn with_pubspec_and_additional_dependencies() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -270,9 +266,8 @@ fn with_pubspec_and_additional_dependencies() {
               print(greet(p.posix.join('Dart', 'Hooks')));
             }
         "},
-        );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -295,7 +290,7 @@ fn with_pubspec_and_additional_dependencies() {
 
 #[test]
 fn additional_dependencies() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -318,9 +313,8 @@ fn additional_dependencies() {
               print('Joined path: $joined');
             }
         "},
-        );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -338,7 +332,7 @@ fn additional_dependencies() {
 
 #[test]
 fn additional_dependencies_with_version() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -360,9 +354,8 @@ fn additional_dependencies_with_version() {
               print('Using path package');
             }
         "},
-        );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -380,7 +373,7 @@ fn additional_dependencies_with_version() {
 
 #[test]
 fn executable_alias() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -411,9 +404,8 @@ fn executable_alias() {
               print('alias executable works');
             }
         "},
-        );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -431,7 +423,7 @@ fn executable_alias() {
 
 #[test]
 fn dart_environment() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -457,9 +449,8 @@ fn dart_environment() {
               }
             }
         "},
-        );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -477,7 +468,8 @@ fn dart_environment() {
 
 #[test]
 fn remote_hook() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/prek-ci/dart-hooks
             rev: v1.1.0
@@ -485,9 +477,8 @@ fn remote_hook() {
               - id: dart-hooks
                 always_run: true
                 verbose: true
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true

--- a/crates/prek/tests/languages/deno.rs
+++ b/crates/prek/tests/languages/deno.rs
@@ -9,7 +9,8 @@ use crate::common::{TestEnv, cmd_snapshot};
 /// Test basic Deno hook execution with an inline script.
 #[test]
 fn basic_deno() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -20,9 +21,8 @@ fn basic_deno() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -41,7 +41,7 @@ fn basic_deno() {
 /// Test running a TypeScript script file with an explicit `deno run` entry.
 #[test]
 fn script_file() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_file(
             "check.ts",
             indoc::indoc! {r#"
@@ -59,9 +59,8 @@ fn script_file() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -80,7 +79,7 @@ fn script_file() {
 /// Test running Deno built-in subcommands with an explicit `deno` prefix.
 #[test]
 fn builtin_commands() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_file(
             "example.ts",
             indoc::indoc! {r"
@@ -98,9 +97,8 @@ fn builtin_commands() {
                 entry: deno fmt --check
                 types: [ts]
                 verbose: true
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -119,7 +117,8 @@ fn builtin_commands() {
 /// Test a remote Deno hook whose manifest installs its own executable.
 #[test]
 fn remote_hook() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/prek-ci/deno-hooks
             rev: v3.1.0
@@ -127,9 +126,8 @@ fn remote_hook() {
               - id: deno-eval
                 always_run: true
                 verbose: true
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -148,7 +146,8 @@ fn remote_hook() {
 /// Test a remote Deno hook whose configured additional dependency installs the executable it runs.
 #[test]
 fn remote_hook_with_additional_dependencies() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: https://github.com/prek-ci/deno-hooks
             rev: v3.1.0
@@ -157,9 +156,8 @@ fn remote_hook_with_additional_dependencies() {
                 additional_dependencies: ["npm:semver@7:semver-tool"]
                 always_run: true
                 verbose: true
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -178,7 +176,8 @@ fn remote_hook_with_additional_dependencies() {
 /// Test a remote Deno hook whose manifest installs a local file as an executable dependency.
 #[test]
 fn remote_hook_with_local_file_additional_dependency() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/prek-ci/deno-hooks
             rev: v3.1.0
@@ -186,9 +185,8 @@ fn remote_hook_with_local_file_additional_dependency() {
               - id: deno-local-dep
                 always_run: true
                 verbose: true
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -207,7 +205,8 @@ fn remote_hook_with_local_file_additional_dependency() {
 /// Test that `additional_dependencies` are installed as CLI executables.
 #[test]
 fn additional_dependencies() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -219,9 +218,8 @@ fn additional_dependencies() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -254,12 +252,14 @@ fn additional_dependencies() {
 /// Test that an absolute file can be installed as an executable additional dependency.
 #[test]
 fn additional_dependencies_absolute_file() {
-    let context = TestEnv::new_git().with_file(
-        "tool.ts",
-        indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_file(
+            "tool.ts",
+            indoc::indoc! {r#"
             console.log("Hello from local additional dependency!");
         "#},
-    );
+        )
+        .init_git();
     let tool = context.child("tool.ts");
     let dependency = serde_json::to_string(&format!("{}:echo-tool", tool.path().display()))
         .expect("Failed to serialize Deno dependency");
@@ -278,7 +278,7 @@ fn additional_dependencies_absolute_file() {
                 pass_filenames: false
     "});
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -299,7 +299,8 @@ fn additional_dependencies_absolute_file() {
 #[cfg(feature = "ci")]
 #[test]
 fn language_version() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -335,9 +336,8 @@ fn language_version() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     let deno_dir = context.home_dir().child("tools").child("deno");
     deno_dir.assert(predicates::path::missing());
@@ -404,7 +404,8 @@ fn language_version() {
 /// Test checksum policy behavior for a Deno release without checksum sidecars.
 #[test]
 fn checksum_policy() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -416,8 +417,8 @@ fn checksum_policy() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     let context = context.with_filter(r"deno-[A-Za-z0-9_-]+\.zip", "deno-[TARGET].zip");
 
@@ -453,7 +454,8 @@ fn checksum_policy() {
 #[cfg(feature = "ci")]
 #[test]
 fn version_range() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -465,9 +467,8 @@ fn version_range() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     let context = context.with_filter(r"Deno \d+\.\d+\.\d+", "Deno [VERSION]");
 
@@ -488,7 +489,7 @@ fn version_range() {
 /// Test that hook failure is properly reported.
 #[test]
 fn hook_failure() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_file(
             "bad.ts",
             indoc::indoc! {r"
@@ -507,9 +508,8 @@ fn hook_failure() {
                 entry: deno lint
                 types: [ts]
                 verbose: true
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     // The lint should fail due to no-explicit-any
     let output = context.run().output().expect("Failed to run hook");
@@ -521,7 +521,7 @@ fn hook_failure() {
 #[test]
 fn script_with_permissions() {
     // Permissions must be specified before the script path when using deno run.
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_file(
             "read_env.ts",
             indoc::indoc! {r#"
@@ -539,9 +539,8 @@ fn script_with_permissions() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run().env("TEST_VAR", "hello"), @r"
     success: true

--- a/crates/prek/tests/languages/docker.rs
+++ b/crates/prek/tests/languages/docker.rs
@@ -3,7 +3,8 @@ use crate::common::{TestEnv, cmd_snapshot};
 /// GitHub Action only has docker for linux hosted runners.
 #[test]
 fn docker() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: https://github.com/prek-ci/docker-hooks
             rev: v1.0
@@ -14,9 +15,8 @@ fn docker() {
                     MESSAGE: "Hello, world"
                 verbose: true
                 always_run: true
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -34,9 +34,10 @@ fn docker() {
 
 #[test]
 fn workspace_docker() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_file("project1/project1.txt", "")
-        .with_file("project2/project2.txt", "");
+        .with_file("project2/project2.txt", "")
+        .init_git();
 
     let config = indoc::indoc! {r"
         repos:
@@ -50,7 +51,7 @@ fn workspace_docker() {
 
     context.write_workspace(["project1", "project2"], config);
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true

--- a/crates/prek/tests/languages/docker_image.rs
+++ b/crates/prek/tests/languages/docker_image.rs
@@ -8,13 +8,15 @@ use crate::common::{TestEnv, cmd_snapshot};
 #[test]
 fn docker_image() {
     // Test suite from https://github.com/super-linter/super-linter/tree/main/test/linters/gitleaks/bad
-    let context = TestEnv::new_git().with_file(
-        "gitleaks_bad_01.txt",
-        indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_file(
+            "gitleaks_bad_01.txt",
+            indoc::indoc! {r"
         aws_access_key_id = AROA47DSWDEZA3RQASWB
         aws_secret_access_key = wQwdsZDiWg4UA5ngO0OSI2TkM4kkYxF6d2S1aYWM
     "},
-    );
+        )
+        .init_git();
 
     // Use fully qualified image name for Podman/Docker compatibility
     Command::new("docker")
@@ -34,7 +36,7 @@ fn docker_image() {
                 entry: docker.io/zricethezav/gitleaks:v8.21.2 git --pre-commit --redact --staged --verbose --no-banner --log-level=error
                 pass_filenames: false
     "});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -67,7 +69,9 @@ fn docker_image() {
 /// Test that `docker_image` does not try to resolve entry in the host system PATH.
 #[test]
 fn docker_image_does_not_resolve_entry() -> Result<()> {
-    let context = TestEnv::new_git().with_executable_file("bin/alpine", "#!/bin/sh\necho host\n");
+    let context = TestEnv::new()
+        .with_executable_file("bin/alpine", "#!/bin/sh\necho host\n")
+        .init_git();
 
     let bin_dir = context.child("bin");
 
@@ -88,7 +92,7 @@ fn docker_image_does_not_resolve_entry() -> Result<()> {
                 always_run: true
                 verbose: true
     "});
-    context.git().add_all();
+    context.git().add(".");
 
     let mut cmd = context.run();
     cmd.env(EnvVars::PATH, prepend_paths(&[bin_dir.path()])?);

--- a/crates/prek/tests/languages/dotnet.rs
+++ b/crates/prek/tests/languages/dotnet.rs
@@ -8,7 +8,8 @@ use crate::common::{TestEnv, cmd_snapshot};
 #[cfg(feature = "ci")]
 #[test]
 fn language_version() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -50,9 +51,8 @@ fn language_version() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     let context = context.with_filter(r"\b(\d+\.\d+)\.\d+\b", "$1.X");
 
@@ -88,7 +88,8 @@ fn language_version() {
 /// Test invalid `language_version` format is rejected.
 #[test]
 fn invalid_language_version() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -100,9 +101,8 @@ fn invalid_language_version() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -121,7 +121,8 @@ fn invalid_language_version() {
 #[cfg(feature = "ci")]
 #[test]
 fn multiple_sdk_versions() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -141,8 +142,8 @@ fn multiple_sdk_versions() -> anyhow::Result<()> {
                 always_run: true
                 pass_filenames: false
                 verbose: true
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     let context = context.with_filter(r"\b(\d+\.\d+)\.\d+\b", "$1.X");
 
@@ -194,7 +195,8 @@ fn multiple_sdk_versions() -> anyhow::Result<()> {
 #[cfg(feature = "ci")]
 #[test]
 fn additional_dependencies_with_version() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -206,8 +208,8 @@ fn additional_dependencies_with_version() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "#});
-    context.git().add_all();
+    "#})
+        .init_git();
 
     let context = context.with_filter(r"\b(4\.7\.1\+)[0-9a-f]+\b", "${1}[SHA]");
 
@@ -245,7 +247,7 @@ fn additional_dependencies_with_version() {
 #[cfg(feature = "ci")]
 #[test]
 fn additional_dependencies_in_remote_repo() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
     let repo = context.create_repo("dotnet-hook").with_file(
         PRE_COMMIT_HOOKS_YAML,
         indoc::indoc! {r#"
@@ -257,7 +259,7 @@ fn additional_dependencies_in_remote_repo() {
         "#},
     );
     let repo_path = repo.path();
-    repo.git().add_all().commit("Add manifest").tag("v0.1.0");
+    repo.git().add(".").commit("Add manifest").tag("v0.1.0");
 
     context.write_config(indoc::formatdoc! {r"
         repos:
@@ -269,7 +271,7 @@ fn additional_dependencies_in_remote_repo() {
                 pass_filenames: false
     ", repo_path.display()});
 
-    context.git().add_all();
+    context.git().add(".");
 
     let context = context.with_filter(r"\b(4\.7\.1\+)[0-9a-f]+\b", "${1}[SHA]");
 
@@ -292,7 +294,7 @@ fn additional_dependencies_in_remote_repo() {
 #[cfg(feature = "ci")]
 #[test]
 fn hook_stderr() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -322,9 +324,8 @@ fn hook_stderr() {
         Console.Error.Flush();
         Environment.Exit(1);
     "#},
-        );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @"
     success: false

--- a/crates/prek/tests/languages/fail.rs
+++ b/crates/prek/tests/languages/fail.rs
@@ -3,7 +3,9 @@ use crate::common::{TestEnv, cmd_snapshot};
 /// GitHub Action only has docker for linux hosted runners.
 #[test]
 fn fail() {
-    let context = TestEnv::new_git().with_file("changelog/changelog.md", "");
+    let context = TestEnv::new()
+        .with_file("changelog/changelog.md", "")
+        .init_git();
 
     context.write_config(indoc::indoc! {r"
         repos:
@@ -16,7 +18,7 @@ fn fail() {
               files: 'changelog/.*(?<!\.rst)$'
     "});
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: false

--- a/crates/prek/tests/languages/golang.rs
+++ b/crates/prek/tests/languages/golang.rs
@@ -11,7 +11,8 @@ use crate::common::{TestEnv, cmd_snapshot};
 #[cfg(feature = "ci")]
 #[test]
 fn language_version() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -57,8 +58,8 @@ fn language_version() -> anyhow::Result<()> {
                 language_version: '<1.25'
                 always_run: true
                 pass_filenames: false
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     let go_dir = context.home_dir().child("tools").child("go");
     go_dir.assert(predicates::path::missing());
@@ -136,7 +137,7 @@ fn language_version() -> anyhow::Result<()> {
 /// Test a remote go hook.
 #[test]
 fn remote_hook() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     // Run hooks with system found go.
     context.write_config(indoc::indoc! {r"
@@ -147,7 +148,7 @@ fn remote_hook() {
               - id: echo
                 verbose: true
         "});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -177,7 +178,7 @@ fn remote_hook() {
                 language_version: '1.23.11' # will auto download
                 pass_filenames: false
     "#});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -212,7 +213,7 @@ fn remote_hook() {
                 verbose: true
                 language_version: '1.23.11' # will auto download
         "});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -232,7 +233,7 @@ fn remote_hook() {
 #[test]
 fn local_additional_deps() {
     // Create a local go hook with additional_dependencies.
-    let go_hook = TestEnv::new_git()
+    let go_hook = TestEnv::new()
         .with_file(
             "go.mod",
             indoc::indoc! {r"
@@ -268,22 +269,24 @@ fn local_additional_deps() {
                   language: golang
                   additional_dependencies: [ ./cmd ]
             "},
-        );
-    go_hook.git().add_all().commit("Initial commit").tag("v1.0");
+        )
+        .init_git();
+    go_hook.git().commit("Initial commit").tag("v1.0");
 
     let hook_url = go_hook.work_dir().to_str().unwrap();
-    let context = TestEnv::new_git().with_file(
-        PRE_COMMIT_CONFIG_YAML,
-        indoc::formatdoc! {r"
+    let context = TestEnv::new()
+        .with_file(
+            PRE_COMMIT_CONFIG_YAML,
+            indoc::formatdoc! {r"
         repos:
           - repo: {hook_url}
             rev: v1.0
             hooks:
               - id: go-hook
                 verbose: true
-   ", hook_url = hook_url},
-    );
-    context.git().add_all();
+       ", hook_url = hook_url},
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -304,7 +307,7 @@ fn local_additional_deps() {
 #[test]
 fn remote_go_mod_metadata_sets_language_version() {
     // Create a remote repo containing a golang hook.
-    let go_hook = TestEnv::new_git()
+    let go_hook = TestEnv::new()
         .with_file(
             "go.mod",
             indoc::indoc! {r"
@@ -322,12 +325,13 @@ fn remote_go_mod_metadata_sets_language_version() {
                   language: golang
                   verbose: true
             "},
-        );
+        )
+        .init_git();
 
-    go_hook.git().add_all().commit("Initial commit").tag("v1.0");
+    go_hook.git().commit("Initial commit").tag("v1.0");
 
     // Use it as a remote repo in a separate project.
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let hook_url = go_hook.work_dir().to_str().unwrap();
     context.write_config(indoc::formatdoc! {r"
@@ -338,7 +342,7 @@ fn remote_go_mod_metadata_sets_language_version() {
             - id: echo
               verbose: true
       ", hook_url = hook_url});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @"
     success: false

--- a/crates/prek/tests/languages/haskell.rs
+++ b/crates/prek/tests/languages/haskell.rs
@@ -4,7 +4,7 @@ use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
 fn local_hook() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -38,9 +38,8 @@ fn local_hook() {
             main :: IO ()
             main = putStrLn "Hello Haskell!"
         "#},
-        );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.run().env(EnvVars::PREK_INTERNAL__SKIP_CABAL_UPDATE, "1"), @"
     success: true
@@ -72,7 +71,8 @@ fn local_hook() {
 
 #[test]
 fn additional_dependencies() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -84,9 +84,8 @@ fn additional_dependencies() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run().env(EnvVars::PREK_INTERNAL__SKIP_CABAL_UPDATE, "1"), @"
     success: true
@@ -104,7 +103,8 @@ fn additional_dependencies() {
 
 #[test]
 fn remote_hook() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/prek-ci/haskell-hooks
             rev: v1.0.0
@@ -112,9 +112,8 @@ fn remote_hook() {
               - id: hello
                 always_run: true
                 verbose: true
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run().env(EnvVars::PREK_INTERNAL__SKIP_CABAL_UPDATE, "1"), @"
     success: true

--- a/crates/prek/tests/languages/julia.rs
+++ b/crates/prek/tests/languages/julia.rs
@@ -2,7 +2,8 @@ use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
 fn local_hook() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -13,9 +14,8 @@ fn local_hook() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -47,7 +47,8 @@ fn local_hook() {
 
 #[test]
 fn additional_dependencies() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -59,9 +60,8 @@ fn additional_dependencies() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -79,13 +79,15 @@ fn additional_dependencies() {
 
 #[test]
 fn project_toml() {
-    let context = TestEnv::new_git().with_file(
-        "Project.toml",
-        indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_file(
+            "Project.toml",
+            indoc::indoc! {r#"
             [deps]
             Example = "7876af07-990d-54b4-ab0e-23690620f79a"
         "#},
-    );
+        )
+        .init_git();
 
     context.write_config(indoc::indoc! {r#"
         repos:
@@ -100,7 +102,7 @@ fn project_toml() {
                 pass_filenames: false
     "#});
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -118,8 +120,9 @@ fn project_toml() {
 
 #[test]
 fn script_file() {
-    let context =
-        TestEnv::new_git().with_file("my_script.jl", r#"println("Hello from script file!")"#);
+    let context = TestEnv::new()
+        .with_file("my_script.jl", r#"println("Hello from script file!")"#)
+        .init_git();
 
     context.write_config(indoc::indoc! {r"
         repos:
@@ -134,7 +137,7 @@ fn script_file() {
                 pass_filenames: false
     "});
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -152,7 +155,8 @@ fn script_file() {
 
 #[test]
 fn remote_hook() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/prek-ci/julia-hooks
             rev: v1.0.0
@@ -160,9 +164,8 @@ fn remote_hook() {
               - id: hello
                 always_run: true
                 verbose: true
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @"
     success: true

--- a/crates/prek/tests/languages/lua.rs
+++ b/crates/prek/tests/languages/lua.rs
@@ -2,7 +2,8 @@ use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
 fn health_check() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -13,9 +14,8 @@ fn health_check() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -48,7 +48,8 @@ fn health_check() {
 /// Test specifying `language_version` for Lua hooks which is not supported for now.
 #[test]
 fn language_version() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -60,9 +61,8 @@ fn language_version() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -79,7 +79,7 @@ fn language_version() {
 /// Test that stderr from hooks is captured and shown to the user.
 #[test]
 fn hook_stderr() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -89,9 +89,8 @@ fn hook_stderr() {
                 language: lua
                 entry: lua ./hook.lua
     "})
-        .with_file("hook.lua", "io.stderr:write('How are you\\n'); os.exit(1)");
-
-    context.git().add_all();
+        .with_file("hook.lua", "io.stderr:write('How are you\\n'); os.exit(1)")
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -110,7 +109,7 @@ fn hook_stderr() {
 /// Test Lua script execution with file arguments.
 #[test]
 fn script_with_files() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -130,9 +129,8 @@ fn script_with_files() {
     "#},
         )
         .with_file("test1.lua", "print('test1')")
-        .with_file("test2.lua", "print('test2')");
-
-    context.git().add_all();
+        .with_file("test2.lua", "print('test2')")
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -154,7 +152,7 @@ fn script_with_files() {
 /// Test Lua environment variables (`LUA_PATH` and `LUA_CPATH`)
 #[test]
 fn lua_environment() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -165,9 +163,7 @@ fn lua_environment() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "#});
-
-    context.git().add_all();
+    "#}).init_git();
 
     let context = context.with_filter(r"lua-[A-Za-z0-9]+", "lua-[HASH]");
 
@@ -205,7 +201,8 @@ fn lua_environment() {
 /// Test Lua hook with additional dependencies.
 #[test]
 fn additional_dependencies() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -217,9 +214,8 @@ fn additional_dependencies() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -238,7 +234,8 @@ fn additional_dependencies() {
 /// Test remote Lua hook from GitHub repository.
 #[test]
 fn remote_hook() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/prek-ci/lua-hooks
             rev: v1.0.0
@@ -246,9 +243,8 @@ fn remote_hook() {
               - id: lua-hooks
                 always_run: true
                 verbose: true
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true

--- a/crates/prek/tests/languages/mise.rs
+++ b/crates/prek/tests/languages/mise.rs
@@ -8,7 +8,8 @@ use crate::common::{TestEnv, cmd_snapshot, make_executable};
 
 #[test]
 fn reuses_managed_mise() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -21,8 +22,8 @@ fn reuses_managed_mise() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "#});
-    context.git().add_all();
+    "#})
+        .init_git();
 
     let context = context.with_filter(
         r"2026\.7\.18 [^\r\n]+ \(\d{4}-\d{2}-\d{2}\)",
@@ -58,7 +59,7 @@ fn reuses_managed_mise() {
                 verbose: true
                 pass_filenames: false
     "});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run()
         .env(EnvVars::PREK_INTERNAL__MISE_BINARY_NAME, "mise-never-exists"), @r#"
@@ -78,7 +79,9 @@ fn reuses_managed_mise() {
 #[test]
 fn system_mise_installs_and_activates_dependencies() -> Result<()> {
     // Early miserc discovery must not read configuration from the calling project.
-    let context = TestEnv::new_git().with_file(".miserc.toml", "not valid = [");
+    let context = TestEnv::new()
+        .with_file(".miserc.toml", "not valid = [")
+        .init_git();
 
     let hook_repo = context
         .create_repo("mise-system-hook")
@@ -98,7 +101,7 @@ fn system_mise_installs_and_activates_dependencies() -> Result<()> {
         )
         // Provisioning must not read configuration from the hook repository.
         .with_file("mise.toml", "not valid = [");
-    hook_repo.git().add_all().commit("Add mise hook");
+    hook_repo.git().add(".").commit("Add mise hook");
     let rev = hook_repo.git().rev_parse("HEAD")?;
 
     // Keep a conflicting executable beside the real system mise. Activating the private tool must
@@ -124,7 +127,7 @@ fn system_mise_installs_and_activates_dependencies() -> Result<()> {
             hooks:
               - id: mise-system
     ", hook_repo.path().display(), rev});
-    context.git().add_all();
+    context.git().add(".");
 
     let ambient_data = context.work_dir().join("ambient-mise-data");
     let path = std::env::join_paths(

--- a/crates/prek/tests/languages/node.rs
+++ b/crates/prek/tests/languages/node.rs
@@ -9,7 +9,7 @@ use crate::common::{TestEnv, cmd_snapshot, remove_bin_from_path};
 
 #[test]
 fn exec_uses_installed_node_environment() -> anyhow::Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_file(
             "node-env-tool/package.json",
             indoc::indoc! {r#"
@@ -28,7 +28,8 @@ fn exec_uses_installed_node_environment() -> anyhow::Result<()> {
         #!/usr/bin/env node
         console.log("exec node env ok");
     "#},
-        );
+        )
+        .init_git();
     let package = context.child("node-env-tool");
 
     let dependency = serde_json::to_string(package.path())?;
@@ -64,7 +65,8 @@ fn exec_uses_installed_node_environment() -> anyhow::Result<()> {
 #[cfg(feature = "ci")]
 #[test]
 fn language_version() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -104,8 +106,8 @@ fn language_version() -> anyhow::Result<()> {
                 entry: node -p 'process.version'
                 language_version: 'lts/iron' # node 20
                 always_run: true
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     let node_dir = context.home_dir().child("tools").child("node");
     node_dir.assert(predicates::path::missing());
@@ -180,7 +182,8 @@ fn language_version() -> anyhow::Result<()> {
 /// Test that `additional_dependencies` are installed correctly.
 #[test]
 fn additional_dependencies() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -192,9 +195,8 @@ fn additional_dependencies() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -247,7 +249,7 @@ fn additional_dependencies() {
 /// <https://github.com/npm/cli/issues/9189>
 #[test]
 fn remote_package_is_installed_from_git() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
     let hook_repo = context
         .create_repo("remote-node-hook")
         .with_file(
@@ -288,7 +290,7 @@ fn remote_package_is_installed_from_git() {
 
     hook_repo
         .git()
-        .add_all()
+        .add(".")
         .commit("Add remote Node hook")
         .tag("v1.0.0");
 
@@ -300,7 +302,7 @@ fn remote_package_is_installed_from_git() {
               - id: remote-node-hook
                 verbose: true
     ", hook_repo.path().display()});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run().env(EnvVars::PREK_HOME, ".prek-cache"), @r"
     success: true
@@ -325,7 +327,7 @@ fn remote_package_is_installed_from_git() {
 /// its development dependencies.
 #[test]
 fn remote_prepare_uses_dev_dependencies() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
     let hook_repo = context
         .create_repo("prepared-node-hook")
         .with_file(
@@ -386,7 +388,7 @@ fn remote_prepare_uses_dev_dependencies() {
 
     hook_repo
         .git()
-        .add_all()
+        .add(".")
         .commit("Add source-built Node hook")
         .tag("v1.0.0");
 
@@ -398,7 +400,7 @@ fn remote_prepare_uses_dev_dependencies() {
               - id: prepared-node-hook
                 verbose: true
     ", hook_repo.path().display()});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -417,7 +419,7 @@ fn remote_prepare_uses_dev_dependencies() {
 /// Test that lowercase npm config inherited from `npm exec` cannot redirect installs.
 #[test]
 fn additional_dependencies_ignore_inherited_npm_config_prefix() -> anyhow::Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_file(
             "prefix-fixture/package.json",
             indoc::indoc! {r#"
@@ -436,7 +438,8 @@ fn additional_dependencies_ignore_inherited_npm_config_prefix() -> anyhow::Resul
         #!/usr/bin/env node
         console.log("prefix fixture ok")
     "#},
-        );
+        )
+        .init_git();
     let package_dir = context.child("prefix-fixture");
 
     let dependency = serde_json::to_string(package_dir.path())?;
@@ -454,7 +457,7 @@ fn additional_dependencies_ignore_inherited_npm_config_prefix() -> anyhow::Resul
                 pass_filenames: false
     "});
 
-    context.git().add_all();
+    context.git().add(".");
 
     let fake_prefix = context.home_dir().child("fake-prefix");
     fake_prefix.create_dir_all()?;
@@ -498,7 +501,8 @@ fn additional_dependencies_ignore_inherited_npm_config_prefix() -> anyhow::Resul
 /// Regression test for #1492: `install()` must use the provisioned toolchain.
 #[test]
 fn additional_dependencies_without_system_node() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -509,9 +513,8 @@ fn additional_dependencies_without_system_node() -> anyhow::Result<()> {
                 additional_dependencies: ["cowsay"]
                 always_run: true
                 pass_filenames: false
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     let new_path = remove_bin_from_path("node", None)?;
 
@@ -530,7 +533,8 @@ fn additional_dependencies_without_system_node() -> anyhow::Result<()> {
 /// Test that `npm.cmd` can be found on Windows.
 #[test]
 fn npm_version() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -541,8 +545,8 @@ fn npm_version() {
                 always_run: true
                 pass_filenames: false
                 verbose: true
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     let context = context.with_filter(r"\d+\.\d+\.\d+", "[NPM_VERSION]");
 
@@ -562,7 +566,7 @@ fn npm_version() {
 
 #[test]
 fn node_install_preserves_global_git_config_and_isolates_repository() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     // Installing this additional dependency forces npm to invoke Git during environment setup.
     let dependency_repo = context.create_repo("sentinel-node-dependency").with_file(
@@ -576,7 +580,7 @@ fn node_install_preserves_global_git_config_and_isolates_repository() -> anyhow:
     );
     dependency_repo
         .git()
-        .add_all()
+        .add(".")
         .commit("Add sentinel Node dependency");
 
     let hook_repo = context
@@ -614,7 +618,7 @@ fn node_install_preserves_global_git_config_and_isolates_repository() -> anyhow:
 
     hook_repo
         .git()
-        .add_all()
+        .add(".")
         .commit("Add sentinel Node hook")
         .tag("v1.0.0");
 
@@ -627,7 +631,7 @@ fn node_install_preserves_global_git_config_and_isolates_repository() -> anyhow:
                 additional_dependencies:
                   - git+file:///prek-node-git-dependency
     ", repo = hook_repo.path().display()});
-    context.git().add_all();
+    context.git().add(".");
 
     // The regression corrupts the calling repository's index, so capture it before npm runs.
     let staged_before = context

--- a/crates/prek/tests/languages/perl.rs
+++ b/crates/prek/tests/languages/perl.rs
@@ -6,7 +6,7 @@ use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
 fn local_hook() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -27,9 +27,8 @@ fn local_hook() {
 
             print "Hello from Perl!\n";
         "#},
-        );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.run().env(EnvVars::HOME, &**context.home_dir()), @r"
     success: true
@@ -47,7 +46,7 @@ fn local_hook() {
 
 #[test]
 fn remote_repo_install() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
     let hook_repo = context
         .create_repo("perl-hook")
         .with_file(
@@ -92,7 +91,7 @@ fn remote_repo_install() {
 
     hook_repo
         .git()
-        .add_all()
+        .add(".")
         .commit("Add perl hook")
         .tag("v1.0.0");
 
@@ -107,7 +106,7 @@ fn remote_repo_install() {
                 pass_filenames: false
     ", hook_repo.path().display()});
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run().env(EnvVars::HOME, &**context.home_dir()), @r"
     success: true
@@ -125,7 +124,8 @@ fn remote_repo_install() {
 
 #[test]
 fn additional_dependencies() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -137,9 +137,8 @@ fn additional_dependencies() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     context
         .run()
@@ -150,7 +149,8 @@ fn additional_dependencies() {
 
 #[test]
 fn language_version() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -162,9 +162,8 @@ fn language_version() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false

--- a/crates/prek/tests/languages/php.rs
+++ b/crates/prek/tests/languages/php.rs
@@ -5,7 +5,7 @@ use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
 fn local_hook() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -18,9 +18,8 @@ fn local_hook() {
                 verbose: true
                 pass_filenames: false
     "})
-        .with_file("hello.php", "<?php echo \"Hello from PHP!\\n\";\n");
-
-    context.git().add_all();
+        .with_file("hello.php", "<?php echo \"Hello from PHP!\\n\";\n")
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -52,7 +51,7 @@ fn local_hook() {
 
 #[test]
 fn remote_repo_install() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
     let hook_repo = context
         .create_repo("php-hook")
         .with_file(
@@ -83,7 +82,7 @@ fn remote_repo_install() -> anyhow::Result<()> {
 
     hook_repo
         .git()
-        .add_all()
+        .add(".")
         .commit("Add PHP hook")
         .tag("v1.0.0");
 
@@ -97,7 +96,7 @@ fn remote_repo_install() -> anyhow::Result<()> {
                 verbose: true
                 pass_filenames: false
     ", hook_repo.path().display()});
-    context.git().add_all();
+    context.git().add(".");
 
     let composer_home = context.home_dir().child("composer");
     composer_home.create_dir_all()?;
@@ -140,7 +139,8 @@ fn additional_dependencies() -> anyhow::Result<()> {
             "#},
         );
 
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -152,8 +152,8 @@ fn additional_dependencies() -> anyhow::Result<()> {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     let composer_home = context.home_dir().child("composer");
     composer_home.create_dir_all()?;
@@ -193,7 +193,8 @@ fn additional_dependencies() -> anyhow::Result<()> {
 
 #[test]
 fn language_version() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -204,8 +205,8 @@ fn language_version() {
                 language_version: '8.4'
                 always_run: true
                 pass_filenames: false
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false

--- a/crates/prek/tests/languages/pygrep.rs
+++ b/crates/prek/tests/languages/pygrep.rs
@@ -3,7 +3,7 @@ use crate::common::{TestEnv, cmd_snapshot};
 /// Test basic pygrep functionality - case-sensitive matching
 #[test]
 fn basic_case_sensitive() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_file(
             "test.py",
             indoc::indoc! {r"
@@ -11,7 +11,8 @@ fn basic_case_sensitive() {
                 print('Hello World')
                 # todo: fix later"},
         )
-        .with_file("other.py", "print('No issues here')\n");
+        .with_file("other.py", "print('No issues here')\n")
+        .init_git();
 
     context.write_config(indoc::indoc! {r#"
         repos:
@@ -23,7 +24,7 @@ fn basic_case_sensitive() {
                 entry: "TODO"
                 files: "\\.py$"
         "#});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -56,7 +57,7 @@ fn basic_case_sensitive() {
 /// Test case-insensitive matching
 #[test]
 fn case_insensitive() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_file(
             "test.py",
             indoc::indoc! {r"
@@ -64,7 +65,8 @@ fn case_insensitive() {
                 print('Hello World')
                 # todo: fix later"},
         )
-        .with_file("other.py", "print('No issues here')\n");
+        .with_file("other.py", "print('No issues here')\n")
+        .init_git();
 
     context.write_config(indoc::indoc! {r#"
         repos:
@@ -77,7 +79,7 @@ fn case_insensitive() {
                 args: ["--ignore-case"]
                 files: "\\.py$"
         "#});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -97,15 +99,17 @@ fn case_insensitive() {
 /// Test multiline mode
 #[test]
 fn multiline_mode() {
-    let context = TestEnv::new_git().with_file(
-        "test.py",
-        indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_file(
+            "test.py",
+            indoc::indoc! {r#"
             def function():
                 """A function
                 with multiline docstring
                 """
                 pass"#},
-    );
+        )
+        .init_git();
 
     context.write_config(indoc::indoc! {r#"
         repos:
@@ -118,7 +122,7 @@ fn multiline_mode() {
                 args: ["--multiline"]
                 files: "\\.py$"
         "#});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -139,9 +143,10 @@ fn multiline_mode() {
 /// Test negate mode - passes when pattern is NOT found
 #[test]
 fn negate_mode() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_file("good.py", "print('Hello World')\n")
-        .with_file("bad.py", "TODO: implement this\nprint('Hello World')\n");
+        .with_file("bad.py", "TODO: implement this\nprint('Hello World')\n")
+        .init_git();
 
     context.write_config(indoc::indoc! {r#"
         repos:
@@ -154,7 +159,7 @@ fn negate_mode() {
                 args: ["--negate"]
                 files: "\\.py$"
         "#});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -173,7 +178,7 @@ fn negate_mode() {
 /// Test negate mode with multiline - should output filename if pattern not found
 #[test]
 fn negate_multiline_mode() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_file("no_pattern.py", "print('Hello World')\n")
         .with_file(
             "has_pattern.py",
@@ -183,7 +188,8 @@ fn negate_multiline_mode() {
                     with multiline docstring
                     """
                     pass"#},
-        );
+        )
+        .init_git();
 
     context.write_config(indoc::indoc! {r#"
         repos:
@@ -196,7 +202,7 @@ fn negate_multiline_mode() {
                 args: ["--multiline", "--negate"]
                 files: "\\.py$"
         "#});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -215,7 +221,7 @@ fn negate_multiline_mode() {
 /// Test invalid regex pattern
 #[test]
 fn invalid_regex() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_file("test.py", "print('Hello World')\n")
         .with_config(indoc::indoc! {r#"
         repos:
@@ -226,8 +232,8 @@ fn invalid_regex() {
                 language: pygrep
                 entry: "[unclosed"
                 files: "\\.py$"
-        "#});
-    context.git().add_all();
+        "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -242,14 +248,16 @@ fn invalid_regex() {
 
 #[test]
 fn python_regex_quirks() {
-    let context = TestEnv::new_git().with_file(
-        "test.py",
-        indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_file(
+            "test.py",
+            indoc::indoc! {r"
             def function(arg1, arg2):
                 pass
             def bad_function():
                 pass"},
-    );
+        )
+        .init_git();
 
     // Test lookbehind assertion - function with arguments
     context.write_config(indoc::indoc! {r#"
@@ -262,7 +270,7 @@ fn python_regex_quirks() {
                 entry: "def\\s+\\w+\\([^)]*\\w[^)]*\\):"
                 files: "\\.py$"
         "#});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -281,14 +289,16 @@ fn python_regex_quirks() {
 /// Test complex regex with word boundaries and character classes
 #[test]
 fn complex_regex_patterns() {
-    let context = TestEnv::new_git().with_file(
-        "test.py",
-        indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_file(
+            "test.py",
+            indoc::indoc! {r"
             import sys
             from os import path
             import json
             from typing import Dict"},
-    );
+        )
+        .init_git();
 
     // Match import statements but not 'from' imports
     context.write_config(indoc::indoc! {r#"
@@ -301,7 +311,7 @@ fn complex_regex_patterns() {
                 entry: "^import\\s+[a-zA-Z_][a-zA-Z0-9_]*$"
                 files: "\\.py$"
         "#});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -321,14 +331,16 @@ fn complex_regex_patterns() {
 /// Test combination of case insensitive and multiline
 #[test]
 fn case_insensitive_multiline() {
-    let context = TestEnv::new_git().with_file(
-        "test.py",
-        indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_file(
+            "test.py",
+            indoc::indoc! {r"
             # TODO: fix this
             def function():
                 # todo: implement
                 pass"},
-    );
+        )
+        .init_git();
 
     context.write_config(indoc::indoc! {r#"
         repos:
@@ -341,7 +353,7 @@ fn case_insensitive_multiline() {
                 args: ["--ignore-case", "--multiline"]
                 files: "\\.py$"
         "#});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -362,7 +374,9 @@ fn case_insensitive_multiline() {
 /// Test successful case where pattern is not found
 #[test]
 fn pattern_not_found() {
-    let context = TestEnv::new_git().with_file("test.py", "print('Hello World')\n# All good here");
+    let context = TestEnv::new()
+        .with_file("test.py", "print('Hello World')\n# All good here")
+        .init_git();
 
     context.write_config(indoc::indoc! {r#"
         repos:
@@ -374,7 +388,7 @@ fn pattern_not_found() {
                 entry: "TODO"
                 files: "\\.py$"
         "#});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -388,7 +402,9 @@ fn pattern_not_found() {
 
 #[test]
 fn invalid_args() {
-    let context = TestEnv::new_git().with_file("test.py", "print('Hello World')\n# All good here");
+    let context = TestEnv::new()
+        .with_file("test.py", "print('Hello World')\n# All good here")
+        .init_git();
 
     context.write_config(indoc::indoc! {r#"
         repos:
@@ -401,7 +417,7 @@ fn invalid_args() {
                 args: ["--hello"]
                 files: "\\.py$"
         "#});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: false

--- a/crates/prek/tests/languages/python.rs
+++ b/crates/prek/tests/languages/python.rs
@@ -12,7 +12,8 @@ use crate::common::{TestEnv, cmd_snapshot};
 #[cfg(feature = "ci")]
 #[test]
 fn language_version() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -57,8 +58,8 @@ fn language_version() -> anyhow::Result<()> {
                 entry: python -c 'import sys; print(sys.version_info[:2])'
                 language_version: '3.11.1' # will auto download
                 always_run: true
-    "#});
-    context.git().add_all();
+    "#})
+        .init_git();
 
     let python_dir = context.home_dir().child("tools").child("python");
     python_dir.assert(predicates::path::missing());
@@ -139,7 +140,8 @@ fn language_version() -> anyhow::Result<()> {
 
 #[test]
 fn invalid_version() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -151,9 +153,8 @@ fn invalid_version() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -170,7 +171,8 @@ fn invalid_version() {
 /// Request a version that neither can be found nor downloaded.
 #[test]
 fn can_not_download() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -180,8 +182,8 @@ fn can_not_download() {
                 entry: python -c 'import sys; print(sys.version_info[:3])'
                 language_version: '<=3.6' # not supported version
                 always_run: true
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     let context = context.with_filters([
         (
@@ -218,7 +220,8 @@ fn can_not_download() {
 /// Test that `additional_dependencies` are installed correctly.
 #[test]
 fn additional_dependencies() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -231,9 +234,8 @@ fn additional_dependencies() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -251,7 +253,7 @@ fn additional_dependencies() {
 
 #[test]
 fn additional_dependencies_in_remote_repo() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
     let repo = context
         .create_repo("python-hook")
         .with_file(
@@ -287,7 +289,7 @@ fn additional_dependencies_in_remote_repo() {
         "#},
         );
     let repo_path = repo.path();
-    repo.git().add_all().commit("Add manifest").tag("v0.1.0");
+    repo.git().add(".").commit("Add manifest").tag("v0.1.0");
 
     context.write_config(indoc::formatdoc! {r"
         repos:
@@ -299,7 +301,7 @@ fn additional_dependencies_in_remote_repo() {
                 verbose: true
     ", repo_path.display()});
 
-    context.git().add_all();
+    context.git().add(".");
     cmd_snapshot!(context, context.run(), @r"
     success: true
     exit_code: 0
@@ -317,7 +319,7 @@ fn additional_dependencies_in_remote_repo() {
 /// Ensure that stderr from hooks is captured and shown to the user.
 #[test]
 fn hook_stderr() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -330,9 +332,8 @@ fn hook_stderr() {
         .with_file(
             "hook.py",
             "import sys; print('How are you', file=sys.stderr); sys.exit(1)",
-        );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -352,7 +353,7 @@ fn hook_stderr() {
 /// Only if no additional dependencies are specified.
 #[test]
 fn pep723_script() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -381,11 +382,12 @@ fn pep723_script() {
         from pyecho import main
         main()
     "#},
-        );
+        )
+        .init_git();
     // On Windows, uv venv does not create `python3.exe`, `python3.12.exe` symlink,
     // be sure to use `python` as the interpreter name.
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -413,16 +415,18 @@ fn pep723_script() {
 /// Regression test for <https://github.com/j178/prek/issues/1354>
 #[test]
 fn git_env_vars_not_leaked_to_pip_install() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_file(
-        "setup.py",
-        indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_file(
+            "setup.py",
+            indoc::indoc! {r#"
         import os, sys
         from setuptools import setup
         if os.environ.get("GIT_DIR"):
             sys.exit("ERROR: GIT_DIR should not leak into pip install")
         setup(name="test", version="0.1.0", extras_require={"test": []})
     "#},
-    );
+        )
+        .init_git();
 
     let dependency = serde_json::to_string(&format!(
         "{}[test]",
@@ -440,7 +444,7 @@ fn git_env_vars_not_leaked_to_pip_install() -> anyhow::Result<()> {
                 always_run: true
     "#});
 
-    context.git().add_all();
+    context.git().add(".");
 
     // Simulate worktree environment by setting GIT_DIR (like git does in worktrees)
     cmd_snapshot!(context, context.run()
@@ -458,16 +462,18 @@ fn git_env_vars_not_leaked_to_pip_install() -> anyhow::Result<()> {
 
 #[test]
 fn configured_env_is_applied_to_python_install() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_file(
-        "setup.py",
-        indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_file(
+            "setup.py",
+            indoc::indoc! {r#"
             import os, sys
             from setuptools import setup
             if os.environ.get("PREK_TEST_INSTALL_ENV") != "configured":
                 sys.exit("configured hook env was not applied during installation")
             setup(name="test-install-env", version="0.1.0")
         "#},
-    );
+        )
+        .init_git();
 
     let dependency = serde_json::to_string(&context.work_dir().path().to_string_lossy())?;
     context.write_config(indoc::formatdoc! {r#"
@@ -483,7 +489,7 @@ fn configured_env_is_applied_to_python_install() -> anyhow::Result<()> {
                   PREK_TEST_INSTALL_ENV: configured
                 always_run: true
     "#});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -500,14 +506,16 @@ fn configured_env_is_applied_to_python_install() -> anyhow::Result<()> {
 /// Regression test for <https://github.com/j178/prek/issues/1603>.
 #[test]
 fn local_relative_additional_dependency_is_not_resolved_from_worktree() {
-    let context = TestEnv::new_git().with_file(
-        "pyproject.toml",
-        indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_file(
+            "pyproject.toml",
+            indoc::indoc! {r#"
             [project]
             name = "local-project"
             version = "0.1.0"
         "#},
-    );
+        )
+        .init_git();
 
     let context = context
         .with_config(indoc::indoc! {r#"
@@ -534,7 +542,7 @@ fn local_relative_additional_dependency_is_not_resolved_from_worktree() {
             ),
         ]);
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -564,7 +572,7 @@ fn health_check_with_symlinked_toolchain() -> anyhow::Result<()> {
     use fs_err::os::unix::fs::symlink;
     use prek_consts::prepend_paths;
 
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     // Find a Python executable, create a symlinked directory to its parent,
     // and prepend that to PATH so that prek picks up the symlinked path.
@@ -584,7 +592,7 @@ fn health_check_with_symlinked_toolchain() -> anyhow::Result<()> {
                 always_run: true
                 pass_filenames: false
     "#});
-    context.git().add_all();
+    context.git().add(".");
 
     // First run installs the hook
     cmd_snapshot!(context, context.run().env(EnvVars::PATH, new_path), @"

--- a/crates/prek/tests/languages/r.rs
+++ b/crates/prek/tests/languages/r.rs
@@ -5,10 +5,12 @@ use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
 fn local_hook() {
-    let context = TestEnv::new_git().with_file(
-        ".Rprofile",
-        r#"stop("project .Rprofile should not be loaded")"#,
-    );
+    let context = TestEnv::new()
+        .with_file(
+            ".Rprofile",
+            r#"stop("project .Rprofile should not be loaded")"#,
+        )
+        .init_git();
 
     context.write_config(indoc::indoc! {r#"
         repos:
@@ -23,7 +25,7 @@ fn local_hook() {
                 pass_filenames: false
     "#});
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -55,7 +57,7 @@ fn local_hook() {
 
 #[test]
 fn local_hook_with_absolute_additional_dependency() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     write_local_r_package(context.work_dir(), "localdep")?;
     let dependency_path = std::path::absolute(context.child("localdep").path())?;
@@ -75,7 +77,7 @@ fn local_hook_with_absolute_additional_dependency() -> anyhow::Result<()> {
                 pass_filenames: false
     "});
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -95,7 +97,7 @@ fn local_hook_with_absolute_additional_dependency() -> anyhow::Result<()> {
 
 #[test]
 fn remote_repo_install() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
     let hook_repo = context
         .create_repo("r-hook")
         .with_file(
@@ -111,7 +113,7 @@ fn remote_repo_install() -> anyhow::Result<()> {
     write_local_r_package(hook_repo.path(), "localdep")?;
     write_renv_project(hook_repo.path())?;
 
-    hook_repo.git().add_all().commit("Add R hook").tag("v1.0.0");
+    hook_repo.git().add(".").commit("Add R hook").tag("v1.0.0");
 
     context.write_config(indoc::formatdoc! {r"
         repos:
@@ -125,7 +127,7 @@ fn remote_repo_install() -> anyhow::Result<()> {
                 pass_filenames: false
     ", hook_repo.path().display()});
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -145,7 +147,8 @@ fn remote_repo_install() -> anyhow::Result<()> {
 
 #[test]
 fn language_version() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -157,9 +160,8 @@ fn language_version() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false

--- a/crates/prek/tests/languages/ruby.rs
+++ b/crates/prek/tests/languages/ruby.rs
@@ -7,10 +7,12 @@ use prek_consts::PRE_COMMIT_HOOKS_YAML;
 use crate::common::{TestEnv, cmd_snapshot};
 
 fn ruby_context() -> TestEnv {
-    TestEnv::new_git().with_filter(
-        r"ruby (\d+\.\d+)\.\d+(?:p\d+)? \(\d{4}-\d{2}-\d{2} revision [0-9a-f]{0,10}\).*?\[.+\]",
-        "ruby $1.X ([DATE] revision [HASH]) [FLAGS] [PLATFORM]",
-    )
+    TestEnv::new()
+        .with_filter(
+            r"ruby (\d+\.\d+)\.\d+(?:p\d+)? \(\d{4}-\d{2}-\d{2} revision [0-9a-f]{0,10}\).*?\[.+\]",
+            "ruby $1.X ([DATE] revision [HASH]) [FLAGS] [PLATFORM]",
+        )
+        .init_git()
 }
 
 /// Test basic Ruby hook with system Ruby
@@ -35,7 +37,7 @@ fn system_ruby() {
                 pass_filenames: false
                 always_run: true
     "});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run().arg("-v"), @r"
     success: true
@@ -73,7 +75,7 @@ fn language_version_default() {
                 pass_filenames: false
                 always_run: true
     "});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run().arg("-v"), @r"
     success: true
@@ -133,7 +135,7 @@ fn specific_ruby_available() {
                 pass_filenames: false
                 always_run: true
     "});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run().arg("-v"), @r"
     success: true
@@ -185,7 +187,7 @@ fn specific_ruby_unavailable() {
                 pass_filenames: false
                 always_run: true
     "});
-    context.git().add_all();
+    context.git().add(".");
 
     #[cfg(target_os = "windows")]
     cmd_snapshot!(context, context.run().arg("-v"), @r"
@@ -220,13 +222,15 @@ fn specific_ruby_unavailable() {
 #[test]
 fn additional_gem_dependencies() {
     // Use a gem that is not bundled with Ruby.
-    let context = TestEnv::new_git().with_file(
-        "test_script.rb",
-        indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_file(
+            "test_script.rb",
+            indoc::indoc! {r"
             require 'rspec'
             puts RSpec::Version::STRING
         "},
-    );
+        )
+        .init_git();
 
     context.write_config(indoc::indoc! {r#"
         repos:
@@ -256,7 +260,7 @@ fn additional_gem_dependencies() {
                 pass_filenames: false
                 always_run: true
     "#});
-    context.git().add_all();
+    context.git().add(".");
 
     let context = context.with_filters([
         // Normalize unpinned rspec version (only for test-gem-require, not test-gem-require-versioned)
@@ -303,7 +307,7 @@ fn additional_gem_dependencies() {
 /// Test Ruby hook with gemspec
 #[test]
 fn gemspec_workflow() -> anyhow::Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_file(
             "test_gem.gemspec",
             indoc::indoc! {r#"
@@ -334,7 +338,8 @@ fn gemspec_workflow() -> anyhow::Result<()> {
             require 'test_gem'
             puts TestGem.hello
         "},
-        );
+        )
+        .init_git();
 
     context.write_config(indoc::indoc! {r"
         repos:
@@ -348,7 +353,7 @@ fn gemspec_workflow() -> anyhow::Result<()> {
                 pass_filenames: false
                 always_run: true
     "});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run().arg("-v"), @r"
     success: true
@@ -382,7 +387,8 @@ fn gemspec_workflow() -> anyhow::Result<()> {
 /// Test environment isolation between Ruby hooks
 #[test]
 fn environment_isolation() -> anyhow::Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -429,8 +435,8 @@ fn environment_isolation() -> anyhow::Result<()> {
                 pass_filenames: false
                 always_run: true
                 verbose: true
-    "#});
-    context.git().add_all();
+    "#})
+        .init_git();
 
     let output = context.run().output()?;
 
@@ -542,7 +548,7 @@ fn environment_isolation() -> anyhow::Result<()> {
 /// Test local Ruby hook repository with gemspec build and install
 #[test]
 fn local_hook_with_gemspec() -> anyhow::Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
     let hook_repo = context
         .create_repo("ruby-hook")
         .with_file(
@@ -578,7 +584,7 @@ fn local_hook_with_gemspec() -> anyhow::Result<()> {
         "},
         );
 
-    hook_repo.git().add_all().commit("Initial commit");
+    hook_repo.git().add(".").commit("Initial commit");
     let rev = hook_repo.git().rev_parse("HEAD")?;
 
     // Configure prek to use this local repo
@@ -619,9 +625,10 @@ fn local_hook_with_gemspec() -> anyhow::Result<()> {
 #[test]
 fn native_gem_dependency() {
     // msgpack is a small native gem that compiles quickly.
-    let context = TestEnv::new_git().with_file(
-        "check_msgpack.rb",
-        indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_file(
+            "check_msgpack.rb",
+            indoc::indoc! {r#"
             #!/usr/bin/env ruby
             require 'msgpack'
 
@@ -633,7 +640,8 @@ fn native_gem_dependency() {
             puts "MessagePack native extension working!"
             puts "Packed size: #{packed.bytesize} bytes"
         "#},
-    );
+        )
+        .init_git();
 
     context.write_config(indoc::indoc! {r"
         repos:
@@ -647,7 +655,7 @@ fn native_gem_dependency() {
                 pass_filenames: false
                 always_run: true
     "});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run().arg("-v"), @r"
     success: true
@@ -667,9 +675,10 @@ fn native_gem_dependency() {
 /// Test Ruby hook that processes files
 #[test]
 fn process_files() {
-    let context = TestEnv::new_git().with_file(
-        "check_ruby.rb",
-        indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_file(
+            "check_ruby.rb",
+            indoc::indoc! {r#"
             ARGV.sort.each do |file|
               unless file.end_with?('.rb')
                 puts "Error: #{file} is not a Ruby file"
@@ -678,7 +687,8 @@ fn process_files() {
               puts "OK: #{file}"
             end
         "#},
-    );
+        )
+        .init_git();
 
     let context = context
         .with_config(indoc::indoc! {r"
@@ -696,7 +706,7 @@ fn process_files() {
         .with_file("test.rb", "puts 'hello'")
         .with_file("test.txt", "hello");
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -743,7 +753,7 @@ fn auto_download() -> anyhow::Result<()> {
                 pass_filenames: false
                 always_run: true
     "});
-    context.git().add_all();
+    context.git().add(".");
 
     let ruby_dir = context.home_dir().child("tools").child("ruby");
     ruby_dir.assert(predicates::path::missing());
@@ -813,7 +823,7 @@ fn auto_download() -> anyhow::Result<()> {
                 pass_filenames: false
                 always_run: true
     "});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run().arg("-v"), @r"
     success: true

--- a/crates/prek/tests/languages/rust.rs
+++ b/crates/prek/tests/languages/rust.rs
@@ -12,7 +12,8 @@ use crate::common::{TestEnv, cmd_snapshot};
 #[cfg(feature = "ci")]
 #[test]
 fn language_version() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -37,8 +38,8 @@ fn language_version() -> Result<()> {
                 language_version: '1.70'
                 always_run: true
                 pass_filenames: false
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     let rust_dir = context.home_dir().child("tools/rustup/toolchains");
     rust_dir.assert(predicates::path::missing());
@@ -101,7 +102,8 @@ fn language_version() -> Result<()> {
 /// Test `rustup` installer.
 #[test]
 fn rustup_installer() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -109,8 +111,9 @@ fn rustup_installer() {
                 name: rustup-test
                 language: rust
                 entry: rustc --version
-   "});
-    context.git().add_all();
+       "})
+        .init_git();
+
     let context = context.with_filter(r"rustc 1\.\d{1,3}\.\d{1,2} .+", "rustc 1.X.X");
 
     cmd_snapshot!(context, context.run().arg("-v").env(EnvVars::PREK_INTERNAL__RUSTUP_BINARY_NAME, "non-exist-rustup"), @r#"
@@ -130,7 +133,8 @@ fn rustup_installer() {
 /// Test that `additional_dependencies` with cli: prefix are installed correctly.
 #[test]
 fn additional_dependencies_cli() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -142,9 +146,8 @@ fn additional_dependencies_cli() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -163,7 +166,8 @@ fn additional_dependencies_cli() {
 /// Test that remote Rust hooks are installed and run correctly.
 #[test]
 fn remote_hooks() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: https://github.com/prek-ci/rust-hooks
             rev: v1.0.0
@@ -173,8 +177,8 @@ fn remote_hooks() {
                 pass_filenames: false
                 always_run: true
                 args: ["Hello World"]
-    "#});
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -194,7 +198,8 @@ fn remote_hooks() {
 /// Test that remote Rust hooks from non-workspace repos are installed and run correctly.
 #[test]
 fn remote_hook_non_workspace() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/prek-ci/rust-hooks-non-workspace
             rev: v1.0.0
@@ -203,8 +208,8 @@ fn remote_hook_non_workspace() {
                 verbose: true
                 pass_filenames: false
                 always_run: true
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -225,7 +230,8 @@ fn remote_hook_non_workspace() {
 /// This verifies that the shared repo is not modified when adding dependencies.
 #[test]
 fn remote_hooks_with_lib_deps() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: https://github.com/prek-ci/rust-hooks
             rev: v1.0.0
@@ -235,8 +241,8 @@ fn remote_hooks_with_lib_deps() {
                 verbose: true
                 pass_filenames: false
                 always_run: true
-    "#});
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true

--- a/crates/prek/tests/languages/script.rs
+++ b/crates/prek/tests/languages/script.rs
@@ -6,7 +6,8 @@ mod unix {
 
     #[test]
     fn script_run() {
-        let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+        let context = TestEnv::new()
+            .with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/prek-ci/script-hooks
             rev: v1.0.0
@@ -20,8 +21,8 @@ mod unix {
                   VAR1: everyone
                   VAR2: galaxy
                 verbose: true
-        "});
-        context.git().add_all();
+        "})
+            .init_git();
 
         cmd_snapshot!(context, context.run(), @r"
         success: true
@@ -56,7 +57,7 @@ mod unix {
                   MESSAGE: "Hello, World"
                 verbose: true
         "#};
-        let context = TestEnv::new_git()
+        let context = TestEnv::new()
             .with_config(config)
             .with_executable_file(
                 "script.sh",
@@ -72,10 +73,11 @@ mod unix {
             #!/usr/bin/env bash
             echo "$MESSAGE from child!"
         "#},
-            );
+            )
+            .init_git();
         let child = context.child("child");
 
-        context.git().add_all();
+        context.git().add(".");
 
         cmd_snapshot!(context, context.run(), @r#"
         success: true
@@ -113,7 +115,7 @@ mod unix {
 
     #[test]
     fn local_repo_bash_shebang() {
-        let context = TestEnv::new_git()
+        let context = TestEnv::new()
             .with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -130,9 +132,8 @@ mod unix {
             #!/usr/bin/env bash
             echo "Hello, World!"
         "#},
-            );
-
-        context.git().add_all();
+            )
+            .init_git();
 
         cmd_snapshot!(context, context.run(), @r"
         success: true
@@ -150,7 +151,7 @@ mod unix {
 
     #[test]
     fn script_shell_runs_entry_as_shell_source() {
-        let context = TestEnv::new_git()
+        let context = TestEnv::new()
             .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -169,9 +170,8 @@ mod unix {
                 args: [configured]
                 verbose: true
         "#})
-            .with_file("a.txt", "a");
-
-        context.git().add_all();
+            .with_file("a.txt", "a")
+            .init_git();
 
         cmd_snapshot!(context, context.run(), @r"
         success: true
@@ -192,7 +192,7 @@ mod unix {
 /// The interpreter must exist in the PATH, the script is not needed to be executable.
 #[test]
 fn windows_script_run() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
     repos:
       - repo: local
@@ -209,9 +209,8 @@ fn windows_script_run() {
         #!/usr/bin/env python3
         print("Hello, World!")
     "#},
-        );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true

--- a/crates/prek/tests/languages/shell.rs
+++ b/crates/prek/tests/languages/shell.rs
@@ -3,7 +3,7 @@ use crate::common::{TestEnv, cmd_snapshot};
 #[cfg(unix)]
 #[test]
 fn bash_shell_adapter_runs_entry() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -19,9 +19,8 @@ fn bash_shell_adapter_runs_entry() {
                 args: [configured]
                 verbose: true
     "#})
-        .with_file("input.txt", "input");
-
-    context.git().add_all();
+        .with_file("input.txt", "input")
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -43,7 +42,7 @@ fn pwsh_shell_adapter_runs_entry() {
         return;
     }
 
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -58,9 +57,8 @@ fn pwsh_shell_adapter_runs_entry() {
                 args: [configured]
                 verbose: true
     "#})
-        .with_file("input.txt", "input");
-
-    context.git().add_all();
+        .with_file("input.txt", "input")
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -79,7 +77,7 @@ fn pwsh_shell_adapter_runs_entry() {
 #[cfg(windows)]
 #[test]
 fn powershell_shell_adapter_runs_entry() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -94,9 +92,8 @@ fn powershell_shell_adapter_runs_entry() {
                 args: [configured]
                 verbose: true
     "#})
-        .with_file("input.txt", "input");
-
-    context.git().add_all();
+        .with_file("input.txt", "input")
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -115,7 +112,7 @@ fn powershell_shell_adapter_runs_entry() {
 #[cfg(windows)]
 #[test]
 fn cmd_shell_adapter_runs_entry() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -131,9 +128,8 @@ fn cmd_shell_adapter_runs_entry() {
                 args: [configured]
                 verbose: true
     "})
-        .with_file("input.txt", "input");
-
-    context.git().add_all();
+        .with_file("input.txt", "input")
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -151,7 +147,8 @@ fn cmd_shell_adapter_runs_entry() {
 
 #[test]
 fn shell_rejected_for_pygrep() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -162,8 +159,8 @@ fn shell_rejected_for_pygrep() {
                 shell: sh
                 always_run: true
                 pass_filenames: false
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false

--- a/crates/prek/tests/languages/swift.rs
+++ b/crates/prek/tests/languages/swift.rs
@@ -5,7 +5,8 @@ use crate::common::{TestEnv, cmd_snapshot};
 /// Test that a local Swift hook with a system command works.
 #[test]
 fn local_hook_system_command() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -16,9 +17,8 @@ fn local_hook_system_command() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -37,7 +37,8 @@ fn local_hook_system_command() {
 /// Test that `language_version` is rejected for Swift.
 #[test]
 fn language_version_rejected() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -48,9 +49,8 @@ fn language_version_rejected() {
                 language_version: '6.0'
                 always_run: true
                 pass_filenames: false
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -67,7 +67,8 @@ fn language_version_rejected() {
 /// Test that health check works after install.
 #[test]
 fn health_check() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -78,9 +79,8 @@ fn health_check() {
                 always_run: true
                 verbose: true
                 pass_filenames: false
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     // First run - installs
     cmd_snapshot!(context, context.run(), @r"
@@ -115,7 +115,7 @@ fn health_check() {
 #[test]
 fn local_package_build() {
     // Create a minimal Swift package
-    let swift_hook = TestEnv::new_git()
+    let swift_hook = TestEnv::new()
         .with_file(
             "Package.swift",
             indoc::indoc! {r#"
@@ -144,14 +144,11 @@ fn local_package_build() {
                   entry: prek-swift-test
                   language: swift
             "},
-        );
-    swift_hook
-        .git()
-        .add_all()
-        .commit("Initial commit")
-        .tag("v1.0");
+        )
+        .init_git();
+    swift_hook.git().commit("Initial commit").tag("v1.0");
 
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let hook_url = swift_hook.work_dir().to_str().unwrap();
     context.write_config(indoc::formatdoc! {r"
@@ -164,7 +161,7 @@ fn local_package_build() {
                 always_run: true
                 pass_filenames: false
     ", hook_url = hook_url});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: true

--- a/crates/prek/tests/languages/system.rs
+++ b/crates/prek/tests/languages/system.rs
@@ -4,7 +4,8 @@ use crate::common::{TestEnv, cmd_snapshot};
 #[cfg(unix)]
 #[test]
 fn multiline_entry_without_shell_uses_argv_semantics() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
     repos:
       - repo: local
         hooks:
@@ -16,8 +17,8 @@ fn multiline_entry_without_shell_uses_argv_semantics() {
               echo second
             pass_filenames: false
             verbose: true
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -36,7 +37,8 @@ fn multiline_entry_without_shell_uses_argv_semantics() {
 #[cfg(unix)]
 #[test]
 fn shell_runs_multiline_entry_as_one_script() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
     repos:
       - repo: local
         hooks:
@@ -49,8 +51,8 @@ fn shell_runs_multiline_entry_as_one_script() {
             shell: sh
             pass_filenames: false
             verbose: true
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -70,7 +72,7 @@ fn shell_runs_multiline_entry_as_one_script() {
 #[cfg(unix)]
 #[test]
 fn shell_entry_receives_hook_args_before_filenames() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
     repos:
       - repo: local
@@ -89,9 +91,8 @@ fn shell_entry_receives_hook_args_before_filenames() {
             args: [configured]
             verbose: true
     "#})
-        .with_file("a.txt", "a");
-
-    context.git().add_all();
+        .with_file("a.txt", "a")
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true

--- a/crates/prek/tests/languages/unsupported.rs
+++ b/crates/prek/tests/languages/unsupported.rs
@@ -4,7 +4,7 @@
 fn unsupported_language() {
     use crate::common::{TestEnv, cmd_snapshot};
 
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -26,9 +26,8 @@ fn unsupported_language() {
             #!/usr/bin/env bash
             echo "Hello, World!"
         "#},
-        );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true

--- a/crates/prek/tests/list.rs
+++ b/crates/prek/tests/list.rs
@@ -5,7 +5,8 @@ mod common;
 
 #[test]
 fn list_basic() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -20,7 +21,8 @@ fn list_basic() {
                 language: system
                 types: [json]
                 description: Validate JSON files
-    "});
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.list(), @r"
     success: true
@@ -35,7 +37,8 @@ fn list_basic() {
 
 #[test]
 fn list_verbose() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -52,7 +55,8 @@ fn list_verbose() {
                 description: Validate JSON files
                 fail_fast: true
                 verbose: true
-    "});
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.list().arg("--verbose"), @r"
     success: true
@@ -118,7 +122,8 @@ fn list_verbose() {
 
 #[test]
 fn list_with_hook_ids_filter() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -137,7 +142,8 @@ fn list_with_hook_ids_filter() {
                 entry: check-toml
                 language: system
                 types: [toml]
-    "});
+    "})
+        .init_git();
 
     // Test filtering by specific hook ID
     cmd_snapshot!(context, context.list().arg("check-yaml"), @r"
@@ -163,7 +169,8 @@ fn list_with_hook_ids_filter() {
 
 #[test]
 fn list_with_language_filter() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -182,7 +189,8 @@ fn list_with_language_filter() {
                 entry: clippy
                 language: rust
                 types: [rust]
-    "});
+    "})
+        .init_git();
 
     // Test filtering by language
     cmd_snapshot!(context, context.list().arg("--language").arg("system"), @r"
@@ -206,7 +214,8 @@ fn list_with_language_filter() {
 
 #[test]
 fn list_with_stage_filter() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -227,7 +236,8 @@ fn list_with_stage_filter() {
                 language: system
                 types: [toml]
                 stages: [pre-commit, pre-push]
-    "});
+    "})
+        .init_git();
 
     // Test filtering by stage
     cmd_snapshot!(context, context.list().arg("--hook-stage").arg("pre-commit"), @r"
@@ -254,7 +264,8 @@ fn list_with_stage_filter() {
 
 #[test]
 fn list_with_group_filter() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -281,7 +292,8 @@ fn list_with_group_filter() {
                 entry: ungrouped
                 language: system
                 types: [text]
-    "});
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.list().arg("--group").arg("ci"), @r"
     success: true
@@ -364,7 +376,8 @@ fn list_with_group_filter() {
 
 #[test]
 fn list_group_excluded_remote_repo_is_not_cloned() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -376,8 +389,8 @@ fn list_group_excluded_remote_repo_is_not_cloned() {
             hooks:
               - id: ruff-check
                 groups: [local]
-        "});
-    context.git().add_all();
+        "})
+        .init_git();
 
     cmd_snapshot!(context,
         context.list().arg("--group").arg("ci"),
@@ -394,7 +407,8 @@ fn list_group_excluded_remote_repo_is_not_cloned() {
 
 #[test]
 fn list_with_aliases() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -409,7 +423,8 @@ fn list_with_aliases() {
                 entry: check-json
                 language: system
                 types: [json]
-    "});
+    "})
+        .init_git();
 
     // Test that aliases are recognized
     cmd_snapshot!(context, context.list().arg("yaml-check"), @r"
@@ -440,7 +455,7 @@ fn list_with_aliases() {
 
 #[test]
 fn list_empty_config() {
-    let context = TestEnv::new_git().with_config("repos: []");
+    let context = TestEnv::new().with_config("repos: []").init_git();
 
     cmd_snapshot!(context, context.list(), @r#"
     success: true
@@ -461,7 +476,7 @@ fn list_empty_config() {
 
 #[test]
 fn list_no_config_file() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     // No config file exists
     cmd_snapshot!(context, context.list(), @r"
@@ -478,7 +493,8 @@ fn list_no_config_file() {
 
 #[test]
 fn list_json_output() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -494,7 +510,8 @@ fn list_json_output() {
                 language: system
                 types: [json]
                 description: Validate JSON files
-    "});
+    "})
+        .init_git();
 
     // Test JSON output for all hooks
     cmd_snapshot!(context, context.list().arg("--output-format=json"), @r#"
@@ -584,7 +601,7 @@ fn list_json_output() {
 
 #[test]
 fn workspace_list() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
     let cwd = context.work_dir().to_path_buf();
 
     let config = indoc! {r"
@@ -607,7 +624,7 @@ fn workspace_list() {
         ],
         config,
     );
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.list(), @r"
     success: true
@@ -771,7 +788,7 @@ fn workspace_list() {
 
 #[test]
 fn list_with_selectors() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let config = indoc! {r"
     repos:
@@ -793,7 +810,7 @@ fn list_with_selectors() {
         ],
         config,
     );
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.list().arg("project2/"), @r"
     success: true

--- a/crates/prek/tests/meta_hooks.rs
+++ b/crates/prek/tests/meta_hooks.rs
@@ -4,7 +4,7 @@ use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
 fn meta_hooks() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_files([
             ("file.txt", "Hello, world!\n"),
             ("valid.json", "{}"),
@@ -30,8 +30,8 @@ fn meta_hooks() {
                 language: system
                 entry: python3 -c 'import sys; sys.exit(0)'
                 exclude: $nonexistent^
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -65,13 +65,14 @@ fn meta_hooks() {
 
 #[test]
 fn meta_hooks_unknown_hook() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: meta
             hooks:
               - id: this-hook-does-not-exist
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @"
     success: false
@@ -114,10 +115,11 @@ fn check_useless_excludes_remote() {
         hooks:
             - id: check-useless-excludes
     "};
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_file("html/file1.html", "<!DOCTYPE html>")
-        .with_config(&pre_commit_config);
-    context.git().add_all();
+        .with_config(&pre_commit_config)
+        .init_git();
+
     cmd_snapshot!(context, context.run().arg("check-useless-excludes"), @r"
     success: false
     exit_code: 1
@@ -134,7 +136,7 @@ fn check_useless_excludes_remote() {
 
 #[test]
 fn meta_hooks_workspace() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_project_config(
             "app",
             indoc::indoc! {r"
@@ -164,8 +166,8 @@ fn meta_hooks_workspace() {
             ("app/invalid.json", "{x}"),
             ("app/main.py", r#"print "abc"  "#),
         ])
-        .with_config("repos: []");
-    context.git().add_all();
+        .with_config("repos: []")
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -207,7 +209,7 @@ fn check_useless_excludes_workspace_paths_are_project_relative() {
     // Regression: in workspace mode, `files`/`exclude` matching must use paths *relative to the
     // nested project root* (so anchored patterns like `^...$` work as expected).
     // The two sentinel files keep the anchored excludes from being reported as useless.
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_file(
             "app/.pre-commit-config.yaml",
             indoc::indoc! {r"
@@ -227,8 +229,8 @@ fn check_useless_excludes_workspace_paths_are_project_relative() {
         )
         .with_file("app/global_excluded", "ignored\n")
         .with_file("app/hook_excluded", "ignored\n")
-        .with_config("repos: []");
-    context.git().add_all();
+        .with_config("repos: []")
+        .init_git();
 
     cmd_snapshot!(context, context.run().arg("check-useless-excludes"), @r#"
     success: true

--- a/crates/prek/tests/run.rs
+++ b/crates/prek/tests/run.rs
@@ -30,7 +30,7 @@ fn with_remote_fetch_error_filters(context: TestEnv) -> TestEnv {
 
 #[test]
 fn run_basic() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -46,9 +46,8 @@ fn run_basic() {
             ("file.txt", "z-project\na-project\n"),
             ("valid.json", "{}"),
             ("main.py", r#"print "abc"  "#),
-        ]);
-
-    context.git().add_all();
+        ])
+        .init_git();
 
     cmd_snapshot!(context, context.run().arg("-q"), @"
     success: false
@@ -82,7 +81,7 @@ fn run_basic() {
 
     assert_eq!(context.read("file.txt"), "a-project\nz-project\n");
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run().arg("trailing-whitespace"), @r#"
     success: true
@@ -96,7 +95,7 @@ fn run_basic() {
 
 #[test]
 fn fast_path_checks_filenames_from_entry_and_args() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -111,9 +110,8 @@ fn fast_path_checks_filenames_from_entry_and_args() {
             ("from-entry.json", "invalid"),
             ("from-args.json", "invalid"),
             ("selected.json", "{}"),
-        ]);
-
-    context.git().add_all();
+        ])
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -133,9 +131,10 @@ fn fast_path_checks_filenames_from_entry_and_args() {
 
 #[test]
 fn run_preserves_stdout_stderr_order() {
-    let context = TestEnv::new_git().with_file(
-        "output.py",
-        indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_file(
+            "output.py",
+            indoc::indoc! {r#"
             import os
 
             os.write(2, b"__PREK_STDERR_1__\n")
@@ -143,7 +142,8 @@ fn run_preserves_stdout_stderr_order() {
             os.write(2, b"__PREK_STDERR_2__\n")
             os.write(1, b"__PREK_STDOUT_2__\n")
         "#},
-    );
+        )
+        .init_git();
 
     context.write_config(indoc::indoc! {r"
         repos:
@@ -157,7 +157,7 @@ fn run_preserves_stdout_stderr_order() {
                 pass_filenames: false
                 verbose: true
     "});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run().args(["--all-files", "--color=never"]), @r"
     success: true
@@ -178,7 +178,8 @@ fn run_preserves_stdout_stderr_order() {
 
 #[test]
 fn hook_details_include_first_description_line() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -199,8 +200,8 @@ fn hook_details_include_first_description_line() {
                 always_run: true
                 pass_filenames: false
                 verbose: true
-    "#});
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -223,7 +224,8 @@ fn hook_details_include_first_description_line() {
 
 #[test]
 fn run_does_not_rewrite_unchanged_config_tracking_file() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -232,8 +234,8 @@ fn run_does_not_rewrite_unchanged_config_tracking_file() -> Result<()> {
                 language: system
                 entry: "true"
                 always_run: true
-    "#});
-    context.git().add_all();
+    "#})
+        .init_git();
 
     context.run().arg("--all-files").assert().success();
 
@@ -263,7 +265,8 @@ fn run_does_not_rewrite_unchanged_config_tracking_file() -> Result<()> {
 
 #[test]
 fn run_tracks_relative_config_as_absolute_path() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -272,8 +275,8 @@ fn run_tracks_relative_config_as_absolute_path() -> Result<()> {
                 language: system
                 entry: "true"
                 always_run: true
-    "#});
-    context.git().add_all();
+    "#})
+        .init_git();
 
     context
         .run()
@@ -296,7 +299,7 @@ fn run_tracks_relative_config_as_absolute_path() -> Result<()> {
 
 #[test]
 fn run_glob_patterns_with_multiple_hooks() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -320,9 +323,8 @@ fn run_glob_patterns_with_multiple_hooks() {
             ("src/main.py", "print('hi')"),
             ("docs/readme.md", "# Docs"),
             ("notes.txt", "note"),
-        ]);
-
-    context.git().add_all();
+        ])
+        .init_git();
 
     cmd_snapshot!(context, context.run().arg("--all-files"), @r"
     success: true
@@ -368,8 +370,7 @@ fn run_in_non_git_repo() {
 
 #[test]
 fn invalid_config() {
-    let context = TestEnv::new_git().with_config("invalid: config");
-    context.git().add_all();
+    let context = TestEnv::new().with_config("invalid: config").init_git();
 
     cmd_snapshot!(context, context.run(), @"
     success: false
@@ -389,7 +390,7 @@ fn invalid_config() {
         files: 12
         repos: []
     "});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @"
     success: false
@@ -412,7 +413,7 @@ fn invalid_config() {
           glog: "*.rs"
         repos: []
     "#});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @"
     success: false
@@ -441,7 +442,7 @@ fn invalid_config() {
                 additional_dependencies: ["swift-format@5.0.0"]
                 entry: echo Hello, world!
     "#});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -464,7 +465,7 @@ fn invalid_config() {
                 language_version: '6'
                 entry: echo Hello, world!
     "});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -481,7 +482,7 @@ fn invalid_config() {
 /// Use same repo multiple times, with same or different revisions.
 #[test]
 fn same_repo() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -502,9 +503,8 @@ fn same_repo() {
             ("valid.json", "{}"),
             ("invalid.json", "{}"),
             ("main.py", r#"print "abc"  "#),
-        ]);
-
-    context.git().add_all();
+        ])
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -526,7 +526,8 @@ fn same_repo() {
 
 #[test]
 fn local() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -535,9 +536,8 @@ fn local() {
                 language: system
                 entry: echo Hello, world!
                 always_run: true
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -551,7 +551,7 @@ fn local() {
 
 #[test]
 fn hook_repo_placeholder_expands_to_local_project() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -563,9 +563,10 @@ fn hook_repo_placeholder_expands_to_local_project() {
                 always_run: true
                 pass_filenames: false
     "#})
-        .with_file("hook-repo-marker", "");
+        .with_file("hook-repo-marker", "")
+        .init_git();
 
-    context.git().add_all().commit("Add local hook");
+    context.git().commit("Add local hook");
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -579,7 +580,7 @@ fn hook_repo_placeholder_expands_to_local_project() {
 
 #[test]
 fn hook_repo_placeholder_expands_to_remote_checkout() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
     let hook_repo = context
         .create_repo("hook-repo-placeholder")
         .with_file(
@@ -596,7 +597,7 @@ fn hook_repo_placeholder_expands_to_remote_checkout() {
         .with_file("hook-repo-marker", "");
     hook_repo
         .git()
-        .add_all()
+        .add(".")
         .commit("Add remote hook")
         .tag("v1.0.0");
 
@@ -607,7 +608,7 @@ fn hook_repo_placeholder_expands_to_remote_checkout() {
             hooks:
               - id: hook-repo-remote
     ", hook_repo.path().display()});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -622,7 +623,8 @@ fn hook_repo_placeholder_expands_to_remote_checkout() {
 /// Test multiple hook IDs scenarios.
 #[test]
 fn multiple_hook_ids() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -643,9 +645,8 @@ fn multiple_hook_ids() {
                 language: system
                 entry: echo shared-b
                 alias: shared-name
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     // Multiple repeated hook-id (should deduplicate)
     cmd_snapshot!(context, context.run().arg("hook1").arg("hook1").arg("hook1"), @r#"
@@ -741,7 +742,8 @@ fn multiple_hook_ids() {
 
 #[test]
 fn run_displays_aliases_for_repeated_hook_ids() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -761,9 +763,8 @@ fn run_displays_aliases_for_repeated_hook_ids() {
                 always_run: true
                 pass_filenames: false
                 verbose: true
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run().arg("repeated"), @r"
     success: true
@@ -784,7 +785,8 @@ fn run_displays_aliases_for_repeated_hook_ids() {
 
 #[test]
 fn priorities_respected() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -806,9 +808,8 @@ fn priorities_respected() {
                 entry: python3 -c "print('middle')"
                 always_run: true
                 priority: 5
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -824,7 +825,8 @@ fn priorities_respected() {
 
 #[test]
 fn priority_aliases_are_resolved_before_scheduling() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         priorities:
           early: 0
           late: 10
@@ -849,9 +851,8 @@ fn priority_aliases_are_resolved_before_scheduling() {
                 entry: python3 -c "print('numeric')"
                 always_run: true
                 priority: 5
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -867,7 +868,8 @@ fn priority_aliases_are_resolved_before_scheduling() {
 
 #[test]
 fn run_group_without_stage_selects_hooks_across_stages() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -905,9 +907,8 @@ fn run_group_without_stage_selects_hooks_across_stages() {
                 entry: python3 -c "print('local')"
                 always_run: true
                 stages: [pre-commit]
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run().arg("--all-files").arg("--group").arg("ci"), @r#"
     success: true
@@ -922,7 +923,8 @@ fn run_group_without_stage_selects_hooks_across_stages() {
 
 #[test]
 fn run_ungrouped_group_selects_hooks_without_groups() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -949,9 +951,8 @@ fn run_ungrouped_group_selects_hooks_without_groups() {
             hooks:
               - id: remote-other
                 groups: [other]
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context,
         context
@@ -975,7 +976,8 @@ fn run_ungrouped_group_selects_hooks_without_groups() {
 
 #[test]
 fn run_required_group_without_stage_warns_when_only_message_file_hooks_match() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -993,9 +995,8 @@ fn run_required_group_without_stage_warns_when_only_message_file_hooks_match() {
                 always_run: true
                 stages: [prepare-commit-msg]
                 groups: [ci]
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run().arg("--all-files").arg("--require-group").arg("ci"), @r#"
     success: false
@@ -1009,7 +1010,8 @@ fn run_required_group_without_stage_warns_when_only_message_file_hooks_match() {
 
 #[test]
 fn run_no_group_excludes_matching_hooks_and_keeps_ungrouped_hooks() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -1024,9 +1026,8 @@ fn run_no_group_excludes_matching_hooks_and_keeps_ungrouped_hooks() {
                 language: system
                 entry: python3 -c "print('lint')"
                 always_run: true
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run().arg("--all-files").arg("--no-group").arg("format"), @r#"
     success: true
@@ -1040,7 +1041,8 @@ fn run_no_group_excludes_matching_hooks_and_keeps_ungrouped_hooks() {
 
 #[test]
 fn run_group_exclusion_wins_over_inclusion() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -1056,9 +1058,8 @@ fn run_group_exclusion_wins_over_inclusion() {
                 entry: python3 -c "print('slow')"
                 always_run: true
                 groups: [ci, slow]
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run().arg("--all-files").arg("--group").arg("ci").arg("--no-group").arg("slow"), @r#"
     success: true
@@ -1072,7 +1073,8 @@ fn run_group_exclusion_wins_over_inclusion() {
 
 #[test]
 fn run_required_groups_intersect_and_compose_with_other_group_filters() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -1106,9 +1108,8 @@ fn run_required_groups_intersect_and_compose_with_other_group_filters() {
                 entry: python3 -c "print('black-fast')"
                 always_run: true
                 groups: [format, slow, ci, fast]
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context,
         context
@@ -1183,7 +1184,8 @@ fn run_required_groups_intersect_and_compose_with_other_group_filters() {
 
 #[test]
 fn run_unknown_group_selectors_warn_and_empty_selection_fails() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -1193,9 +1195,8 @@ fn run_unknown_group_selectors_warn_and_empty_selection_fails() {
                 entry: python3 -c "print('lint')"
                 always_run: true
                 groups: [ci]
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run().arg("--all-files").arg("--group").arg("missing"), @r#"
     success: false
@@ -1220,7 +1221,8 @@ fn run_unknown_group_selectors_warn_and_empty_selection_fails() {
 
 #[test]
 fn run_group_selectors_reject_invalid_names() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -1230,9 +1232,8 @@ fn run_group_selectors_reject_invalid_names() {
                 entry: python3 -c "print('lint')"
                 always_run: true
                 groups: [ci]
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run().arg("--all-files").arg("--group").arg("ci slow"), @r#"
     success: false
@@ -1267,7 +1268,8 @@ fn run_group_selectors_reject_invalid_names() {
 
 #[test]
 fn run_required_group_and_stage_filters_intersect() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -1292,9 +1294,8 @@ fn run_required_group_and_stage_filters_intersect() {
                 always_run: true
                 stages: [pre-push]
                 groups: [other]
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run().arg("--all-files").arg("--require-group").arg("ci").arg("--stage").arg("pre-push"), @r#"
     success: true
@@ -1308,7 +1309,8 @@ fn run_required_group_and_stage_filters_intersect() {
 
 #[test]
 fn priority_fail_fast_stops_later_groups() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -1331,9 +1333,8 @@ fn priority_fail_fast_stops_later_groups() {
                 entry: python3 -c "print('later ran')"
                 always_run: true
                 priority: 10
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -1350,7 +1351,7 @@ fn priority_fail_fast_stops_later_groups() {
 
 #[test]
 fn explicitly_skipped_hook_does_not_affect_priority_group_outcome() {
-    let context = TestEnv::new_git().with_file("file.txt", "hello\n");
+    let context = TestEnv::new().with_file("file.txt", "hello\n").init_git();
 
     context
         .write_config(indoc::indoc! {r#"
@@ -1378,7 +1379,7 @@ fn explicitly_skipped_hook_does_not_affect_priority_group_outcome() {
                 priority: 10
     "#});
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run().arg("--skip").arg("skipped"), @r#"
     success: false
@@ -1407,7 +1408,7 @@ fn explicitly_skipped_hook_does_not_affect_priority_group_outcome() {
 
 #[test]
 fn priority_group_modified_files_is_group_failure_and_output_is_indented() {
-    let context = TestEnv::new_git().with_file("file.txt", "hello\n");
+    let context = TestEnv::new().with_file("file.txt", "hello\n").init_git();
 
     context.write_config(indoc::indoc! {r#"
         repos:
@@ -1448,7 +1449,7 @@ fn priority_group_modified_files_is_group_failure_and_output_is_indented() {
                 priority: 10
     "#});
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run().arg("--skip").arg("skipped"), @r"
     success: false
@@ -1489,9 +1490,9 @@ fn priority_group_modified_files_is_group_failure_and_output_is_indented() {
 /// `.pre-commit-config.yaml` is not staged.
 #[test]
 fn config_not_staged() {
-    let context = TestEnv::new_git().with_file(PRE_COMMIT_CONFIG_YAML, "");
-
-    context.git().add_all();
+    let context = TestEnv::new()
+        .with_file(PRE_COMMIT_CONFIG_YAML, "")
+        .init_git();
 
     context.write_config(indoc::indoc! {r"
         repos:
@@ -1552,7 +1553,8 @@ fn config_outside_repo() -> Result<()> {
 /// Test the output format for a hook with a CJK name.
 #[test]
 fn cjk_hook_name() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -1564,9 +1566,8 @@ fn cjk_hook_name() {
                 name: fix end of files
                 language: system
                 entry: python3 -V
-    "});
-
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -1582,7 +1583,8 @@ fn cjk_hook_name() {
 /// Skips hooks based on the `SKIP` environment variable.
 #[test]
 fn skips() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -1598,8 +1600,8 @@ fn skips() {
                 name: check json
                 language: system
                 entry: python3 -c "exit(1)"
-    "#});
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run().env("SKIP", "end-of-file-fixer"), @r#"
     success: false
@@ -1632,7 +1634,8 @@ fn skips() {
 
 #[test]
 fn hide_status_filters_hook_reports() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -1652,8 +1655,8 @@ fn hide_status_filters_hook_reports() {
                 language: system
                 entry: echo
                 files: \.py$
-    "#});
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run().arg("--skip").arg("pass").arg("--hide-status").arg("passed,skipped"), @r#"
     success: false
@@ -1685,7 +1688,7 @@ fn hide_status_filters_hook_reports() {
 
 #[test]
 fn hide_status_uses_final_display_status() {
-    let context = TestEnv::new_git().with_file("file.txt", "hello\n");
+    let context = TestEnv::new().with_file("file.txt", "hello\n").init_git();
 
     context.write_config(indoc::indoc! {r#"
         repos:
@@ -1697,7 +1700,7 @@ fn hide_status_uses_final_display_status() {
                 entry: python3 -c "from pathlib import Path; p = Path('file.txt'); p.write_text(p.read_text() + 'changed')"
                 always_run: true
     "#});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run().arg("--hide-status").arg("passed"), @r#"
     success: false
@@ -1713,7 +1716,8 @@ fn hide_status_uses_final_display_status() {
 
 #[test]
 fn hidden_failed_status_still_writes_log_file() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -1723,8 +1727,8 @@ fn hidden_failed_status_still_writes_log_file() {
                 entry: python3 -c "import sys; print('logged output'); sys.exit(1)"
                 always_run: true
                 log_file: hook.log
-    "#});
-    context.git().add_all();
+    "#})
+        .init_git();
 
     context
         .run()
@@ -1739,7 +1743,8 @@ fn hidden_failed_status_still_writes_log_file() {
 /// Run hooks with matched `stage`.
 #[test]
 fn stage() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -1758,8 +1763,8 @@ fn stage() {
                 language: system
                 entry: echo post-commit-stage
                 stages: [ post-commit ]
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     // By default, run hooks with `pre-commit` stage.
     cmd_snapshot!(context, context.run(), @r#"
@@ -1796,7 +1801,8 @@ fn stage() {
 
 #[test]
 fn fallback_to_manual_stage() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -1819,8 +1825,8 @@ fn fallback_to_manual_stage() {
                 language: system
                 entry: echo pre-push
                 stages: [ pre-push ]
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     // With pre-commit hooks present, default `prek run` stays on pre-commit.
     cmd_snapshot!(context, context.run(), @r"
@@ -1888,11 +1894,12 @@ fn fallback_to_manual_stage() {
 /// Test global `files`, `exclude`, and hook level `files`, `exclude`.
 #[test]
 fn files_and_exclude() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_file("file.txt", "Hello, world!  \n")
         .with_file("valid.json", "{}\n  ")
         .with_file("invalid.json", "{}")
-        .with_file("main.py", r#"print "abc"  "#);
+        .with_file("main.py", r#"print "abc"  "#)
+        .init_git();
 
     // Global files and exclude.
     context.write_config(indoc::indoc! {r"
@@ -1916,7 +1923,7 @@ fn files_and_exclude() {
                 entry: python3 -c 'import sys; print(sys.argv[1:]); exit(1)'
                 types: [json]
     "});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -1958,7 +1965,7 @@ fn files_and_exclude() {
                 language: system
                 entry: python3 -c 'import sys; print(sys.argv[1:]); exit(1)'
     "});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -1983,10 +1990,11 @@ fn files_and_exclude() {
 /// Test selecting files by type, `types`, `types_or`, and `exclude_types`.
 #[test]
 fn file_types() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_file("file.txt", "Hello, world!  ")
         .with_file("json.json", "{}\n  ")
-        .with_file("main.py", r#"print "abc"  "#);
+        .with_file("main.py", r#"print "abc"  "#)
+        .init_git();
 
     context.write_config(indoc::indoc! {r#"
         repos:
@@ -2020,7 +2028,7 @@ fn file_types() {
                 types: ["json" ]
                 exclude_types: ["json"]
     "#});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -2050,7 +2058,8 @@ fn file_types() {
 /// Abort the run if a hook fails.
 #[test]
 fn fail_fast() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -2076,8 +2085,8 @@ fn fail_fast() {
                 language: system
                 entry: python3 -V
                 always_run: true
-    "#});
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -2101,7 +2110,8 @@ fn fail_fast() {
 /// Test --fail-fast CLI flag stops execution after first failure.
 #[test]
 fn fail_fast_cli_flag() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -2115,8 +2125,8 @@ fn fail_fast_cli_flag() {
                 language: system
                 entry: python3 -c 'print("Passed")'
                 always_run: true
-    "#});
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -2149,7 +2159,8 @@ fn fail_fast_cli_flag() {
 /// Test --no-fail-fast CLI flag overrides config-level `fail_fast`.
 #[test]
 fn no_fail_fast_cli_flag() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         fail_fast: true
         repos:
           - repo: local
@@ -2164,8 +2175,8 @@ fn no_fail_fast_cli_flag() {
                 language: system
                 entry: python3 -c 'print("Passed")'
                 always_run: true
-    "#});
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -2198,7 +2209,7 @@ fn no_fail_fast_cli_flag() {
 /// Run from a subdirectory. File arguments should be fixed to be relative to the root.
 #[test]
 fn subdirectory() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_file("foo/bar/baz/file.txt", "Hello, world!\n")
         .with_config(indoc::indoc! {r"
         repos:
@@ -2209,10 +2220,11 @@ fn subdirectory() {
                 language: system
                 entry: python3 -c 'import sys; print(sys.argv[1]); exit(1)'
                 always_run: true
-    "});
+    "})
+        .init_git();
     let child = context.child("foo/bar/baz");
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run().current_dir(&child).arg("--files").arg("file.txt"), @r"
     success: false
@@ -2271,9 +2283,10 @@ fn global_path_options_expand_tilde() -> Result<()> {
 /// Test hook `log_file` option.
 #[test]
 fn log_file() -> Result<()> {
-    let context = TestEnv::new_git().with_file(
-        "config/.pre-commit-config.yaml",
-        indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_file(
+            "config/.pre-commit-config.yaml",
+            indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -2284,10 +2297,11 @@ fn log_file() -> Result<()> {
                 always_run: true
                 log_file: log.txt
         "#},
-    );
+        )
+        .init_git();
     let config_dir = context.child("config");
     let config_file = config_dir.child(PRE_COMMIT_CONFIG_YAML);
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run().arg("-c").arg(config_file.path()), @r#"
     success: false
@@ -2309,7 +2323,8 @@ fn log_file() -> Result<()> {
 /// Pass pre-commit environment variables to the hook.
 #[test]
 fn pass_env_vars() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -2318,7 +2333,8 @@ fn pass_env_vars() {
                 language: system
                 entry: python3 -c "import os, sys; print(os.getenv('PRE_COMMIT')); sys.exit(1)"
                 always_run: true
-    "#});
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -2336,7 +2352,7 @@ fn pass_env_vars() {
 
 #[test]
 fn staged_files_only() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -2347,10 +2363,9 @@ fn staged_files_only() {
                 entry: python3 -c 'print(open("file.txt", "rt").read())'
                 verbose: true
                 types: [text]
-   "#})
-        .with_file("file.txt", "Hello, world!");
-
-    context.git().add_all();
+       "#})
+        .with_file("file.txt", "Hello, world!")
+        .init_git();
 
     // Non-staged files should be stashed and restored.
     context.write_file("file.txt", "Hello world again!");
@@ -2376,7 +2391,8 @@ fn staged_files_only() {
 
 #[test]
 fn intent_to_add_file_survives_conflicted_stash_restore() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -2385,7 +2401,8 @@ fn intent_to_add_file_survives_conflicted_stash_restore() -> Result<()> {
                 language: system
                 entry: python3 -c 'open("test.py", "w").write("a = 1\n")'
                 files: ^test\.py$
-   "#});
+       "#})
+        .init_git();
 
     context.git().add(PRE_COMMIT_CONFIG_YAML);
 
@@ -2438,9 +2455,9 @@ fn intent_to_add_file_survives_conflicted_stash_restore() -> Result<()> {
 #[cfg(unix)]
 #[test]
 fn restore_on_interrupt() -> Result<()> {
-    let context = TestEnv::new_git();
     // The hook will sleep for 3 seconds.
-    let context = context.with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -2451,9 +2468,8 @@ fn restore_on_interrupt() -> Result<()> {
                 verbose: true
                 types: [text]
    "#})
-        .with_file("file.txt", "Hello, world!");
-
-    context.git().add_all();
+        .with_file("file.txt", "Hello, world!")
+        .init_git();
 
     // Non-staged files should be stashed and restored.
     context.write_file("file.txt", "Hello world again!");
@@ -2485,18 +2501,20 @@ fn restore_on_interrupt() -> Result<()> {
 /// When in merge conflict, runs on files that have conflicts fixed.
 #[test]
 fn merge_conflicts() {
-    let context = TestEnv::new_git().with_file("file.txt", "Hello, world!");
+    let context = TestEnv::new()
+        .with_file("file.txt", "Hello, world!")
+        .init_git();
 
     // Create a merge conflict.
-    context.git().add_all().commit("Initial commit");
+    context.git().commit("Initial commit");
 
     context.git().branch("feature").checkout("feature");
     context.write_file("file.txt", "Hello, world again!");
-    context.git().add_all().commit("Feature commit");
+    context.git().add(".").commit("Feature commit");
 
     context.git().checkout("master");
     context.write_file("file.txt", "Hello, world from master!");
-    context.git().add_all().commit("Master commit");
+    context.git().add(".").commit("Master commit");
 
     context
         .git()
@@ -2528,7 +2546,7 @@ fn merge_conflicts() {
     "#);
 
     // Fix the conflict and run again.
-    context.git().add_all();
+    context.git().add(".");
     cmd_snapshot!(context, context.run(), @r"
     success: true
     exit_code: 0
@@ -2546,7 +2564,8 @@ fn merge_conflicts() {
 /// Local python hook with no additional dependencies.
 #[test]
 fn local_python_hook() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -2554,9 +2573,8 @@ fn local_python_hook() {
                 name: local-python-hook
                 language: python
                 entry: python3 -c 'import sys; print("Hello, world!"); sys.exit(1)'
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: false
@@ -2575,7 +2593,8 @@ fn local_python_hook() {
 /// Invalid `entry`
 #[test]
 fn invalid_entry() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -2583,9 +2602,8 @@ fn invalid_entry() {
                 name: entry
                 language: python
                 entry: '"'
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: false
@@ -2602,15 +2620,16 @@ fn invalid_entry() {
 /// Initialize a repo that does not exist.
 #[test]
 fn init_nonexistent_repo() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: https://notexistentatallnevergonnahappen.com/nonexistent/repo
             rev: v1.0.0
             hooks:
               - id: nonexistent
                 name: nonexistent
-        "});
-    context.git().add_all();
+        "})
+        .init_git();
 
     let context = with_remote_fetch_error_filters(context);
 
@@ -2634,7 +2653,8 @@ fn init_nonexistent_repo() {
 
 #[test]
 fn skipped_remote_repo_is_not_cloned() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -2644,8 +2664,8 @@ fn skipped_remote_repo_is_not_cloned() {
             rev: v1.0.0
             hooks:
               - id: ruff-check
-        "});
-    context.git().add_all();
+        "})
+        .init_git();
 
     cmd_snapshot!(context,
         context.run().arg("--all-files").arg("--skip").arg("ruff-check"),
@@ -2662,7 +2682,7 @@ fn skipped_remote_repo_is_not_cloned() {
 
 #[test]
 fn skipped_same_key_remote_repo_entry_is_not_initialized() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
     let hook_repo = context.create_repo("duplicate-key-hook").with_file(
         PRE_COMMIT_HOOKS_YAML,
         indoc::indoc! {r"
@@ -2676,7 +2696,7 @@ fn skipped_same_key_remote_repo_entry_is_not_initialized() {
 
     hook_repo
         .git()
-        .add_all()
+        .add(".")
         .commit("Initial commit")
         .tag("v1.0.0");
 
@@ -2692,7 +2712,7 @@ fn skipped_same_key_remote_repo_entry_is_not_initialized() {
             hooks:
               - id: test-hook
     ", repo = hook_repo.path().display()});
-    context.git().add_all();
+    context.git().add(".");
 
     context
         .run()
@@ -2705,7 +2725,8 @@ fn skipped_same_key_remote_repo_entry_is_not_initialized() {
 
 #[test]
 fn required_group_excluded_remote_repo_is_not_cloned() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -2717,8 +2738,8 @@ fn required_group_excluded_remote_repo_is_not_cloned() {
             hooks:
               - id: ruff-check
                 groups: [ci]
-        "});
-    context.git().add_all();
+        "})
+        .init_git();
 
     cmd_snapshot!(context,
         context
@@ -2741,7 +2762,8 @@ fn required_group_excluded_remote_repo_is_not_cloned() {
 
 #[test]
 fn unmatched_skip_does_not_suppress_remote_clone() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
@@ -2751,8 +2773,8 @@ fn unmatched_skip_does_not_suppress_remote_clone() {
             rev: v1.0.0
             hooks:
               - id: ruff-check
-        "});
-    context.git().add_all();
+        "})
+        .init_git();
 
     let context = with_remote_fetch_error_filters(context);
 
@@ -2781,7 +2803,7 @@ fn unmatched_skip_does_not_suppress_remote_clone() {
 /// Test hooks that specifies `types: [directory]`.
 #[test]
 fn types_directory() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -2792,9 +2814,8 @@ fn types_directory() {
                 entry: echo
                 types: [directory]
         "})
-        .with_file("dir/file.txt", "Hello, world!");
-
-    context.git().add_all();
+        .with_file("dir/file.txt", "Hello, world!")
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -2837,7 +2858,7 @@ fn types_directory() {
 #[test]
 fn run_last_commit() {
     // file2 starts with issues but is intentionally absent from the last commit.
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -2847,15 +2868,16 @@ fn run_last_commit() {
               - id: end-of-file-fixer
     "})
         .with_file("file1.txt", "Hello, world!\n")
-        .with_file("file2.txt", "Initial content with trailing spaces   \n");
+        .with_file("file2.txt", "Initial content with trailing spaces   \n")
+        .init_git();
 
-    context.git().add_all().commit("Initial commit");
+    context.git().commit("Initial commit");
 
     // Modify files and make second commit with trailing whitespace
     context.write_file("file1.txt", "Hello, world!   \n"); // trailing whitespace
     context.write_file("file3.txt", "New file"); // missing newline
     // Note: file2.txt is NOT modified in this commit, so it should be filtered out by --last-commit
-    context.git().add_all().commit("Second commit with issues");
+    context.git().add(".").commit("Second commit with issues");
 
     // Run with --last-commit should only check files from the last commit
     // This should only process file1.txt and file3.txt, NOT file2.txt
@@ -2914,7 +2936,7 @@ fn run_last_commit() {
 /// Test `prek run --files` with multiple files.
 #[test]
 fn run_multiple_files() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -2927,9 +2949,9 @@ fn run_multiple_files() {
                 types: [text]
     "})
         .with_file("file1.txt", "Hello, world!")
-        .with_file("file2.txt", "Hello, world!");
+        .with_file("file2.txt", "Hello, world!")
+        .init_git();
 
-    context.git().add_all();
     // `--files` with multiple files
     cmd_snapshot!(context, context.run().arg("--files").arg("file1.txt").arg("file2.txt"), @r#"
     success: true
@@ -2948,7 +2970,7 @@ fn run_multiple_files() {
 /// Test `prek run --glob` and its interaction with other explicit file selectors.
 #[test]
 fn run_glob() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -2966,9 +2988,9 @@ fn run_glob() {
             ("src/lib.py", "print('hello')"),
             ("src/nested/mod.rs", "pub mod nested;"),
             ("docs/readme.md", "# Readme"),
-        ]);
+        ])
+        .init_git();
 
-    context.git().add_all();
     context.write_file("src/untracked.rs", "pub fn untracked() {}");
 
     cmd_snapshot!(context, context.run().arg("--glob").arg("src/**/*.rs"), @r#"
@@ -3019,7 +3041,8 @@ fn run_glob() {
 /// Test `prek run --files` with no files.
 #[test]
 fn run_no_files() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -3028,8 +3051,9 @@ fn run_no_files() {
                 language: system
                 entry: echo
                 verbose: true
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
+
     // `--files` with no files
     cmd_snapshot!(context, context.run().arg("--files"), @r"
     success: true
@@ -3048,7 +3072,7 @@ fn run_no_files() {
 /// Test `prek run --directory` flags.
 #[test]
 fn run_directory() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -3060,10 +3084,11 @@ fn run_directory() {
                 verbose: true
     "})
         .with_file("dir1/file.txt", "Hello, world!")
-        .with_file("dir2/file.txt", "Hello, world!");
+        .with_file("dir2/file.txt", "Hello, world!")
+        .init_git();
     let cwd = context.work_dir();
 
-    context.git().add_all();
+    context.git().add(".");
 
     // one `--directory`
     cmd_snapshot!(context, context.run().arg("--directory").arg("dir1"), @r"
@@ -3174,7 +3199,7 @@ fn run_directory() {
 /// Test `minimum_prek_version` option.
 #[test]
 fn minimum_prek_version() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_filter(
             r"but version `\d+\.\d+\.\d+(?:-[0-9A-Za-z]+(?:\.[0-9A-Za-z]+)*)?` is installed",
             "but version `[CURRENT_VERSION]` is installed",
@@ -3189,8 +3214,8 @@ fn minimum_prek_version() {
                 language: system
                 entry: echo
                 verbose: true
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @"
     success: false
@@ -3214,7 +3239,16 @@ fn minimum_prek_version() {
 #[test]
 #[cfg(not(windows))]
 fn color() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let script = indoc::indoc! {r"
+      import sys
+      if sys.stdout.isatty():
+          print('\033[1;32mHello, world!\033[0m')
+      else:
+          print('Hello, world!')
+      sys.stdout.flush()
+  "};
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
       repos:
         - repo: local
           hooks:
@@ -3224,19 +3258,9 @@ fn color() {
               entry: python ./color.py
               verbose: true
               pass_filenames: false
-  "});
-
-    let script = indoc::indoc! {r"
-      import sys
-      if sys.stdout.isatty():
-          print('\033[1;32mHello, world!\033[0m')
-      else:
-          print('Hello, world!')
-      sys.stdout.flush()
-  "};
-    let context = context.with_file("color.py", script);
-
-    context.git().add_all();
+      "})
+        .with_file("color.py", script)
+        .init_git();
 
     // Run default. In integration tests, we don't have a TTY.
     // So this prints without color.
@@ -3271,18 +3295,6 @@ fn color() {
 #[test]
 #[cfg(not(windows))]
 fn tty_output_preserves_color_without_replaying_terminal_controls() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
-      repos:
-        - repo: local
-          hooks:
-            - id: terminal-output
-              name: terminal-output
-              language: python
-              entry: python ./terminal_output.py
-              verbose: true
-              pass_filenames: false
-  "});
-
     let script = indoc::indoc! {r"
       import sys
 
@@ -3293,9 +3305,20 @@ fn tty_output_preserves_color_without_replaying_terminal_controls() {
       sys.stdout.write('\033]0;title\007plain\n')
       sys.stdout.flush()
   "};
-    let context = context.with_file("terminal_output.py", script);
-
-    context.git().add_all();
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
+      repos:
+        - repo: local
+          hooks:
+            - id: terminal-output
+              name: terminal-output
+              language: python
+              entry: python ./terminal_output.py
+              verbose: true
+              pass_filenames: false
+      "})
+        .with_file("terminal_output.py", script)
+        .init_git();
 
     cmd_snapshot!(context,
         context.run().arg("--color=always"),
@@ -3318,7 +3341,7 @@ fn tty_output_preserves_color_without_replaying_terminal_controls() {
 /// Test running hook whose `entry` is script with shebang on Windows.
 #[test]
 fn shebang_script() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     // Create a script with shebang.
     let script = indoc::indoc! {r"
@@ -3341,7 +3364,7 @@ fn shebang_script() {
               pass_filenames: false
               always_run: true
     "});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -3360,7 +3383,7 @@ fn shebang_script() {
 /// Test `git commit -a` works without `.git/index.lock exists` error.
 #[test]
 fn git_commit_a() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_filter("7c8398204bbc95c33a6d2543f86a27621647cf78", "[HASH]")
         .with_config(indoc::indoc! {r"
         repos:
@@ -3372,7 +3395,8 @@ fn git_commit_a() {
                 entry: echo
                 verbose: true
     "})
-        .with_file("file.txt", "Hello, world!\n");
+        .with_file("file.txt", "Hello, world!\n")
+        .init_git();
 
     cmd_snapshot!(context, context.install(), @r#"
     success: true
@@ -3383,7 +3407,7 @@ fn git_commit_a() {
     ----- stderr -----
     "#);
 
-    context.git().add_all().commit("Initial commit");
+    context.git().add(".").commit("Initial commit");
 
     // Edit the file
     context.write_file("file.txt", "Hello, world again!\n");
@@ -3420,7 +3444,7 @@ fn git_commit_a_currently_fails_when_hook_writes_to_temp_git_index() {
     // path in the parent repo. `prek` treats the post-hook diff as a best-effort
     // snapshot, so the commit continues until Git tries to build trees from the
     // corrupted temporary index and fails with `invalid object ... for 'file.txt'`.
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_filter(
             r"invalid object 100644 [0-9a-f]{40}",
             "invalid object 100644 [HASH]",
@@ -3449,7 +3473,8 @@ fn git_commit_a_currently_fails_when_hook_writes_to_temp_git_index() {
                 always_run: true
                 verbose: true
     "})
-        .with_file("file.txt", "Hello, world!\n");
+        .with_file("file.txt", "Hello, world!\n")
+        .init_git();
 
     cmd_snapshot!(context, context.install(), @r#"
     success: true
@@ -3460,7 +3485,7 @@ fn git_commit_a_currently_fails_when_hook_writes_to_temp_git_index() {
     ----- stderr -----
     "#);
 
-    context.git().add_all().commit("Initial commit");
+    context.git().add(".").commit("Initial commit");
 
     // `git commit` does not set `GIT_INDEX_FILE`; `git commit -a` does.
     // The repro only triggers on the `-a` path.
@@ -3513,7 +3538,7 @@ fn write_project_config(path: &Path, hooks: &[(&str, &str)]) -> Result<()> {
 #[cfg(unix)]
 #[test]
 fn selectors_completion() -> Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
     let cwd = context.work_dir();
 
     // Root project with regular and colon-containing hook ids
@@ -3687,7 +3712,7 @@ fn selectors_completion() -> Result<()> {
 /// Test reusing hook environments only when dependencies are exactly same. (ignore order)
 #[test]
 fn reuse_env() -> Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_file(
             "local_pkg/setup.py",
             indoc::indoc! {r#"
@@ -3703,7 +3728,8 @@ fn reuse_env() -> Result<()> {
         .with_file(
             "local_pkg/local_pkg.py",
             "def hello():\n     print('hello')\n",
-        );
+        )
+        .init_git();
     let pkg_dir = context.child("local_pkg");
 
     let dependency = serde_json::to_string(&std::path::absolute(pkg_dir.path())?)?;
@@ -3719,7 +3745,7 @@ fn reuse_env() -> Result<()> {
             additional_dependencies: [{dependency}]
             verbose: true
     "#});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -3746,7 +3772,7 @@ fn reuse_env() -> Result<()> {
             pass_filenames: false
             verbose: true
     "#});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -3769,7 +3795,8 @@ fn reuse_env() -> Result<()> {
 
 #[test]
 fn dry_run() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -3777,8 +3804,8 @@ fn dry_run() {
                 name: fail
                 entry: fail
                 language: fail
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     // Run with `--dry-run`
     cmd_snapshot!(context, context.run().arg("--dry-run").arg("-v"), @r"
@@ -3799,9 +3826,10 @@ fn dry_run() {
 /// Supports reading `pre-commit-config.yml` as well.
 #[test]
 fn alternate_config_file() {
-    let context = TestEnv::new_git().with_file(
-        PRE_COMMIT_CONFIG_YML,
-        indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_file(
+            PRE_COMMIT_CONFIG_YML,
+            indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -3810,9 +3838,8 @@ fn alternate_config_file() {
                 language: python
                 entry: python3 -c 'import sys; print("Hello, world!")'
     "#},
-    );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.run().arg("-v"), @r"
     success: true
@@ -3839,7 +3866,7 @@ fn alternate_config_file() {
                 entry: python3 -c 'import sys; print("Hello, world!")'
     "#},
     );
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run().arg("--refresh").arg("-v"), @r"
     success: true
@@ -3870,7 +3897,7 @@ fn alternate_config_file() {
         ]
     "#},
     );
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run().arg("--refresh").arg("-v"), @r"
     success: true
@@ -3890,9 +3917,10 @@ fn alternate_config_file() {
 /// Supports `prek.toml` as configuration file.
 #[test]
 fn prek_toml() {
-    let context = TestEnv::new_git().with_file(
-        PREK_TOML,
-        indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_file(
+            PREK_TOML,
+            indoc::indoc! {r#"
         [[repos]]
         repo = "local"
         hooks = [
@@ -3904,9 +3932,8 @@ fn prek_toml() {
           }
         ]
     "#},
-    );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.run().arg("-v"), @r"
     success: true
@@ -3924,9 +3951,10 @@ fn prek_toml() {
 
 #[test]
 fn prek_toml_resolves_priority_aliases() {
-    let context = TestEnv::new_git().with_file(
-        PREK_TOML,
-        indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_file(
+            PREK_TOML,
+            indoc::indoc! {r#"
         [priorities]
         early = 0
         late = 10
@@ -3952,9 +3980,8 @@ fn prek_toml_resolves_priority_aliases() {
           },
         ]
     "#},
-    );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -3969,8 +3996,9 @@ fn prek_toml_resolves_priority_aliases() {
 
 #[test]
 fn show_diff_on_failure() {
-    let context =
-        TestEnv::new_git().with_filter(r"index \w{7}\.\.\w{7} \d{6}", "index [OLD]..[NEW] 100644");
+    let context = TestEnv::new()
+        .with_filter(r"index \w{7}\.\.\w{7} \d{6}", "index [OLD]..[NEW] 100644")
+        .init_git();
 
     let config = indoc::indoc! {r#"
         repos:
@@ -3986,7 +4014,7 @@ fn show_diff_on_failure() {
         .with_config(config)
         .with_file("file.txt", "Original line\n");
 
-    context.git().add_all();
+    context.git().add(".");
 
     // When failed in CI environment
     cmd_snapshot!(context, context.run().env(EnvVars::CI, "1").arg("--show-diff-on-failure").arg("-v"), @"
@@ -4015,7 +4043,7 @@ fn show_diff_on_failure() {
     ");
 
     context.write_file("file.txt", "Original line\n");
-    context.git().add_all();
+    context.git().add(".");
     // When failed in non-CI environment
     cmd_snapshot!(context, context.run().env_remove(EnvVars::CI).arg("--show-diff-on-failure").arg("-v"), @r"
     success: false
@@ -4063,7 +4091,7 @@ fn show_diff_on_failure() {
     ----- stderr -----
     ");
 
-    context.git().add_all();
+    context.git().add(".");
 
     // Run in the root
     // Since we add a new subproject, use `--refresh` to find that.
@@ -4103,7 +4131,8 @@ fn show_diff_on_failure() {
 
 #[test]
 fn run_quiet() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -4115,8 +4144,8 @@ fn run_quiet() {
                 name: fail
                 entry: fail
                 language: fail
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     // Run with `--quiet`, only print failed hooks.
     cmd_snapshot!(context, context.run().arg("--quiet"), @r"
@@ -4147,7 +4176,8 @@ fn run_quiet() {
 /// Test `PREK_QUIET` environment variable.
 #[test]
 fn run_quiet_env() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -4159,8 +4189,8 @@ fn run_quiet_env() {
                 name: fail
                 entry: fail
                 language: fail
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     // Run with `PREK_QUIET=1`, only print failed hooks.
     cmd_snapshot!(context, context.run().env(EnvVars::PREK_QUIET, "1"), @r"
@@ -4191,7 +4221,8 @@ fn run_quiet_env() {
 /// Test `prek run --log-file <file>` flag.
 #[test]
 fn run_log_file() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -4199,8 +4230,8 @@ fn run_log_file() {
                 name: fail
                 entry: fail
                 language: fail
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     // Run with `--no-log-file`, no `prek.log` is created.
     cmd_snapshot!(context, context.run().arg("--no-log-file"), @r"
@@ -4244,7 +4275,8 @@ fn run_log_file() {
 #[cfg(feature = "ci")]
 #[test]
 fn system_language_version() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -4272,8 +4304,8 @@ fn system_language_version() {
                 language_version: system
                 entry: dotnet --version
                 pass_filenames: false
-   "});
-    context.git().add_all();
+       "})
+        .init_git();
 
     // Binaries can't be found, `system` must fail.
     cmd_snapshot!(context,
@@ -4336,7 +4368,8 @@ fn system_language_version() {
 /// Tests that empty `entry` field.
 #[test]
 fn empty_entry() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -4345,8 +4378,8 @@ fn empty_entry() {
                 language: python
                 entry: ''
                 pass_filenames: false
-   "});
-    context.git().add_all();
+       "})
+        .init_git();
 
     // Go and Node can't be found, `system` must fail.
     cmd_snapshot!(context, context.run(), @r"
@@ -4364,7 +4397,7 @@ fn empty_entry() {
 /// Test that hooks are run with stdin closed.
 #[test]
 fn run_with_stdin_closed() {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new().with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -4374,8 +4407,7 @@ fn run_with_stdin_closed() {
                 entry: python -c 'import sys; sys.stdin.read(); print("STDIN closed"); sys.stdout.flush()'
                 pass_filenames: false
                 verbose: true
-    "#});
-    context.git().add_all();
+    "#}).init_git();
 
     cmd_snapshot!(context, context.run(), @r"
     success: true
@@ -4427,7 +4459,8 @@ fn version_info() {
 
 #[test]
 fn expands_tilde_in_prek_home() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
         repos:
           - repo: local
             hooks:
@@ -4435,8 +4468,8 @@ fn expands_tilde_in_prek_home() -> Result<()> {
                 name: ok
                 entry: echo ok
                 language: system
-    "});
-    context.git().add_all();
+    "})
+        .init_git();
 
     let fake_home = context.child("fake-home");
     fake_home.create_dir_all()?;
@@ -4468,7 +4501,7 @@ fn expands_tilde_in_prek_home() -> Result<()> {
 
 #[test]
 fn run_with_tree_object_as_ref() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -4479,9 +4512,10 @@ fn run_with_tree_object_as_ref() {
                 language: system
                 pass_filenames: true
     "})
-        .with_file("file1.txt", "hello");
+        .with_file("file1.txt", "hello")
+        .init_git();
 
-    context.git().add_all().commit("Initial commit");
+    context.git().commit("Initial commit");
 
     // Create some changes and stage them
     context.write_file("file2.txt", "world");
@@ -4515,7 +4549,7 @@ fn run_with_tree_object_as_ref() {
 /// With n=1, each matched file gets its own invocation.
 #[test]
 fn pass_filenames_1_limits_batch_size() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     // Use a script that errors if it receives more than one filename argument.
     let context = context
@@ -4533,7 +4567,7 @@ fn pass_filenames_1_limits_batch_size() {
     "#})
         .with_files([("a.txt", "a"), ("b.txt", "b"), ("c.txt", "c")]);
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run().arg("--all-files"), @r"
     success: true
@@ -4551,7 +4585,7 @@ fn pass_filenames_1_limits_batch_size() {
 /// With n=2 and more than 2 matching files, multiple batches are spawned.
 #[test]
 fn pass_filenames_2_limits_batch_size() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     // Use a script that errors if it receives more than two filename arguments.
     let context = context
@@ -4575,7 +4609,7 @@ fn pass_filenames_2_limits_batch_size() {
             ("e.txt", "e"),
         ]);
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run().arg("--all-files"), @r"
     success: true

--- a/crates/prek/tests/skipped_hooks.rs
+++ b/crates/prek/tests/skipped_hooks.rs
@@ -46,7 +46,7 @@ fn remove_loose_blob(context: &TestEnv, filename: &str) -> Result<()> {
 /// All hooks skip when no staged files match their file patterns.
 #[test]
 fn all_hooks_skipped_no_matching_files() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -69,9 +69,8 @@ fn all_hooks_skipped_no_matching_files() {
     "#})
         .with_file("readme.txt", "Hello")
         .with_file("data.json", "{}")
-        .with_file("config.yaml", "key: value");
-
-    context.git().add_all();
+        .with_file("config.yaml", "key: value")
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -88,7 +87,7 @@ fn all_hooks_skipped_no_matching_files() {
 /// Installable hooks with no matching files should not create environments.
 #[test]
 fn skipped_installable_hook_does_not_install_env() -> Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -99,9 +98,8 @@ fn skipped_installable_hook_does_not_install_env() -> Result<()> {
                 entry: python -c "print('checking python')"
                 files: \.py$
     "#})
-        .with_file("README.md", "Hello");
-
-    context.git().add_all();
+        .with_file("README.md", "Hello")
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -120,7 +118,8 @@ fn skipped_installable_hook_does_not_install_env() -> Result<()> {
 /// Installable hooks excluded by group selection should not create environments.
 #[test]
 fn group_excluded_installable_hook_does_not_install_env() -> Result<()> {
-    let context = TestEnv::new_git().with_config(indoc::indoc! {r#"
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
             hooks:
@@ -136,9 +135,8 @@ fn group_excluded_installable_hook_does_not_install_env() -> Result<()> {
                 entry: python -c "print('excluded')"
                 always_run: true
                 groups: [slow]
-    "#});
-
-    context.git().add_all();
+    "#})
+        .init_git();
 
     cmd_snapshot!(context, context.run().arg("--all-files").arg("--group").arg("ci"), @r#"
     success: true
@@ -157,7 +155,7 @@ fn group_excluded_installable_hook_does_not_install_env() -> Result<()> {
 /// `always_run` installable hooks still install and run without matching files.
 #[test]
 fn always_run_installable_hook_installs_without_matching_files() -> Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -170,9 +168,8 @@ fn always_run_installable_hook_installs_without_matching_files() -> Result<()> {
                 always_run: true
                 pass_filenames: false
     "#})
-        .with_file("README.md", "Hello");
-
-    context.git().add_all();
+        .with_file("README.md", "Hello")
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -191,7 +188,7 @@ fn always_run_installable_hook_installs_without_matching_files() -> Result<()> {
 /// `--dry-run` skips hooks without executing them.
 #[test]
 fn dry_run_skips_all_hooks() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -207,9 +204,8 @@ fn dry_run_skips_all_hooks() {
                 entry: echo "linting"
                 files: \.txt$
     "#})
-        .with_file("file.txt", "content");
-
-    context.git().add_all();
+        .with_file("file.txt", "content")
+        .init_git();
 
     cmd_snapshot!(context, context.run().arg("--dry-run"), @r#"
     success: true
@@ -227,7 +223,7 @@ fn dry_run_skips_all_hooks() {
 /// Hooks that match staged files run; others are skipped.
 #[test]
 fn mixed_skipped_and_executed_hooks() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -248,9 +244,8 @@ fn mixed_skipped_and_executed_hooks() {
                 entry: echo "checking rs"
                 files: \.rs$
     "#})
-        .with_file("readme.txt", "Hello");
-
-    context.git().add_all();
+        .with_file("readme.txt", "Hello")
+        .init_git();
 
     cmd_snapshot!(context, context.run(), @r#"
     success: true
@@ -267,7 +262,7 @@ fn mixed_skipped_and_executed_hooks() {
 /// Skipped hooks in untouched workspace projects should not install environments.
 #[test]
 fn skipped_workspace_project_installable_hook_does_not_install_env() -> Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -304,8 +299,8 @@ fn skipped_workspace_project_installable_hook_does_not_install_env() -> Result<(
                 files: \.py$
     "#},
         )
-        .with_file("proj-a/README.txt", "Hello");
-    context.git().add_all();
+        .with_file("proj-a/README.txt", "Hello")
+        .init_git();
 
     let output = context.run().output()?;
     assert!(output.status.success(), "prek should succeed");
@@ -320,7 +315,7 @@ fn skipped_workspace_project_installable_hook_does_not_install_env() -> Result<(
 
 #[test]
 fn orphan_project_early_match_still_hides_child_files_from_parent_install() -> Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -346,8 +341,8 @@ fn orphan_project_early_match_still_hides_child_files_from_parent_install() -> R
                 pass_filenames: false
     "#},
         )
-        .with_file("child/child.py", "print('child')\n");
-    context.git().add_all();
+        .with_file("child/child.py", "print('child')\n")
+        .init_git();
 
     cmd_snapshot!(context, context.run().arg("--all-files"), @r#"
     success: true
@@ -377,7 +372,7 @@ fn orphan_project_early_match_still_hides_child_files_from_parent_install() -> R
 /// contains non-deterministic timestamps and timing data unsuitable for snapshots.
 #[test]
 fn all_hooks_skipped_multiple_priority_groups() -> Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -401,9 +396,8 @@ fn all_hooks_skipped_multiple_priority_groups() -> Result<()> {
                 files: \.go$
                 priority: 30
     "#})
-        .with_file("data.json", "{}");
-
-    context.git().add_all();
+        .with_file("data.json", "{}")
+        .init_git();
 
     // Run with trace logging to verify #1335 fix
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
@@ -430,7 +424,7 @@ fn all_hooks_skipped_multiple_priority_groups() -> Result<()> {
 
 #[test]
 fn external_hook_without_changes_uses_quiet_diff_check() -> Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -441,9 +435,8 @@ fn external_hook_without_changes_uses_quiet_diff_check() -> Result<()> {
                 entry: python3 -c "pass"
                 pass_filenames: false
     "#})
-        .with_file("file.txt", "original\n");
-
-    context.git().add_all();
+        .with_file("file.txt", "original\n")
+        .init_git();
 
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
 
@@ -469,7 +462,7 @@ fn external_hook_without_changes_uses_quiet_diff_check() -> Result<()> {
 #[test]
 #[cfg(unix)]
 fn identical_rewrite_with_stat_change_is_not_modified() -> Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -495,9 +488,8 @@ fn identical_rewrite_with_stat_change_is_not_modified() -> Result<()> {
             os.utime(path, (timestamp, timestamp))
     "},
         )
-        .with_file("file.txt", "original\n");
-
-    context.git().add_all();
+        .with_file("file.txt", "original\n")
+        .init_git();
 
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
 
@@ -530,7 +522,7 @@ fn identical_rewrite_with_stat_change_is_not_modified() -> Result<()> {
 
 #[test]
 fn modifying_hook_uses_clean_baseline_diff_detection() -> Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -541,9 +533,7 @@ fn modifying_hook_uses_clean_baseline_diff_detection() -> Result<()> {
                 entry: python3 -c "from pathlib import Path; Path('file.txt').write_text('changed\n')"
                 pass_filenames: false
     "#})
-        .with_file("file.txt", "original\n");
-
-    context.git().add_all();
+        .with_file("file.txt", "original\n").init_git();
 
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
 
@@ -610,7 +600,7 @@ fn binary_diff_snapshots_use_full_object_ids() -> Result<()> {
     // The two replacement blobs have distinct SHA-1s whose first seven
     // hexadecimal digits are both `4b8e34c`.
 
-    context.git().add_all();
+    context.git().add(".");
 
     let status = context
         .git()
@@ -638,7 +628,7 @@ fn binary_diff_snapshots_use_full_object_ids() -> Result<()> {
 
 #[test]
 fn all_files_with_existing_unstaged_changes_uses_snapshot_baseline() -> Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -650,9 +640,8 @@ fn all_files_with_existing_unstaged_changes_uses_snapshot_baseline() -> Result<(
                 pass_filenames: false
     "#})
         .with_file("file.txt", "original\n")
-        .with_file("hook.txt", "original\n");
+        .with_file("hook.txt", "original\n").init_git();
 
-    context.git().add_all();
     context.write_file("file.txt", "unstaged\n");
 
     let output = context
@@ -689,7 +678,7 @@ fn all_files_with_existing_unstaged_changes_uses_snapshot_baseline() -> Result<(
 
 #[test]
 fn all_files_clean_missing_blob_ignores_diff_snapshot_errors() -> Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -700,9 +689,10 @@ fn all_files_clean_missing_blob_ignores_diff_snapshot_errors() -> Result<()> {
                 entry: python3 -c "pass"
                 pass_filenames: false
     "#})
-        .with_file("file.txt", "original\n");
+        .with_file("file.txt", "original\n")
+        .init_git();
 
-    context.git().add_all().commit("init");
+    context.git().commit("init");
 
     remove_loose_blob(&context, "file.txt")?;
 
@@ -749,7 +739,7 @@ fn all_files_clean_missing_blob_ignores_diff_snapshot_errors() -> Result<()> {
 
 #[test]
 fn later_project_snapshots_diff_left_by_previous_project() -> Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: local
@@ -775,8 +765,7 @@ fn later_project_snapshots_diff_left_by_previous_project() -> Result<()> {
                 pass_filenames: false
     "#},
         )
-        .with_file("child/child.txt", "original\n");
-    context.git().add_all();
+        .with_file("child/child.txt", "original\n").init_git();
 
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
 
@@ -806,16 +795,15 @@ fn later_project_snapshots_diff_left_by_previous_project() -> Result<()> {
 
 #[test]
 fn read_only_builtin_hook_does_not_run_diff_detection() -> Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-toml
     "})
-        .with_file("pyproject.toml", "[project]\nname = \"demo\"\n");
-
-    context.git().add_all();
+        .with_file("pyproject.toml", "[project]\nname = \"demo\"\n")
+        .init_git();
 
     let output = context
         .run()
@@ -838,7 +826,7 @@ fn read_only_builtin_hook_does_not_run_diff_detection() -> Result<()> {
 
 #[test]
 fn read_only_languages_do_not_run_diff_detection() -> Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: local
@@ -854,9 +842,8 @@ fn read_only_languages_do_not_run_diff_detection() -> Result<()> {
                 entry: not-present
                 files: \.txt$
     "})
-        .with_file("file.txt", "original\n");
-
-    context.git().add_all();
+        .with_file("file.txt", "original\n")
+        .init_git();
 
     let output = context
         .run()
@@ -890,7 +877,7 @@ fn read_only_languages_do_not_run_diff_detection() -> Result<()> {
 
 #[test]
 fn same_group_known_modification_skips_diff_detection() -> Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: builtin
@@ -906,9 +893,8 @@ fn same_group_known_modification_skips_diff_detection() -> Result<()> {
                 pass_filenames: false
                 priority: 0
     "#})
-        .with_file("file.txt", "missing newline");
-
-    context.git().add_all();
+        .with_file("file.txt", "missing newline")
+        .init_git();
 
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
 
@@ -944,7 +930,7 @@ fn same_group_known_modification_skips_diff_detection() -> Result<()> {
 
 #[test]
 fn same_group_known_modification_rebaselines_later_external_hook() -> Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: builtin
@@ -966,9 +952,8 @@ fn same_group_known_modification_rebaselines_later_external_hook() -> Result<()>
                 pass_filenames: false
                 priority: 1
     "#})
-        .with_file("file.txt", "missing newline");
-
-    context.git().add_all();
+        .with_file("file.txt", "missing newline")
+        .init_git();
 
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
 
@@ -1004,7 +989,7 @@ fn same_group_known_modification_rebaselines_later_external_hook() -> Result<()>
 
 #[test]
 fn modifying_builtin_invalidates_baseline_for_later_external_hook() -> Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r#"
         repos:
           - repo: builtin
@@ -1020,9 +1005,8 @@ fn modifying_builtin_invalidates_baseline_for_later_external_hook() -> Result<()
                 pass_filenames: false
                 priority: 1
     "#})
-        .with_file("file.txt", "missing newline");
-
-    context.git().add_all();
+        .with_file("file.txt", "missing newline")
+        .init_git();
 
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
 
@@ -1057,7 +1041,7 @@ fn modifying_builtin_invalidates_baseline_for_later_external_hook() -> Result<()
 
 #[test]
 fn failed_non_modifying_builtin_skips_diff_detection() -> Result<()> {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
@@ -1065,9 +1049,8 @@ fn failed_non_modifying_builtin_skips_diff_detection() -> Result<()> {
               - id: mixed-line-ending
                 args: ['--fix=no']
     "})
-        .with_file("mixed.txt", "first\r\nsecond\n");
-
-    context.git().add_all();
+        .with_file("mixed.txt", "first\r\nsecond\n")
+        .init_git();
 
     let output = context.run().env("RUST_LOG", "prek::git=trace").output()?;
 

--- a/crates/prek/tests/try_repo.rs
+++ b/crates/prek/tests/try_repo.rs
@@ -35,7 +35,7 @@ fn create_hook_repo(context: &TestEnv, repo_name: &str) -> PathBuf {
             "from setuptools import setup; setup(name='dummy-pkg', version='0.0.1')",
         );
 
-    repo.git().add_all().commit("Initial commit");
+    repo.git().add(".").commit("Initial commit");
 
     repo.path().to_path_buf()
 }
@@ -52,15 +52,14 @@ fn create_failing_hook_repo(context: &TestEnv, repo_name: &str) -> PathBuf {
         "#},
     );
 
-    repo.git().add_all().commit("Initial commit");
+    repo.git().add(".").commit("Initial commit");
 
     repo.path().to_path_buf()
 }
 
 #[test]
 fn try_repo_basic() {
-    let context = TestEnv::new_git().with_file("test.txt", "test");
-    context.git().add_all();
+    let context = TestEnv::new().with_file("test.txt", "test").init_git();
 
     let repo_path = create_hook_repo(&context, "try-repo-basic");
 
@@ -86,8 +85,7 @@ fn try_repo_basic() {
 
 #[test]
 fn try_repo_failing_hook() {
-    let context = TestEnv::new_git().with_file("test.txt", "test");
-    context.git().add_all();
+    let context = TestEnv::new().with_file("test.txt", "test").init_git();
 
     let repo_path = create_failing_hook_repo(&context, "try-repo-failing");
 
@@ -115,11 +113,11 @@ fn try_repo_failing_hook() {
 
 #[test]
 fn try_repo_specific_hook() {
-    let context = TestEnv::new_git().with_file("test.txt", "test");
+    let context = TestEnv::new().with_file("test.txt", "test").init_git();
 
     let repo_path = create_hook_repo(&context, "try-repo-specific-hook");
 
-    context.git().add_all();
+    context.git().add(".");
 
     let context = with_try_repo_filters(context);
 
@@ -143,8 +141,7 @@ fn try_repo_specific_hook() {
 
 #[test]
 fn try_repo_specific_rev() -> Result<()> {
-    let context = TestEnv::new_git().with_file("test.txt", "test");
-    context.git().add_all();
+    let context = TestEnv::new().with_file("test.txt", "test").init_git();
 
     let repo_path = create_hook_repo(&context, "try-repo-specific-rev");
     let git = context.git_at(&repo_path);
@@ -189,7 +186,7 @@ fn try_repo_specific_rev() -> Result<()> {
 
 #[test]
 fn try_repo_uncommitted_changes() -> Result<()> {
-    let context = TestEnv::new_git().with_file("test.txt", "test");
+    let context = TestEnv::new().with_file("test.txt", "test").init_git();
 
     let repo_path = create_hook_repo(&context, "try-repo-uncommitted");
 
@@ -207,7 +204,7 @@ fn try_repo_uncommitted_changes() -> Result<()> {
         .write_str("new")?;
     context.git_at(&repo_path).add("new-file.txt");
 
-    context.git().add_all();
+    context.git().add(".");
 
     let context = context.with_filters([
         (r"try-repo-[^/\\]+", "[REPO]"),
@@ -238,8 +235,7 @@ fn try_repo_uncommitted_changes() -> Result<()> {
 
 #[test]
 fn try_repo_relative_path() {
-    let context = TestEnv::new_git().with_file("test.txt", "test");
-    context.git().add_all();
+    let context = TestEnv::new().with_file("test.txt", "test").init_git();
 
     let _repo_path = create_hook_repo(&context, "try-repo-relative");
     let relative_path = "../home/test-repos/try-repo-relative".to_string();
@@ -302,8 +298,7 @@ fn try_repo_dot_path() -> Result<()> {
 
 #[test]
 fn try_repo_builtin_hook() {
-    let context = TestEnv::new_git().with_file("test.txt", "test\n");
-    context.git().add_all();
+    let context = TestEnv::new().with_file("test.txt", "test\n").init_git();
 
     cmd_snapshot!(context, context.try_repo().arg("builtin").arg("check-merge-conflict").arg("--all-files"), @r#"
     success: true
@@ -324,8 +319,7 @@ fn try_repo_builtin_hook() {
 
 #[test]
 fn try_repo_meta_hook() {
-    let context = TestEnv::new_git().with_file("test.txt", "test\n");
-    context.git().add_all();
+    let context = TestEnv::new().with_file("test.txt", "test\n").init_git();
 
     cmd_snapshot!(context, context.try_repo().arg("meta").arg("identity").arg("--all-files"), @r#"
     success: true

--- a/crates/prek/tests/update.rs
+++ b/crates/prek/tests/update.rs
@@ -25,7 +25,7 @@ fn git_command_at(git: &TestGit<'_>, timestamp: u64) -> Command {
 }
 
 fn context_with_commit_sha_filter() -> TestEnv {
-    TestEnv::new_git().with_filter(r"[a-f0-9]{40}", "[COMMIT_SHA]")
+    TestEnv::new().with_filter(r"[a-f0-9]{40}", "[COMMIT_SHA]")
 }
 
 /// Helper function to create a local git repository with hooks and incrementing timestamps.
@@ -141,7 +141,7 @@ fn create_local_git_repo_with_tag_timestamps(
 
 #[test]
 fn update_basic() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(&context, "test-repo", &["v1.0.0", "v1.1.0", "v2.0.0"]);
 
@@ -152,7 +152,7 @@ fn update_basic() {
             hooks:
               - id: test-hook
     ", repo_path});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -175,7 +175,7 @@ fn update_basic() {
 
 #[test]
 fn update_already_up_to_date() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(&context, "up-to-date-repo", &["v1.0.0"]);
 
@@ -187,7 +187,7 @@ fn update_already_up_to_date() {
               - id: test-hook
     ", repo_path});
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -208,7 +208,7 @@ fn update_already_up_to_date() {
 
 #[test]
 fn update_cooldown_does_not_downgrade_current_rev() -> Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo_with_tag_ages(
         &context,
@@ -224,7 +224,7 @@ fn update_cooldown_does_not_downgrade_current_rev() -> Result<()> {
               - id: test-hook
     ", repo_path});
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("7"), @"
     success: true
@@ -257,15 +257,15 @@ fn update_freeze_still_freezes_skipped_cooldown_downgrade() -> Result<()> {
         &[("v0.9.25", 8), ("v0.10.2", 2), ("v0.10.3", 1)],
     )?;
 
-    context.write_config(indoc::formatdoc! {r"
+    let context = context
+        .with_config(indoc::formatdoc! {r"
         repos:
           - repo: {}
             rev: v0.10.2
             hooks:
               - id: test-hook
-    ", repo_path});
-
-    context.git().add_all();
+    ", repo_path})
+        .init_git();
 
     cmd_snapshot!(context, context.update().arg("--freeze").arg("--cooldown-days").arg("7"), @"
     success: true
@@ -290,7 +290,7 @@ fn update_freeze_still_freezes_skipped_cooldown_downgrade() -> Result<()> {
 
 #[test]
 fn update_already_up_to_date_verbose() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(&context, "up-to-date-repo-verbose", &["v1.0.0"]);
 
@@ -302,7 +302,7 @@ fn update_already_up_to_date_verbose() {
               - id: test-hook
     ", repo_path});
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update().arg("-v").arg("--cooldown-days").arg("0"), @"
     success: true
@@ -320,7 +320,7 @@ fn update_already_up_to_date_verbose() {
 fn update_does_not_rewrite_config_when_up_to_date() -> Result<()> {
     use std::time::UNIX_EPOCH;
 
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(&context, "up-to-date-repo-mtime", &["v1.0.0"]);
 
@@ -331,7 +331,7 @@ fn update_does_not_rewrite_config_when_up_to_date() -> Result<()> {
             hooks:
               - id: test-hook
     ", repo_path});
-    context.git().add_all();
+    context.git().add(".");
 
     let config_path = context.child(PRE_COMMIT_CONFIG_YAML);
 
@@ -360,7 +360,7 @@ fn update_does_not_rewrite_config_when_up_to_date() -> Result<()> {
 
 #[test]
 fn update_multiple_repos_mixed() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo1_path = create_local_git_repo(&context, "repo1", &["v1.0.0", "v1.1.0"]);
     let repo2_path = create_local_git_repo(&context, "repo2", &["v2.0.0"]);
@@ -381,7 +381,7 @@ fn update_multiple_repos_mixed() {
               - id: another-hook
     ", repo1_path, repo1_path, repo2_path});
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: false
@@ -415,7 +415,7 @@ fn update_multiple_repos_mixed() {
 /// Test that `prek update` ignores the `GIT_DIR` environment variable.
 #[test]
 fn test_resolve_revision_ignores_git_dir_env_var() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(&context, "target-repo", &["v0.1.0", "v0.2.0"]);
     let external_repo_path = create_local_git_repo(&context, "external-repo", &["v9.9.9"]);
@@ -427,7 +427,7 @@ fn test_resolve_revision_ignores_git_dir_env_var() {
             hooks:
               - id: test-hook
     ", repo_path});
-    context.git().add_all();
+    context.git().add(".");
 
     let mut cmd = context.update();
     cmd.arg("--cooldown-days")
@@ -455,7 +455,7 @@ fn test_resolve_revision_ignores_git_dir_env_var() {
 
 #[test]
 fn update_specific_repos() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo1_path = create_local_git_repo(&context, "repo1", &["v1.0.0", "v1.1.0"]);
     let repo2_path = create_local_git_repo(&context, "repo2", &["v2.0.0", "v2.1.0"]);
@@ -472,7 +472,7 @@ fn update_specific_repos() {
               - id: another-hook
     ", repo1_path, repo2_path});
 
-    context.git().add_all();
+    context.git().add(".");
 
     // Update only repo1
     cmd_snapshot!(context, context.update().arg("--repo").arg(&repo1_path).arg("--cooldown-days").arg("0"), @"
@@ -523,7 +523,7 @@ fn update_specific_repos() {
 
 #[test]
 fn update_warns_for_missing_repos() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(&context, "configured-repo", &["v1.0.0", "v1.1.0"]);
 
@@ -534,7 +534,7 @@ fn update_warns_for_missing_repos() {
             hooks:
               - id: test-hook
     ", repo_path});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update()
         .arg("--repo").arg(&repo_path)
@@ -560,7 +560,7 @@ fn update_warns_for_missing_repos() {
 
 #[test]
 fn update_warns_when_repo_override_matches_another_project() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo1_path = create_local_git_repo(&context, "project-repo-1", &["v1.0.0", "v1.1.0"]);
     let repo2_path = create_local_git_repo(&context, "project-repo-2", &["v1.0.0", "v1.1.0"]);
@@ -596,7 +596,7 @@ fn update_warns_when_repo_override_matches_another_project() {
     "#, repo1_path, repo2_path},
         );
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update().arg("--jobs").arg("1"), @"
     success: true
@@ -621,7 +621,7 @@ fn update_warns_when_repo_override_matches_another_project() {
 
 #[test]
 fn update_repo_options_match_relative_config_value() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let selected_path = create_local_git_repo(
         &context,
@@ -641,7 +641,7 @@ fn update_repo_options_match_relative_config_value() {
             hooks:
               - id: test-hook
     "});
-    context.git().add_all();
+    context.git().add(".");
 
     let include_filter = format!("{selected_repo}=v1.*");
     let exclude_filter = format!("{selected_repo}=v1.2.0");
@@ -674,7 +674,7 @@ fn update_repo_options_match_relative_config_value() {
 
 #[test]
 fn update_exclude_repo_skips_fetching_repo() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(&context, "included-repo", &["v1.0.0", "v1.1.0"]);
     let missing_repo_path = context
@@ -695,7 +695,7 @@ fn update_exclude_repo_skips_fetching_repo() {
               - id: another-hook
     ", repo_path, missing_repo_path});
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update().arg("--exclude-repo").arg(&missing_repo_path).arg("--cooldown-days").arg("0"), @"
     success: true
@@ -722,7 +722,7 @@ fn update_exclude_repo_skips_fetching_repo() {
 
 #[test]
 fn update_exclude_repo_matches_relative_config_value() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     create_local_git_repo(&context, "relative-excluded", &["v1.0.0", "v2.0.0"]);
     create_local_git_repo(&context, "relative-included", &["v1.0.0", "v2.0.0"]);
@@ -740,7 +740,7 @@ fn update_exclude_repo_matches_relative_config_value() {
             hooks:
               - id: test-hook
     "});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update()
         .arg("--exclude-repo").arg(excluded_repo)
@@ -769,7 +769,7 @@ fn update_exclude_repo_matches_relative_config_value() {
 
 #[test]
 fn update_tag_filters_include_then_exclude() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(
         &context,
@@ -785,7 +785,7 @@ fn update_tag_filters_include_then_exclude() {
               - id: test-hook
     ", repo_path});
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update()
         .arg("--include-tag").arg("v1.*")
@@ -812,7 +812,7 @@ fn update_tag_filters_include_then_exclude() {
 
 #[test]
 fn update_uses_project_tag_filter_config() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo1_path = create_local_git_repo(
         &context,
@@ -844,7 +844,7 @@ fn update_uses_project_tag_filter_config() {
               - id: test-hook
     "#, repo1_path, repo1_path, repo2_path});
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update().arg("--jobs").arg("1"), @"
     success: true
@@ -881,7 +881,7 @@ fn update_uses_project_tag_filter_config() {
 
 #[test]
 fn update_tag_filters_can_select_older_track_without_cooldown() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(
         &context,
@@ -897,7 +897,7 @@ fn update_tag_filters_can_select_older_track_without_cooldown() {
               - id: test-hook
     ", repo_path});
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update()
         .arg("--include-tag").arg("v1.*")
@@ -922,7 +922,7 @@ fn update_tag_filters_can_select_older_track_without_cooldown() {
 
 #[test]
 fn update_repo_include_tag_is_repo_specific() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo1_path = create_local_git_repo(
         &context,
@@ -947,7 +947,7 @@ fn update_repo_include_tag_is_repo_specific() {
               - id: test-hook
     ", repo1_path, repo2_path});
 
-    context.git().add_all();
+    context.git().add(".");
 
     let repo1_filter = format!("{repo1_path}=v1.*");
 
@@ -982,7 +982,7 @@ fn update_repo_include_tag_is_repo_specific() {
 
 #[test]
 fn update_repo_include_tag_overrides_global_include_tag() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(
         &context,
@@ -998,7 +998,7 @@ fn update_repo_include_tag_overrides_global_include_tag() {
               - id: test-hook
     ", repo_path});
 
-    context.git().add_all();
+    context.git().add(".");
 
     let repo_filter = format!("{repo_path}=v*.1.0");
 
@@ -1026,7 +1026,7 @@ fn update_repo_include_tag_overrides_global_include_tag() {
 
 #[test]
 fn update_repo_exclude_tag_can_leave_repo_unchanged() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo1_path = create_local_git_repo(&context, "repo-exclude-tag-1", &["v1.0.0", "v2.0.0"]);
     let repo2_path = create_local_git_repo(&context, "repo-exclude-tag-2", &["v1.0.0", "v2.0.0"]);
@@ -1043,7 +1043,7 @@ fn update_repo_exclude_tag_can_leave_repo_unchanged() {
               - id: test-hook
     ", repo1_path, repo2_path});
 
-    context.git().add_all();
+    context.git().add(".");
 
     let repo1_filter = format!("{repo1_path}=v2.*");
 
@@ -1080,15 +1080,15 @@ fn update_bleeding_edge() {
 
     let repo_path = create_local_git_repo(&context, "bleeding-repo", &["v1.0.0"]);
 
-    context.write_config(indoc::formatdoc! {r"
+    let context = context
+        .with_config(indoc::formatdoc! {r"
         repos:
           - repo: {}
             rev: v1.0.0
             hooks:
               - id: test-hook
-    ", repo_path});
-
-    context.git().add_all();
+    ", repo_path})
+        .init_git();
 
     cmd_snapshot!(context, context.update().arg("--bleeding-edge"), @"
     success: true
@@ -1126,7 +1126,8 @@ fn update_freeze() {
         .assert()
         .success();
 
-    context.write_config(indoc::formatdoc! {r"
+    let context = context
+        .with_config(indoc::formatdoc! {r"
         update:
           freeze: true
         repos:
@@ -1134,9 +1135,8 @@ fn update_freeze() {
             rev: v1.0.0
             hooks:
               - id: test-hook
-    ", repo_path});
-
-    context.git().add_all();
+    ", repo_path})
+        .init_git();
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -1162,7 +1162,7 @@ fn update_freeze() {
 
 #[test]
 fn update_freeze_uses_dereferenced_commit_for_annotated_tags() -> Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(&context, "freeze-annotated-repo", &["v1.0.0", "v1.1.0"]);
 
@@ -1182,7 +1182,7 @@ fn update_freeze_uses_dereferenced_commit_for_annotated_tags() -> Result<()> {
             hooks:
               - id: test-hook
     ", repo_path});
-    context.git().add_all();
+    context.git().add(".");
 
     context
         .update()
@@ -1211,7 +1211,7 @@ fn update_freeze_uses_dereferenced_commit_for_annotated_tags() -> Result<()> {
 
 #[test]
 fn update_shared_target_with_different_frozen_comments_displays_sha() -> Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(
         &context,
@@ -1242,7 +1242,7 @@ fn update_shared_target_with_different_frozen_comments_displays_sha() -> Result<
               - id: test-hook
     ", repo_path, old_commit_sha, repo_path, old_commit_sha});
 
-    context.git().add_all();
+    context.git().add(".");
 
     let context = context.with_filter(old_commit_sha.clone(), "[OLD_COMMIT_SHA]");
 
@@ -1274,7 +1274,7 @@ fn update_shared_target_with_different_frozen_comments_displays_sha() -> Result<
 
 #[test]
 fn update_preserve_quote_style() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo1_path = create_local_git_repo(&context, "repo1", &["v1.0.0", "v1.1.0"]);
     let repo2_path = create_local_git_repo(&context, "repo2", &["v1.0.0", "v1.1.0"]);
@@ -1303,7 +1303,7 @@ fn update_preserve_quote_style() {
                 name: Test Hook
     "#, repo1_path, repo1_path, repo2_path });
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -1345,7 +1345,7 @@ fn update_preserve_quote_style() {
 
 #[test]
 fn update_with_existing_frozen_comment() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(&context, "frozen-repo", &["v1.0.0", "v1.1.0", "v1.2.0"]);
 
@@ -1359,7 +1359,7 @@ fn update_with_existing_frozen_comment() {
               - id: test-hook
     ", repo_path, commit_sha});
 
-    context.git().add_all();
+    context.git().add(".");
 
     let context = context.with_filter(commit_sha, "[COMMIT_SHA]");
 
@@ -1391,7 +1391,7 @@ fn update_with_existing_frozen_comment() {
 
 #[test]
 fn update_updates_mismatched_frozen_comment() -> Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(&context, "check-frozen-repo", &["v1.0.0", "v1.1.0"]);
 
@@ -1405,7 +1405,7 @@ fn update_updates_mismatched_frozen_comment() -> Result<()> {
               - id: test-hook
     ", repo_path, commit_sha});
 
-    context.git().add_all();
+    context.git().add(".");
 
     let context = context.with_filter(commit_sha.clone(), "[COMMIT_SHA]");
 
@@ -1439,7 +1439,7 @@ fn update_updates_mismatched_frozen_comment() -> Result<()> {
 
 #[test]
 fn update_updates_unresolvable_frozen_comment() -> Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(
         &context,
@@ -1457,7 +1457,7 @@ fn update_updates_unresolvable_frozen_comment() -> Result<()> {
               - id: test-hook
     ", repo_path, commit_sha});
 
-    context.git().add_all();
+    context.git().add(".");
 
     let context = context.with_filter(commit_sha.clone(), "[COMMIT_SHA]");
 
@@ -1491,7 +1491,7 @@ fn update_updates_unresolvable_frozen_comment() -> Result<()> {
 
 #[test]
 fn update_removes_frozen_comment_when_pinned_commit_has_no_tag() -> Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(
         &context,
@@ -1509,7 +1509,7 @@ fn update_removes_frozen_comment_when_pinned_commit_has_no_tag() -> Result<()> {
               - id: test-hook
     ", repo_path, commit_sha});
 
-    context.git().add_all();
+    context.git().add(".");
 
     let context = context.with_filter(commit_sha.clone(), "[COMMIT_SHA]");
 
@@ -1543,7 +1543,7 @@ fn update_removes_frozen_comment_when_pinned_commit_has_no_tag() -> Result<()> {
 
 #[test]
 fn update_warns_for_branch_only_pinned_commit_with_frozen_comment() -> Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(
         &context,
@@ -1580,7 +1580,7 @@ fn update_warns_for_branch_only_pinned_commit_with_frozen_comment() -> Result<()
               - id: test-hook
     ", repo_path, branch_commit});
 
-    context.git().add_all();
+    context.git().add(".");
 
     let context = context.with_filter(branch_commit.clone(), "[BRANCH_ONLY_COMMIT]");
     let context = context.with_filter(r"[a-f0-9]{40}", "[COMMIT_SHA]");
@@ -1615,7 +1615,7 @@ fn update_warns_for_branch_only_pinned_commit_with_frozen_comment() -> Result<()
 
 #[test]
 fn update_warns_for_invalid_pinned_commit_with_frozen_comment() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(
         &context,
@@ -1633,7 +1633,7 @@ fn update_warns_for_invalid_pinned_commit_with_frozen_comment() {
               - id: test-hook
     ", repo_path, invalid_commit});
 
-    context.git().add_all();
+    context.git().add(".");
 
     let context = context.with_filters([
         (invalid_commit, "[INVALID_COMMIT]"),
@@ -1668,7 +1668,7 @@ fn update_warns_for_invalid_pinned_commit_with_frozen_comment() {
 
 #[test]
 fn update_dry_run_warns_for_mismatched_frozen_comment() -> Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path =
         create_local_git_repo(&context, "check-frozen-dry-run-repo", &["v1.0.0", "v1.1.0"]);
@@ -1683,7 +1683,7 @@ fn update_dry_run_warns_for_mismatched_frozen_comment() -> Result<()> {
               - id: test-hook
     ", repo_path, commit_sha});
 
-    context.git().add_all();
+    context.git().add(".");
 
     let context = context.with_filter(commit_sha.clone(), "[COMMIT_SHA]");
 
@@ -1717,7 +1717,7 @@ fn update_dry_run_warns_for_mismatched_frozen_comment() -> Result<()> {
 
 #[test]
 fn update_check_fails_for_mismatched_frozen_comment() -> Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path =
         create_local_git_repo(&context, "check-frozen-check-repo", &["v1.0.0", "v1.1.0"]);
@@ -1732,7 +1732,7 @@ fn update_check_fails_for_mismatched_frozen_comment() -> Result<()> {
               - id: test-hook
     ", repo_path, commit_sha});
 
-    context.git().add_all();
+    context.git().add(".");
 
     let context = context.with_filter(commit_sha.clone(), "[COMMIT_SHA]");
 
@@ -1766,16 +1766,17 @@ fn update_check_fails_for_mismatched_frozen_comment() -> Result<()> {
 
 #[test]
 fn update_updates_mismatched_frozen_comment_toml() -> Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new();
 
     let repo_path =
         create_local_git_repo(&context, "check-frozen-repo-toml", &["v1.0.0", "v1.1.0"]);
 
     let commit_sha = context.git_at(&repo_path).rev_parse("v1.1.0^{}")?;
 
-    let context = context.with_file(
-        PREK_TOML,
-        indoc::formatdoc! {r#"
+    let context = context
+        .with_file(
+            PREK_TOML,
+            indoc::formatdoc! {r#"
         [[repos]]
         repo = "{}"
         rev = "{}" # frozen: v1.0.0
@@ -1783,9 +1784,8 @@ fn update_updates_mismatched_frozen_comment_toml() -> Result<()> {
           {{ id = "test-hook" }},
         ]
         "#, repo_path, commit_sha},
-    );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     let context = context.with_filter(commit_sha.clone(), "[COMMIT_SHA]");
 
@@ -1820,7 +1820,7 @@ fn update_updates_mismatched_frozen_comment_toml() -> Result<()> {
 
 #[test]
 fn update_local_repo_ignored() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(&context, "remote-repo", &["v1.0.0", "v1.1.0"]);
 
@@ -1838,7 +1838,7 @@ fn update_local_repo_ignored() {
               - id: test-hook
     ", repo_path});
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -1867,7 +1867,7 @@ fn update_local_repo_ignored() {
 
 #[test]
 fn missing_hook_ids() -> Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(&context, "missing-hook-repo", &["v1.0.0"]);
 
@@ -1894,7 +1894,7 @@ fn missing_hook_ids() -> Result<()> {
             hooks:
               - id: test-hook
     ", repo_path});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: false
@@ -1911,7 +1911,7 @@ fn missing_hook_ids() -> Result<()> {
 
 #[test]
 fn update_workspace() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo1_path =
         create_local_git_repo(&context, "workspace-repo1", &["v1.0.0", "v1.1.0", "v2.0.0"]);
@@ -1953,7 +1953,7 @@ fn update_workspace() {
     ", repo2_path, repo3_path},
         );
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2000,7 +2000,7 @@ fn update_workspace() {
 
 #[test]
 fn update_workspace_same_repo_uses_project_cooldown() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
     context.write_user_config(indoc::indoc! {r"
         [update]
         cooldown_days = 1
@@ -2048,7 +2048,7 @@ fn update_workspace_same_repo_uses_project_cooldown() {
     ", repo_path},
         );
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update(), @"
     success: true
@@ -2089,7 +2089,7 @@ fn update_workspace_same_repo_uses_project_cooldown() {
 // - is most similar to the current revision, as measured by Levenshtein distance.
 #[test]
 fn prefer_similar_tags() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(&context, "remote-repo", &["v1.0.0", "v1.1.0"]);
     // Add a second tag (`foo-v1.1.0`) pointing at the same commit as `v1.1.0`.
@@ -2134,7 +2134,7 @@ fn prefer_similar_tags() {
               - id: test-hook
     ", repo_path});
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2163,7 +2163,7 @@ fn prefer_similar_tags() {
 
 #[test]
 fn update_dry_run() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(&context, "test-repo", &["v1.0.0", "v1.1.0", "v2.0.0"]);
 
@@ -2174,7 +2174,7 @@ fn update_dry_run() {
             hooks:
               - id: test-hook
     ", repo_path});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update().arg("--dry-run").arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2197,7 +2197,7 @@ fn update_dry_run() {
 
 #[test]
 fn update_check() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path =
         create_local_git_repo(&context, "check-test-repo", &["v1.0.0", "v1.1.0", "v2.0.0"]);
@@ -2209,7 +2209,7 @@ fn update_check() {
             hooks:
               - id: test-hook
     ", repo_path});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update().arg("--check").arg("--cooldown-days").arg("0"), @"
     success: false
@@ -2232,7 +2232,7 @@ fn update_check() {
 
 #[test]
 fn update_dry_run_exit_code() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(
         &context,
@@ -2247,7 +2247,7 @@ fn update_dry_run_exit_code() {
             hooks:
               - id: test-hook
     ", repo_path});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update().arg("--dry-run").arg("--exit-code").arg("--cooldown-days").arg("0"), @"
     success: false
@@ -2270,7 +2270,7 @@ fn update_dry_run_exit_code() {
 
 #[test]
 fn update_exit_code_updates_config() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(
         &context,
@@ -2285,7 +2285,7 @@ fn update_exit_code_updates_config() {
             hooks:
               - id: test-hook
     ", repo_path});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update().arg("--exit-code").arg("--cooldown-days").arg("0"), @"
     success: false
@@ -2308,7 +2308,7 @@ fn update_exit_code_updates_config() {
 
 #[test]
 fn update_exit_code_succeeds_when_up_to_date() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(
         &context,
@@ -2323,7 +2323,7 @@ fn update_exit_code_succeeds_when_up_to_date() {
             hooks:
               - id: test-hook
     ", repo_path});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update().arg("--exit-code").arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2344,7 +2344,7 @@ fn update_exit_code_succeeds_when_up_to_date() {
 
 #[test]
 fn quoting_float_like_version_number() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(&context, "test-repo", &["0.49", "0.50"]);
 
@@ -2357,7 +2357,7 @@ fn quoting_float_like_version_number() {
             hooks:
               - id: test-hook
     "#, repo_path});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2380,7 +2380,7 @@ fn quoting_float_like_version_number() {
 
 #[test]
 fn quoting_float_like_version_number_without_existing_quotes() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo(&context, "test-repo", &["v0.19", "0.51"]);
 
@@ -2391,7 +2391,7 @@ fn quoting_float_like_version_number_without_existing_quotes() {
             hooks:
               - id: test-hook
     ", repo_path});
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2414,8 +2414,9 @@ fn quoting_float_like_version_number_without_existing_quotes() {
 
 #[test]
 fn update_with_invalid_config_file() {
-    let context =
-        TestEnv::new_git().with_file(PRE_COMMIT_CONFIG_YAML, "invalid_yaml: [unclosed_list");
+    let context = TestEnv::new()
+        .with_file(PRE_COMMIT_CONFIG_YAML, "invalid_yaml: [unclosed_list")
+        .init_git();
 
     cmd_snapshot!(context, context.update(), @"
     success: false
@@ -2434,14 +2435,15 @@ fn update_with_invalid_config_file() {
 
 #[test]
 fn update_toml() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new();
 
     let repo_path =
         create_local_git_repo(&context, "test-repo-toml", &["v1.0.0", "v1.1.0", "v2.0.0"]);
 
-    let context = context.with_file(
-        PREK_TOML,
-        indoc::formatdoc! {r#"
+    let context = context
+        .with_file(
+            PREK_TOML,
+            indoc::formatdoc! {r#"
         [[repos]]
         repo = "{}"
         rev = "v1.0.0"
@@ -2449,8 +2451,8 @@ fn update_toml() {
           {{ id = "test-hook" }},
         ]
       "#, repo_path},
-    );
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2474,14 +2476,15 @@ fn update_toml() {
 
 #[test]
 fn update_toml_with_comment() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new();
 
     let repo_path =
         create_local_git_repo(&context, "test-repo-toml", &["v1.0.0", "v1.1.0", "v2.0.0"]);
 
-    let context = context.with_file(
-        PREK_TOML,
-        indoc::formatdoc! {r#"
+    let context = context
+        .with_file(
+            PREK_TOML,
+            indoc::formatdoc! {r#"
         [[repos]]
         repo = "{}"
         rev = "v1.0.0" # This is a comment
@@ -2489,9 +2492,8 @@ fn update_toml_with_comment() {
           {{ id = "test-hook" }},
         ]
       "#, repo_path},
-    );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2525,7 +2527,7 @@ fn update_toml_with_comment() {
       "#, repo_path},
     );
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2568,9 +2570,10 @@ fn update_freeze_toml() {
         .assert()
         .success();
 
-    let context = context.with_file(
-        PREK_TOML,
-        indoc::formatdoc! {r#"
+    let context = context
+        .with_file(
+            PREK_TOML,
+            indoc::formatdoc! {r#"
         [[repos]]
         repo = "{}"
         rev = "v1.0.0"
@@ -2578,9 +2581,8 @@ fn update_freeze_toml() {
           {{ id = "test-hook" }},
         ]
     "#, repo_path},
-    );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2605,7 +2607,7 @@ fn update_freeze_toml() {
 
 #[test]
 fn update_equal_timestamp_tags_picks_highest_version() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo_fixed_ts(
         &context,
@@ -2621,7 +2623,7 @@ fn update_equal_timestamp_tags_picks_highest_version() {
               - id: test-hook
     ", repo_path});
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2646,7 +2648,7 @@ fn update_equal_timestamp_tags_picks_highest_version() {
 // semver tags should be preferred and sorted highest-first.
 #[test]
 fn update_equal_timestamp_prefers_semver_over_nonsemver() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let repo_path = create_local_git_repo_fixed_ts(
         &context,
@@ -2662,7 +2664,7 @@ fn update_equal_timestamp_prefers_semver_over_nonsemver() {
               - id: test-hook
     ", repo_path});
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2687,7 +2689,7 @@ fn update_equal_timestamp_prefers_semver_over_nonsemver() {
 // Within an equal-timestamp group, semver tiebreaker picks the highest version.
 #[test]
 fn update_mixed_timestamps_with_equal_subgroups() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     // Create base repo with v1.0.x tags at incrementing timestamps.
     let repo_path = create_local_git_repo(&context, "mixed-ts-repo", &["v1.0.0", "v1.0.1"]);
@@ -2728,7 +2730,7 @@ fn update_mixed_timestamps_with_equal_subgroups() {
               - id: test-hook
     ", repo_path});
 
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.update().arg("--cooldown-days").arg("0"), @"
     success: true
@@ -2766,9 +2768,10 @@ fn update_freeze_toml_with_comment() {
         .assert()
         .success();
 
-    let context = context.with_file(
-        PREK_TOML,
-        indoc::formatdoc! {r#"
+    let context = context
+        .with_file(
+            PREK_TOML,
+            indoc::formatdoc! {r#"
         [[repos]]
         repo = "{}"
         # A comment above
@@ -2778,9 +2781,8 @@ fn update_freeze_toml_with_comment() {
           {{ id = "test-hook" }},
         ]
     "#, repo_path},
-    );
-
-    context.git().add_all();
+        )
+        .init_git();
 
     cmd_snapshot!(context, context.update().arg("--freeze").arg("--cooldown-days").arg("0"), @"
     success: true

--- a/crates/prek/tests/workspace.rs
+++ b/crates/prek/tests/workspace.rs
@@ -9,7 +9,7 @@ use crate::common::{TestEnv, cmd_snapshot};
 
 #[test]
 fn basic_discovery() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
     let cwd = context.work_dir();
     let config = indoc! {r"
     repos:
@@ -31,7 +31,7 @@ fn basic_discovery() {
         ],
         config,
     );
-    context.git().add_all();
+    context.git().add(".");
 
     // Run from the root directory
     cmd_snapshot!(context, context.run(), @r#"
@@ -154,7 +154,7 @@ fn basic_discovery() {
 
     // Ignore `project5` in `project3`
     context.write_file("project3/.prekignore", "project5/\n");
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run().arg("--refresh").arg("--cd").arg(cwd.join("project3")), @r#"
     success: true
@@ -172,7 +172,7 @@ fn basic_discovery() {
 
     // Ignoring everything under project3, but when runs from project3, it’s still getting picked up.
     context.write_file("project3/.prekignore", "*\n");
-    context.git().add_all();
+    context.git().add(".");
     cmd_snapshot!(context, context.run().arg("--refresh").arg("--cd").arg(cwd.join("project3")), @r#"
     success: true
     exit_code: 0
@@ -190,9 +190,11 @@ fn basic_discovery() {
 
 #[test]
 fn same_depth_project_concurrency_has_stable_output() {
-    let context = TestEnv::new_git().with_config("repos: []").with_file(
-        "concurrent_hook.py",
-        indoc! {r#"
+    let context = TestEnv::new()
+        .with_config("repos: []")
+        .with_file(
+            "concurrent_hook.py",
+            indoc! {r#"
             from pathlib import Path
             import time
 
@@ -212,7 +214,8 @@ fn same_depth_project_concurrency_has_stable_output() {
             if project == "a":
                 time.sleep(0.5)
         "#},
-    );
+        )
+        .init_git();
 
     let config = indoc! {r"
     repos:
@@ -230,7 +233,7 @@ fn same_depth_project_concurrency_has_stable_output() {
         context.write_file(format!("{project}/{PRE_COMMIT_CONFIG_YAML}"), config);
         context.write_file(format!("{project}/file.txt"), "");
     }
-    context.git().add_all();
+    context.git().add(".");
 
     let mut run = context.run();
     run.arg("--all-files")
@@ -283,12 +286,11 @@ fn fail_fast_stops_after_current_project_level() {
           always_run: true
     "#};
 
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(root_config)
         .with_file("a/.pre-commit-config.yaml", failing_config)
-        .with_file("b/.pre-commit-config.yaml", passing_config);
-
-    context.git().add_all();
+        .with_file("b/.pre-commit-config.yaml", passing_config)
+        .init_git();
 
     let mut run = context.run();
     run.arg("--all-files")
@@ -310,7 +312,7 @@ fn fail_fast_stops_after_current_project_level() {
 
 #[test]
 fn config_not_staged() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
     let cwd = context.work_dir();
 
     let config = indoc! {r"
@@ -332,7 +334,7 @@ fn config_not_staged() {
         ],
         config,
     );
-    context.git().add_all();
+    context.git().add(".");
 
     let config = indoc! {r"
     repos:
@@ -394,7 +396,7 @@ fn config_not_staged() {
 
 #[test]
 fn run_with_selectors() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let config = indoc! {r"
     repos:
@@ -416,7 +418,7 @@ fn run_with_selectors() {
         ],
         config,
     );
-    context.git().add_all();
+    context.git().add(".");
 
     cmd_snapshot!(context, context.run().arg("--hide-status").arg("passed"), @r#"
     success: true
@@ -712,7 +714,7 @@ fn run_with_selectors() {
 
 #[test]
 fn run_with_mixed_project_and_hook_selectors() {
-    let context = TestEnv::new_git()
+    let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
     repos:
       - repo: local
@@ -738,9 +740,8 @@ fn run_with_mixed_project_and_hook_selectors() {
         )
         .with_file("sub/file.txt", "")
         .with_project_config("empty", "repos: []\n")
-        .with_project_config("unselected", "invalid: config\n");
-
-    context.git().add_all();
+        .with_project_config("unselected", "invalid: config\n")
+        .init_git();
 
     cmd_snapshot!(context, context.run().arg("--all-files").arg("sub/").arg(".:root-hook"), @r"
     success: true
@@ -778,7 +779,7 @@ fn run_with_mixed_project_and_hook_selectors() {
 
 #[test]
 fn skips() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let config = indoc! {r"
     repos:
@@ -792,7 +793,7 @@ fn skips() {
     "};
 
     context.write_workspace(["project2", "project3", "project3/project4"], config);
-    context.git().add_all();
+    context.git().add(".");
 
     // Test CLI skip
     cmd_snapshot!(context, context.run().arg("--skip").arg("project2/"), @r#"
@@ -962,7 +963,7 @@ fn skips() {
 
     // Add an invalid config
     context.write_file("project3/.pre-commit-config.yaml", "invalid_yaml: [");
-    context.git().add_all();
+    context.git().add(".");
 
     // Should error out because of the invalid config
     cmd_snapshot!(context, context.run(), @"
@@ -1005,8 +1006,7 @@ fn skips() {
 
 #[test]
 fn workspace_no_projects() {
-    let context = TestEnv::new_git().with_config("repos: []");
-    context.git().add_all();
+    let context = TestEnv::new().with_config("repos: []").init_git();
 
     cmd_snapshot!(context, context.run().arg("--skip").arg("."), @r"
     success: false
@@ -1022,8 +1022,6 @@ fn workspace_no_projects() {
 
 #[test]
 fn gitignore_respected() {
-    let context = TestEnv::new_git();
-
     let config = indoc! {r"
     repos:
       - repo: local
@@ -1036,18 +1034,17 @@ fn gitignore_respected() {
     "};
 
     // Create a project structure with directories that should be ignored
-    context.write_workspace(
-        [
-            "src",
-            "node_modules/ignored", // Should be ignored by .gitignore
-            "target/ignored",       // Should be ignored by .gitignore
-        ],
-        config,
-    );
-
-    let context = context.with_file(".gitignore", "node_modules/\ntarget/\n");
-
-    context.git().add_all();
+    let context = TestEnv::new()
+        .with_workspace(
+            [
+                "src",
+                "node_modules/ignored", // Should be ignored by .gitignore
+                "target/ignored",       // Should be ignored by .gitignore
+            ],
+            config,
+        )
+        .with_file(".gitignore", "node_modules/\ntarget/\n")
+        .init_git();
 
     // Run from the root - should not discover projects in node_modules or target
     cmd_snapshot!(context, context.run(), @r#"
@@ -1075,8 +1072,6 @@ fn gitignore_respected() {
 
 #[test]
 fn nested_project_exclude_is_relative() {
-    let context = TestEnv::new_git();
-
     // Regression test for nested workspaces:
     // `exclude` must be evaluated against paths *relative to each project root*.
     //
@@ -1096,19 +1091,17 @@ fn nested_project_exclude_is_relative() {
           verbose: true
     "#};
 
-    // Workspace with a nested project.
-    context.write_workspace(["nested"], config);
-
     // A root-level file which should be excluded by the root project (path is `excluded_by_project`).
     // This keeps the snapshot focused on the nested files, while proving the regex is not
     // accidentally matching `nested/excluded_by_project`.
-    let context = context.with_files([
-        ("excluded_by_project", ""),
-        ("nested/include", ""),
-        ("nested/excluded_by_project", ""),
-    ]);
-
-    context.git().add_all();
+    let context = TestEnv::new()
+        .with_workspace(["nested"], config)
+        .with_files([
+            ("excluded_by_project", ""),
+            ("nested/include", ""),
+            ("nested/excluded_by_project", ""),
+        ])
+        .init_git();
 
     // When running from the root with --all-files, the nested project's exclude
     // pattern should see paths relative to `nested/`, so `noinclude` is excluded
@@ -1140,8 +1133,6 @@ fn nested_project_exclude_is_relative() {
 /// Tests that `--files` arguments references files in other projects, should be filtered out properly.
 #[test]
 fn reference_files_across_projects() {
-    let context = TestEnv::new_git();
-
     let config = indoc! {r"
     repos:
       - repo: local
@@ -1154,10 +1145,10 @@ fn reference_files_across_projects() {
     "};
 
     // Create a project structure with directories that should be ignored
-    context.write_workspace(["frontend", "backend"], config);
-
-    let context = context.with_file("backend/app.py", "print('Hello from backend')");
-    context.git().add_all();
+    let context = TestEnv::new()
+        .with_workspace(["frontend", "backend"], config)
+        .with_file("backend/app.py", "print('Hello from backend')")
+        .init_git();
     // Run with --files referencing a file in another project
     cmd_snapshot!(context, context.run().current_dir(context.child("frontend")).arg("--files").arg("../backend/app.py").arg("../backend/non-exist.py"), @r"
     success: true
@@ -1172,7 +1163,7 @@ fn reference_files_across_projects() {
 
 #[test]
 fn submodule_discovery() -> Result<()> {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let config = indoc! {r"
     repos:
@@ -1185,16 +1176,16 @@ fn submodule_discovery() -> Result<()> {
           verbose: true
     "};
 
-    context.write_workspace(["project2"], config);
+    context.write_workspace(["project2", "submodule"], config);
 
     // Create a submodule
     let submodule_path = context.child("submodule");
-    let submodule_context = TestEnv::new_git_at(&submodule_path).with_config(config);
-    submodule_context.git().add_all().commit("Initial commit");
+    let submodule_git = context.git_at(&submodule_path);
+    submodule_git.init().add(".").commit("Initial commit");
 
     // Add submodule to the main project
     context.git().run(["submodule", "add", "./submodule"]);
-    context.git().add_all();
+    context.git().add(".");
 
     // 1. Test that workspace discovery does not recurse into git submodules
     cmd_snapshot!(context, context.run().arg("--all-files"), @r#"
@@ -1237,7 +1228,7 @@ fn submodule_discovery() -> Result<()> {
     // 3. Test that current directory is in the submodule without .pre-commit-config
     // Remove the config file in the submodule
     fs_err::remove_file(submodule_path.join(".pre-commit-config.yaml"))?;
-    submodule_context.git().add_all().commit("Remove config");
+    submodule_git.add(".").commit("Remove config");
 
     cmd_snapshot!(context, context.run().current_dir(&submodule_path), @r"
     success: false
@@ -1255,7 +1246,7 @@ fn submodule_discovery() -> Result<()> {
 
 #[test]
 fn cookiecutter_template_directories_are_skipped() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     let config = indoc! {r"
     repos:
@@ -1302,7 +1293,7 @@ fn cookiecutter_template_directories_are_skipped() {
 
 #[test]
 fn orphan_projects() {
-    let context = TestEnv::new_git();
+    let context = TestEnv::new().init_git();
 
     // Create a hook that shows which files it processes
     let config = indoc! {r#"
@@ -1325,7 +1316,7 @@ fn orphan_projects() {
             ("src/test.py", ""),
             ("test.py", ""),
         ]);
-    context.git().add_all();
+    context.git().add(".");
 
     // Without `orphan`: files in subprojects are processed multiple times
     cmd_snapshot!(context, context.run().arg("--all-files"), @r#"
@@ -1448,16 +1439,18 @@ fn orphan_projects() {
 
 fn setup_relative_repo_path_project() -> Result<TestEnv> {
     // Create a local hook repository at the root level
-    let context = TestEnv::new_git().with_file(
-        "hook-repo/.pre-commit-hooks.yaml",
-        indoc! {r"
+    let context = TestEnv::new()
+        .with_file(
+            "hook-repo/.pre-commit-hooks.yaml",
+            indoc! {r"
         - id: test-hook
           name: Test Hook
           entry: echo test
           language: system
           always_run: true
         "},
-    );
+        )
+        .init_git();
     let hook_repo = context.child("hook-repo");
 
     let git = context.git_at(&hook_repo);
@@ -1492,7 +1485,7 @@ fn setup_relative_repo_path_project() -> Result<TestEnv> {
                 always_run: true
     "});
 
-    context.git().add_all();
+    context.git().add(".");
 
     Ok(context)
 }


### PR DESCRIPTION
Refactors `TestEnv` setup so files are declared before a final `init_git()` step, which initializes the repository and stages its contents.

Also narrows the shared test helper API and removes redundant Git wrappers.
