### PR TITLE
Disable error snippets in check-yaml diagnostics

### DIFF
--- a/crates/prek/src/hooks/pre_commit_hooks/check_yaml.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_yaml.rs
@@ -75,6 +75,8 @@ fn check_loaded(filename: &Path, content: &[u8], allow_multi_docs: bool) -> Hook
         emit_comments: false,
         // Do not require `!!binary` scalars to decode as UTF-8. See #1102.
         ignore_binary_tag_for_string: true,
+        // `%TAG` directives map tag handles to prefixes. The predefined `!!`
+        // handle expands to `tag:yaml.org,2002:`, while `!` is the local tag handle.
         // Match ruamel.yaml's safe loader by rejecting tags without constructors. See #2604.
         reject_unsupported_tags: true,
         // The scalar values are discarded, so only validate whether they are

--- a/crates/prek/src/hooks/pre_commit_hooks/check_yaml.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_yaml.rs
@@ -89,7 +89,11 @@ fn check_loaded(filename: &Path, content: &[u8], allow_multi_docs: bool) -> Hook
     match result {
         Ok(()) => HookOutput::unchanged(0, Vec::new()),
         Err(e) => {
-            let err = e.render_with_formatter(&serde_saphyr::UserMessageFormatter);
+            let formatter = &serde_saphyr::UserMessageFormatter;
+            let err = e.render_with_options(serde_saphyr::render_options! {
+                snippets: serde_saphyr::SnippetMode::Off,
+                formatter: formatter,
+            });
             let error_message = format!("{}: Failed to yaml decode ({err})\n", filename.display());
             HookOutput::unchanged(1, error_message.into_bytes())
         }
@@ -316,13 +320,7 @@ key2: value2
 
         let result = check_loaded(filename, content, false);
         assert_eq!(result.exit_status, 1);
-        insta::assert_snapshot!(String::from_utf8_lossy(&result.output), @r#"
-        tagged.yaml: Failed to yaml decode (error: line 1 column 17: unsupported tag `!reference`
-         --> <input>:1:17
-          |
-        1 | foo: !reference [.bar, script]
-          |                 ^ unsupported tag `!reference`)
-        "#);
+        insta::assert_snapshot!(String::from_utf8_lossy(&result.output), @"tagged.yaml: Failed to yaml decode (unsupported tag `!reference` at line 1, column 17)");
 
         let result = check_syntax(filename, content);
         assert_eq!((result.exit_status, result.output), (0, Vec::new()));

--- a/crates/prek/src/hooks/pre_commit_hooks/check_yaml.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_yaml.rs
@@ -75,6 +75,7 @@ fn check_loaded(filename: &Path, content: &[u8], allow_multi_docs: bool) -> Hook
         emit_comments: false,
         // Do not require `!!binary` scalars to decode as UTF-8. See #1102.
         ignore_binary_tag_for_string: true,
+        // A YAML tag identifies a node's type or application-specific semantics.
         // `%TAG` directives map tag handles to prefixes. The predefined `!!`
         // handle expands to `tag:yaml.org,2002:`, while `!` is the local tag handle.
         // Match ruamel.yaml's safe loader by rejecting tags without constructors. See #2604.

--- a/crates/prek/tests/builtin_hooks.rs
+++ b/crates/prek/tests/builtin_hooks.rs
@@ -599,7 +599,7 @@ fn check_yaml_hook() {
         .init_git();
 
     // First run: hooks should fail
-    cmd_snapshot!(context, context.run(), @"
+    cmd_snapshot!(context, context.run(), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -608,20 +608,11 @@ fn check_yaml_hook() {
     - description: Checks YAML files for parseable syntax
     - exit code: 1
 
-      duplicate.yaml: Failed to yaml decode (error: line 2 column 1: duplicate mapping key: a not allowed here
-       --> <input>:2:1
-        |
-      1 | a: 1
-      2 | a: 2
-        | ^ duplicate mapping key: a not allowed here)
-      invalid.yaml: Failed to yaml decode (error: line 1 column 5: mapping values are not allowed in this context
-       --> <input>:1:5
-        |
-      1 | a: b: c
-        |     ^ mapping values are not allowed in this context)
+      duplicate.yaml: Failed to yaml decode (duplicate mapping key: a not allowed here at line 2, column 1)
+      invalid.yaml: Failed to yaml decode (mapping values are not allowed in this context at line 1, column 5)
 
     ----- stderr -----
-    ");
+    "#);
 
     // Fix the files
     context.write_file("invalid.yaml", "a:\n  b: c");
@@ -665,7 +656,7 @@ fn check_yaml_multiple_document() {
         )
         .init_git();
 
-    cmd_snapshot!(context, context.run(), @"
+    cmd_snapshot!(context, context.run(), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -675,16 +666,10 @@ fn check_yaml_multiple_document() {
     - description: Checks YAML files for parseable syntax
     - exit code: 1
 
-      multiple.yaml: Failed to yaml decode (error: line 4 column 1: only single YAML document expected but multiple found
-       --> <input>:4:1
-        |
-      2 | a: 1
-      3 | ---
-      4 | b: 2
-        | ^ only single YAML document expected but multiple found)
+      multiple.yaml: Failed to yaml decode (only single YAML document expected but multiple found at line 4, column 1)
 
     ----- stderr -----
-    ");
+    "#);
 }
 
 #[test]

--- a/crates/prek/tests/builtin_hooks.rs
+++ b/crates/prek/tests/builtin_hooks.rs
@@ -1172,17 +1172,8 @@ fn builtin_hooks_workspace_mode() {
       - description: Checks YAML files for parseable syntax
       - exit code: 1
 
-        duplicate.yaml: Failed to yaml decode (error: line 2 column 1: duplicate mapping key: a not allowed here
-         --> <input>:2:1
-          |
-        1 | a: 1
-        2 | a: 2
-          | ^ duplicate mapping key: a not allowed here)
-        invalid.yaml: Failed to yaml decode (error: line 1 column 5: mapping values are not allowed in this context
-         --> <input>:1:5
-          |
-        1 | a: b: c
-          |     ^ mapping values are not allowed in this context)
+        duplicate.yaml: Failed to yaml decode (duplicate mapping key: a not allowed here at line 2, column 1)
+        invalid.yaml: Failed to yaml decode (mapping values are not allowed in this context at line 1, column 5)
       check json.............................................................Failed
       - hook id: check-json
       - description: Checks JSON files for parseable syntax


### PR DESCRIPTION
Disable source snippets in `check-yaml` decode errors while preserving the error message and line and column location.
