### PR TITLE
Warn about unused keys in user settings

### DIFF
--- a/crates/prek/src/config/mod.rs
+++ b/crates/prek/src/config/mod.rs
@@ -28,6 +28,7 @@ pub(crate) use update::{StringOrList, UpdateOptions};
 
 use crate::fs::Simplified;
 use crate::install_source::InstallSource;
+use crate::settings::{push_unused_paths, warn_unused_paths};
 use crate::version;
 use crate::warn_user;
 use crate::warn_user_once;
@@ -157,24 +158,6 @@ impl Error {
 /// Keys that prek does not use.
 const EXPECTED_UNUSED: &[&str] = &["minimum_pre_commit_version", "ci"];
 
-fn push_unused_paths<'a, I>(acc: &mut Vec<String>, prefix: &str, keys: I)
-where
-    I: Iterator<Item = &'a str>,
-{
-    for key in keys {
-        // Silently ignore extension keys starting with 'x-' (used for YAML anchors and custom metadata).
-        if key.starts_with("x-") {
-            continue;
-        }
-        let path = if prefix.is_empty() {
-            key.to_string()
-        } else {
-            format!("{prefix}.{key}")
-        };
-        acc.push(path);
-    }
-}
-
 fn collect_unused_paths(config: &Config) -> Vec<String> {
     let mut paths = Vec::new();
 
@@ -218,32 +201,6 @@ fn collect_unused_paths(config: &Config) -> Vec<String> {
     }
 
     paths
-}
-
-fn warn_unused_paths(path: &Path, entries: &[String]) {
-    if entries.is_empty() {
-        return;
-    }
-
-    if entries.len() < 4 {
-        let inline = entries
-            .iter()
-            .map(|entry| format!("`{}`", entry.yellow()))
-            .join(", ");
-        warn_user!(
-            "Ignored unexpected keys in `{}`: {inline}",
-            path.user_display().cyan()
-        );
-    } else {
-        let list = entries
-            .iter()
-            .map(|entry| format!("  - `{}`", entry.yellow()))
-            .join("\n");
-        warn_user!(
-            "Ignored unexpected keys in `{}`:\n{list}",
-            path.user_display().cyan()
-        );
-    }
 }
 
 /// Read the configuration file from the given path.

--- a/crates/prek/src/settings.rs
+++ b/crates/prek/src/settings.rs
@@ -6,10 +6,58 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use etcetera::BaseStrategy;
 use globset::Glob;
+use itertools::Itertools;
+use owo_colors::OwoColorize;
 use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use serde::Deserialize;
 
 use crate::config::{StringOrList, UpdateOptions as ProjectUpdateOptions};
+use crate::fs::Simplified;
+use crate::warn_user;
+
+pub(crate) fn push_unused_paths<'a, I>(acc: &mut Vec<String>, prefix: &str, keys: I)
+where
+    I: Iterator<Item = &'a str>,
+{
+    for key in keys {
+        // Silently ignore extension keys starting with 'x-' (used for YAML anchors and custom metadata).
+        if key.starts_with("x-") {
+            continue;
+        }
+        let path = if prefix.is_empty() {
+            key.to_string()
+        } else {
+            format!("{prefix}.{key}")
+        };
+        acc.push(path);
+    }
+}
+
+pub(crate) fn warn_unused_paths(path: &Path, entries: &[String]) {
+    if entries.is_empty() {
+        return;
+    }
+
+    if entries.len() < 4 {
+        let inline = entries
+            .iter()
+            .map(|entry| format!("`{}`", entry.yellow()))
+            .join(", ");
+        warn_user!(
+            "Ignored unexpected keys in `{}`: {inline}",
+            path.user_display().cyan()
+        );
+    } else {
+        let list = entries
+            .iter()
+            .map(|entry| format!("  - `{}`", entry.yellow()))
+            .join("\n");
+        warn_user!(
+            "Ignored unexpected keys in `{}`:\n{list}",
+            path.user_display().cyan()
+        );
+    }
+}
 
 fn user_config_path() -> Option<PathBuf> {
     if let Some(path) = EnvVars.var_os(EnvVars::PREK_INTERNAL__USER_CONFIG_PATH) {
@@ -63,10 +111,11 @@ impl FilesystemOptions {
             }
         };
 
-        toml::from_str(&content)
-            .map(Self)
-            .map(Some)
-            .with_context(|| format!("Failed to parse global config `{}`", path.display()))
+        let options: Options = toml::from_str(&content)
+            .with_context(|| format!("Failed to parse global config `{}`", path.display()))?;
+        warn_unused_paths(path, &options.unused_paths());
+
+        Ok(Some(Self(options)))
     }
 }
 
@@ -83,6 +132,24 @@ impl Deref for FilesystemOptions {
 #[serde(default, rename_all = "snake_case")]
 pub(crate) struct Options {
     update: Option<GlobalUpdateOptions>,
+
+    #[serde(flatten)]
+    _unused_keys: BTreeMap<String, serde_json::Value>,
+}
+
+impl Options {
+    fn unused_paths(&self) -> Vec<String> {
+        let mut paths = Vec::new();
+        push_unused_paths(&mut paths, "", self._unused_keys.keys().map(String::as_str));
+        if let Some(update) = &self.update {
+            push_unused_paths(
+                &mut paths,
+                "update",
+                update._unused_keys.keys().map(String::as_str),
+            );
+        }
+        paths
+    }
 }
 
 /// Default update options represented in the global `prek.toml` file.
@@ -93,6 +160,9 @@ struct GlobalUpdateOptions {
     freeze: Option<bool>,
     include_tags: Option<StringOrList>,
     exclude_tags: Option<StringOrList>,
+
+    #[serde(flatten)]
+    _unused_keys: BTreeMap<String, serde_json::Value>,
 }
 
 /// Tag filters supplied on the command line.

--- a/crates/prek/tests/global_config.rs
+++ b/crates/prek/tests/global_config.rs
@@ -16,14 +16,15 @@ fn global_config_missing_file_is_optional() {
 }
 
 #[test]
-fn global_config_ignores_unknown_options() {
+fn global_config_warns_about_unknown_options() {
     let context = TestEnv::new().with_config("repos: []").init_git();
     context.write_user_config(indoc::indoc! {r#"
-        future_option = true
+        future_date = 1979-05-27T07:32:00Z
+        future_option = { nested = [true, { value = 1 }] }
 
         [update]
         cooldown_days = 3
-        future_option = "ignored"
+        future_option = ["ignored", { nested = true }]
     "#});
 
     cmd_snapshot!(context, context.update(), @"
@@ -32,6 +33,7 @@ fn global_config_ignores_unknown_options() {
     ----- stdout -----
 
     ----- stderr -----
+    warning: Ignored unexpected keys in `[HOME]/config/prek/prek.toml`: `future_date`, `future_option`, `update.future_option`
     ");
 }
 


### PR DESCRIPTION
Warn when user-level `prek.toml` files contain unsupported keys.
