### PR TITLE
Show verbose builtin details by default

### DIFF
--- a/crates/prek/src/cli/list_builtins.rs
+++ b/crates/prek/src/cli/list_builtins.rs
@@ -19,7 +19,6 @@ struct SerializableBuiltinHook {
 /// List all builtin hooks.
 pub(crate) fn list_builtins(
     output_format: ListOutputFormat,
-    verbose: bool,
     printer: Printer,
 ) -> anyhow::Result<ExitStatus> {
     let hooks = BuiltinHooks::iter().map(|variant| {
@@ -31,24 +30,18 @@ pub(crate) fn list_builtins(
     let mut stdout = printer.stdout_important();
     match output_format {
         ListOutputFormat::Text => {
-            if verbose {
-                for (variant, hook) in hooks {
-                    writeln!(stdout, "{}", hook.id.bold())?;
-                    if let Some(description) = &hook.options.description {
-                        writeln!(stdout, "  {description}")?;
-                    }
-                    if let Some(flags_help) = variant.flags_help() {
-                        writeln!(stdout, "  flags:")?;
-                        for line in flags_help.lines() {
-                            writeln!(stdout, "  {line}")?;
-                        }
-                    }
-                    writeln!(stdout)?;
+            for (variant, hook) in hooks {
+                writeln!(stdout, "{}", hook.id.bold())?;
+                if let Some(description) = &hook.options.description {
+                    writeln!(stdout, "  {description}")?;
                 }
-            } else {
-                for (_, hook) in hooks {
-                    writeln!(stdout, "{}", hook.id)?;
+                if let Some(flags_help) = variant.flags_help() {
+                    writeln!(stdout, "  flags:")?;
+                    for line in flags_help.lines() {
+                        writeln!(stdout, "  {line}")?;
+                    }
                 }
+                writeln!(stdout)?;
             }
         }
         ListOutputFormat::Json => {

--- a/crates/prek/src/main.rs
+++ b/crates/prek/src/main.rs
@@ -387,9 +387,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
         }
         Command::Util(UtilNamespace { command }) => match command {
             UtilCommand::Identify(args) => cli::identify(&args.paths, args.output_format, printer),
-            UtilCommand::ListBuiltins(args) => {
-                cli::list_builtins(args.output_format, cli.globals.verbose > 0, printer)
-            }
+            UtilCommand::ListBuiltins(args) => cli::list_builtins(args.output_format, printer),
             UtilCommand::InitTemplateDir(args) => {
                 cli::init_template_dir(
                     &store,

--- a/crates/prek/tests/list_builtins.rs
+++ b/crates/prek/tests/list_builtins.rs
@@ -3,51 +3,10 @@ use crate::common::{TestEnv, cmd_snapshot};
 mod common;
 
 #[test]
-fn list_builtins_basic() {
+fn list_builtins_defaults_to_verbose_output() {
     let context = TestEnv::new();
 
-    cmd_snapshot!(context, context.command().arg("util").arg("list-builtins"), @r"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    check-added-large-files
-    check-case-conflict
-    check-executables-have-shebangs
-    check-illegal-windows-names
-    check-json
-    check-json5
-    check-merge-conflict
-    check-shebang-scripts-are-executable
-    check-symlinks
-    check-toml
-    check-vcs-permalinks
-    check-xml
-    check-yaml
-    deny-filename-pattern
-    deny-pattern
-    destroyed-symlinks
-    detect-private-key
-    end-of-file-fixer
-    file-contents-sorter
-    fix-byte-order-marker
-    forbid-new-submodules
-    mixed-line-ending
-    no-commit-to-branch
-    pretty-format-json
-    require-filename-pattern
-    require-pattern
-    requirements-txt-fixer
-    trailing-whitespace
-
-    ----- stderr -----
-    ");
-}
-
-#[test]
-fn list_builtins_verbose() {
-    let context = TestEnv::new();
-
-    cmd_snapshot!(context, context.command().arg("util").arg("list-builtins").arg("--verbose"), @r#"
+    cmd_snapshot!(context, context.command().arg("util").arg("list-builtins"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----

--- a/docs/builtin.md
+++ b/docs/builtin.md
@@ -136,7 +136,7 @@ This mode has significant benefits:
 List the builtins bundled with your installed prek version using:
 
 ```bash
-prek util list-builtins -v
+prek util list-builtins
 ```
 
 ### Supported Hooks


### PR DESCRIPTION
Make `prek util list-builtins` show descriptions and supported flags without requiring `--verbose`.
