### PR TITLE
Support delta-only matching in builtin pattern hooks (#2610)

### DIFF
--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -218,6 +218,14 @@ pub(crate) async fn run(
     }
 
     let (from_ref, to_ref) = selection.refs();
+    let diff_mode = match (&selection, from_ref, to_ref) {
+        (_, Some(from), Some(to)) => hooks::DiffMode::Range {
+            from: from.to_string(),
+            to: to.to_string(),
+        },
+        (FileSelection::All { .. }, _, _) => hooks::DiffMode::None,
+        _ => hooks::DiffMode::Staged,
+    };
     set_env_vars(from_ref, to_ref, &extra_args);
 
     let input = collect_run_input(
@@ -263,6 +271,7 @@ pub(crate) async fn run(
         should_stash,
         verbose,
         printer,
+        diff_mode,
     )
     .await
 }
@@ -473,6 +482,7 @@ async fn run_hooks<'paths>(
     worktree_cleaned: bool,
     verbose: bool,
     printer: Printer,
+    diff_mode: hooks::DiffMode,
 ) -> Result<ExitStatus> {
     debug_assert!(!hooks.is_empty(), "No hooks to run");
 
@@ -497,6 +507,7 @@ async fn run_hooks<'paths>(
         verbose,
         show_project_headers,
         printer,
+        diff_mode,
     );
 
     for projects in ProjectDepthGroups::new(workspace.all_projects()) {
@@ -697,6 +708,7 @@ struct HookRunSession<'a> {
     verbose: bool,
     failed: bool,
     modified_files: bool,
+    diff_mode: hooks::DiffMode,
 }
 
 impl<'a> HookRunSession<'a> {
@@ -708,6 +720,7 @@ impl<'a> HookRunSession<'a> {
         verbose: bool,
         show_project_headers: bool,
         printer: Printer,
+        diff_mode: hooks::DiffMode,
     ) -> Self {
         let status_printer = StatusPrinter::for_hooks(hooks, printer);
         let reporter =
@@ -723,6 +736,7 @@ impl<'a> HookRunSession<'a> {
             verbose,
             failed: false,
             modified_files: false,
+            diff_mode,
         }
     }
 
@@ -882,6 +896,7 @@ impl<'a> HookRunSession<'a> {
                 self.dry_run,
                 &self.reporter,
                 Rc::clone(&semaphore),
+                &self.diff_mode,
             ));
         }
 
@@ -1501,6 +1516,7 @@ async fn run_hook(
     dry_run: bool,
     reporter: &HookRunReporter,
     semaphore: Rc<Semaphore>,
+    diff_mode: &hooks::DiffMode,
 ) -> Result<HookRunResult> {
     let installed_hook = match &hook {
         HookPlan::Run(hook) => hook,
@@ -1536,19 +1552,25 @@ async fn run_hook(
             HookRunInput::Filenames(filenames) => {
                 installed_hook
                     .language
-                    .run(store, installed_hook, filenames, reporter)
+                    .run(store, installed_hook, filenames, reporter, diff_mode)
                     .await
             }
             HookRunInput::Filename(filename) => {
                 installed_hook
                     .language
-                    .run(store, installed_hook, slice::from_ref(filename), reporter)
+                    .run(
+                        store,
+                        installed_hook,
+                        slice::from_ref(filename),
+                        reporter,
+                        diff_mode,
+                    )
                     .await
             }
             HookRunInput::WithoutFilenames { .. } => {
                 installed_hook
                     .language
-                    .run(store, installed_hook, &[], reporter)
+                    .run(store, installed_hook, &[], reporter, diff_mode)
                     .await
             }
         }

--- a/crates/prek/src/git.rs
+++ b/crates/prek/src/git.rs
@@ -6,12 +6,12 @@ use std::sync::{LazyLock, OnceLock};
 
 use anyhow::Result;
 use prek_consts::env_vars::{EnvVars, EnvVarsRead};
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use same_file::is_same_file;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing::{debug, instrument, warn};
 
-use crate::fs::PathClean;
+use crate::fs::{PathClean, normalize_path};
 use crate::process;
 use crate::process::{Cmd, StatusError};
 
@@ -154,7 +154,7 @@ fn zsplit(s: &[u8]) -> Result<Vec<PathBuf>, Utf8Error> {
 
 #[cfg(unix)]
 #[expect(clippy::unnecessary_wraps)]
-fn path_from_git_bytes(bytes: &[u8]) -> Result<PathBuf, Utf8Error> {
+pub(crate) fn path_from_git_bytes(bytes: &[u8]) -> Result<PathBuf, Utf8Error> {
     use std::ffi::OsStr;
     use std::os::unix::ffi::OsStrExt as _;
 
@@ -162,7 +162,7 @@ fn path_from_git_bytes(bytes: &[u8]) -> Result<PathBuf, Utf8Error> {
 }
 
 #[cfg(not(unix))]
-fn path_from_git_bytes(bytes: &[u8]) -> Result<PathBuf, Utf8Error> {
+pub(crate) fn path_from_git_bytes(bytes: &[u8]) -> Result<PathBuf, Utf8Error> {
     str::from_utf8(bytes).map(PathBuf::from)
 }
 
@@ -251,6 +251,148 @@ pub(crate) async fn changed_files(
         .output()
         .await?;
     Ok(zsplit(&output.stdout)?)
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct AddedHunk {
+    pub(crate) start_line: usize,
+    pub(crate) content: Vec<u8>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct GitDelta {
+    pub(crate) added_lines: FxHashMap<PathBuf, Vec<(usize, Vec<u8>)>>,
+    pub(crate) added_hunks: FxHashMap<PathBuf, Vec<AddedHunk>>,
+}
+
+pub(crate) async fn fetch_diff_delta(
+    work_dir: &Path,
+    diff_target: Option<(&str, &str)>,
+    filenames: &[&Path],
+) -> Result<GitDelta, Error> {
+    if filenames.is_empty() {
+        return Ok(GitDelta::default());
+    }
+
+    let build_cmd = |target_args: &[&str]| -> Result<Cmd, Error> {
+        let mut cmd = git_cmd()?;
+        cmd.current_dir(work_dir)
+            .arg("-c")
+            .arg("core.quotePath=false")
+            .arg("diff")
+            .hidden_args(["--no-ext-diff", "--no-color"])
+            .arg("-U0")
+            .arg("--no-prefix")
+            .arg("--relative");
+        for &arg in target_args {
+            cmd.arg(arg);
+        }
+        cmd.arg("--").file_args(filenames);
+        Ok(cmd)
+    };
+
+    let output = if let Some((old, new)) = diff_target {
+        let three_dot = format!("{old}...{new}");
+        let out = build_cmd(&[&three_dot])?.check(false).output().await?;
+        if out.status.success() {
+            out.stdout
+        } else {
+            let two_dot = format!("{old}..{new}");
+            build_cmd(&[&two_dot])?.check(true).output().await?.stdout
+        }
+    } else {
+        build_cmd(&["--cached"])?.check(true).output().await?.stdout
+    };
+
+    Ok(parse_git_diff_delta(&output))
+}
+
+pub(crate) fn parse_git_diff_delta(diff_output: &[u8]) -> GitDelta {
+    let mut delta = GitDelta::default();
+    let mut current_path: Option<PathBuf> = None;
+    let mut curr_line = 0;
+    let mut in_hunk = false;
+    let mut current_hunk: Option<AddedHunk> = None;
+
+    let flush_hunk =
+        |path: Option<&PathBuf>, hunk: &mut Option<AddedHunk>, delta: &mut GitDelta| {
+            if let Some(h) = hunk.take() {
+                if let Some(p) = path {
+                    delta.added_hunks.entry(p.clone()).or_default().push(h);
+                }
+            }
+        };
+
+    for raw_line in diff_output.split(|&b| b == b'\n') {
+        let line = raw_line.strip_suffix(b"\r").unwrap_or(raw_line);
+        if line.starts_with(b"diff --git ") {
+            flush_hunk(current_path.as_ref(), &mut current_hunk, &mut delta);
+            current_path = None;
+            in_hunk = false;
+        } else if let Some(path_bytes) = line.strip_prefix(b"+++ ") {
+            flush_hunk(current_path.as_ref(), &mut current_hunk, &mut delta);
+            let path_bytes =
+                memchr::memchr(b'\t', path_bytes).map_or(path_bytes, |pos| &path_bytes[..pos]);
+            current_path = if path_bytes == b"/dev/null" {
+                None
+            } else {
+                path_from_git_bytes(path_bytes).ok().map(normalize_path)
+            };
+            in_hunk = false;
+        } else if line.starts_with(b"@@ ") {
+            flush_hunk(current_path.as_ref(), &mut current_hunk, &mut delta);
+            if let Some((start, count)) = parse_hunk_range(line) {
+                curr_line = start;
+                in_hunk = count > 0;
+            } else {
+                in_hunk = false;
+            }
+        } else if in_hunk && let Some(path) = current_path.as_ref() {
+            if let Some(content) = line.strip_prefix(b"+") {
+                delta
+                    .added_lines
+                    .entry(path.clone())
+                    .or_default()
+                    .push((curr_line, content.to_vec()));
+
+                if let Some(hunk) = current_hunk.as_mut() {
+                    hunk.content.extend_from_slice(content);
+                    hunk.content.push(b'\n');
+                } else {
+                    let mut hunk_content = Vec::with_capacity(content.len() + 1);
+                    hunk_content.extend_from_slice(content);
+                    hunk_content.push(b'\n');
+                    current_hunk = Some(AddedHunk {
+                        start_line: curr_line,
+                        content: hunk_content,
+                    });
+                }
+                curr_line += 1;
+            } else if line.starts_with(b" ") {
+                flush_hunk(current_path.as_ref(), &mut current_hunk, &mut delta);
+                curr_line += 1;
+            }
+        }
+    }
+
+    flush_hunk(current_path.as_ref(), &mut current_hunk, &mut delta);
+
+    delta
+}
+
+fn parse_hunk_range(line: &[u8]) -> Option<(usize, usize)> {
+    let plus_pos = memchr::memchr(b'+', line)?;
+    let remainder = &line[plus_pos + 1..];
+    let header_end = remainder
+        .iter()
+        .position(|&b| b == b' ' || b == b'@')
+        .unwrap_or(remainder.len());
+    let spec = std::str::from_utf8(&remainder[..header_end]).ok()?;
+    if let Some((start, count)) = spec.split_once(',') {
+        Some((start.parse().ok()?, count.parse().ok()?))
+    } else {
+        Some((spec.parse().ok()?, 1))
+    }
 }
 
 #[instrument(level = "trace", skip(paths))]

--- a/crates/prek/src/hooks/builtin_hooks/mod.rs
+++ b/crates/prek/src/hooks/builtin_hooks/mod.rs
@@ -18,7 +18,7 @@ use crate::hooks::pre_commit_hooks::{
 };
 use crate::store::Store;
 
-use super::{HookFuture, HookOutput};
+use super::{DiffMode, HookFuture, HookOutput};
 
 mod check_json5;
 mod pattern;
@@ -78,7 +78,8 @@ impl BuiltinHooks {
             Self::DenyFilenamePattern | Self::RequireFilenamePattern => {
                 pattern::FilenameArgs::command()
             }
-            Self::DenyPattern | Self::RequirePattern => pattern::Args::command(),
+            Self::DenyPattern => pattern::DenyArgs::command(),
+            Self::RequirePattern => pattern::Args::command(),
             Self::FileContentsSorter => file_contents_sorter::Args::command(),
             Self::MixedLineEnding => mixed_line_ending::Args::command(),
             Self::NoCommitToBranch => no_commit_to_branch::Args::command(),
@@ -100,6 +101,7 @@ impl BuiltinHooks {
         hook: &Hook,
         filenames: &[&Path],
         reporter: &HookRunReporter,
+        diff_mode: &DiffMode,
     ) -> Result<HookOutput> {
         let progress = reporter.on_run_start(hook, filenames.len());
         let future: HookFuture<'_> = match self {
@@ -125,7 +127,7 @@ impl BuiltinHooks {
             Self::DenyFilenamePattern => Box::pin(std::future::ready(
                 pattern::deny_filename_pattern(hook, filenames),
             )),
-            Self::DenyPattern => Box::pin(pattern::deny_pattern(hook, filenames)),
+            Self::DenyPattern => Box::pin(pattern::deny_pattern(hook, filenames, diff_mode)),
             Self::DestroyedSymlinks => Box::pin(destroyed_symlinks::run(hook, filenames)),
             Self::DetectPrivateKey => Box::pin(detect_private_key::run(hook, filenames)),
             Self::EndOfFileFixer => Box::pin(fix_end_of_file::run(hook, filenames)),

--- a/crates/prek/src/hooks/builtin_hooks/pattern.rs
+++ b/crates/prek/src/hooks/builtin_hooks/pattern.rs
@@ -7,10 +7,11 @@ use clap::Parser;
 use memchr::memchr_iter;
 use regex_automata::{MatchKind, meta::Regex, util::syntax};
 
+use crate::fs::normalize_path;
+use crate::git;
 use crate::hook::Hook;
-use crate::hooks::HookOutput;
 use crate::hooks::pre_commit_hooks::parse_hook_args;
-use crate::hooks::run_concurrent_file_checks;
+use crate::hooks::{DiffMode, HookOutput, run_concurrent_file_checks};
 use crate::run::INTERNAL_CONCURRENCY;
 
 #[derive(Parser)]
@@ -38,6 +39,18 @@ pub(crate) struct FilenameArgs {
     ignore_case: bool,
     #[arg(required = true, value_name = "PATTERN")]
     patterns: Vec<String>,
+}
+
+#[derive(Parser)]
+#[command(disable_help_subcommand = true)]
+#[command(disable_version_flag = true)]
+#[command(disable_help_flag = true)]
+pub(crate) struct DenyArgs {
+    #[command(flatten)]
+    common: Args,
+    /// Evaluate patterns only against newly added or modified lines in git diffs.
+    #[arg(long, alias = "check-delta")]
+    delta_only: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -99,12 +112,31 @@ fn build_regex(patterns: &[String], ignore_case: bool, multiline: bool) -> Resul
         .context("Failed to compile regex patterns")
 }
 
-pub(crate) async fn deny_pattern(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
-    run(hook, filenames, MatchPolicy::Deny).await
+pub(crate) async fn deny_pattern(
+    hook: &Hook,
+    filenames: &[&Path],
+    diff_mode: &DiffMode,
+) -> Result<HookOutput> {
+    let args = parse_hook_args::<DenyArgs>(hook)?;
+    let matcher = Matcher::new(&args.common)?;
+
+    if args.delta_only {
+        let diff_target = match diff_mode {
+            DiffMode::None => return Ok(HookOutput::unchanged(0, Vec::new())),
+            DiffMode::Staged => None,
+            DiffMode::Range { from, to } => Some((from.as_str(), to.as_str())),
+        };
+        let delta = git::fetch_diff_delta(hook.work_dir(), diff_target, filenames).await?;
+        run_delta_scan(hook, filenames, &matcher, &delta).await
+    } else {
+        run_scan(hook, filenames, &matcher, MatchPolicy::Deny).await
+    }
 }
 
 pub(crate) async fn require_pattern(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
-    run(hook, filenames, MatchPolicy::Require).await
+    let args = parse_hook_args::<Args>(hook)?;
+    let matcher = Matcher::new(&args)?;
+    run_scan(hook, filenames, &matcher, MatchPolicy::Require).await
 }
 
 pub(crate) fn deny_filename_pattern(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> {
@@ -142,15 +174,18 @@ fn run_filename_pattern(
     Ok(HookOutput::unchanged(i32::from(failed), output))
 }
 
-async fn run(hook: &Hook, filenames: &[&Path], policy: MatchPolicy) -> Result<HookOutput> {
-    let args = parse_hook_args::<Args>(hook)?;
-    let matcher = Matcher::new(&args)?;
+async fn run_scan(
+    hook: &Hook,
+    filenames: &[&Path],
+    matcher: &Matcher,
+    policy: MatchPolicy,
+) -> Result<HookOutput> {
     let file_base = hook.project().relative_path();
 
     run_concurrent_file_checks(
         filenames.iter().copied(),
         *INTERNAL_CONCURRENCY,
-        |filename| check_file(file_base, filename, &matcher, policy),
+        |filename| check_file(file_base, filename, matcher, policy),
     )
     .await
 }
@@ -253,4 +288,69 @@ fn missing_match(filename: &Path) -> (i32, Vec<u8>) {
 fn trim_line_ending(line: &[u8]) -> &[u8] {
     let line = line.strip_suffix(b"\n").unwrap_or(line);
     line.strip_suffix(b"\r").unwrap_or(line)
+}
+
+async fn run_delta_scan(
+    hook: &Hook,
+    filenames: &[&Path],
+    matcher: &Matcher,
+    delta: &git::GitDelta,
+) -> Result<HookOutput> {
+    let _ = hook;
+
+    run_concurrent_file_checks(
+        filenames.iter().copied(),
+        *INTERNAL_CONCURRENCY,
+        |filename| std::future::ready(check_delta_file(filename, matcher, delta)),
+    )
+    .await
+}
+
+fn check_delta_file(
+    filename: &Path,
+    matcher: &Matcher,
+    delta: &git::GitDelta,
+) -> Result<HookOutput> {
+    let normalized = normalize_path(filename.to_path_buf());
+
+    match matcher.scan_mode {
+        ScanMode::Lines => {
+            let Some(added_lines) = delta.added_lines.get(&normalized) else {
+                return Ok(HookOutput::unchanged(0, Vec::new()));
+            };
+            let mut matched = false;
+            let mut output = Vec::new();
+            for &(line_number, ref content) in added_lines {
+                if matcher.regex.is_match(content) {
+                    matched = true;
+                    write!(output, "{}:{line_number}:", filename.display())?;
+                    output.write_all(content)?;
+                    writeln!(output)?;
+                }
+            }
+            Ok(HookOutput::unchanged(i32::from(matched), output))
+        }
+        ScanMode::Multiline => {
+            let Some(hunks) = delta.added_hunks.get(&normalized) else {
+                return Ok(HookOutput::unchanged(0, Vec::new()));
+            };
+
+            for hunk in hunks {
+                if let Some(matched) = matcher.regex.find(&hunk.content) {
+                    let line_offset = memchr_iter(b'\n', &hunk.content[..matched.start()]).count();
+                    let line_number = hunk.start_line + line_offset;
+                    let matched_bytes = &hunk.content[matched.range()];
+                    let mut output = Vec::new();
+                    write!(output, "{}:{line_number}:", filename.display())?;
+                    output.write_all(matched_bytes)?;
+                    if !matched_bytes.ends_with(b"\n") {
+                        writeln!(output)?;
+                    }
+                    return Ok(HookOutput::unchanged(1, output));
+                }
+            }
+
+            Ok(HookOutput::unchanged(0, Vec::new()))
+        }
+    }
 }

--- a/crates/prek/src/hooks/mod.rs
+++ b/crates/prek/src/hooks/mod.rs
@@ -20,6 +20,13 @@ mod pre_commit_hooks;
 // Erase hook implementation futures before awaiting them so dispatchers have one suspension point.
 type HookFuture<'a> = Pin<Box<dyn Future<Output = anyhow::Result<HookOutput>> + 'a>>;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DiffMode {
+    Staged,
+    Range { from: String, to: String },
+    None,
+}
+
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub(crate) enum FileChanges {
     Unchanged,

--- a/crates/prek/src/languages/mod.rs
+++ b/crates/prek/src/languages/mod.rs
@@ -17,7 +17,7 @@ use crate::fs::PathClean;
 use crate::git::GitCommandExt;
 use crate::hook::{Hook, InstallInfo, InstalledHook, Repo};
 use crate::hook_entry::PreparedHookEntry;
-use crate::hooks::{self, HookOutput};
+use crate::hooks::{self, DiffMode, HookOutput};
 use crate::process::{Cmd, with_command_env};
 use crate::run::run_by_batch;
 use crate::store::{CacheBucket, Store, ToolBucket};
@@ -583,6 +583,7 @@ impl Language {
         hook: &'a InstalledHook,
         filenames: &'a [&'p Path],
         reporter: &'a HookRunReporter,
+        diff_mode: &DiffMode,
     ) -> Result<HookOutput>
     where
         'p: 'a,
@@ -597,7 +598,7 @@ impl Language {
             Repo::Builtin => {
                 hooks::BuiltinHooks::from_str(&hook.id)
                     .unwrap()
-                    .run(store, hook, filenames, reporter)
+                    .run(store, hook, filenames, reporter, diff_mode)
                     .await
             }
             // Fast path for hooks implemented in Rust

--- a/crates/prek/tests/builtin_hooks.rs
+++ b/crates/prek/tests/builtin_hooks.rs
@@ -293,6 +293,334 @@ fn require_pattern_hook_reports_files_without_any_match() {
 }
 
 #[test]
+fn deny_pattern_hook_delta_only_staged() {
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
+        repos:
+          - repo: builtin
+            hooks:
+              - id: deny-pattern
+                args: [--delta-only, --ignore-case, '\btodo\b']
+                files: '\.txt$'
+    "})
+        .with_file("legacy.txt", "legacy TODO: do not touch\nline 2\n")
+        .init_git();
+    context.git().commit("Initial commit");
+
+    // 1. Modifying legacy.txt with a clean line passes (legacy TODO untouched)
+    context.write_file(
+        "legacy.txt",
+        "legacy TODO: do not touch\nline 2\nclean line 3\n",
+    );
+    context.git().add(".");
+
+    cmd_snapshot!(context, context.run(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    deny patterns............................................................Passed
+
+    ----- stderr -----
+    ");
+
+    // 2. Adding a new line with TODO fails
+    context.write_file(
+        "legacy.txt",
+        "legacy TODO: do not touch\nline 2\nclean line 3\nnew TODO added\n",
+    );
+    context.git().add(".");
+
+    cmd_snapshot!(context, context.run(), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    deny patterns............................................................Failed
+    - hook id: deny-pattern
+    - description: Fails if any file contains a matching regular expression
+    - exit code: 1
+
+      legacy.txt:4:new TODO added
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn deny_pattern_hook_delta_only_ref_range() {
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
+        repos:
+          - repo: builtin
+            hooks:
+              - id: deny-pattern
+                args: [--delta-only, 'banned_func\(\)']
+                files: '\.py$'
+    "})
+        .with_file("app.py", "def run():\n    pass\n")
+        .init_git();
+    context.git().commit("Initial commit");
+
+    context.write_file("app.py", "def run():\n    banned_func()\n    pass\n");
+    context.git().add(".");
+    context.git().commit("Second commit with banned call");
+
+    let mut cmd = context.run();
+    cmd.arg("--from-ref")
+        .arg("HEAD~1")
+        .arg("--to-ref")
+        .arg("HEAD");
+
+    cmd_snapshot!(context, cmd, @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    deny patterns............................................................Failed
+    - hook id: deny-pattern
+    - description: Fails if any file contains a matching regular expression
+    - exit code: 1
+
+      app.py:2:    banned_func()
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn deny_pattern_hook_delta_only_all_files_noop() {
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
+        repos:
+          - repo: builtin
+            hooks:
+              - id: deny-pattern
+                args: [--delta-only, 'TODO']
+                files: '\.txt$'
+    "})
+        .with_file("legacy.txt", "line 1\nlegacy TODO here\nline 3\n")
+        .init_git();
+
+    // Running with --all-files has no diff context, so delta-only passes without scanning legacy files
+    let mut cmd = context.run();
+    cmd.arg("--all-files");
+
+    cmd_snapshot!(context, cmd, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    deny patterns............................................................Passed
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn deny_pattern_hook_delta_only_multiline() {
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
+        repos:
+          - repo: builtin
+            hooks:
+              - id: deny-pattern
+                args: [--delta-only, -m, 'BEGIN(?s:.*?)END']
+                files: '\.txt$'
+    "})
+        .with_file("block.txt", "line 1\nBEGIN\nlegacy\nEND\nline 5\n")
+        .init_git();
+    context.git().commit("Initial commit");
+
+    // 1. Modifying a line outside the multiline block passes
+    context.write_file("block.txt", "line 1 modified\nBEGIN\nlegacy\nEND\nline 5\n");
+    context.git().add(".");
+
+    cmd_snapshot!(context, context.run(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    deny patterns............................................................Passed
+
+    ----- stderr -----
+    ");
+
+    // 2. Modifying a line inside the legacy multiline block does not falsely trigger
+    context.write_file(
+        "block.txt",
+        "line 1 modified\nBEGIN\nlegacy touched\nEND\nline 5\n",
+    );
+    context.git().add(".");
+
+    cmd_snapshot!(context, context.run(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    deny patterns............................................................Passed
+
+    ----- stderr -----
+    ");
+
+    // 3. Adding a new multiline block in the diff triggers failure
+    context.write_file(
+        "block.txt",
+        "line 1 modified\nBEGIN\nlegacy touched\nEND\nline 5\n\nBEGIN\nnew banned block\nEND\n",
+    );
+    context.git().add(".");
+
+    cmd_snapshot!(context, context.run(), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    deny patterns............................................................Failed
+    - hook id: deny-pattern
+    - description: Fails if any file contains a matching regular expression
+    - exit code: 1
+
+      block.txt:7:BEGIN
+      new banned block
+      END
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn deny_pattern_hook_delta_only_explicit_files() {
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
+        repos:
+          - repo: builtin
+            hooks:
+              - id: deny-pattern
+                args: [--delta-only, --ignore-case, '\btodo\b']
+                files: '\.txt$'
+    "})
+        .with_file("legacy.txt", "legacy TODO: do not touch\nline 2\n")
+        .init_git();
+    context.git().commit("Initial commit");
+
+    // Modifying legacy.txt with a clean line and running with --files passes
+    context.write_file(
+        "legacy.txt",
+        "legacy TODO: do not touch\nline 2\nclean line 3\n",
+    );
+    context.git().add(".");
+
+    let mut cmd = context.run();
+    cmd.arg("--files").arg("legacy.txt");
+
+    cmd_snapshot!(context, cmd, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    deny patterns............................................................Passed
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn deny_pattern_hook_delta_only_multiline_trailing_newline() {
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
+        repos:
+          - repo: builtin
+            hooks:
+              - id: deny-pattern
+                args: [--delta-only, -m, 'BANNED\n']
+                files: '\.txt$'
+    "})
+        .with_file("file.txt", "line 1\nBANNED\nline 3\n")
+        .init_git();
+    context.git().commit("Initial commit");
+
+    // Modifying line 3 does not trigger false intersection with BANNED\n on line 2
+    context.write_file("file.txt", "line 1\nBANNED\nline 3 modified\n");
+    context.git().add(".");
+
+    cmd_snapshot!(context, context.run(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    deny patterns............................................................Passed
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn deny_pattern_hook_delta_only_multiline_formatted_call() {
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
+        repos:
+          - repo: builtin
+            hooks:
+              - id: deny-pattern
+                args: [--delta-only, -m, 'FooFuncNotAllowedWithSpecificArg\([\s\S]*?specificArg']
+                files: '\.py$'
+    "})
+        .with_file("legacy.py", "def existing():\n    good_call()\n")
+        .init_git();
+    context.git().commit("Initial commit");
+
+    // Adding the banned function call formatted across lines fails the hook
+    context.write_file(
+        "legacy.py",
+        indoc::indoc! {r"
+        def existing():
+            good_call()
+
+        def new_func():
+            FooFuncNotAllowedWithSpecificArg(
+                specificArg,
+                goodArg,
+            )
+    "},
+    );
+    context.git().add(".");
+
+    cmd_snapshot!(context, context.run(), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    deny patterns............................................................Failed
+    - hook id: deny-pattern
+    - description: Fails if any file contains a matching regular expression
+    - exit code: 1
+
+      legacy.py:5:FooFuncNotAllowedWithSpecificArg(
+              specificArg
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn require_pattern_hook_rejects_delta_only() {
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
+        repos:
+          - repo: builtin
+            hooks:
+              - id: require-pattern
+                args: [--delta-only, 'copyright']
+    "})
+        .with_file("file.txt", "content\n")
+        .init_git();
+
+    cmd_snapshot!(context, context.run(), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to run hook `require-pattern`
+      caused by: error: unexpected argument '--delta-only' found
+
+      tip: to pass '--delta-only' as a value, use '-- --delta-only'
+
+    Usage: require-pattern [OPTIONS] <PATTERN>...
+    ");
+}
+
+#[test]
 fn end_of_file_fixer_hook() {
     let context = TestEnv::new()
         .with_config(indoc::indoc! {r"

--- a/docs/builtin.md
+++ b/docs/builtin.md
@@ -517,6 +517,12 @@ When multiple patterns are provided, matching any one of them is sufficient.
 - `-m`, `--multiline`
     - Search each file as a whole, with `^` and `$` matching line boundaries and `.` matching newlines.
     - Reads each selected file into memory.
+- `--delta-only` (alias: `--check-delta`)
+    - Evaluate patterns only against newly added or modified lines in git diffs rather than entire files. Useful for ratcheting bans in legacy codebases without breaking on pre-existing lines.
+    - In staged runs (`prek run`), evaluates only lines added in the staged diff (`git diff --cached`).
+    - In revision-range runs (`prek run --from-ref <FROM> [--to-ref <TO>]`), evaluates only lines added within the diff range.
+    - When no diff context applies (such as `prek run --all-files`), passes without scanning full files so ratcheting checks never break on untouched legacy files.
+    - When combined with `-m` / `--multiline`, matches are evaluated in memory against contiguous added hunk blocks in the diff.
 
 By default, each matching line is reported as `path:line:contents`. A line matching more than one pattern is reported only once. With `--multiline`, the earliest match in each file is reported as `path:start-line:matched-block`.
 


### PR DESCRIPTION
## Summary

Closes #2610.

Adds native `--delta-only` (alias: `--check-delta`) support to the builtin `deny-pattern` hook.

### Key Changes
- **Delta-only matching**: When `--delta-only` is provided, `deny-pattern` inspects added lines in git diffs (`git diff --cached -U0` in staged runs or `git diff -U0 <FROM>...<TO>` in revision-range runs) and evaluates patterns only against newly added lines. Pre-existing matches on untouched lines are ignored, enabling ratcheted bans in legacy repositories.
- **In-memory hunk evaluation**: Contiguous added hunk blocks are parsed directly from git diff stdout in-memory. Multiline (`-m`) patterns are evaluated across contiguous added lines without reading full files from disk, avoiding unstaged working-tree leaks and false positives on historical blocks.
- **Repository-wide safety**: When no diff context applies (such as `prek run --all-files`), the hook passes cleanly without scanning full files so ratcheting checks never fail on untouched legacy code.
- **Tests & Docs**: Added integration tests using `cmd_snapshot!` covering staged runs, revision ranges, multiline formatted calls, and `--all-files` no-op behavior. Updated `docs/builtin.md`.