### PR TITLE
Allow unknown tags by default in `check-yaml`

### DIFF
--- a/crates/prek/src/hooks/pre_commit_hooks/check_yaml.rs
+++ b/crates/prek/src/hooks/pre_commit_hooks/check_yaml.rs
@@ -18,9 +18,9 @@ pub(crate) struct Args {
     /// Allow multiple YAML documents.
     #[arg(long, short = 'm', visible_alias = "multi")]
     allow_multiple_documents: bool,
-    /// Allow unrecognized YAML tags.
-    #[arg(long)]
-    allow_unknown_tags: bool,
+    /// Reject unrecognized YAML tags.
+    #[arg(long, conflicts_with = "unsafe")]
+    disallow_unknown_tags: bool,
     /// Parse YAML syntax without loading it. Implies `--allow-multiple-documents`.
     #[arg(long)]
     r#unsafe: bool,
@@ -32,7 +32,7 @@ pub(crate) struct Args {
 enum CheckMode {
     Load {
         multiple: bool,
-        allow_unknown_tags: bool,
+        disallow_unknown_tags: bool,
     },
     SyntaxOnly,
 }
@@ -45,7 +45,7 @@ pub(crate) async fn run(hook: &Hook, filenames: &[&Path]) -> Result<HookOutput> 
     } else {
         CheckMode::Load {
             multiple: args.allow_multiple_documents,
-            allow_unknown_tags: args.allow_unknown_tags,
+            disallow_unknown_tags: args.disallow_unknown_tags,
         }
     };
 
@@ -66,8 +66,8 @@ async fn check_file(file_base: &Path, filename: &Path, mode: CheckMode) -> Resul
     let output = match mode {
         CheckMode::Load {
             multiple,
-            allow_unknown_tags,
-        } => check_loaded(filename, &content, multiple, allow_unknown_tags),
+            disallow_unknown_tags,
+        } => check_loaded(filename, &content, multiple, disallow_unknown_tags),
         CheckMode::SyntaxOnly => check_syntax(filename, &content),
     };
     Ok(output)
@@ -77,7 +77,7 @@ fn check_loaded(
     filename: &Path,
     content: &[u8],
     allow_multi_docs: bool,
-    allow_unknown_tags: bool,
+    disallow_unknown_tags: bool,
 ) -> HookOutput {
     let options = serde_saphyr::options! {
         budget: serde_saphyr::budget! {
@@ -93,9 +93,9 @@ fn check_loaded(
         // A YAML tag identifies a node's type or application-specific semantics.
         // `%TAG` directives map tag handles to prefixes. The predefined `!!`
         // handle expands to `tag:yaml.org,2002:`, while `!` is the local tag handle.
-        // Match ruamel.yaml's safe loader by rejecting tags without constructors unless
-        // the user explicitly opts into application-specific tags. See #2604 and #2674.
-        reject_unsupported_tags: !allow_unknown_tags,
+        // Unknown tags are application-defined, and deserializing into `IgnoredAny` does not
+        // construct their values. Reject them only when explicitly requested. See #2674.
+        reject_unsupported_tags: disallow_unknown_tags,
         // The scalar values are discarded, so only validate whether they are
         // legal YAML, not whether an untyped data model can represent them. See #2544.
         reject_non_finite_typeless_float: false,
@@ -156,11 +156,11 @@ mod tests {
 
     const LOAD_SINGLE_DOCUMENT: CheckMode = CheckMode::Load {
         multiple: false,
-        allow_unknown_tags: false,
+        disallow_unknown_tags: false,
     };
     const LOAD_MULTIPLE_DOCUMENTS: CheckMode = CheckMode::Load {
         multiple: true,
-        allow_unknown_tags: false,
+        disallow_unknown_tags: false,
     };
 
     async fn create_test_file(
@@ -338,11 +338,20 @@ key2: value2
     }
 
     #[test]
-    fn test_unknown_yaml_tag_is_rejected_by_default() {
+    fn test_unknown_yaml_tag_is_allowed_by_default() {
         let filename = Path::new("tagged.yaml");
         let content = b"foo: !reference [.bar, script]\n";
 
         let result = check_loaded(filename, content, false, false);
+        assert_eq!((result.exit_status, result.output), (0, Vec::new()));
+    }
+
+    #[test]
+    fn test_disallow_unknown_tags_rejects_unknown_yaml_tag() {
+        let filename = Path::new("tagged.yaml");
+        let content = b"foo: !reference [.bar, script]\n";
+
+        let result = check_loaded(filename, content, false, true);
         assert_eq!(result.exit_status, 1);
         insta::assert_snapshot!(String::from_utf8_lossy(&result.output), @"tagged.yaml: Failed to yaml decode (unsupported tag `!reference` at line 1, column 17)");
     }

--- a/crates/prek/tests/builtin_hooks.rs
+++ b/crates/prek/tests/builtin_hooks.rs
@@ -673,17 +673,17 @@ fn check_yaml_multiple_document() {
 }
 
 #[test]
-fn check_yaml_allow_unknown_tags() {
+fn check_yaml_disallow_unknown_tags() {
     let context = TestEnv::new()
         .with_config(indoc::indoc! {r"
         repos:
           - repo: builtin
             hooks:
               - id: check-yaml
-                name: reject unknown tags
-              - id: check-yaml
                 name: allow unknown tags
-                args: [ --allow-unknown-tags ]
+              - id: check-yaml
+                name: reject unknown tags
+                args: [ --disallow-unknown-tags ]
     "})
         .with_file("tagged.yaml", "foo: !reference [.bar, script]\n")
         .init_git();
@@ -692,13 +692,13 @@ fn check_yaml_allow_unknown_tags() {
     success: false
     exit_code: 1
     ----- stdout -----
+    allow unknown tags.......................................................Passed
     reject unknown tags......................................................Failed
     - hook id: check-yaml
     - description: Checks YAML files for parseable syntax
     - exit code: 1
 
       tagged.yaml: Failed to yaml decode (unsupported tag `!reference` at line 1, column 17)
-    allow unknown tags.......................................................Passed
 
     ----- stderr -----
     "#);

--- a/crates/prek/tests/list_builtins.rs
+++ b/crates/prek/tests/list_builtins.rs
@@ -57,7 +57,7 @@ fn list_builtins_defaults_to_verbose_output() {
       Checks YAML files for parseable syntax.
       flags:
         -m, --allow-multiple-documents  Allow multiple YAML documents [alias: --multi]
-            --allow-unknown-tags        Allow unrecognized YAML tags
+            --disallow-unknown-tags     Reject unrecognized YAML tags
             --unsafe                    Parse YAML syntax without loading it. Implies
                                         `--allow-multiple-documents`
 

--- a/docs/builtin.md
+++ b/docs/builtin.md
@@ -452,10 +452,14 @@ Attempts to load all YAML files to verify syntax.
 
 - `-m`, `--allow-multiple-documents` (alias: `--multi`)
     - Allow YAML multi-document syntax (`---`).
-- `--allow-unknown-tags`
-    - Allow unrecognized YAML tags.
+- `--disallow-unknown-tags`
+    - Reject unrecognized YAML tags.
 - `--unsafe`
     - Parse YAML syntax without loading it. Implies `--allow-multiple-documents`.
+
+**Behavior / caveats**
+
+- Unrecognized YAML tags are allowed by default. This differs from the pinned `pre-commit-hooks` implementation, which rejects them while loading. Use `--disallow-unknown-tags` to match that behavior.
 
 ---
 


### PR DESCRIPTION
Follow-up to #2674.

Rejecting unknown tags by default causes false positives in ecosystems such as MkDocs and Ansible. A generic YAML checker cannot know the tag vocabulary of the application that consumes a file, so an unrecognized application-specific tag does not make the YAML invalid.

This intentionally differs from upstream `check-yaml`. prek allows unknown tags by default and provides `--disallow-unknown-tags` for users who want to enforce a closed tag vocabulary. Only tag rejection changes; all other loading checks remain enabled.
