### PR TITLE
chore: update asyncband to 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,12 +222,11 @@ dependencies = [
 
 [[package]]
 name = "asyncband"
-version = "0.6.7"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a214ba60d6231afd0e805e3c27c45a1626d9debaa5a5061c45a1ea1b2f1ed0"
+checksum = "9c0760bfe4d98dc80094270772af5a31eb431bb2212d2ce559a3af18d04632fb"
 dependencies = [
  "hashbrown",
- "slab",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ anyhow = { version = "1.0.86" }
 async-trait = { version = "0.1.89" }
 async-compression = { version = "0.4.18", features = ["gzip", "xz", "tokio"] }
 async_zip = { version = "0.0.20", package = "astral_async_zip", features = ["deflate", "tokio"] }
+asyncband = { version = "0.7", features = ["once-cell", "once-map", "semaphore"] }
 axoupdater = { version = "0.10.0", default-features = false, features = ["github_releases"] }
 bstr = { version = "1.11.0", default-features = false, features = ["std"] }
 cargo_metadata = { version = "0.23.1" }
@@ -48,7 +49,6 @@ libc = { version = "0.2.182" }
 # Enable static linking for liblzma
 # This is required for the `xz` feature in `async-compression`
 liblzma = { version = "0.4.5", features = ["static"] }
-asyncband = { version = "0.6.7" }
 memchr = { version = "2.7.5" }
 owo-colors = { version = "4.1.0" }
 phf = { version = "0.14.0", default-features = false, features = ["macros"] }


### PR DESCRIPTION
## Summary

Update AsyncBand to 0.7 and enable only the `once-cell`, `once-map`, and `semaphore` primitives used by prek.
