### PR TITLE
chore: update asyncband to 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "asyncband"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c0760bfe4d98dc80094270772af5a31eb431bb2212d2ce559a3af18d04632fb"
+checksum = "2e52766975a4f080528a898235c51e82e65df9db713419067b5368040eeb5659"
 dependencies = [
  "hashbrown",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ anyhow = { version = "1.0.86" }
 async-trait = { version = "0.1.89" }
 async-compression = { version = "0.4.18", features = ["gzip", "xz", "tokio"] }
 async_zip = { version = "0.0.20", package = "astral_async_zip", features = ["deflate", "tokio"] }
-asyncband = { version = "0.7", features = ["once-cell", "once-map", "semaphore"] }
+asyncband = { version = "0.7.1", features = ["once-cell", "once-map", "semaphore"] }
 axoupdater = { version = "0.10.0", default-features = false, features = ["github_releases"] }
 bstr = { version = "1.11.0", default-features = false, features = ["std"] }
 cargo_metadata = { version = "0.23.1" }


### PR DESCRIPTION
## Summary

Update AsyncBand from 0.7.0 to 0.7.1 because 0.7.0 has been yanked.
