### PR TITLE
Skip file type detection for unmatched paths

### DIFF
--- a/crates/prek/src/cli/run/filter.rs
+++ b/crates/prek/src/cli/run/filter.rs
@@ -8,11 +8,11 @@ use anyhow::{Context, Result};
 use globset::Glob;
 use prek_consts::env_vars::{EnvVars, EnvVarsRead};
 use prek_identify::{TagSet, tags_from_path};
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::{debug, error, instrument};
 
-use crate::config::{FilePattern, GlobPatterns, Stage};
+use crate::config::{FilePattern, GlobPatterns, PassFilenames, Stage};
 use crate::fs::PathClean;
 use crate::git::GIT_ROOT;
 use crate::hook::Hook;
@@ -152,15 +152,19 @@ impl FileTagCache {
     pub(crate) fn from_paths(paths: &[PathBuf]) -> Self {
         let tags_by_file = paths
             .par_iter()
-            .map(|path| match tags_from_path(path) {
-                Ok(tags) => Some(tags),
-                Err(err) => {
-                    error!(filename = ?path.display(), error = %err, "Failed to get tags");
-                    None
-                }
-            })
+            .map(|path| Self::identify(path))
             .collect();
         Self { tags_by_file }
+    }
+
+    fn identify(path: &Path) -> Option<TagSet> {
+        match tags_from_path(path) {
+            Ok(tags) => Some(tags),
+            Err(err) => {
+                error!(filename = ?path.display(), error = %err, "Failed to get tags");
+                None
+            }
+        }
     }
 
     pub(crate) fn tags(&self, file_idx: usize) -> Option<&TagSet> {
@@ -339,7 +343,11 @@ pub(crate) struct RunFileIndex<'a> {
 }
 
 impl<'a> RunFileIndex<'a> {
-    pub(crate) fn new(input: &'a RunInput, projects: &[Arc<Project>]) -> Self {
+    pub(crate) fn new<'hooks>(
+        input: &'a RunInput,
+        projects: &[Arc<Project>],
+        hooks: impl IntoIterator<Item = &'hooks Hook>,
+    ) -> Self {
         let RunInput::Files(filenames) = input else {
             return Self {
                 projects: Vec::new(),
@@ -377,6 +385,19 @@ impl<'a> RunFileIndex<'a> {
             })
             .collect::<Vec<_>>();
 
+        let mut hook_filters: Vec<Vec<FilenameFilter<'_>>> =
+            projects.iter().map(|_| Vec::new()).collect();
+        for hook in hooks {
+            if hook.always_run && matches!(hook.pass_filenames, PassFilenames::None) {
+                continue;
+            }
+            hook_filters[hook.project().idx()].push(FilenameFilter::new(
+                hook.files.as_ref(),
+                hook.exclude.as_ref(),
+            ));
+        }
+
+        let mut needs_tags = vec![false; filenames.len()];
         let mut matching_projects = Vec::new();
         for (file_idx, filename) in filenames.iter().enumerate() {
             project_tree.matching_projects(filename, &mut matching_projects);
@@ -390,6 +411,13 @@ impl<'a> RunFileIndex<'a> {
                     .expect("matched project path must be a file prefix");
                 if project_filters[project_idx].matches(hook_path) {
                     project_files[project_idx].push(file_idx, hook_path);
+                    if !needs_tags[file_idx]
+                        && hook_filters[project_idx]
+                            .iter()
+                            .any(|filter| filter.matches(hook_path))
+                    {
+                        needs_tags[file_idx] = true;
+                    }
                 }
                 if project.config().orphan.unwrap_or(false) {
                     break;
@@ -397,9 +425,23 @@ impl<'a> RunFileIndex<'a> {
             }
         }
 
+        // Keep a single pre-hook snapshot: a hook may change a file's contents or mode.
+        // Paths rejected by every runnable hook need no filesystem access for tags.
+        let tags_by_file = filenames
+            .par_iter()
+            .enumerate()
+            .map(|(file_idx, path)| {
+                if needs_tags[file_idx] {
+                    FileTagCache::identify(path)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
         Self {
             projects: project_files,
-            tag_cache: FileTagCache::from_paths(filenames),
+            tag_cache: FileTagCache { tags_by_file },
         }
     }
 
@@ -719,7 +761,156 @@ pub(super) const fn stage_uses_message_file_input(stage: Stage) -> bool {
 mod tests {
     use super::*;
     use crate::cli::FileSelectionArgs;
-    use crate::config::GlobPatterns;
+    use crate::config::{GlobPatterns, LocalHook};
+    use crate::hook::Repo;
+
+    async fn file_index_fixture(
+        config: &str,
+        hook: &str,
+    ) -> Result<(tempfile::TempDir, Arc<Project>, Hook)> {
+        let temp = tempfile::tempdir()?;
+        let config_path = temp.path().join(prek_consts::PRE_COMMIT_CONFIG_YAML);
+        fs_err::write(&config_path, config)?;
+        let mut project = Project::from_config_file(config_path.into(), None)?;
+        // Absolute inputs let this fixture exercise project-relative filtering without
+        // changing the process working directory shared by other tests.
+        project.with_relative_path(temp.path().to_path_buf());
+        let project = Arc::new(project);
+        let local_hook: LocalHook = serde_saphyr::from_str(hook)?;
+        let hook = Hook::from_spec(
+            Arc::clone(&project),
+            Arc::new(Repo::Local),
+            local_hook.into(),
+            0,
+        )
+        .await?;
+        Ok((temp, project, hook))
+    }
+
+    #[tokio::test]
+    async fn run_file_index_identifies_only_candidate_files() -> Result<()> {
+        let (temp, project, hook) = file_index_fixture(
+            "repos: []\nexclude: ^ignored-project/\n",
+            indoc::indoc! {r#"
+                id: source
+                name: source
+                entry: echo
+                language: system
+                files:
+                  glob: ["src/**", "ignored-project/**"]
+                exclude:
+                  glob: "**/ignored.txt"
+                types: [text]
+            "#},
+        )
+        .await?;
+        let files = [
+            "src/kept.txt",
+            "src/binary.png",
+            "src/ignored.txt",
+            "ignored-project/kept.txt",
+            "docs/readme.json",
+        ];
+        let mut paths = Vec::new();
+        for filename in files {
+            let path = temp.path().join(filename);
+            if let Some(parent) = path.parent() {
+                fs_err::create_dir_all(parent)?;
+            }
+            fs_err::write(&path, "{}\n")?;
+            paths.push(path);
+        }
+        let input = RunInput::Files(paths);
+        let index = RunFileIndex::new(&input, std::slice::from_ref(&project), [&hook]);
+        let cache = index.tag_cache();
+        assert!(cache.tags(0).is_some());
+        assert!(cache.tags(1).is_some());
+        for (idx, filename) in files.iter().enumerate().skip(2) {
+            assert!(cache.tags(idx).is_none(), "unexpected tags for {filename}");
+        }
+        assert_eq!(
+            index.project_files(&project).matching_filenames(&hook, cache),
+            vec![Path::new("src/kept.txt")],
+        );
+
+        let mut docs_hook = hook.clone();
+        docs_hook.files = Some(regex_pattern(r"\.json$"));
+        docs_hook.exclude = None;
+        let index = RunFileIndex::new(
+            &input,
+            std::slice::from_ref(&project),
+            [&hook, &docs_hook],
+        );
+        assert_eq!(
+            index
+                .project_files(&project)
+                .matching_filenames(&docs_hook, index.tag_cache()),
+            vec![Path::new("docs/readme.json")],
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn run_file_index_preserves_initial_file_tags() -> Result<()> {
+        let (temp, project, hook) = file_index_fixture(
+            "repos: []\n",
+            indoc::indoc! {r"
+                id: text
+                name: text
+                entry: echo
+                language: system
+                types: [text]
+            "},
+        )
+        .await?;
+        let existing = temp.path().join("existing");
+        let missing = temp.path().join("missing");
+        fs_err::write(&existing, "text\n")?;
+        let input = RunInput::Files(vec![existing.clone(), missing.clone()]);
+        let index = RunFileIndex::new(&input, std::slice::from_ref(&project), [&hook]);
+
+        fs_err::write(&existing, b"\0")?;
+        fs_err::write(&missing, "text\n")?;
+        assert_eq!(
+            index
+                .project_files(&project)
+                .matching_filenames(&hook, index.tag_cache()),
+            vec![Path::new("existing")],
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn run_file_index_skips_unneeded_tag_queries() -> Result<()> {
+        let (temp, project, mut hook) = file_index_fixture(
+            "repos: []\n",
+            indoc::indoc! {r"
+                id: check
+                name: check
+                entry: echo
+                language: system
+            "},
+        )
+        .await?;
+        let file = temp.path().join("file.txt");
+        fs_err::write(&file, "text\n")?;
+        let input = RunInput::Files(vec![file]);
+
+        for (always_run, pass_filenames, needs_tags) in [
+            (true, PassFilenames::None, false),
+            (false, PassFilenames::None, true),
+            (true, PassFilenames::All, true),
+        ] {
+            hook.always_run = always_run;
+            hook.pass_filenames = pass_filenames;
+            let index = RunFileIndex::new(&input, std::slice::from_ref(&project), [&hook]);
+            assert_eq!(index.tag_cache().tags(0).is_some(), needs_tags);
+        }
+
+        let index = RunFileIndex::new(&input, std::slice::from_ref(&project), []);
+        assert!(index.tag_cache().tags(0).is_none());
+        Ok(())
+    }
 
     #[test]
     fn all_file_selection_preserves_partial_refs() {

--- a/crates/prek/src/cli/run/run.rs
+++ b/crates/prek/src/cli/run/run.rs
@@ -239,7 +239,14 @@ pub(crate) async fn run(
         )
     })?;
 
-    let file_index = RunFileIndex::new(&input, workspace.all_projects());
+    let file_index = RunFileIndex::new(
+        &input,
+        workspace.all_projects(),
+        selected_hooks
+            .iter()
+            .filter_map(HookPlan::as_run)
+            .map(|hook| hook.as_ref()),
+    );
     let installed_hooks = ensure_hooks_installed(
         store,
         printer,

--- a/scripts/benchmark-file-filtering.py
+++ b/scripts/benchmark-file-filtering.py
@@ -1,0 +1,204 @@
+# /// script
+# requires-python = ">=3.11"
+# ///
+
+"""Compare two release binaries on warm, file-filtering workloads.
+
+Build both binaries with the same toolchain and release flags. This script runs
+real hooks, checks their dry-run file lists first, and alternates command order.
+The unfiltered case is a control; improvements are reported per workload.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import re
+import statistics
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+
+CASES = ("unfiltered", "project-exclude", "selected-hook", "selected-project")
+CONFIG_NAME = ".pre-commit-config.yaml"
+CONFIG = """exclude: '(^|/)\\.pre-commit-config\\.yaml$'
+repos:
+  - repo: builtin
+    hooks:
+      - id: trailing-whitespace
+"""
+
+
+def checked_run(command: list[str], cwd: Path, env: dict[str, str]) -> bytes:
+    result = subprocess.run(command, cwd=cwd, env=env, capture_output=True, check=True)
+    if result.stderr:
+        raise RuntimeError(result.stderr.decode(errors="replace"))
+    return result.stdout
+
+
+def create_fixture(root: Path, case: str, files: int, selected: int) -> tuple[Path, list[str], int]:
+    repo = root / case / "repo"
+    repo.mkdir(parents=True)
+    for directory, count in (("src", selected), ("vendor", files - selected)):
+        target = repo / directory
+        target.mkdir()
+        for index in range(count):
+            (target / f"file{index:06}.txt").write_text("clean line\n" * 16)
+
+    config = CONFIG
+    command = ["run", "--all-files", "--color=never"]
+    expected = selected
+    if case == "unfiltered":
+        expected = files
+    elif case == "project-exclude":
+        config = config.replace("(^|/)", "^vendor/|(^|/)", 1)
+    elif case == "selected-hook":
+        config += "        files: ^src/\n      - id: end-of-file-fixer\n"
+        command.append("trailing-whitespace")
+    elif case == "selected-project":
+        (repo / "src" / CONFIG_NAME).write_text("orphan: true\n" + CONFIG)
+        command.append("src/")
+    else:
+        raise ValueError(case)
+    (repo / CONFIG_NAME).write_text(config)
+
+    git = ["git", "-c", "core.hooksPath=/dev/null", "-c", "commit.gpgsign=false"]
+    subprocess.run([*git, "init", "-q"], cwd=repo, check=True)
+    subprocess.run([*git, "add", "."], cwd=repo, check=True)
+    subprocess.run(
+        [*git, "-c", "user.name=Benchmark", "-c", "user.email=bench@prek.dev",
+         "commit", "-qm", "Create benchmark fixture"],
+        cwd=repo,
+        check=True,
+    )
+    return repo, command, expected
+
+
+def normalize(output: bytes) -> bytes:
+    return re.sub(rb"(?m)^\s*- duration:.*$", b"", output)
+
+
+def summary(samples: list[float]) -> dict[str, float]:
+    return {
+        "mean_seconds": statistics.mean(samples),
+        "median_seconds": statistics.median(samples),
+        "stdev_seconds": statistics.stdev(samples),
+        "min_seconds": min(samples),
+        "max_seconds": max(samples),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", type=Path, required=True, help="Baseline release binary")
+    parser.add_argument("--head", type=Path, required=True, help="Modified release binary")
+    parser.add_argument("--files", type=int, default=10000)
+    parser.add_argument("--selected", type=int, default=100)
+    parser.add_argument("--runs", type=int, default=30)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--case", choices=CASES, action="append")
+    parser.add_argument("--output", type=Path, help="Save metadata and every timing sample as JSON")
+    args = parser.parse_args()
+    if not 0 < args.selected <= args.files:
+        parser.error("require 0 < --selected <= --files")
+    if args.runs < 2 or args.warmup < 1:
+        parser.error("require --runs >= 2 and --warmup >= 1")
+
+    binaries = {"base": args.base.resolve(), "head": args.head.resolve()}
+    for path in binaries.values():
+        if not path.is_file() or not os.access(path, os.X_OK):
+            parser.error(f"not an executable file: {path}")
+    report = {
+        "platform": platform.platform(),
+        "cpu_count": os.cpu_count(),
+        "files": args.files,
+        "selected_files": args.selected,
+        "runs": args.runs,
+        "warmup": args.warmup,
+        "cache": "warm",
+        "order": "alternating base/head and head/base",
+        "binaries": {
+            label: {"path": str(path), "sha256": hashlib.sha256(path.read_bytes()).hexdigest()}
+            for label, path in binaries.items()
+        },
+        "results": [],
+    }
+    env = os.environ.copy()
+    env.update({"NO_COLOR": "1", "TERM": "dumb", "GIT_CONFIG_GLOBAL": os.devnull,
+                "GIT_CONFIG_NOSYSTEM": "1", "GIT_TERMINAL_PROMPT": "0"})
+    report["concurrency_environment"] = {
+        key: value for key, value in env.items()
+        if key.startswith("RAYON_") or (key.startswith("PREK_") and "CONCURRENCY" in key)
+    }
+
+    with tempfile.TemporaryDirectory(prefix="prek-filter-bench-") as directory:
+        root = Path(directory)
+        for case in args.case or CASES:
+            repo, command, expected = create_fixture(root, case, args.files, args.selected)
+            environments = {
+                label: {**env, "PREK_HOME": str(root / case / f"{label}-home")}
+                for label in binaries
+            }
+            for label, path in binaries.items():
+                report["binaries"][label]["version"] = checked_run(
+                    [str(path), "--version"], repo, environments[label]
+                ).decode().strip()
+
+            plans = {}
+            for label, path in binaries.items():
+                plan_env = {**environments[label], "PREK_INTERNAL__SORT_FILENAMES": "1"}
+                plans[label] = normalize(checked_run(
+                    [str(path), *command, "--dry-run", "--verbose"], repo, plan_env
+                ))
+                counts = re.findall(rb"would be run on (\d+) files:", plans[label])
+                if counts != [str(expected).encode()]:
+                    raise RuntimeError(f"{case}: unexpected file counts for {label}: {counts}")
+            if plans["base"] != plans["head"]:
+                raise RuntimeError(f"{case}: base/head dry-run file lists differ")
+
+            expected_output = None
+            samples = {label: [] for label in binaries}
+            for iteration in range(args.warmup + args.runs):
+                order = ("base", "head") if iteration % 2 == 0 else ("head", "base")
+                for label in order:
+                    start = time.perf_counter()
+                    output = checked_run(
+                        [str(binaries[label]), *command], repo, environments[label]
+                    )
+                    elapsed = time.perf_counter() - start
+                    if expected_output is None:
+                        expected_output = output
+                    if output != expected_output:
+                        raise RuntimeError(f"{case}: hook output changed for {label}")
+                    if iteration >= args.warmup:
+                        samples[label].append(elapsed)
+
+            summaries = {label: summary(values) for label, values in samples.items()}
+            base_time = summaries["base"]["median_seconds"]
+            head_time = summaries["head"]["median_seconds"]
+            reduction = 100 * (1 - head_time / base_time)
+            speedup = base_time / head_time
+            report["results"].append({
+                "case": case,
+                "command": command,
+                "expected_hook_files": expected,
+                "summaries": summaries,
+                "samples_seconds": samples,
+                "median_time_reduction_percent": reduction,
+                "median_speedup_ratio": speedup,
+                "at_least_30_percent_less_time": reduction >= 30,
+            })
+            print(f"{case}: {base_time * 1000:.2f} -> {head_time * 1000:.2f} ms; "
+                  f"{reduction:+.1f}% less time; {speedup:.2f}x", flush=True)
+            if args.output:
+                args.output.parent.mkdir(parents=True, exist_ok=True)
+                args.output.write_text(json.dumps(report, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Runs currently identify file types even for excluded paths. Limit identification to files that selected hooks may use, preserving pre-hook tag snapshots and orphan ownership. Unconditional hooks that take no filenames need no tag matching.