### PR TITLE
Fix `check-hooks-apply` for builtin Windows filename checks

### DIFF
--- a/crates/prek/src/hook.rs
+++ b/crates/prek/src/hook.rs
@@ -216,16 +216,11 @@ impl From<MetaHook> for HookSpec {
 
 impl From<BuiltinHook> for HookSpec {
     fn from(hook: BuiltinHook) -> Self {
-        let language = match hook.id.as_str() {
-            "check-illegal-windows-names" => Language::Fail,
-            _ => Language::System,
-        };
-
         Self {
             id: hook.id,
             name: hook.name,
             entry: hook.entry,
-            language,
+            language: Language::System,
             language_overridden: false,
             priority: hook.priority,
             groups: hook.groups,

--- a/crates/prek/src/hook.rs
+++ b/crates/prek/src/hook.rs
@@ -216,11 +216,16 @@ impl From<MetaHook> for HookSpec {
 
 impl From<BuiltinHook> for HookSpec {
     fn from(hook: BuiltinHook) -> Self {
+        let language = match hook.id.as_str() {
+            "check-illegal-windows-names" => Language::Fail,
+            _ => Language::System,
+        };
+
         Self {
             id: hook.id,
             name: hook.name,
             entry: hook.entry,
-            language: Language::System,
+            language,
             language_overridden: false,
             priority: hook.priority,
             groups: hook.groups,

--- a/crates/prek/src/hooks/meta_hooks.rs
+++ b/crates/prek/src/hooks/meta_hooks.rs
@@ -13,7 +13,7 @@ use crate::cli::run::{
 };
 use crate::config::{FilePattern, HookOptions, Language, MetaHook};
 use crate::hook::{Hook, Repo};
-use crate::hooks::HookOutput;
+use crate::hooks::{BuiltinHooks, HookOutput};
 use crate::store::Store;
 use crate::workspace::{HookInitFilters, Project};
 
@@ -142,8 +142,8 @@ pub(crate) async fn check_hooks_apply(
                 // Builtins use `system`, but this hook only selects invalid filenames,
                 // so having no matches is expected, just like `language: fail`.
                 !matches!(
-                    (hook.repo(), hook.id.as_str()),
-                    (Repo::Builtin, "check-illegal-windows-names")
+                    hook.repo(),
+                    Repo::Builtin if hook.id == BuiltinHooks::CheckIllegalWindowsNames.as_ref()
                 )
             })
             .collect::<Vec<_>>();

--- a/crates/prek/src/hooks/meta_hooks.rs
+++ b/crates/prek/src/hooks/meta_hooks.rs
@@ -12,7 +12,7 @@ use crate::cli::run::{
     CollectOptions, FileTagCache, FileTagFilter, HookFileFilter, ProjectFiles, collect_run_input,
 };
 use crate::config::{FilePattern, HookOptions, Language, MetaHook};
-use crate::hook::{Hook, Repo};
+use crate::hook::Hook;
 use crate::hooks::HookOutput;
 use crate::store::Store;
 use crate::workspace::{HookInitFilters, Project};
@@ -134,18 +134,7 @@ pub(crate) async fn check_hooks_apply(
             .context("Failed to init hooks")?;
         let hooks = project_hooks
             .iter()
-            .filter(|hook| {
-                if hook.always_run || hook.language == Language::Fail {
-                    return false;
-                }
-
-                // Builtins use `system`, but this hook only selects invalid filenames,
-                // so having no matches is expected, just like `language: fail`.
-                !matches!(
-                    (hook.repo(), hook.id.as_str()),
-                    (Repo::Builtin, "check-illegal-windows-names")
-                )
-            })
+            .filter(|hook| !hook.always_run && hook.language != Language::Fail)
             .collect::<Vec<_>>();
         if hooks.is_empty() {
             continue;

--- a/crates/prek/src/hooks/meta_hooks.rs
+++ b/crates/prek/src/hooks/meta_hooks.rs
@@ -12,7 +12,7 @@ use crate::cli::run::{
     CollectOptions, FileTagCache, FileTagFilter, HookFileFilter, ProjectFiles, collect_run_input,
 };
 use crate::config::{FilePattern, HookOptions, Language, MetaHook};
-use crate::hook::Hook;
+use crate::hook::{Hook, Repo};
 use crate::hooks::HookOutput;
 use crate::store::Store;
 use crate::workspace::{HookInitFilters, Project};
@@ -134,7 +134,18 @@ pub(crate) async fn check_hooks_apply(
             .context("Failed to init hooks")?;
         let hooks = project_hooks
             .iter()
-            .filter(|hook| !hook.always_run && hook.language != Language::Fail)
+            .filter(|hook| {
+                if hook.always_run || hook.language == Language::Fail {
+                    return false;
+                }
+
+                // Builtins use `system`, but this hook only selects invalid filenames,
+                // so having no matches is expected, just like `language: fail`.
+                !matches!(
+                    (hook.repo(), hook.id.as_str()),
+                    (Repo::Builtin, "check-illegal-windows-names")
+                )
+            })
             .collect::<Vec<_>>();
         if hooks.is_empty() {
             continue;

--- a/crates/prek/tests/meta_hooks.rs
+++ b/crates/prek/tests/meta_hooks.rs
@@ -64,6 +64,69 @@ fn meta_hooks() {
 }
 
 #[test]
+fn check_hooks_apply_builtin_illegal_windows_names() {
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
+        repos:
+          - repo: builtin
+            hooks:
+              - id: check-illegal-windows-names
+          - repo: meta
+            hooks:
+              - id: check-hooks-apply
+    "})
+        .with_file("normal.txt", "ok")
+        .init_git();
+
+    cmd_snapshot!(context, context.run().arg("--all-files"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    check illegal windows names..........................(no files to check)Skipped
+    Check hooks apply........................................................Passed
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
+fn check_hooks_apply_still_checks_other_hooks() {
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r"
+        repos:
+          - repo: builtin
+            hooks:
+              - id: check-illegal-windows-names
+              - id: check-json
+          - repo: local
+            hooks:
+              - id: check-illegal-windows-names
+                name: local check
+                language: system
+                entry: echo
+                files: ^nonexistent$
+          - repo: meta
+            hooks:
+              - id: check-hooks-apply
+    "})
+        .init_git();
+
+    cmd_snapshot!(context, context.run().arg("check-hooks-apply"), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    Check hooks apply........................................................Failed
+    - hook id: check-hooks-apply
+    - exit code: 1
+
+      check-json does not apply to this repository
+      check-illegal-windows-names does not apply to this repository
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
 fn meta_hooks_unknown_hook() {
     let context = TestEnv::new()
         .with_config(indoc::indoc! {r"


### PR DESCRIPTION
Closes #2687