### PR TITLE
Allow disabling automatic uv installation

### DIFF
--- a/crates/prek/src/languages/python/uv.rs
+++ b/crates/prek/src/languages/python/uv.rs
@@ -233,6 +233,8 @@ impl PyPiMirror {
 
 #[derive(Debug, PartialEq, Eq)]
 enum InstallSource {
+    /// Disable automatic uv installation.
+    None,
     /// Download uv from Astral's CDN (the default).
     Astral,
     /// Download uv from GitHub releases.
@@ -246,6 +248,12 @@ enum InstallSource {
 impl InstallSource {
     async fn install(&self, store: &Store, target: &Path) -> Result<Uv> {
         match self {
+            Self::None => bail!(
+                "No compatible uv found and automatic installation is disabled by {}=none. \
+                 Install uv ({}) and add it to PATH",
+                EnvVars::PREK_UV_SOURCE,
+                *UV_VERSION_RANGE,
+            ),
             Self::Astral => {
                 self.install_from_release_archive(store, target, ASTRAL_UV_RELEASE_BASE, &HOST)
                     .await?;
@@ -667,6 +675,7 @@ impl Uv {
 fn uv_source_from_env(env_vars: &impl EnvVarsRead) -> Option<InstallSource> {
     let var = env_vars.var(EnvVars::PREK_UV_SOURCE).ok()?;
     match var.as_str() {
+        "none" => Some(InstallSource::None),
         "astral" => Some(InstallSource::Astral),
         "github" => Some(InstallSource::GitHub),
         "pypi" => Some(InstallSource::PyPi(PyPiMirror::Pypi)),
@@ -677,7 +686,7 @@ fn uv_source_from_env(env_vars: &impl EnvVarsRead) -> Option<InstallSource> {
         custom if custom.starts_with("http") => Some(InstallSource::PyPi(PyPiMirror::Custom(var))),
         _ => {
             warn_user!(
-                "Invalid value for {}: {:?}. Expected astral, github, pypi, tuna, aliyun, tencent, pip, or an http(s) URL; using default ({:?})",
+                "Invalid value for {}: {:?}. Expected none, astral, github, pypi, tuna, aliyun, tencent, pip, or an http(s) URL; using default ({:?})",
                 EnvVars::PREK_UV_SOURCE,
                 var,
                 "auto",

--- a/crates/prek/src/languages/python/uv.rs
+++ b/crates/prek/src/languages/python/uv.rs
@@ -232,9 +232,14 @@ impl PyPiMirror {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-enum InstallSource {
-    /// Disable automatic uv installation.
+enum UvSource {
+    Auto,
     None,
+    Explicit(InstallSource),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum InstallSource {
     /// Download uv from Astral's CDN (the default).
     Astral,
     /// Download uv from GitHub releases.
@@ -248,12 +253,6 @@ enum InstallSource {
 impl InstallSource {
     async fn install(&self, store: &Store, target: &Path) -> Result<Uv> {
         match self {
-            Self::None => bail!(
-                "No compatible uv found and automatic installation is disabled by {}=none. \
-                 Install uv ({}) and add it to PATH",
-                EnvVars::PREK_UV_SOURCE,
-                *UV_VERSION_RANGE,
-            ),
             Self::Astral => {
                 self.install_from_release_archive(store, target, ASTRAL_UV_RELEASE_BASE, &HOST)
                     .await?;
@@ -648,6 +647,17 @@ impl Uv {
             }
         }
 
+        let source = match uv_source_from_env(&EnvVars) {
+            UvSource::Auto => None,
+            UvSource::None => bail!(
+                "No compatible uv found and automatic installation is disabled by {}=none. \
+                 Install uv ({}) and add it to PATH",
+                EnvVars::PREK_UV_SOURCE,
+                *UV_VERSION_RANGE,
+            ),
+            UvSource::Explicit(source) => Some(source),
+        };
+
         // Install new managed uv with proper locking
         fs_err::tokio::create_dir_all(&uv_dir).await?;
         let _lock = LockedFile::acquire(uv_dir.join(".lock"), "uv").await?;
@@ -664,7 +674,7 @@ impl Uv {
             }
         }
 
-        if let Some(source) = uv_source_from_env(&EnvVars) {
+        if let Some(source) = source {
             source.install(store, uv_dir).await
         } else {
             Self::install_with_fallbacks(store, uv_dir).await
@@ -672,18 +682,22 @@ impl Uv {
     }
 }
 
-fn uv_source_from_env(env_vars: &impl EnvVarsRead) -> Option<InstallSource> {
-    let var = env_vars.var(EnvVars::PREK_UV_SOURCE).ok()?;
+fn uv_source_from_env(env_vars: &impl EnvVarsRead) -> UvSource {
+    let Ok(var) = env_vars.var(EnvVars::PREK_UV_SOURCE) else {
+        return UvSource::Auto;
+    };
     match var.as_str() {
-        "none" => Some(InstallSource::None),
-        "astral" => Some(InstallSource::Astral),
-        "github" => Some(InstallSource::GitHub),
-        "pypi" => Some(InstallSource::PyPi(PyPiMirror::Pypi)),
-        "tuna" => Some(InstallSource::PyPi(PyPiMirror::Tuna)),
-        "aliyun" => Some(InstallSource::PyPi(PyPiMirror::Aliyun)),
-        "tencent" => Some(InstallSource::PyPi(PyPiMirror::Tencent)),
-        "pip" => Some(InstallSource::Pip),
-        custom if custom.starts_with("http") => Some(InstallSource::PyPi(PyPiMirror::Custom(var))),
+        "none" => UvSource::None,
+        "astral" => UvSource::Explicit(InstallSource::Astral),
+        "github" => UvSource::Explicit(InstallSource::GitHub),
+        "pypi" => UvSource::Explicit(InstallSource::PyPi(PyPiMirror::Pypi)),
+        "tuna" => UvSource::Explicit(InstallSource::PyPi(PyPiMirror::Tuna)),
+        "aliyun" => UvSource::Explicit(InstallSource::PyPi(PyPiMirror::Aliyun)),
+        "tencent" => UvSource::Explicit(InstallSource::PyPi(PyPiMirror::Tencent)),
+        "pip" => UvSource::Explicit(InstallSource::Pip),
+        custom if custom.starts_with("http") => {
+            UvSource::Explicit(InstallSource::PyPi(PyPiMirror::Custom(var)))
+        }
         _ => {
             warn_user!(
                 "Invalid value for {}: {:?}. Expected none, astral, github, pypi, tuna, aliyun, tencent, pip, or an http(s) URL; using default ({:?})",
@@ -691,7 +705,7 @@ fn uv_source_from_env(env_vars: &impl EnvVarsRead) -> Option<InstallSource> {
                 var,
                 "auto",
             );
-            None
+            UvSource::Auto
         }
     }
 }
@@ -732,35 +746,39 @@ mod tests {
 
     #[test]
     fn uv_source_from_env_reads_source_override() {
-        assert_eq!(uv_source_from_env(&EnvVars::from_map(&[])), None);
+        assert_eq!(uv_source_from_env(&EnvVars::from_map(&[])), UvSource::Auto);
+        assert_eq!(
+            uv_source_from_env(&EnvVars::from_map(&[(EnvVars::PREK_UV_SOURCE, "none")])),
+            UvSource::None
+        );
         assert_eq!(
             uv_source_from_env(&EnvVars::from_map(&[(EnvVars::PREK_UV_SOURCE, "astral")])),
-            Some(InstallSource::Astral)
+            UvSource::Explicit(InstallSource::Astral)
         );
         assert_eq!(
             uv_source_from_env(&EnvVars::from_map(&[(EnvVars::PREK_UV_SOURCE, "github")])),
-            Some(InstallSource::GitHub)
+            UvSource::Explicit(InstallSource::GitHub)
         );
         assert_eq!(
             uv_source_from_env(&EnvVars::from_map(&[(EnvVars::PREK_UV_SOURCE, "pypi")])),
-            Some(InstallSource::PyPi(PyPiMirror::Pypi))
+            UvSource::Explicit(InstallSource::PyPi(PyPiMirror::Pypi))
         );
         assert_eq!(
             uv_source_from_env(&EnvVars::from_map(&[(EnvVars::PREK_UV_SOURCE, "pip")])),
-            Some(InstallSource::Pip)
+            UvSource::Explicit(InstallSource::Pip)
         );
         assert_eq!(
             uv_source_from_env(&EnvVars::from_map(&[(
                 EnvVars::PREK_UV_SOURCE,
                 "https://example.com/simple",
             )])),
-            Some(InstallSource::PyPi(PyPiMirror::Custom(
+            UvSource::Explicit(InstallSource::PyPi(PyPiMirror::Custom(
                 "https://example.com/simple".to_string()
             )))
         );
         assert_eq!(
             uv_source_from_env(&EnvVars::from_map(&[(EnvVars::PREK_UV_SOURCE, "unknown")])),
-            None
+            UvSource::Auto
         );
     }
 

--- a/crates/prek/tests/languages/python.rs
+++ b/crates/prek/tests/languages/python.rs
@@ -1,9 +1,13 @@
+#[cfg(feature = "ci")]
 use assert_fs::assert::PathAssert;
 use assert_fs::fixture::PathChild;
 use prek_consts::env_vars::EnvVars;
 
-use crate::common::{TestEnv, cmd_snapshot, remove_bin_from_path};
+#[cfg(feature = "ci")]
+use crate::common::remove_bin_from_path;
+use crate::common::{TestEnv, cmd_snapshot};
 
+#[cfg(feature = "ci")]
 #[test]
 fn uv_source_none() -> anyhow::Result<()> {
     let context = TestEnv::new()
@@ -21,10 +25,7 @@ fn uv_source_none() -> anyhow::Result<()> {
         .init_git();
 
     let path = remove_bin_from_path("uv", None)?;
-    let uv_path = context
-        .home_dir()
-        .child("tools/uv")
-        .child(format!("uv{}", std::env::consts::EXE_SUFFIX));
+    let uv_dir = context.home_dir().child("tools/uv");
 
     cmd_snapshot!(context, context.run()
         .env(EnvVars::PREK_UV_SOURCE, "none")
@@ -38,8 +39,10 @@ fn uv_source_none() -> anyhow::Result<()> {
       caused by: Failed to install uv
       caused by: No compatible uv found and automatic installation is disabled by PREK_UV_SOURCE=none. Install uv (>=0.7.0) and add it to PATH
     "#);
-    uv_path.assert(predicates::path::missing());
+    uv_dir.assert(predicates::path::missing());
 
+    fs_err::create_dir_all(&uv_dir)?;
+    let uv_path = uv_dir.child(format!("uv{}", std::env::consts::EXE_SUFFIX));
     fs_err::copy(which::which("uv")?, &uv_path)?;
 
     cmd_snapshot!(context, context.run()

--- a/crates/prek/tests/languages/python.rs
+++ b/crates/prek/tests/languages/python.rs
@@ -1,9 +1,60 @@
-#[cfg(feature = "ci")]
 use assert_fs::assert::PathAssert;
 use assert_fs::fixture::PathChild;
 use prek_consts::env_vars::EnvVars;
 
-use crate::common::{TestEnv, cmd_snapshot};
+use crate::common::{TestEnv, cmd_snapshot, remove_bin_from_path};
+
+#[test]
+fn uv_source_none() -> anyhow::Result<()> {
+    let context = TestEnv::new()
+        .with_config(indoc::indoc! {r#"
+        repos:
+          - repo: local
+            hooks:
+              - id: local
+                name: local
+                language: python
+                entry: python -c 'print("Hello, world!")'
+                always_run: true
+                pass_filenames: false
+    "#})
+        .init_git();
+
+    let path = remove_bin_from_path("uv", None)?;
+    let uv_path = context
+        .home_dir()
+        .child("tools/uv")
+        .child(format!("uv{}", std::env::consts::EXE_SUFFIX));
+
+    cmd_snapshot!(context, context.run()
+        .env(EnvVars::PREK_UV_SOURCE, "none")
+        .env(EnvVars::PATH, &path), @r#"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to install hook `local`
+      caused by: Failed to install uv
+      caused by: No compatible uv found and automatic installation is disabled by PREK_UV_SOURCE=none. Install uv (>=0.7.0) and add it to PATH
+    "#);
+    uv_path.assert(predicates::path::missing());
+
+    fs_err::copy(which::which("uv")?, &uv_path)?;
+
+    cmd_snapshot!(context, context.run()
+        .env(EnvVars::PREK_UV_SOURCE, "none")
+        .env(EnvVars::PATH, &path), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    local....................................................................Passed
+
+    ----- stderr -----
+    "#);
+
+    Ok(())
+}
 
 /// Test `language_version` parsing and downloading.
 /// We use `setup-python` action to install Python 3.12 in CI, when running tests uv can find them.

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -535,6 +535,9 @@ prek uses `uv` for creating virtual environments and installing dependencies:
 - If not found, automatically installs `uv` from Astral's CDN, falling back to PyPI (and mirrors) then `pip`
 - Automatically installs the required Python version if it's not already available
 
+Set [`PREK_UV_SOURCE=none`](reference/environment-variables.md#prek_uv_source) to
+disable automatic uv installation and require an existing compatible uv.
+
 !!! warning "Environment variables"
 
     Since prek calls `uv` under the hood to create Python virtual environments and install dependencies, most `uv` environment variables will affect prek's behavior. For example, setting `UV_RESOLUTION=lowest-direct` in your environment will cause hook dependencies to be resolved to their lowest compatible versions, which may lead to installation failures with old packages on modern Python versions.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -59,6 +59,7 @@ See [Built-in Fast Hooks](../builtin.md) for details.
 Choose one source for installing uv, the Python package installer.
 Options:
 
+- `none` (disable automatic uv installation)
 - `astral` (download from Astral's CDN)
 - `github` (download from GitHub releases)
 - `pypi` (install from PyPI)
@@ -70,6 +71,10 @@ Options:
 
 If not set, prek tries Astral's CDN, PyPI and its configured mirrors, then `pip`
 until one succeeds. The `github` source is used only when selected explicitly.
+
+With `none`, prek still uses a compatible uv found alongside the prek binary, on
+`PATH`, or in prek's cache. If none is available, prek returns an error instead of
+installing uv. This does not disable Python or package downloads by uv.
 
 ### `PREK_NATIVE_TLS`
 


### PR DESCRIPTION
Add `PREK_UV_SOURCE=none` to require an existing compatible uv and fail instead of installing it.

Refs https://github.com/j178/prek/discussions/2699.
